### PR TITLE
Fix bulk archiver: TIF intermediate instead of BMP

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -137,7 +137,7 @@ function extractJp2Zip(zipPath, destDir) {
 async function jp2ToJpeg(jp2Path) {
   // opj_decompress → BMP → sharp → JPEG
   // Sharp's libvips JP2 support is unreliable on some builds, so use opj_decompress
-  const bmpPath = jp2Path + '.out.bmp';
+  const bmpPath = jp2Path + '.out.tif';
   try {
     await execFileAsync('opj_decompress', ['-i', jp2Path, '-o', bmpPath, '-threads', 'ALL_CPUS'], { timeout: 120000 });
   } catch (err) {


### PR DESCRIPTION
Sharp can't read opj_decompress BMP output. TIF works. Tested on Hetzner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)