### PR TITLE
Add Vatican and Austrian National Library import routes

### DIFF
--- a/src/app/api/import/onb/route.ts
+++ b/src/app/api/import/onb/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from the Austrian National Library (ONB)
+ *
+ * POST /api/import/onb
+ * Body: {
+ *   z_id: string,              // ONB Z-ID, e.g. "Z165851607"
+ *   collection?: string,       // "ABO" (default) or "REPO"
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * IIIF manifest patterns:
+ *   ABO:  https://iiif.onb.ac.at/presentation/ABO/{z_id}/manifest
+ *   REPO: https://iiif.onb.ac.at/presentation/REPO/{numeric_id}/manifest
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { z_id, collection, title, display_title, author, language, published, categories, work_id } = body;
+
+    if (!z_id || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: z_id, title, author' },
+        { status: 400 }
+      );
+    }
+
+    const coll = collection || 'ABO';
+    const manifestUrl = `https://iiif.onb.ac.at/presentation/${coll}/${z_id}/manifest`;
+
+    return await importBookFromIIIF({
+      provider: 'onb',
+      provider_name: 'Austrian National Library (Österreichische Nationalbibliothek)',
+      manifest_url: manifestUrl,
+      identifier: z_id,
+      source_url: `https://onb.ac.at/en/collections/catalogueofdigitalresources?ident=+${z_id}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC-BY-4.0',
+      attribution_default: 'Österreichische Nationalbibliothek',
+      duplicate_query: {
+        $or: [
+          { onb_z_id: z_id },
+          { 'dublin_core.dc_identifier': `ONB:${z_id}` },
+          { 'image_source.iiif_manifest': manifestUrl },
+        ],
+      },
+      identifier_field: { onb_z_id: z_id },
+    }, request);
+  } catch (error) {
+    console.error('ONB import error:', error);
+    return NextResponse.json(
+      { error: 'Import failed', details: String(error) },
+      { status: 500 }
+    );
+  }
+});

--- a/src/app/api/import/vatlib/route.ts
+++ b/src/app/api/import/vatlib/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from the Vatican Apostolic Library (DigiVatLib)
+ *
+ * POST /api/import/vatlib
+ * Body: {
+ *   mss_id: string,            // Shelfmark, e.g. "Vat.gr.1209", "Pal.gr.108"
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * IIIF manifest pattern: https://digi.vatlib.it/iiif/MSS_{shelfmark}/manifest.json
+ * Shelfmark encoding: spaces → underscores, dots preserved
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { mss_id, title, display_title, author, language, published, categories, work_id } = body;
+
+    if (!mss_id || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: mss_id, title, author' },
+        { status: 400 }
+      );
+    }
+
+    // Normalize shelfmark: spaces to underscores for IIIF URL
+    const normalizedId = mss_id.replace(/\s+/g, '_');
+    const iiifId = `MSS_${normalizedId}`;
+
+    return await importBookFromIIIF({
+      provider: 'vatlib',
+      provider_name: 'Vatican Apostolic Library (DigiVatLib)',
+      manifest_url: `https://digi.vatlib.it/iiif/${iiifId}/manifest.json`,
+      identifier: mss_id,
+      source_url: `https://digi.vatlib.it/view/${iiifId}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC-BY-NC-4.0',
+      attribution_default: 'Biblioteca Apostolica Vaticana',
+      duplicate_query: {
+        $or: [
+          { vatlib_mss_id: mss_id },
+          { 'dublin_core.dc_identifier': `VATLIB:${mss_id}` },
+          { 'image_source.iiif_manifest': `https://digi.vatlib.it/iiif/${iiifId}/manifest.json` },
+        ],
+      },
+      identifier_field: { vatlib_mss_id: mss_id },
+    }, request);
+  } catch (error) {
+    console.error('Vatican import error:', error);
+    return NextResponse.json(
+      { error: 'Import failed', details: String(error) },
+      { status: 500 }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- New `/api/import/vatlib` route — Vatican Apostolic Library (DigiVatLib) IIIF import via shelfmark (e.g. `Vat.gr.1209`, `Pal.gr.108`)
- New `/api/import/onb` route — Austrian National Library IIIF import via Z-ID (ABO/REPO collections)
- Both use `importBookFromIIIF` helper, matching existing Bodleian/MDZ patterns

Part of a larger Byzantine philosophy acquisition session:
- 124 books imported (13 from IA/Gallica, 111 from Bodleian discovery pipeline)
- 26,731 total pages
- New "Byzantine Philosophy" collection created
- Bodleian JSON search API confirmed as best discovery pipeline (public, no auth, 1,003 Greek MSS)
- Vatican IIIF works but rate-limits aggressively — route ready for careful manual use

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Test Vatican import with a known digitized MS
- [ ] Test ONB import with a known Z-ID
- [ ] Verify dedup catches re-imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)