### PR TITLE
Fix batch OCR RECITATION blocking (#256)

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -341,6 +341,26 @@ async function processOneJob(db, job) {
     };
 
   } else if (state === 'JOB_STATE_PENDING' || state === 'JOB_STATE_RUNNING') {
+    // Check for stale jobs — if PENDING for >6 hours with no progress, cancel and let orchestrator retry
+    const STALE_HOURS = 6;
+    const jobAge = (Date.now() - new Date(job.created_at).getTime()) / 3600000;
+    if (state === 'JOB_STATE_PENDING' && jobAge > STALE_HOURS) {
+      console.log(`  Stale PENDING job (${jobAge.toFixed(1)}h old): ${job.job_name || job.gemini_job_name} — cancelling`);
+      if (!DRY_RUN) {
+        // Cancel the Gemini job
+        try {
+          const cancelUrl = `${GEMINI_API_BASE}/${job.job_name || job.gemini_job_name}:cancel?key=${ALL_KEYS[0]}`;
+          await fetch(cancelUrl, { method: 'POST' });
+        } catch (_) { /* best effort */ }
+
+        await db.collection('batch_jobs').updateOne(
+          { _id: job._id },
+          { $set: { status: 'failed', gemini_state: state, error: `Stale: PENDING for ${jobAge.toFixed(1)}h with no progress`, updated_at: new Date() } }
+        );
+      }
+      return { status: 'failed', state: 'STALE_PENDING', bookId: job.book_id, type: job.type };
+    }
+
     // Update status to reflect current state
     const newStatus = state === 'JOB_STATE_RUNNING' ? 'processing' : 'pending';
     if (job.status !== newStatus) {

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -766,6 +766,13 @@ async function submitOcrDirectly(db, book, { modelOverride } = {}) {
               { inlineData: { mimeType: item.image.mimeType, data: item.image.data } },
             ],
           }],
+          safetySettings: [
+            { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
+          ],
           generationConfig: {
             temperature: 0.1,
             maxOutputTokens: 16384,
@@ -795,6 +802,13 @@ async function submitOcrDirectly(db, book, { modelOverride } = {}) {
               { inlineData: { mimeType: item.image.mimeType, data: item.image.data } },
             ],
           }],
+          safetySettings: [
+            { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
+          ],
           generationConfig: {
             temperature: 0.1,
             maxOutputTokens: 16384,
@@ -1389,8 +1403,8 @@ async function run() {
     }
 
     // ── Phase 2: Submit OCR via Gemini Batch API (archive_complete -> ocr_submitted) ──
-    // DISABLED: Batch API returning 0 pages — see #256. Using Phase 1.5 Lambda preview instead.
-    if (false && shouldRun(2)) {
+    // Re-enabled: RECITATION fix applied (BLOCK_NONE safety settings + model fallback). See #256.
+    if (shouldRun(2)) {
       console.log('\n--- Phase 2: OCR submission ---');
 
       const activeBatchOcr = await db.collection('batch_jobs').countDocuments({


### PR DESCRIPTION
## Summary
- Add `BLOCK_NONE` safety settings to batch OCR requests — root cause of RECITATION on historical texts
- Add stale job detection: cancel PENDING batch jobs stuck >6h
- Re-enable Phase 2 (batch OCR submission) in pipeline orchestrator

## Context
Gemini's Batch API was flagging 400-year-old texts as "copyrighted" (RECITATION filter). The realtime OCR calls already had `BLOCK_NONE` safety settings, but the batch OCR requests in `submitOcrDirectly()` were missing them. This caused all batch OCR jobs to return 0 pages, blocking 5,800 books at `archive_complete`.

The RECITATION detection, recovery flow (recitation_retry flag + gemini-2.5-flash fallback), and failed-status handling were already merged to main from earlier work. This PR adds the missing prevention (safety settings) and cleanup (stale detection), then re-enables the pipeline.

Cherry-picked from the relevant fixes in `fix/batch-collector-recitation` (PR #259), which has merge conflicts and bundles unrelated changes.

Closes #256

## Test plan
- [ ] Deploy to Hetzner and run `pipeline-orchestrator.mjs --phase 2 --dry-run` to verify Phase 2 activates
- [ ] Submit a test batch OCR job and confirm responses include OCR text (no RECITATION)
- [ ] Monitor batch-collector for stale job detection on any lingering PENDING jobs
- [ ] Watch first full orchestrator cycle for successful end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)