### PR TITLE
Pre-render top 30 collection pages at build time

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -17,7 +17,21 @@ export const revalidate = 600;
 export const dynamicParams = true;
 export const maxDuration = 60;
 export async function generateStaticParams() {
-  return []; // All paths generated on demand via ISR
+  // Pre-render top collections at build time so the first visitor never hits a cold cache
+  try {
+    const db = await Promise.race([
+      getDb(),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
+    ]);
+    const collections = await db.collection('collections')
+      .find({ hidden: { $ne: true } }, { projection: { slug: 1 } })
+      .sort({ book_count: -1 })
+      .limit(30)
+      .toArray();
+    return collections.map(c => ({ id: c.slug }));
+  } catch {
+    return []; // Fallback: generate on demand
+  }
 }
 
 interface Props {


### PR DESCRIPTION
## Summary
- `generateStaticParams` now fetches the 30 largest non-hidden collections from MongoDB
- These pages are built during deploy, so the first visitor never hits a cold cache
- Falls back to on-demand generation if the DB query fails (5s timeout)

Previously `generateStaticParams` returned `[]`, meaning every collection page was generated on first visit — adding ~2-5s latency for that visitor.

## Test plan
- [ ] Verify deploy succeeds (build should take slightly longer as it pre-renders 30 pages)
- [ ] Hit a collection page immediately after deploy — should be instant, not a cold render

🤖 Generated with [Claude Code](https://claude.com/claude-code)