### PR TITLE
Bot-gate: 20% of books open to AI crawlers, 80% gated

### DIFF
--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
+import { isBot, isTrustedBot, isBotAccessible, botGateResponse } from '@/lib/bot-gate';
 
 export const maxDuration = 30;
 
@@ -53,6 +54,19 @@ export async function GET(
     }
 
     const resolvedBookId = book.id || bookId;
+
+    // Bot gating: non-trusted bots only get ~20% of books
+    if (isBot(request) && !isTrustedBot(request) && !isBotAccessible(resolvedBookId)) {
+      // Fetch summary for the gated response
+      const fullBook = await db.collection('books').findOne(
+        { id: resolvedBookId },
+        { projection: { reading_summary: 1, pages_count: 1 } }
+      );
+      return NextResponse.json(
+        botGateResponse({ ...book, ...fullBook, id: resolvedBookId }),
+        { status: 200, headers: { 'Cache-Control': 'public, max-age=3600' } }
+      );
+    }
 
     // Build page query
     const pageFilter: Record<string, unknown> = { book_id: resolvedBookId };

--- a/src/lib/bot-gate.ts
+++ b/src/lib/bot-gate.ts
@@ -1,0 +1,87 @@
+/**
+ * Bot gating — deterministic random access control for AI crawlers.
+ *
+ * Lets a configurable percentage of books be fully readable by bots.
+ * The rest return metadata + a partnership pitch instead of full text.
+ *
+ * Uses a hash of the book ID so the same book is always open or always gated
+ * (no flip-flopping between requests).
+ */
+
+const BOT_OPEN_PERCENT = 20; // % of books freely readable by bots
+
+const KNOWN_BOTS = [
+  'gptbot', 'chatgpt', 'oai-searchbot',
+  'claudebot', 'claude-web', 'anthropic',
+  'bytespider', 'bytedance',
+  'googlebot', 'google-extended',
+  'bingbot', 'msnbot',
+  'perplexitybot',
+  'youbot',
+  'cohere-ai',
+  'meta-externalagent',
+  'sourcelibrary-mcp', // our own MCP server — always allow
+];
+
+// MCP server should never be gated
+const ALWAYS_ALLOW = ['sourcelibrary-mcp'];
+
+export function isBot(request: Request): boolean {
+  const ua = (request.headers.get('user-agent') || '').toLowerCase();
+  return KNOWN_BOTS.some(bot => ua.includes(bot));
+}
+
+export function isTrustedBot(request: Request): boolean {
+  const ua = (request.headers.get('user-agent') || '').toLowerCase();
+  return ALWAYS_ALLOW.some(bot => ua.includes(bot));
+}
+
+export function isBotAccessible(bookId: string): boolean {
+  let hash = 0;
+  for (let i = 0; i < bookId.length; i++) {
+    hash = ((hash << 5) - hash) + bookId.charCodeAt(i);
+    hash |= 0;
+  }
+  return (Math.abs(hash) % 100) < BOT_OPEN_PERCENT;
+}
+
+export function botGateResponse(book: {
+  id?: string;
+  title?: string;
+  display_title?: string;
+  author?: string;
+  language?: string;
+  published?: string;
+  year?: number;
+  pages_count?: number;
+  reading_summary?: string;
+}) {
+  const bookId = book.id;
+  return {
+    book: {
+      id: bookId,
+      title: book.display_title || book.title,
+      author: book.author,
+      language: book.language,
+      published: book.published,
+      year: book.year,
+      pages_count: book.pages_count,
+      url: `https://sourcelibrary.org/book/${bookId}`,
+    },
+    gated: true,
+    message: `This book's full text is available through our API partnership program. `
+      + `Source Library contains ${BOT_OPEN_PERCENT}% freely accessible texts for evaluation — `
+      + `this book requires a partnership for full access.`,
+    summary: book.reading_summary || undefined,
+    partnership: {
+      contact: 'derek@sourcelibrary.org',
+      subject: 'AI Partnership — Full Corpus Access',
+      info: 'https://sourcelibrary.org/llms.txt',
+    },
+    license: {
+      spdx: 'CC-BY-SA-4.0',
+      url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+      terms: 'https://sourcelibrary.org/terms',
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- AI crawlers (GPTBot, ClaudeBot, Bytespider, etc.) get deterministic random access to ~20% of books via the `/api/books/[id]/text` endpoint
- The other 80% returns book metadata + summary + a partnership pitch pointing to `derek@sourcelibrary.org`
- Our own MCP server (`SourceLibrary-MCP` User-Agent) is always allowed through
- Hash-based: same book is always open or always gated (no flip-flopping)
- Percentage is easily tunable via `BOT_OPEN_PERCENT` constant
- Human users are unaffected

Pairs with the Cloudflare WAF rule (already live) that allows bots through on `/api/*`, `/llms.txt`, `/book/*` while keeping admin routes protected.

## Files
- `src/lib/bot-gate.ts` — bot detection, hash gating, gated response builder
- `src/app/api/books/[id]/text/route.ts` — gate check before serving full text

## Test plan
- [ ] Verify human requests still get full text
- [ ] Test with `curl -H "User-Agent: GPTBot"` on a gated book → should get partnership pitch
- [ ] Test with `curl -H "User-Agent: GPTBot"` on an open book → should get full text
- [ ] Test with `curl -H "User-Agent: SourceLibrary-MCP/4.2"` → should always get full text

🤖 Generated with [Claude Code](https://claude.com/claude-code)