### PR TITLE
Fix collection pages crashing on mobile Safari

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -435,10 +435,10 @@ export default async function CollectionDetailPage({ params }: Props) {
   const { collection, books, highlights: curatedHighlightsData, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, exhibition, exhibitionBooks, childCollections } = data;
   const languages = (collection.languages || []).filter((l: { count: number }) => l.count > 2);
 
-  // Group curated highlights by tier
-  const tier1 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 1);
-  const tier2 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 2);
-  const tier3 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 3);
+  // Group curated highlights by tier — cap each to avoid heavy pages crashing mobile Safari
+  const tier1 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 1).slice(0, 6);
+  const tier2 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 2).slice(0, 9);
+  const tier3 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 3).slice(0, 8);
   const hasCuratedHighlights = curatedHighlightsData.length > 0;
 
   // Build a diverse pool of ~50 top images (max 2 per book), then randomly pick 9 for display
@@ -639,6 +639,7 @@ export default async function CollectionDetailPage({ params }: Props) {
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-300"
                         sizes="(min-width: 1024px) 200px, (min-width: 640px) 160px, 120px"
+                        unoptimized
                       />
                     ) : (
                       <div className="w-full h-full bg-cream flex items-center justify-center">

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -188,7 +188,7 @@ export default function CollectionAllBooks({
                 ? Math.round((book.pages_translated / book.pages_ocr) * 100)
                 : 0,
             }}
-            priority={!expanded && i < 10}
+            priority={!expanded && i < 4}
           />
         ))}
 


### PR DESCRIPTION
## Summary
- Cap curated highlights per tier (6/9/8 = 23 max, down from 59) to reduce page weight
- Reduce priority image preloads from 10 to 4 (was generating 17 `<link rel="preload">` tags)
- Add `unoptimized` to gallery images (already served from R2 CDN, no need for `/_next/image` proxy)

The indic-traditions collection page was 323KB (vs ~150KB for other collections) with 59 highlighted books each rendering a `next/image` component. This was crashing mobile Safari during hydration ("can't open this page" error).

## Test plan
- [ ] Load https://sourcelibrary.org/collections/indic-traditions on mobile Safari
- [ ] Verify curated highlights still display (Essential Reading, Important Works, Also Notable)
- [ ] Check other collection pages with highlights still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)