### PR TITLE
Post-import automation pipeline

### DIFF
--- a/src/app/api/admin/enroll-pipeline/route.ts
+++ b/src/app/api/admin/enroll-pipeline/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import type { PipelineAutoStatus } from '@/lib/types/pipeline';
+
+export const maxDuration = 60;
+
+/**
+ * GET /api/admin/enroll-pipeline
+ *
+ * Pipeline status overview — counts per status.
+ */
+export async function GET() {
+  const db = await getDb();
+
+  const statusCounts = await db.collection('books').aggregate([
+    { $match: { pipeline_auto: { $exists: true } } },
+    { $group: { _id: '$pipeline_auto.status', count: { $sum: 1 } } },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+
+  const counts = Object.fromEntries(statusCounts.map(s => [s._id, s.count]));
+  const total = statusCounts.reduce((sum, s) => sum + s.count, 0);
+
+  // Count books without pipeline_auto
+  const unenrolled = await db.collection('books').countDocuments({
+    pipeline_auto: { $exists: false },
+  });
+
+  // Recent failures with details
+  const recentFailed = await db.collection('books')
+    .find({ 'pipeline_auto.status': 'failed' })
+    .project({ id: 1, title: 1, 'pipeline_auto.error': 1, 'pipeline_auto.retry_count': 1 })
+    .limit(20)
+    .toArray();
+
+  return NextResponse.json({
+    total_enrolled: total,
+    unenrolled,
+    status_counts: counts,
+    recent_failures: recentFailed.map(b => ({
+      id: b.id,
+      title: b.title,
+      error: b.pipeline_auto?.error,
+      retries: b.pipeline_auto?.retry_count,
+    })),
+  });
+}
+
+/**
+ * POST /api/admin/enroll-pipeline
+ *
+ * Enroll books into the auto pipeline.
+ * Body: { bookIds?: string[], limit?: number, dryRun?: boolean, reEnrollFailed?: boolean }
+ */
+export async function POST(request: NextRequest) {
+  const db = await getDb();
+  const body = await request.json().catch(() => ({}));
+  const { bookIds, limit = 50, dryRun = false, reEnrollFailed = false } = body as {
+    bookIds?: string[];
+    limit?: number;
+    dryRun?: boolean;
+    reEnrollFailed?: boolean;
+  };
+
+  let query: Record<string, unknown>;
+
+  if (bookIds?.length) {
+    // Enroll specific books
+    query = { id: { $in: bookIds } };
+  } else if (reEnrollFailed) {
+    // Re-enroll failed books
+    query = { 'pipeline_auto.status': 'failed' };
+  } else {
+    // Enroll all books without pipeline_auto
+    query = { pipeline_auto: { $exists: false } };
+  }
+
+  const books = await db.collection('books')
+    .find(query)
+    .project({ id: 1, title: 1, pages_count: 1, created_at: 1, 'pipeline_auto.status': 1 })
+    .limit(limit)
+    .toArray();
+
+  if (dryRun) {
+    return NextResponse.json({
+      dryRun: true,
+      wouldEnroll: books.length,
+      books: books.map(b => ({
+        id: b.id,
+        title: b.title,
+        pages: b.pages_count,
+        currentStatus: b.pipeline_auto?.status || 'none',
+      })),
+    });
+  }
+
+  let enrolled = 0;
+  const status: PipelineAutoStatus = 'queued';
+
+  for (const book of books) {
+    await db.collection('books').updateOne(
+      { id: book.id },
+      {
+        $set: {
+          pipeline_auto: {
+            status,
+            source: 'admin',
+            queued_at: new Date(),
+            last_updated: new Date(),
+            retry_count: 0,
+          },
+          updated_at: new Date(),
+        },
+      }
+    );
+    enrolled++;
+  }
+
+  return NextResponse.json({
+    success: true,
+    enrolled,
+    books: books.map(b => ({ id: b.id, title: b.title })),
+    message: `Enrolled ${enrolled} books. The pipeline cron will start processing within 10 minutes.`,
+  });
+}

--- a/src/app/api/books/[id]/batch-ocr-async/route.ts
+++ b/src/app/api/books/[id]/batch-ocr-async/route.ts
@@ -19,6 +19,8 @@ import { PROMPT_VERSION, extractPageType, parseDetectedImages } from '@/lib/type
  * GET /api/books/[id]/batch-ocr-async?jobName=xxx - Check job status
  */
 
+export const maxDuration = 300; // 5 minutes for large books (image downloads)
+
 const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY || '' });
 
 // Build image URL for a page

