### PR TITLE
Inline Reading Guide on book page

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -21,6 +21,7 @@ import EditionsPanel from '@/components/editions/EditionsPanel';
 import SchemaOrgMetadata from '@/components/seo/SchemaOrgMetadata';
 import CategoryPicker from '@/components/ui/CategoryPicker';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
+import ExpandableGuide from '@/components/book/ExpandableGuide';
 import { linkEntities, buildEntityList } from '@/lib/link-entities';
 import { BookShare } from '@/components/ui/ShareButton';
 import LikeButton from '@/components/ui/LikeButton';
@@ -554,14 +555,7 @@ async function BookInfo({ id }: { id: string }) {
                     ))}
                   </div>
                   {hasTranslations && (
-                    <Link
-                      href={`/book/${book.id}/guide`}
-                      className="mt-4 inline-flex items-center gap-2 text-sm font-medium text-accent-rust hover:text-accent-gold-dark transition-colors group"
-                    >
-                      <BookText className="w-4 h-4" />
-                      Open the full Reading Guide: chapter-by-chapter summary, selected quotes and illustrations
-                      <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
-                    </Link>
+                    <ExpandableGuide bookId={book.id} />
                   )}
                 </>
               ) : hasTranslations ? (

--- a/src/components/book/ExpandableGuide.tsx
+++ b/src/components/book/ExpandableGuide.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BookText, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
+import { books, gallery } from '@/lib/api-client';
+import SectionsNav from '@/components/layout/SectionsNav';
+
+interface SectionSummary {
+  title: string;
+  startPage: number;
+  endPage: number;
+  summary: string;
+  quotes?: Array<{ text: string; page: number; page_id?: string; significance?: string }>;
+  concepts?: string[];
+}
+
+interface GalleryItem {
+  pageId: string;
+  bookId: string;
+  pageNumber: number;
+  detectionIndex: number;
+  imageUrl: string;
+  description: string;
+  type?: string;
+  bbox?: { x: number; y: number; width: number; height: number };
+  extractedUrl?: string;
+  thumbnailUrl?: string;
+}
+
+interface ExpandableGuideProps {
+  bookId: string;
+}
+
+export default function ExpandableGuide({ bookId }: ExpandableGuideProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [detailedSummary, setDetailedSummary] = useState<string | null>(null);
+  const [sections, setSections] = useState<SectionSummary[]>([]);
+  const [illustrations, setIllustrations] = useState<GalleryItem[]>([]);
+  const [showSections, setShowSections] = useState(true);
+  const [showIllustrations, setShowIllustrations] = useState(true);
+  const [pages, setPages] = useState<Array<{ id: string; page_number: number }>>([]);
+
+  const expand = async () => {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+
+    // Already loaded — just toggle
+    if (detailedSummary) {
+      setExpanded(true);
+      return;
+    }
+
+    setLoading(true);
+    setExpanded(true);
+
+    try {
+      // Fetch index (has detailed summary + sections) and illustrations in parallel
+      const [indexData, bookData, galleryData] = await Promise.all([
+        books.index.get(bookId),
+        books.get(bookId, { full: false }) as Promise<any>,
+        gallery.list({ bookId, limit: 50, minQuality: 0.75 }).catch(() => ({ items: [] })),
+      ]);
+
+      if (indexData?.bookSummary?.detailed) {
+        setDetailedSummary(indexData.bookSummary.detailed);
+      } else if (indexData?.bookSummary?.abstract) {
+        setDetailedSummary(indexData.bookSummary.abstract);
+      }
+
+      if (indexData?.sectionSummaries && Array.isArray(indexData.sectionSummaries)) {
+        setSections(indexData.sectionSummaries);
+      }
+
+      // Get page list for section nav links
+      if (bookData?.pages) {
+        setPages(bookData.pages.map((p: any) => ({ id: p.id || p._id, page_number: p.page_number })));
+      }
+
+      setIllustrations(galleryData.items || []);
+    } catch (err) {
+      console.error('Failed to load guide:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      <button
+        onClick={expand}
+        className="inline-flex items-center gap-2 text-sm font-medium text-accent-rust hover:text-accent-gold-dark transition-colors group"
+      >
+        <BookText className="w-4 h-4" />
+        {expanded ? 'Collapse Reading Guide' : 'Reading Guide: chapter-by-chapter summary, selected quotes and illustrations'}
+        {loading ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : expanded ? (
+          <ChevronUp className="w-3.5 h-3.5" />
+        ) : (
+          <ChevronDown className="w-3.5 h-3.5" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-5 space-y-6">
+          {/* Detailed Summary */}
+          {detailedSummary && (
+            <div>
+              <h3 className="text-base font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>Overview</h3>
+              <div className="prose-content max-w-none">
+                {detailedSummary.split('\n\n').map((p, i) => (
+                  <p key={i} className="mb-3 last:mb-0 text-sm leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{p}</p>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Sections */}
+          {sections.length > 0 && (
+            <div>
+              <button
+                onClick={() => setShowSections(!showSections)}
+                className="w-full flex items-center justify-between py-2 text-left"
+              >
+                <h3 className="text-base font-semibold flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+                  Table of Contents
+                  <span className="text-xs font-normal text-stone-400">({sections.length} sections)</span>
+                </h3>
+                {showSections ? (
+                  <ChevronUp className="w-4 h-4 text-stone-400" />
+                ) : (
+                  <ChevronDown className="w-4 h-4 text-stone-400" />
+                )}
+              </button>
+              {showSections && (
+                <SectionsNav
+                  bookId={bookId}
+                  sections={sections}
+                  pages={pages}
+                  illustrations={illustrations}
+                />
+              )}
+            </div>
+          )}
+
+          {/* Illustrations */}
+          {illustrations.length > 0 && (
+            <div>
+              <button
+                onClick={() => setShowIllustrations(!showIllustrations)}
+                className="w-full flex items-center justify-between py-2 text-left"
+              >
+                <h3 className="text-base font-semibold flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+                  Illustrations
+                  <span className="text-xs font-normal text-stone-400">({illustrations.length} images)</span>
+                </h3>
+                {showIllustrations ? (
+                  <ChevronUp className="w-4 h-4 text-stone-400" />
+                ) : (
+                  <ChevronDown className="w-4 h-4 text-stone-400" />
+                )}
+              </button>
+              {showIllustrations && (
+                <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
+                  {illustrations.map((item) => {
+                    const imageId = `${item.pageId}-${item.detectionIndex}`;
+                    const displayUrl = item.extractedUrl || item.thumbnailUrl || item.imageUrl;
+                    return (
+                      <Link
+                        key={imageId}
+                        href={`/gallery/image/${imageId}`}
+                        className="group relative aspect-square rounded-lg overflow-hidden hover:shadow-md transition-shadow"
+                        style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
+                      >
+                        <Image
+                          src={displayUrl}
+                          alt={item.description || 'Illustration'}
+                          fill
+                          sizes="(max-width: 640px) 33vw, 25vw"
+                          className="object-cover group-hover:scale-105 transition-transform duration-300"
+                        />
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+                          <p className="absolute bottom-0 left-0 right-0 p-1.5 text-white text-[10px] line-clamp-2">
+                            {item.description || `Page ${item.pageNumber}`}
+                          </p>
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+              <div className="mt-3 text-center">
+                <Link
+                  href={`/gallery?bookId=${bookId}`}
+                  className="text-xs text-accent-rust hover:text-accent-gold-dark transition-colors"
+                >
+                  View all in Gallery &rarr;
+                </Link>
+              </div>
+            </div>
+          )}
+
+          {loading && !detailedSummary && (
+            <div className="flex items-center gap-2 text-sm text-stone-400 py-4">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading guide...
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the "Open the full Reading Guide" link with an expandable section right on the book page
- Clicking "Reading Guide: chapter-by-chapter summary, selected quotes and illustrations" lazy-loads the detailed summary, sections (via SectionsNav), and illustration gallery inline
- Zero impact on initial page load — the component renders just a button, data is fetched only on expand
- Collapsible sections for Table of Contents and Illustrations
- The standalone /guide page still works as before

## Test plan
- [ ] Visit a book with a summary — verify the Reading Guide expand button appears below the brief summary
- [ ] Click to expand — verify detailed summary, sections, and illustrations load inline
- [ ] Click to collapse — verify content hides
- [ ] Re-expand — verify it toggles instantly (data cached in state)
- [ ] Visit /book/{id}/guide directly — verify standalone page still works

Generated with [Claude Code](https://claude.com/claude-code)