### PR TITLE
Collections: 4-col grid, pinned order, shuffled rest

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -34,10 +34,21 @@ interface CollectionDoc {
   languages: { lang: string; count: number }[];
 }
 
+const PINNED_SLUGS = ['natural-philosophy', 'classical-philosophy', 'renaissance-philosophy', 'sacred-texts'];
+
 async function fetchCollections(): Promise<CollectionDoc[]> {
   const db = await getDb();
-  const docs = await db.collection('collections').find({}).sort({ order: 1 }).toArray();
-  return docs.map(({ _id, ...rest }) => rest) as unknown as CollectionDoc[];
+  const docs = await db.collection('collections').find({}).toArray();
+  const all = docs.map(({ _id, ...rest }) => rest) as unknown as CollectionDoc[];
+
+  const pinned = PINNED_SLUGS.map(s => all.find(c => c.slug === s)).filter(Boolean) as CollectionDoc[];
+  const rest = all.filter(c => !PINNED_SLUGS.includes(c.slug));
+  // Fisher-Yates shuffle
+  for (let i = rest.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [rest[i], rest[j]] = [rest[j], rest[i]];
+  }
+  return [...pinned, ...rest];
 }
 
 export default async function CollectionsPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,23 +18,16 @@ export const maxDuration = 60;
 
 // ---------- Collection ordering (user-specified) ----------
 
-const COLLECTION_ORDER = [
-  'Natural Philosophy',
-  'Theology',
-  'Classical Philosophy',
-  'Alchemy',
-  'Indic',
-  'Chinese',
-  'Magic',
-  'Medicine',
-  'Art',
-  'Secret Societies',
-  'Leonardo',
-];
+const PINNED_COLLECTION_SLUGS = ['natural-philosophy', 'classical-philosophy', 'renaissance-philosophy', 'sacred-texts'];
 
-function collectionSortIndex(name: string): number {
-  const idx = COLLECTION_ORDER.findIndex(prefix => name.includes(prefix));
-  return idx === -1 ? COLLECTION_ORDER.length : idx;
+function sortCollections<T extends { slug: string }>(collections: T[]): T[] {
+  const pinned = PINNED_COLLECTION_SLUGS.map(s => collections.find(c => c.slug === s)).filter(Boolean) as T[];
+  const rest = collections.filter(c => !PINNED_COLLECTION_SLUGS.includes(c.slug));
+  for (let i = rest.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [rest[i], rest[j]] = [rest[j], rest[i]];
+  }
+  return [...pinned, ...rest];
 }
 
 // ---------- Book projection shared across queries ----------
@@ -206,10 +199,7 @@ async function getRemainingCollections(): Promise<CollectionForGrid[]> {
     }
   }
 
-  // Sort by user-specified order
-  result.sort((a, b) => collectionSortIndex(a.name) - collectionSortIndex(b.name));
-
-  return result;
+  return sortCollections(result);
 }
 
 async function getDiscoverBooks(): Promise<Book[]> {
@@ -346,10 +336,7 @@ const FALLBACK_DISCOVER_BOOKS = [
   { id: '69906828249ce014347d5b4d', slug: 'the-great-journey-of-yoga-brhadyogayatra-varahamihira', title: 'Brhadyogayatra of Varahamihira', display_title: 'The Great Journey of Yoga (Brhadyogayatra)', author: 'Varahamihira', language: 'Sanskrit', published: 'Unknown', thumbnail: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/archived/69906828249ce014347d5b4d/4.jpg', thumbnail_blob: 'https://3kwioilsplnmnkv8.public.blob.vercel-storage.com/thumbnails/69906828249ce014347d5b4d/1.jpg', is_first_translation: false, pages_count: 11, pages_translated: 11, pages_ocr: 11, translation_percent: 100 },
 ] as unknown as Book[];
 
-// Pre-sorted fallback (matches collectionSortIndex order)
-const SORTED_FALLBACK_COLLECTIONS = [...FALLBACK_COLLECTIONS].sort(
-  (a, b) => collectionSortIndex(a.name) - collectionSortIndex(b.name)
-);
+const SORTED_FALLBACK_COLLECTIONS = sortCollections([...FALLBACK_COLLECTIONS]);
 
 // ---------- Blog posts (curated subset for homepage) ----------
 


### PR DESCRIPTION
## Summary
- Flip card text: book count above title (title in darkest gradient area)
- /collections page: 4-column grid matching home page style
- Pin first 4 collections: Natural Philosophy, Classical Philosophy, Renaissance Philosophy, Sacred Texts
- Remaining collections shuffled on each page load

## Test plan
- [ ] Home page shows pinned collections first, rest randomized
- [ ] /collections page matches home page card style
- [ ] Refresh shows different order for non-pinned collections
- [ ] Title readable at bottom of gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)