--- a/src/app/api/cron/post-import-pipeline/route.ts
+++ b/src/app/api/cron/post-import-pipeline/route.ts
@@ -1,0 +1,401 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import type { PipelineAutoStatus } from '@/lib/types/pipeline';
+
+export const maxDuration = 300;
+
+const TIME_BUDGET_MS = 270_000; // 4.5 min — leave 30s buffer before Vercel's 300s limit
+const ENROLL_LIMIT = 10;
+const ARCHIVE_LIMIT = 3;
+const OCR_SUBMIT_LIMIT = 2;
+const TRANSLATE_SUBMIT_LIMIT = 2;
+const ENRICH_LIMIT = 1;
+const MAX_RETRIES = 3;
+const ENROLL_WINDOW_DAYS = 7;
+
+function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_URL
+    || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+}
+
+function hasTimeBudget(startTime: number): boolean {
+  return Date.now() - startTime < TIME_BUDGET_MS;
+}
+
+async function setPipelineStatus(
+  db: Awaited<ReturnType<typeof getDb>>,
+  bookId: string,
+  status: PipelineAutoStatus,
+  extra: Record<string, unknown> = {},
+) {
+  await db.collection('books').updateOne(
+    { id: bookId },
+    {
+      $set: {
+        'pipeline_auto.status': status,
+        'pipeline_auto.last_updated': new Date(),
+        ...Object.fromEntries(
+          Object.entries(extra).map(([k, v]) => [`pipeline_auto.${k}`, v])
+        ),
+        updated_at: new Date(),
+      },
+    }
+  );
+}
+
+async function markFailed(
+  db: Awaited<ReturnType<typeof getDb>>,
+  bookId: string,
+  error: string,
+  retryCount: number,
+) {
+  await setPipelineStatus(db, bookId, 'failed', { error, retry_count: retryCount });
+}
+
+/**
+ * GET /api/cron/post-import-pipeline
+ *
+ * Cron-driven post-import pipeline orchestrator.
+ * Discovers books needing work and advances them through:
+ *   archive -> OCR -> translate -> summary/index
+ *
+ * Scheduled: every 10 minutes via Vercel cron.
+ */
+export async function GET(request: NextRequest) {
+  const startTime = Date.now();
+  const baseUrl = getBaseUrl();
+  const db = await getDb();
+
+  const log = {
+    enrolled: 0,
+    archived: 0,
+    ocr_submitted: 0,
+    ocr_advanced: 0,
+    translate_submitted: 0,
+    translate_advanced: 0,
+    enriched: 0,
+    errors: [] as string[],
+  };
+
+  try {
+    // ── Phase 0: Auto-enroll recently imported books ──
+    if (hasTimeBudget(startTime)) {
+      const cutoff = new Date(Date.now() - ENROLL_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+      const newBooks = await db.collection('books')
+        .find({
+          pipeline_auto: { $exists: false },
+          created_at: { $gte: cutoff },
+        })
+        .project({ id: 1 })
+        .limit(ENROLL_LIMIT)
+        .toArray();
+
+      for (const book of newBooks) {
+        await db.collection('books').updateOne(
+          { id: book.id },
+          {
+            $set: {
+              pipeline_auto: {
+                status: 'queued',
+                source: 'cron',
+                queued_at: new Date(),
+                last_updated: new Date(),
+                retry_count: 0,
+              },
+              updated_at: new Date(),
+            },
+          }
+        );
+        log.enrolled++;
+      }
+    }
+
+    // ── Phase 1: Archive images (queued -> archiving -> archive_complete) ──
+    if (hasTimeBudget(startTime)) {
+      // Start archiving for queued books
+      const queuedBooks = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'queued' })
+        .project({ id: 1, title: 1 })
+        .limit(ARCHIVE_LIMIT)
+        .toArray();
+
+      for (const book of queuedBooks) {
+        if (!hasTimeBudget(startTime)) break;
+        await setPipelineStatus(db, book.id, 'archiving', { started_at: new Date() });
+      }
+
+      // Continue archiving for books in archiving state
+      const archivingBooks = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'archiving' })
+        .project({ id: 1, title: 1, 'pipeline_auto.retry_count': 1 })
+        .limit(ARCHIVE_LIMIT)
+        .toArray();
+
+      for (const book of archivingBooks) {
+        if (!hasTimeBudget(startTime)) break;
+        try {
+          const res = await fetch(`${baseUrl}/api/books/${book.id}/archive-images`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ limit: 50 }),
+          });
+
+          if (!res.ok) {
+            const retries = book.pipeline_auto?.retry_count || 0;
+            if (retries >= MAX_RETRIES) {
+              await markFailed(db, book.id, `Archive failed: HTTP ${res.status}`, retries);
+            } else {
+              await setPipelineStatus(db, book.id, 'archiving', { retry_count: retries + 1 });
+            }
+            log.errors.push(`Archive ${book.id}: HTTP ${res.status}`);
+            continue;
+          }
+
+          const data = await res.json();
+          log.archived++;
+
+          // Check if archiving is complete (no remaining pages)
+          if ((data.remaining || 0) === 0) {
+            await setPipelineStatus(db, book.id, 'archive_complete', { retry_count: 0 });
+          }
+          // Otherwise stays in 'archiving' — next invocation continues
+        } catch (err) {
+          log.errors.push(`Archive ${book.id}: ${err instanceof Error ? err.message : 'unknown'}`);
+        }
+      }
+    }
+
+    // ── Phase 2: Submit OCR (archive_complete -> ocr_submitted) ──
+    if (hasTimeBudget(startTime)) {
+      const readyForOcr = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'archive_complete' })
+        .project({ id: 1, title: 1, pages_count: 1 })
+        .limit(OCR_SUBMIT_LIMIT)
+        .toArray();
+
+      for (const book of readyForOcr) {
+        if (!hasTimeBudget(startTime)) break;
+        try {
+          const res = await fetch(`${baseUrl}/api/books/${book.id}/batch-ocr-async`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ limit: book.pages_count || 500 }),
+          });
+
+          if (!res.ok) {
+            log.errors.push(`OCR submit ${book.id}: HTTP ${res.status}`);
+            continue;
+          }
+
+          const data = await res.json();
+
+          if (data.jobName) {
+            await setPipelineStatus(db, book.id, 'ocr_submitted', {
+              ocr_job_name: data.jobName,
+            });
+            log.ocr_submitted++;
+          } else if (data.processed === 0 || data.message?.includes('No pages need OCR')) {
+            // Already OCR'd — skip to translate
+            await setPipelineStatus(db, book.id, 'ocr_complete');
+            log.ocr_advanced++;
+          } else {
+            log.errors.push(`OCR submit ${book.id}: unexpected response`);
+          }
+        } catch (err) {
+          log.errors.push(`OCR submit ${book.id}: ${err instanceof Error ? err.message : 'unknown'}`);
+        }
+      }
+    }
+
+    // ── Phase 3: Check OCR completion (ocr_submitted -> ocr_complete) ──
+    if (hasTimeBudget(startTime)) {
+      const ocrPending = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'ocr_submitted' })
+        .project({ id: 1, 'pipeline_auto.ocr_job_name': 1, 'pipeline_auto.ocr_batch_id': 1 })
+        .toArray();
+
+      for (const book of ocrPending) {
+        if (!hasTimeBudget(startTime)) break;
+        const jobName = book.pipeline_auto?.ocr_job_name;
+
+        // Check batch_jobs collection for completion
+        const batchJob = jobName
+          ? await db.collection('batch_jobs').findOne({
+              book_id: book.id,
+              type: 'ocr',
+              $or: [
+                { job_name: jobName },
+                { gemini_job_name: jobName },
+              ],
+            })
+          : null;
+
+        // Also check for parent jobs (large books split into children)
+        const parentJob = await db.collection('batch_jobs').findOne({
+          book_id: book.id,
+          type: 'ocr',
+          child_job_ids: { $exists: true, $ne: [] },
+          status: { $in: ['completed', 'saved', 'completed_with_errors'] },
+        });
+
+        if (
+          batchJob && ['saved', 'completed', 'completed_with_errors'].includes(batchJob.status) ||
+          parentJob
+        ) {
+          await setPipelineStatus(db, book.id, 'ocr_complete');
+          log.ocr_advanced++;
+        }
+        // Otherwise keep waiting — process-batches cron will collect results
+      }
+    }
+
+    // ── Phase 4: Submit translation (ocr_complete -> translate_submitted) ──
+    if (hasTimeBudget(startTime)) {
+      const readyForTranslate = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'ocr_complete' })
+        .project({ id: 1, title: 1, pages_count: 1 })
+        .limit(TRANSLATE_SUBMIT_LIMIT)
+        .toArray();
+
+      for (const book of readyForTranslate) {
+        if (!hasTimeBudget(startTime)) break;
+        try {
+          const res = await fetch(`${baseUrl}/api/books/${book.id}/batch-translate-async`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ limit: book.pages_count || 500 }),
+          });
+
+          if (!res.ok) {
+            log.errors.push(`Translate submit ${book.id}: HTTP ${res.status}`);
+            continue;
+          }
+
+          const data = await res.json();
+
+          if (data.jobName) {
+            await setPipelineStatus(db, book.id, 'translate_submitted', {
+              translate_job_name: data.jobName,
+            });
+            log.translate_submitted++;
+          } else if (data.processed === 0 || data.message?.includes('No pages need translation')) {
+            await setPipelineStatus(db, book.id, 'translate_complete');
+            log.translate_advanced++;
+          } else {
+            log.errors.push(`Translate submit ${book.id}: unexpected response`);
+          }
+        } catch (err) {
+          log.errors.push(`Translate submit ${book.id}: ${err instanceof Error ? err.message : 'unknown'}`);
+        }
+      }
+    }
+
+    // ── Phase 5: Check translation completion (translate_submitted -> translate_complete) ──
+    if (hasTimeBudget(startTime)) {
+      const translatePending = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'translate_submitted' })
+        .project({ id: 1, 'pipeline_auto.translate_job_name': 1 })
+        .toArray();
+
+      for (const book of translatePending) {
+        if (!hasTimeBudget(startTime)) break;
+        const jobName = book.pipeline_auto?.translate_job_name;
+
+        const batchJob = jobName
+          ? await db.collection('batch_jobs').findOne({
+              book_id: book.id,
+              type: 'translation',
+              $or: [
+                { job_name: jobName },
+                { gemini_job_name: jobName },
+              ],
+            })
+          : null;
+
+        const parentJob = await db.collection('batch_jobs').findOne({
+          book_id: book.id,
+          type: 'translation',
+          child_job_ids: { $exists: true, $ne: [] },
+          status: { $in: ['completed', 'saved', 'completed_with_errors'] },
+        });
+
+        if (
+          batchJob && ['saved', 'completed', 'completed_with_errors'].includes(batchJob.status) ||
+          parentJob
+        ) {
+          await setPipelineStatus(db, book.id, 'translate_complete');
+          log.translate_advanced++;
+        }
+      }
+    }
+
+    // ── Phase 6: Enrich — generate summary + index (translate_complete -> complete) ──
+    if (hasTimeBudget(startTime)) {
+      const readyForEnrich = await db.collection('books')
+        .find({ 'pipeline_auto.status': 'translate_complete' })
+        .project({ id: 1, title: 1, 'pipeline_auto.retry_count': 1 })
+        .limit(ENRICH_LIMIT)
+        .toArray();
+
+      for (const book of readyForEnrich) {
+        if (!hasTimeBudget(startTime)) break;
+        try {
+          await setPipelineStatus(db, book.id, 'enriching');
+
+          // GET /api/books/{id}/index generates summary + index if stale
+          const res = await fetch(`${baseUrl}/api/books/${book.id}/index`, {
+            method: 'GET',
+          });
+
+          if (!res.ok) {
+            const retries = book.pipeline_auto?.retry_count || 0;
+            if (retries >= MAX_RETRIES) {
+              await markFailed(db, book.id, `Enrich failed: HTTP ${res.status}`, retries);
+            } else {
+              await setPipelineStatus(db, book.id, 'translate_complete', { retry_count: retries + 1 });
+            }
+            log.errors.push(`Enrich ${book.id}: HTTP ${res.status}`);
+            continue;
+          }
+
+          await setPipelineStatus(db, book.id, 'complete', {
+            completed_at: new Date(),
+            retry_count: 0,
+          });
+          log.enriched++;
+        } catch (err) {
+          log.errors.push(`Enrich ${book.id}: ${err instanceof Error ? err.message : 'unknown'}`);
+        }
+      }
+    }
+
+    const duration = Date.now() - startTime;
+
+    // Summary counts
+    const statusCounts = await db.collection('books').aggregate([
+      { $match: { pipeline_auto: { $exists: true } } },
+      { $group: { _id: '$pipeline_auto.status', count: { $sum: 1 } } },
+    ]).toArray();
+
+    const counts = Object.fromEntries(statusCounts.map(s => [s._id, s.count]));
+
+    return NextResponse.json({
+      success: true,
+      duration_ms: duration,
+      actions: log,
+      pipeline_status: counts,
+    });
+  } catch (error) {
+    console.error('[post-import-pipeline] Error:', error);
+    return NextResponse.json({
+      error: 'Pipeline cron failed',
+      details: error instanceof Error ? error.message : 'Unknown error',
+      partial: log,
+    }, { status: 500 });
+  }
+}
+
+// Support POST for Vercel Cron
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -55,6 +55,56 @@ MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer see
 
 Return ONLY a valid JSON array. If no illustrations, return: []`;
 
+/**
+ * Build OCR-aware context to append to extraction prompt.
+ * Gives the model text layout awareness for better bounding boxes.
+ */
+function buildOcrContext(ocrData: string): string {
+  const parts: string[] = [];
+
+  // Extract page-type
+  const pageTypeMatch = ocrData.match(/<page-type>([\s\S]*?)<\/page-type>/i);
+  if (pageTypeMatch) {
+    parts.push(`Page type: ${pageTypeMatch[1].trim()}`);
+  }
+
+  // Extract preliminary image detections from OCR
+  const imgMatch = ocrData.match(/<detected-images>([\s\S]*?)<\/detected-images>/i);
+  if (imgMatch) {
+    try {
+      const preliminary = JSON.parse(imgMatch[1].trim());
+      if (Array.isArray(preliminary) && preliminary.length > 0) {
+        parts.push(`OCR detected ${preliminary.length} preliminary image(s):`);
+        for (const img of preliminary) {
+          const bbox = img.bbox ? `bbox={x:${img.bbox.x},y:${img.bbox.y},w:${img.bbox.width},h:${img.bbox.height}}` : 'no bbox';
+          parts.push(`  - "${img.description || '?'}" (${img.type || '?'}, ${bbox})`);
+        }
+        parts.push('These are rough estimates from OCR. Refine the bounding boxes to tightly enclose each illustration.');
+      }
+    } catch {
+      // malformed JSON, skip
+    }
+  }
+
+  // Summarize text layout — where text blocks are helps locate image regions
+  const textLines = ocrData
+    .replace(/<[^>]+>/g, '') // strip tags
+    .split('\n')
+    .filter(l => l.trim().length > 0);
+  const totalLines = textLines.length;
+
+  if (totalLines === 0) {
+    parts.push('This page has no transcribed text — likely a full-page illustration.');
+  } else if (totalLines < 5) {
+    parts.push(`Minimal text (${totalLines} lines) — mostly illustration with brief captions or labels.`);
+  } else {
+    parts.push(`Text-heavy page (${totalLines} lines). Illustrations are embedded between or alongside text blocks.`);
+  }
+
+  if (parts.length === 0) return '';
+  return '\n\nOCR CONTEXT (use to improve bounding box accuracy):\n' + parts.join('\n');
+}
+
 export interface ImageMetadata {
   subjects?: string[];
   figures?: string[];
@@ -113,12 +163,12 @@ export async function extractWithGemini(
 export async function extractWithGemini(
   imageUrl: string,
   model: string,
-  options: { returnUsage: true }
+  options: { returnUsage: true; ocrData?: string }
 ): Promise<ExtractionResult>;
 export async function extractWithGemini(
   imageUrl: string,
   model: string = DEFAULT_MODEL,
-  options?: { returnUsage: true }
+  options?: { returnUsage?: true; ocrData?: string }
 ): Promise<DetectedImage[] | ExtractionResult> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
@@ -131,6 +181,10 @@ export async function extractWithGemini(
     ? { base64: imageData, mimeType: getMimeType(imageUrl, null) }
     : { base64: imageData.base64, mimeType: imageData.mimeType };
 
+  // Build prompt — append OCR context if available for better bounding boxes
+  const ocrContext = options?.ocrData ? buildOcrContext(options.ocrData) : '';
+  const prompt = IMAGE_EXTRACTION_PROMPT + ocrContext;
+
   const response = await fetch(
     `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
     {
@@ -139,7 +193,7 @@ export async function extractWithGemini(
       body: JSON.stringify({
         contents: [{
           parts: [
-            { text: IMAGE_EXTRACTION_PROMPT },
+            { text: prompt },
             { inline_data: { mime_type: mimeType, data: base64Image } }
           ]
         }],

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -292,6 +292,13 @@ export async function importBookFromIIIF(
         : {}),
     },
     status: 'draft',
+    pipeline_auto: {
+      status: 'queued',
+      source: 'import',
+      queued_at: new Date(),
+      last_updated: new Date(),
+      retry_count: 0,
+    },
     created_at: new Date(),
     updated_at: new Date(),
   };
@@ -346,6 +353,15 @@ export async function importBookFromIIIF(
     method: 'GET',
   }).catch(() => {
     console.log(`[Import] Split check queued for ${bookIdStr}`);
+  });
+
+  // Kick off image archiving (non-blocking, first batch)
+  fetch(`${baseUrl}/api/books/${bookIdStr}/archive-images`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ limit: 50 }),
+  }).catch(() => {
+    console.log(`[Import] Archive kick-off queued for ${bookIdStr}`);
   });
 
   // Notify search engines (non-blocking)

