### PR TITLE
Add Yale, Harvard, Penn, Huntington, Getty import routes

### DIFF
--- a/src/app/api/import/getty/route.ts
+++ b/src/app/api/import/getty/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from the Getty Research Institute
+ *
+ * POST /api/import/getty
+ * Body: {
+ *   object_id: string,         // Getty object UUID or identifier
+ *   manifest_url?: string,     // Direct IIIF manifest URL (if known)
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * Getty uses UUID-based IIIF v3 manifests. Manifest URLs vary by collection.
+ * Provide manifest_url directly, or object_id for lookup.
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { object_id, manifest_url, title, display_title, author, language, published, categories, work_id } = body;
+
+    if ((!object_id && !manifest_url) || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: (object_id or manifest_url), title, author' },
+        { status: 400 }
+      );
+    }
+
+    const identifier = object_id || manifest_url;
+    const iiifUrl = manifest_url || `https://data.getty.edu/museum/api/iiif/manifest:${object_id}`;
+
+    return await importBookFromIIIF({
+      provider: 'getty',
+      provider_name: 'Getty Research Institute',
+      manifest_url: iiifUrl,
+      identifier: identifier!,
+      source_url: `https://www.getty.edu/art/collection/object/${object_id}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC-BY-4.0',
+      attribution_default: 'Getty Research Institute',
+      duplicate_query: {
+        $or: [
+          { getty_object_id: object_id },
+          { 'dublin_core.dc_identifier': `GETTY:${object_id}` },
+          { 'image_source.iiif_manifest': iiifUrl },
+        ],
+      },
+      identifier_field: { getty_object_id: object_id || manifest_url },
+    }, request);
+  } catch (error) {
+    console.error('Getty import error:', error);
+    return NextResponse.json({ error: 'Import failed', details: String(error) }, { status: 500 });
+  }
+});

--- a/src/app/api/import/harvard/route.ts
+++ b/src/app/api/import/harvard/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from Harvard Library (Houghton, Widener, etc.)
+ *
+ * POST /api/import/harvard
+ * Body: {
+ *   drs_id: string,            // DRS numeric ID, e.g. "5765704"
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * IIIF v2 manifest: https://iiif.lib.harvard.edu/manifests/drs:{drs_id}
+ * Viewer: https://id.lib.harvard.edu/curiosity/{drs_id}
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { drs_id, title, display_title, author, language, published, categories, work_id } = body;
+
+    if (!drs_id || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: drs_id, title, author' },
+        { status: 400 }
+      );
+    }
+
+    return await importBookFromIIIF({
+      provider: 'harvard',
+      provider_name: 'Harvard University Library',
+      manifest_url: `https://iiif.lib.harvard.edu/manifests/drs:${drs_id}`,
+      identifier: drs_id,
+      source_url: `https://id.lib.harvard.edu/curiosity/${drs_id}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC-BY-4.0',
+      attribution_default: 'Harvard University Library',
+      duplicate_query: {
+        $or: [
+          { harvard_drs_id: drs_id },
+          { 'dublin_core.dc_identifier': `HARVARD:${drs_id}` },
+          { 'image_source.iiif_manifest': `https://iiif.lib.harvard.edu/manifests/drs:${drs_id}` },
+        ],
+      },
+      identifier_field: { harvard_drs_id: drs_id },
+    }, request);
+  } catch (error) {
+    console.error('Harvard import error:', error);
+    return NextResponse.json({ error: 'Import failed', details: String(error) }, { status: 500 });
+  }
+});

--- a/src/app/api/import/huntington/route.ts
+++ b/src/app/api/import/huntington/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from the Huntington Library (San Marino, CA)
+ *
+ * POST /api/import/huntington
+ * Body: {
+ *   collection: string,        // Collection code, e.g. "p15150coll7"
+ *   item_id: string,           // Item ID within collection
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * IIIF v2 manifest: https://hdl.huntington.org/iiif/2/{collection}:{item_id}/manifest.json
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { collection, item_id, title, display_title, author, language, published, categories, work_id } = body;
+
+    if (!collection || !item_id || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: collection, item_id, title, author' },
+        { status: 400 }
+      );
+    }
+
+    const identifier = `${collection}:${item_id}`;
+
+    return await importBookFromIIIF({
+      provider: 'huntington',
+      provider_name: 'The Huntington Library, Art Museum, and Botanical Gardens',
+      manifest_url: `https://hdl.huntington.org/iiif/2/${identifier}/manifest.json`,
+      identifier,
+      source_url: `https://hdl.huntington.org/digital/collection/${collection}/id/${item_id}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC-BY-NC-4.0',
+      attribution_default: 'The Huntington Library',
+      duplicate_query: {
+        $or: [
+          { huntington_id: identifier },
+          { 'dublin_core.dc_identifier': `HUNTINGTON:${identifier}` },
+          { 'image_source.iiif_manifest': `https://hdl.huntington.org/iiif/2/${identifier}/manifest.json` },
+        ],
+      },
+      identifier_field: { huntington_id: identifier },
+    }, request);
+  } catch (error) {
+    console.error('Huntington import error:', error);
+    return NextResponse.json({ error: 'Import failed', details: String(error) }, { status: 500 });
+  }
+});

