### PR TITLE
Fix missing OG metadata on page reader URLs

### DIFF
--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { getDb } from '@/lib/mongodb';
-import { Book, Page } from '@/lib/types';
+import { Book, Page, TranslationEdition } from '@/lib/types';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -62,6 +62,17 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 
   const pageUrl = `/book/${id}/page/${pageId}`;
 
+  // Image fallback chain
+  const imageUrl = page.cropped_photo || page.archived_photo || page.photo || page.photo_original;
+
+  // Publication date from edition or book creation
+  const currentEdition = (book.editions as TranslationEdition[] | undefined)?.find(e => e.status === 'published');
+  const publishedDate = currentEdition?.published_at
+    ? new Date(currentEdition.published_at).toISOString()
+    : book.created_at
+    ? new Date(book.created_at).toISOString()
+    : undefined;
+
   return {
     title: `${title} - Source Library`,
     description,
@@ -75,20 +86,22 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
       siteName: 'Source Library',
       locale: 'en_US',
       url: pageUrl,
-      ...(page.photo && {
+      ...(imageUrl && {
         images: [
           {
-            url: page.photo,
+            url: imageUrl,
             alt: `${bookTitle} - Page ${pageNum}`,
           },
         ],
       }),
+      ...(publishedDate && { publishedTime: publishedDate }),
+      authors: [book.author],
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      ...(page.photo && { images: [page.photo] }),
+      ...(imageUrl && { images: [imageUrl] }),
     },
   };
 }


### PR DESCRIPTION
## Summary
- **Author**: Added `authors: [book.author]` to OpenGraph config — was completely missing
- **Image**: Replaced single `page.photo` check with full fallback chain (`cropped_photo` → `archived_photo` → `photo` → `photo_original`) — many pages have archived images but empty `photo` fields
- **Publish date**: Added `publishedTime` with edition-or-creation-date logic matching the book detail page

## Test plan
- [ ] Share a page reader URL in Facebook Sharing Debugger — verify author, image, and date now appear
- [ ] Check Twitter Card Validator for the same URL
- [ ] Test a page with `archived_photo` but no `photo` — image should now be found

🤖 Generated with [Claude Code](https://claude.com/claude-code)