--- a/src/lib/types/pipeline.ts
+++ b/src/lib/types/pipeline.ts
@@ -46,3 +46,37 @@ export interface PipelineState {
 
   config: PipelineConfig;
 }
+
+// ─── Auto Pipeline (cron-driven post-import processing) ───
+
+export type PipelineAutoStatus =
+  | 'queued'
+  | 'archiving'
+  | 'archive_complete'
+  | 'ocr_submitted'
+  | 'ocr_complete'
+  | 'translate_submitted'
+  | 'translate_complete'
+  | 'enriching'
+  | 'complete'
+  | 'failed';
+
+export interface PipelineAutoState {
+  status: PipelineAutoStatus;
+  source: 'import' | 'admin' | 'cron';
+  queued_at: Date;
+  started_at?: Date;
+  completed_at?: Date;
+  error?: string;
+  retry_count?: number;
+  /** Gemini Batch API job name for OCR */
+  ocr_job_name?: string;
+  /** Gemini Batch API job name for translation */
+  translate_job_name?: string;
+  /** batch_jobs collection ID for OCR */
+  ocr_batch_id?: string;
+  /** batch_jobs collection ID for translation */
+  translate_batch_id?: string;
+  /** Last time the cron touched this book */
+  last_updated?: Date;
+}

--- a/src/workers/image-extraction-processor-logic.ts
+++ b/src/workers/image-extraction-processor-logic.ts
@@ -92,8 +92,9 @@ export async function processImageExtractionPage(message: PageProcessingMessage)
   const startTime = Date.now();
 
   try {
-    // Extract images with AI vision (with usage tracking)
-    const result = await extractWithGemini(imageUrl, modelId, { returnUsage: true });
+    // Pass OCR data if available — helps model place bounding boxes accurately
+    const ocrData = (page.ocr?.data && typeof page.ocr.data === 'string') ? page.ocr.data : undefined;
+    const result = await extractWithGemini(imageUrl, modelId, { returnUsage: true, ocrData });
     const durationMs = Date.now() - startTime;
 
     // Save results to page

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,10 @@
     {
       "path": "/api/cron/sync-page-counts",
       "schedule": "0 */6 * * *"
+    },
+    {
+      "path": "/api/cron/post-import-pipeline",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Cron orchestrator** (`/api/cron/post-import-pipeline`, every 10 min) auto-discovers recent imports and advances them through: archive images → OCR → translation → enrichment (summary + index)
- **Admin enrollment API** (`/api/admin/enroll-pipeline`) for manual enrollment, re-enrollment of failed books, and status overview with dry-run support
- **9-state machine** with retry logic (max 3 attempts), phase gates, and time-budgeted execution (stays under Vercel 300s limit)
- **Image extraction enhancement** — passes OCR text as context to Gemini for better bounding box detection on illustrations

## Test plan
- [ ] Import a test book and verify it auto-enrolls and advances through pipeline phases
- [ ] Check `/api/admin/enroll-pipeline` GET returns status overview
- [ ] Verify cron respects time budget and doesn't exceed 270s per invocation
- [ ] Test image extraction on a book with OCR — verify bounding boxes improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)