### PR TITLE
Stop auto-regenerating book indexes on GET

### DIFF
--- a/src/app/api/books/[id]/index/route.ts
+++ b/src/app/api/books/[id]/index/route.ts
@@ -1086,18 +1086,12 @@ export async function GET(
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 
-    // Check if we have a cached index
+    // Return cached index if it exists — regeneration only via POST
     if (book.index && book.index.generatedAt) {
-      const indexAge = Date.now() - new Date(book.index.generatedAt).getTime();
-      const oneDay = 24 * 60 * 60 * 1000;
-
-      // Return cached if less than 1 day old
-      if (indexAge < oneDay) {
-        return NextResponse.json(book.index);
-      }
+      return NextResponse.json(book.index);
     }
 
-    // Generate fresh index
+    // No index exists yet — generate one
     const pages = await db.collection('pages')
       .find({ book_id: id })
       .sort({ page_number: 1 })


### PR DESCRIPTION
## Summary
- Index GET endpoint was auto-regenerating via Gemini if cached index was >24h old, causing 30-60s timeouts
- Now returns cached index immediately if it exists, or generates once if no index exists at all
- Explicit regeneration still available via POST (admin-only)

## Context
This was the root cause of the Reading Guide expand timeout — and also caused 6 books to have stale indexes that only covered pages 1-10 (generated before translation was complete, then never properly regenerated because the 24h window kept resetting).

## Test plan
- [ ] GET /api/books/{id}/index — returns cached index instantly
- [ ] POST /api/books/{id}/index — still regenerates (admin auth required)
- [ ] Book with no index — GET generates it once, subsequent GETs return cached

Generated with [Claude Code](https://claude.com/claude-code)