### PR TITLE
Fix bulk archiver: use sharp for JP2 decoding

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -19,9 +19,6 @@
 import { MongoClient } from 'mongodb';
 import sharp from 'sharp';
 import { execSync } from 'child_process';
-import { execFile as execFileCb } from 'child_process';
-import { promisify } from 'util';
-const execFileAsync = promisify(execFileCb);
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -51,8 +48,7 @@ const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary
 if (!MONGODB_URI) { console.error('Missing MONGODB_URI'); process.exit(1); }
 if (!R2_ACCOUNT_ID) { console.error('Missing R2_ACCOUNT_ID'); process.exit(1); }
 
-try { execSync('which opj_decompress', { stdio: 'pipe' }); }
-catch { console.error('opj_decompress not found. Install: apt-get install libopenjp2-tools'); process.exit(1); }
+// sharp handles JP2 decoding via libvips — no external tools needed
 
 const USER_AGENT = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)';
 
@@ -134,20 +130,14 @@ function extractJp2Zip(zipPath, destDir) {
 }
 
 async function jp2ToJpeg(jp2Path) {
-  const bmpPath = jp2Path + '.out.bmp';
-  try {
-    await execFileAsync('opj_decompress', ['-i', jp2Path, '-o', bmpPath, '-threads', 'ALL_CPUS'], { timeout: 120000 });
-  } catch (err) {
-    if (!fs.existsSync(bmpPath)) throw new Error(`opj_decompress failed: ${err.stderr?.slice(0, 200) || err.message}`);
-  }
-  let sharpPipeline = sharp(bmpPath);
+  // Use sharp directly — it has built-in JPEG2000 support via libvips
+  // No need for opj_decompress intermediate step
+  let sharpPipeline = sharp(jp2Path);
   const meta = await sharpPipeline.metadata();
   if (meta.width > MAX_DIMENSION || meta.height > MAX_DIMENSION) {
-    sharpPipeline = sharp(bmpPath).resize(MAX_DIMENSION, MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true });
+    sharpPipeline = sharp(jp2Path).resize(MAX_DIMENSION, MAX_DIMENSION, { fit: 'inside', withoutEnlargement: true });
   }
-  const jpegBuffer = await sharpPipeline.jpeg({ quality: JPEG_QUALITY }).toBuffer();
-  try { fs.unlinkSync(bmpPath); } catch {}
-  return jpegBuffer;
+  return sharpPipeline.jpeg({ quality: JPEG_QUALITY }).toBuffer();
 }
 
 async function processBook(book, db) {


### PR DESCRIPTION
opj_decompress fails on some IA JP2 files. sharp has built-in JP2 support via libvips — simpler and more reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)