### PR TITLE
Wire CiteButton into reader + expose scholarly/bilingual EPUB downloads

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -29,6 +29,7 @@ import HighlightedText from '@/components/search/HighlightedText';
 import HighlightSelection from '@/components/annotations/HighlightSelection';
 import ChapterDropdown from '@/components/reader/ChapterDropdown';
 import ShareButton from '@/components/ui/ShareButton';
+import CiteButton from '@/components/ui/CiteButton';
 import { prompts as promptsApi, analytics, pages as pagesApi, processing as processingApi } from '@/lib/api-client';
 import LikeButton from '@/components/ui/LikeButton';
 import { getShortUrl } from '@/lib/shortlinks';
@@ -1046,7 +1047,7 @@ export default function TranslationEditor({
                 </div>
               </AuthCheck>
 
-              {/* Like + Share */}
+              {/* Like + Share + Cite */}
               <div className="flex items-center">
                 <LikeButton
                   targetType="page"
@@ -1063,6 +1064,19 @@ export default function TranslationEditor({
                   url={`https://sourcelibrary.org/book/${(book as any).slug || book.id}?page=${page.page_number}`}
                   doi={book.doi}
                   className="!p-1.5 !text-stone-500 hover:!text-stone-700 hover:!bg-stone-100 !rounded-full"
+                />
+                <CiteButton
+                  bookId={book.id}
+                  title={book.title}
+                  displayTitle={book.display_title}
+                  author={book.author || 'Anonymous'}
+                  year={book.published}
+                  publisher={book.publisher}
+                  placePublished={book.place_published}
+                  language={book.language}
+                  doi={book.doi}
+                  pageNumber={page.page_number}
+                  className="!p-1.5 !text-stone-500 hover:!text-stone-700 hover:!bg-stone-100 !rounded-full text-sm"
                 />
               </div>
             </div>

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
-import { Download, ChevronDown, FileText, Languages, Layers, BookOpen, Columns, Image } from 'lucide-react';
+import { Download, ChevronDown, FileText, Languages, Layers, BookOpen, Columns, Image, GraduationCap } from 'lucide-react';
 import { BookDownloadFormats, books } from '@/lib/api-client';
 
 interface DownloadButtonProps {
@@ -221,6 +221,16 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
             <FormatOption format="epub-parallel" label="Parallel Text" desc="Facing pages"
               icon={<Columns className="w-4 h-4 text-accent-rust" />}
               onDownload={handleDownload} downloading={downloading} className="border-t border-stone-100" />
+          )}
+          {hasTranslations && (
+            <FormatOption format="epub-scholarly" label="Scholarly Edition" desc="With introduction & apparatus"
+              icon={<GraduationCap className="w-4 h-4 text-stone-700" />}
+              onDownload={handleDownload} downloading={downloading} />
+          )}
+          {hasTranslations && hasOcr && (
+            <FormatOption format="epub-bilingual" label="Bilingual Scholarly" desc="Original + translation with apparatus"
+              icon={<GraduationCap className="w-4 h-4 text-accent-rust" />}
+              onDownload={handleDownload} downloading={downloading} />
           )}
           {hasTranslations && hasImages && !imageRestricted && (
             <FormatOption format="epub-facsimile" label="Facsimile Edition" desc="Page images + translation"

--- a/src/lib/api-client/types/books.ts
+++ b/src/lib/api-client/types/books.ts
@@ -195,5 +195,7 @@ export type BookDownloadFormats =
   'epub-both' |
   'epub-parallel' |
   'epub-facsimile' |
+  'epub-scholarly' |
+  'epub-bilingual' |
   'epub-images' |
   'images-zip'


### PR DESCRIPTION
## Summary
- Add CiteButton (APA + BibTeX with page numbers) to the page reading toolbar, next to Like/Share
- Expose epub-scholarly and epub-bilingual formats in the DownloadButton dropdown
- Add both format types to BookDownloadFormats union type

## Test plan
- [ ] Open a book page, verify Cite button appears next to Share
- [ ] Click Cite, verify APA and BibTeX citations include page number
- [ ] Open download dropdown, verify Scholarly Edition and Bilingual Scholarly options appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)