### PR TITLE
Priority queue for archiving + unblock OCR for archiving books

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1131,11 +1131,26 @@ async function run() {
       console.log('\n--- Phase 1: Archive check ---');
 
       // Move queued -> archiving
+      // Priority: confirmed first translations > non-English (likely first) > English
+      const ENGLISH_VARIANTS_P1 = ['english', 'eng', 'en'];
       const queuedBooks = await db.collection('books')
-        .find({ 'pipeline_auto.status': 'queued' })
-        .sort({ hidden: 1 })
-        .project({ id: 1 })
-        .limit(ARCHIVE_LIMIT)
+        .aggregate([
+          { $match: { 'pipeline_auto.status': 'queued' } },
+          { $addFields: {
+            _priority: {
+              $switch: {
+                branches: [
+                  { case: { $eq: ['$is_first_translation', true] }, then: 0 },
+                  { case: { $in: [{ $toLower: { $ifNull: ['$language', ''] } }, ENGLISH_VARIANTS_P1] }, then: 2 },
+                ],
+                default: 1,
+              },
+            },
+          }},
+          { $sort: { _priority: 1, hidden: 1 } },
+          { $project: { id: 1 } },
+          { $limit: ARCHIVE_LIMIT },
+        ])
         .toArray();
 
       if (!DRY_RUN) {
@@ -1147,11 +1162,25 @@ async function run() {
       console.log(`  Queued -> archiving: ${queuedBooks.length}`);
 
       // Check archiving books for completion
+      // Priority: confirmed first translations > non-English > English
       const archivingBooks = await db.collection('books')
-        .find({ 'pipeline_auto.status': 'archiving' })
-        .sort({ hidden: 1 })
-        .project({ id: 1 })
-        .limit(ARCHIVE_LIMIT)
+        .aggregate([
+          { $match: { 'pipeline_auto.status': 'archiving' } },
+          { $addFields: {
+            _priority: {
+              $switch: {
+                branches: [
+                  { case: { $eq: ['$is_first_translation', true] }, then: 0 },
+                  { case: { $in: [{ $toLower: { $ifNull: ['$language', ''] } }, ENGLISH_VARIANTS_P1] }, then: 2 },
+                ],
+                default: 1,
+              },
+            },
+          }},
+          { $sort: { _priority: 1, hidden: 1 } },
+          { $project: { id: 1 } },
+          { $limit: ARCHIVE_LIMIT },
+        ])
         .toArray();
 
       let archiveCompleted = 0;
@@ -1581,11 +1610,30 @@ async function run() {
 
       const ocrLimit = activeBatchOcr >= MAX_ACTIVE_BATCH_OCR ? 0 : OCR_SUBMIT_LIMIT;
 
+      // Also accept 'archiving' books — batch OCR downloads images directly from source,
+      // so R2 archiving is not a prerequisite. This unblocks 15K+ books stuck in archiving
+      // because archive-ocr.mjs requires OCR data (chicken-and-egg).
+      // Priority: confirmed first translations > non-English > English
+      const ENGLISH_VARIANTS_P2 = ['english', 'eng', 'en'];
       const readyForOcr = ocrLimit > 0 ? await db.collection('books')
-        .find({ 'pipeline_auto.status': 'archive_complete' })
-        .sort({ hidden: 1 })
-        .project({ id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1 })
-        .limit(ocrLimit)
+        .aggregate([
+          { $match: { 'pipeline_auto.status': { $in: ['archive_complete', 'archiving'] } } },
+          { $addFields: {
+            _priority: {
+              $switch: {
+                branches: [
+                  { case: { $eq: ['$is_first_translation', true] }, then: 0 },
+                  { case: { $eq: ['$pipeline_auto.status', 'archive_complete'] }, then: 1 }, // archive_complete before archiving
+                  { case: { $in: [{ $toLower: { $ifNull: ['$language', ''] } }, ENGLISH_VARIANTS_P2] }, then: 3 },
+                ],
+                default: 2,
+              },
+            },
+          }},
+          { $sort: { _priority: 1, hidden: 1 } },
+          { $project: { id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1 } },
+          { $limit: ocrLimit },
+        ])
         .toArray() : [];
 
       console.log(`  Books ready for OCR: ${readyForOcr.length}`);


### PR DESCRIPTION
## Summary

Two changes to dramatically speed up the OCR pipeline:

### 1. Priority sorting for Phase 1 and Phase 2
First translations processed first: confirmed first translations > non-English > English. Same pattern as preview OCR and image extraction.

### 2. Unblock OCR for books stuck in `archiving`

**Problem:** 15,891 books (4.3M pages) stuck in a deadlock:
- Phase 1 won't advance them (pages not archived)
- archive-ocr won't archive pages (requires OCR data first)
- Phase 2 won't OCR them (requires archive_complete)

**Fix:** Phase 2 now also accepts `archiving` books. Batch OCR downloads directly from source URLs — R2 archiving is not a prerequisite. Turns a 7-month backlog into an immediately processable queue.

## Test plan
- [ ] Verify Phase 2 picks up archiving books after archive_complete ones
- [ ] Monitor source domain rate limiting (IA, Gallica)

🤖 Generated with [Claude Code](https://claude.com/claude-code)