### PR TITLE
Fix collections page: 30s load time and missing header

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -6,7 +6,7 @@ import { sortCollections } from '@/lib/collections-utils';
 import EraTimeline, { type DecadeBucket } from '@/components/collections/EraTimeline';
 import type { Metadata } from 'next';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 3600; // ISR: rebuild every hour
 
 export const metadata: Metadata = {
   title: 'Collections | Source Library',
@@ -148,11 +148,14 @@ export default async function CollectionsPage() {
   const totalBooks = categories.reduce((s, c) => s + c.book_count, 0);
 
   return (
-    <ContentPageLayout>
-      <ContentHeader
-        title="Collections"
-        subtitle={`${totalBooks.toLocaleString()} books organized into ${categories.length} thematic collections spanning three millennia of human knowledge.`}
-      />
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Collections"
+          subtitle={`${totalBooks.toLocaleString()} books organized into ${categories.length} thematic collections spanning three millennia of human knowledge.`}
+        />
+      }
+    >
 
       {/* Link to curated exhibitions */}
       <div className="mb-8">

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -115,11 +115,14 @@ export default async function TopicsPage() {
   const { topics, totalBooks } = await fetchTopics();
 
   return (
-    <ContentPageLayout>
-      <ContentHeader
-        title="Browse by Topic"
-        subtitle={`${totalBooks.toLocaleString()} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
-      />
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Browse by Topic"
+          subtitle={`${totalBooks.toLocaleString()} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
+        />
+      }
+    >
 
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {topics.map((topic) => (

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -120,11 +120,14 @@ export default async function TopicsPage() {
   const { groups, totalBooks } = await fetchFacetCounts();
 
   return (
-    <ContentPageLayout>
-      <ContentHeader
-        title="Browse the Library"
-        subtitle={`${totalBooks.toLocaleString()} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
-      />
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Browse the Library"
+          subtitle={`${totalBooks.toLocaleString()} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
+        />
+      }
+    >
 
       <div className="space-y-12">
         {groups.map((group) => (


### PR DESCRIPTION
## Summary
- Collections page was taking **30 seconds** to load due to `force-dynamic` — switched to ISR with 1-hour revalidation
- Site header ("Source Library") was missing on collections, topics, and topics/clusters pages because `ContentHeader` was passed as a child instead of the `header` prop on `ContentPageLayout`

## Test plan
- [ ] Visit https://sourcelibrary.org/collections — should load fast and show site header
- [ ] Click "See 13 more collections" on homepage — should navigate without QUIC errors
- [ ] Check /topics and /topics/clusters also show headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)