### PR TITLE
Fix E2E tests: use slug URLs instead of hex IDs

### DIFF
--- a/e2e/book-detail.spec.ts
+++ b/e2e/book-detail.spec.ts
@@ -4,7 +4,7 @@ import { BOOK } from './fixtures';
 
 test.describe('Book Detail', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/book/${BOOK.id}`);
+    await page.goto(`/book/${BOOK.slug}`);
   });
 
   test.afterEach(async ({ page }, testInfo) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -2,6 +2,7 @@
 
 export const BOOK = {
   id: '695203a5ab34727b1f041c53',
+  slug: 'the-hermetic-museum-various-sendivogius',
   title: 'The Hermetic Museum, Restored and Enlarged',
   language: 'Latin',
   year: 1678,

--- a/e2e/navigation-flow.spec.ts
+++ b/e2e/navigation-flow.spec.ts
@@ -10,7 +10,7 @@ test.describe('Navigation Flow', () => {
     await measurePerf(page, 'nav-flow: homepage');
 
     // 2. Navigate to known featured book (instead of clicking random first book)
-    await page.goto(`/book/${BOOK.id}`);
+    await page.goto(`/book/${BOOK.slug}`);
 
     // 3. Verify book detail page
     await expect(page).toHaveURL(/\/book\//);

--- a/e2e/page-reader.spec.ts
+++ b/e2e/page-reader.spec.ts
@@ -4,7 +4,7 @@ import { BOOK, PAGE } from './fixtures';
 
 test.describe('Page Reader', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`/book/${BOOK.id}/page/${PAGE.id}`);
+    await page.goto(`/book/${BOOK.slug}/page/${PAGE.id}`);
   });
 
   test.afterEach(async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary
- E2E tests were navigating to `/book/{hexId}` which now 301-redirects to slug URLs
- Playwright's `toBeVisible()` was timing out because the redirect wasn't landing correctly
- Updated fixtures to include `slug` field, all tests now use `/book/{slug}` directly

Fixes #285, #266, #255 (all E2E failure issues from same root cause)

## Test plan
- [ ] CI E2E run passes after merge
- [ ] Manual: `npx playwright test` against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)