### PR TITLE
Fix Reading Guide expand timeout

### DIFF
--- a/src/components/book/ExpandableGuide.tsx
+++ b/src/components/book/ExpandableGuide.tsx
@@ -59,21 +59,21 @@ export default function ExpandableGuide({ bookId }: ExpandableGuideProps) {
     setExpanded(true);
 
     try {
-      // Fetch index (has detailed summary + sections) and illustrations in parallel
-      const [indexData, bookData, galleryData] = await Promise.all([
-        books.index.get(bookId),
-        books.get(bookId, { full: false }) as Promise<any>,
+      // Fetch book (with full index + pages) and illustrations in parallel
+      const [bookData, galleryData] = await Promise.all([
+        books.get(bookId, { full: true }) as Promise<any>,
         gallery.list({ bookId, limit: 50, minQuality: 0.75 }).catch(() => ({ items: [] })),
       ]);
 
-      if (indexData?.bookSummary?.detailed) {
-        setDetailedSummary(indexData.bookSummary.detailed);
-      } else if (indexData?.bookSummary?.abstract) {
-        setDetailedSummary(indexData.bookSummary.abstract);
+      const idx = bookData?.index;
+      if (idx?.bookSummary?.detailed) {
+        setDetailedSummary(idx.bookSummary.detailed);
+      } else if (idx?.bookSummary?.abstract) {
+        setDetailedSummary(idx.bookSummary.abstract);
       }
 
-      if (indexData?.sectionSummaries && Array.isArray(indexData.sectionSummaries)) {
-        setSections(indexData.sectionSummaries);
+      if (idx?.sectionSummaries && Array.isArray(idx.sectionSummaries)) {
+        setSections(idx.sectionSummaries);
       }
 
       // Get page list for section nav links


### PR DESCRIPTION
## Summary
- The index API (`/api/books/{id}/index`) auto-regenerates stale indexes via Gemini, causing 30s+ timeouts when expanding the Reading Guide
- Switch to `books.get(id, { full: true })` which returns the cached index data from the book document without triggering regeneration
- Also reduces from 3 parallel API calls to 2 (book + gallery)

## Test plan
- [ ] Expand the Reading Guide on a book page — should load in <2s instead of timing out

Generated with [Claude Code](https://claude.com/claude-code)