--- a/src/app/api/import/penn/route.ts
+++ b/src/app/api/import/penn/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from University of Pennsylvania (Colenda / Schoenberg Collection)
+ *
+ * POST /api/import/penn
+ * Body: {
+ *   ark_id: string,            // ARK identifier, e.g. "p2vd6p31p"
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * IIIF v2 manifest: https://colenda.library.upenn.edu/items/ark:/81431/{ark_id}/manifest
+ * Browse: https://colenda.library.upenn.edu/catalog/ark:/81431/{ark_id}
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { ark_id, title, display_title, author, language, published, categories, work_id } = body;
+
+    if (!ark_id || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: ark_id, title, author' },
+        { status: 400 }
+      );
+    }
+
+    const fullArk = `ark:/81431/${ark_id}`;
+
+    return await importBookFromIIIF({
+      provider: 'penn_colenda',
+      provider_name: 'University of Pennsylvania Libraries (Schoenberg Collection)',
+      manifest_url: `https://colenda.library.upenn.edu/items/${fullArk}/manifest`,
+      identifier: ark_id,
+      source_url: `https://colenda.library.upenn.edu/catalog/${fullArk}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC-BY-4.0',
+      attribution_default: 'Kislak Center for Special Collections, University of Pennsylvania',
+      duplicate_query: {
+        $or: [
+          { penn_ark_id: ark_id },
+          { 'dublin_core.dc_identifier': `PENN:${ark_id}` },
+          { 'image_source.iiif_manifest': `https://colenda.library.upenn.edu/items/${fullArk}/manifest` },
+        ],
+      },
+      identifier_field: { penn_ark_id: ark_id },
+    }, request);
+  } catch (error) {
+    console.error('Penn import error:', error);
+    return NextResponse.json({ error: 'Import failed', details: String(error) }, { status: 500 });
+  }
+});

--- a/src/app/api/import/yale/route.ts
+++ b/src/app/api/import/yale/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { importBookFromIIIF } from '@/lib/import-utils';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 300;
+
+/**
+ * Import a book from Yale Beinecke Rare Book & Manuscript Library
+ *
+ * POST /api/import/yale
+ * Body: {
+ *   catalog_id: string,        // Numeric catalog ID, e.g. "10842249"
+ *   title: string,
+ *   display_title?: string,
+ *   author: string,
+ *   language?: string,
+ *   published?: string,
+ *   categories?: string[],
+ *   work_id?: string
+ * }
+ *
+ * IIIF v3 manifest: https://collections.library.yale.edu/manifests/{catalog_id}
+ * Browse: https://collections.library.yale.edu/catalog/{catalog_id}
+ */
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await request.json();
+    const { catalog_id, title, display_title, author, language, published, categories, work_id } = body;
+
+    if (!catalog_id || !title || !author) {
+      return NextResponse.json(
+        { error: 'Missing required fields: catalog_id, title, author' },
+        { status: 400 }
+      );
+    }
+
+    return await importBookFromIIIF({
+      provider: 'yale_beinecke',
+      provider_name: 'Yale University, Beinecke Rare Book & Manuscript Library',
+      manifest_url: `https://collections.library.yale.edu/manifests/${catalog_id}`,
+      identifier: catalog_id,
+      source_url: `https://collections.library.yale.edu/catalog/${catalog_id}`,
+      title,
+      display_title,
+      author,
+      language,
+      published,
+      categories,
+      work_id,
+      license_default: 'CC0-1.0',
+      attribution_default: 'Beinecke Rare Book & Manuscript Library, Yale University',
+      duplicate_query: {
+        $or: [
+          { yale_catalog_id: catalog_id },
+          { 'dublin_core.dc_identifier': `YALE:${catalog_id}` },
+          { 'image_source.iiif_manifest': `https://collections.library.yale.edu/manifests/${catalog_id}` },
+        ],
+      },
+      identifier_field: { yale_catalog_id: catalog_id },
+    }, request);
+  } catch (error) {
+    console.error('Yale import error:', error);
+    return NextResponse.json({ error: 'Import failed', details: String(error) }, { status: 500 });
+  }
+});


### PR DESCRIPTION
## Summary
5 new IIIF import pipelines for major US research libraries:

| Route | Library | IIIF | Key Collections |
|-------|---------|------|-----------------|
| `/api/import/yale` | Beinecke (Yale) | v3 | Voynich MS, alchemical MSS, Osborn Collection |
| `/api/import/harvard` | Houghton (Harvard) | v2 | Islamic Heritage Project, medieval codices |
| `/api/import/penn` | Schoenberg (Penn) | v2 | LJS medieval scientific MSS |
| `/api/import/huntington` | Huntington Library | v2 | Ellesmere Chaucer, early English MSS |
| `/api/import/getty` | Getty Research Institute | v3 | Alchemical MSS, emblem books |

Also noted: OPenn (Penn) has 51K+ MSS as bulk CC0 TIFFs — future batch source.

## Test plan
- [ ] `npx tsc --noEmit` passes (confirmed)
- [ ] Test Yale: catalog_id `10842249` (alchemical treatise)
- [ ] Test Harvard: drs_id for a known Houghton MS

🤖 Generated with [Claude Code](https://claude.com/claude-code)