### PR TITLE
Add createdAt timestamp to user signups

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -152,6 +152,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
   events: {
     async createUser({ user }) {
+      // Timestamp new users (MongoDBAdapter doesn't set createdAt)
+      try {
+        const client = await clientPromise;
+        const db = client.db(dbName);
+        await db.collection('users').updateOne(
+          { email: user.email },
+          { $set: { createdAt: new Date() } }
+        );
+      } catch (error) {
+        console.error('[auth] Failed to set createdAt:', error);
+      }
+
       // Auto-add new users to Resend audience + send welcome email
       if (user.email && process.env.RESEND_API_KEY) {
         try {


### PR DESCRIPTION
## Summary
- MongoDBAdapter doesn't set `createdAt` on user documents, so we couldn't track when Google Auth users signed up
- Added timestamp in the `createUser` NextAuth event
- Backfilled all 44 existing users from their ObjectId timestamps (already done in prod DB)

## Context
We had 44 Google Auth signups but no way to see growth trends. Turns out 14 signed up today alone and 24 in the last week — way more active than the 13 email subscribers suggested.

## Test plan
- [ ] New Google sign-in creates user with `createdAt` field
- [ ] Existing users already backfilled in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)