### PR TITLE
Guard against malformed detected_images entries (#329)

### DIFF
--- a/src/app/api/admin/generate-gallery-thumbnails/route.ts
+++ b/src/app/api/admin/generate-gallery-thumbnails/route.ts
@@ -80,7 +80,9 @@ export const POST = withAdminAuth(async (request, session) => {
         return (page.detected_images || [])
           .map((det: Record<string, unknown>, idx: number) => ({ det, idx }))
           .filter(({ det }: { det: Record<string, unknown> }) =>
-            det.bbox && !det.extracted_url &&
+            det && det.bbox && !det.extracted_url &&
+            // Guard: only process real detections (not null-padded or skeleton entries)
+            (det.description || det.detection_source) &&
             (minQuality <= 0 || (typeof det.gallery_quality === 'number' && det.gallery_quality >= minQuality))
           )
           .map(async ({ det, idx }: { det: Record<string, unknown>; idx: number }) => {
@@ -96,8 +98,13 @@ export const POST = withAdminAuth(async (request, session) => {
                 detectionIndex: idx,
               });
 
+              // Guard: only write if a real detection still exists at this index
+              // (prevents MongoDB from null-padding the array if it was modified)
               await db.collection('pages').updateOne(
-                { id: page.id },
+                {
+                  id: page.id,
+                  [`detected_images.${idx}.description`]: { $exists: true },
+                },
                 {
                   $set: {
                     [`detected_images.${idx}.extracted_url`]: result.extractedUrl,


### PR DESCRIPTION
## Summary

- Adds prevention guards to `src/app/api/admin/generate-gallery-thumbnails/route.ts` to stop MongoDB from creating null-padded or skeleton `detected_images` entries when writing by array index
- The filter now skips entries that lack `description` or `detection_source` (null/skeleton entries)
- The `$set` update query requires `detected_images[idx].description` to exist before writing, preventing race conditions where the array changed between read and write

## Context

Issue #329: `backfill-gallery-dimensions.mjs` already had this guard (lines 104-119). The thumbnail generation route was the remaining vector. The cleanup script (`scripts/cleanup-malformed-detections.mjs`) also already exists for fixing existing bad data.

## Test plan

- [ ] Deploy preview and run `POST /api/admin/generate-gallery-thumbnails?bookId=ec135ab7-b367-4579-81ca-2a0901d34630&dry_run=true` to confirm it still finds real detections
- [ ] Run cleanup script in dry-run mode to verify existing malformed entries are detected
- [ ] Run cleanup script with `--apply` to fix existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)