### PR TITLE
Add pipeline funnel and enrichment coverage to analytics

### DIFF
--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: progress
-description: Check pipeline processing progress — translation backfills, OCR jobs, image extraction. Shows real page-level verification, not just job counters. Use when asked "how's it going?", "progress?", "status?", "now?", or any progress check.
+description: Check pipeline processing progress — all phases including OCR, translation, image extraction, enrichment, and more. Shows real page-level verification, not just job counters. Use when asked "how's it going?", "progress?", "status?", "now?", or any progress check.
 ---
 
 # Pipeline Progress Check
 
-Report on processing progress with **verified page-level data**. Job counters lie — always cross-reference against actual page records.
+Report on processing progress with **verified page-level data** across ALL pipeline phases. Job counters lie — always cross-reference against actual page records.
+
+Also remind the user: full pipeline dashboard is live at https://sourcelibrary.org/analytics (Pipeline tab).
 
 ## Critical Diagnostic Rules
 
@@ -21,7 +23,7 @@ Run a single MongoDB script that reports ALL of the following. Use `set -a; sour
 ### 1. Pipeline Funnel (bird's eye)
 
 ```javascript
-// Pipeline status distribution
+// Pipeline status distribution — full lifecycle
 const funnel = await db.collection('books').aggregate([
   { $match: { 'pipeline_auto.status': { $exists: true } } },
   { $group: { _id: '$pipeline_auto.status', count: { $sum: 1 } } },
@@ -29,20 +31,54 @@ const funnel = await db.collection('books').aggregate([
 ]).toArray();
 ```
 
-### 2. Fully Translated Books
+Status order: `queued → archiving → archive_complete → ocr_submitted → ocr_complete → metadata_enriched → ft_verifying → ft_verified → translate_submitted → translate_complete → enriching → enriched → chapters → chapters_complete → images_submitted → images_complete → complete` (plus `needs_attention`, `failed`)
+
+### 2. Enrichment Coverage (all phases)
 
 ```javascript
-// Count books where pages_translated >= pages_count
-const fullyTranslated = await db.collection('books').countDocuments({
-  pages_count: { $gt: 0 },
-  pages_translated: { $gt: 0 },
-  $expr: { $gte: ['$pages_translated', '$pages_count'] }
-});
+// Single aggregation for all enrichment phases
+const enrichment = await db.collection('books').aggregate([
+  { $match: { status: { $ne: 'deleted' }, pages_count: { $gt: 0 } } },
+  { $group: {
+    _id: null,
+    total: { $sum: 1 },
+    has_ocr: { $sum: { $cond: [{ $gt: ['$pages_ocr', 0] }, 1, 0] } },
+    has_translation: { $sum: { $cond: [{ $gt: ['$pages_translated', 0] }, 1, 0] } },
+    has_metadata: { $sum: { $cond: [{ $ifNull: ['$ai_metadata.enriched_at', false] }, 1, 0] } },
+    has_ft_verification: { $sum: { $cond: [{ $ifNull: ['$translation_verification.verified_at', false] }, 1, 0] } },
+    has_summary: { $sum: { $cond: [{ $ifNull: ['$index.generatedAt', false] }, 1, 0] } },
+    has_chapters: { $sum: { $cond: [{ $ifNull: ['$chapters', false] }, 1, 0] } },
+    has_collections: { $sum: { $cond: [{ $ifNull: ['$collection_scores', false] }, 1, 0] } },
+    has_quality_score: { $sum: { $cond: [{ $ifNull: ['$quality_score', false] }, 1, 0] } },
+    has_faceted_tags: { $sum: { $cond: [{ $ifNull: ['$faceted_tags', false] }, 1, 0] } },
+    has_author_entity: { $sum: { $cond: [{ $ifNull: ['$author_entity_id', false] }, 1, 0] } },
+    fully_translated: { $sum: { $cond: [{ $and: [{ $gt: ['$pages_translated', 0] }, { $gte: ['$pages_translated', '$pages_count'] }] }, 1, 0] } },
+    pipeline_complete: { $sum: { $cond: [{ $eq: ['$pipeline_auto.status', 'complete'] }, 1, 0] } },
+  }}
+]).toArray();
 ```
 
-Note: `pages_translated` is a cache refreshed every 6h by `sync-page-counts` cron. For exact count, query pages collection directly (slower).
+### 3. Image Extraction & Gallery
 
-### 3. Active Jobs by Type
+```javascript
+// Books with extracted images (from pages collection)
+const booksWithImages = await db.collection('pages').distinct('book_id', {
+  'detected_images.0': { $exists: true }
+});
+console.log(`Books with extracted images: ${booksWithImages.length}`);
+
+// Gallery images count
+const galleryCount = await db.collection('gallery_images').estimatedDocumentCount();
+console.log(`Gallery images: ${galleryCount}`);
+
+// Image extraction jobs
+const imageJobs = await db.collection('jobs').aggregate([
+  { $match: { type: 'image_extraction', status: { $in: ['pending', 'processing'] } } },
+  { $group: { _id: '$status', count: { $sum: 1 }, pages: { $sum: '$progress.total' }, done: { $sum: '$progress.completed' } } }
+]).toArray();
+```
+
+### 4. Active Jobs by Type (all types)
 
 ```javascript
 const activeJobs = await db.collection('jobs').aggregate([
@@ -58,7 +94,7 @@ const activeJobs = await db.collection('jobs').aggregate([
 ]).toArray();
 ```
 
-### 4. Stuck Job Detection (CRITICAL)
+### 5. Stuck Job Detection (CRITICAL)
 
 ```javascript
 const twoHoursAgo = new Date(Date.now() - 2 * 3600000);
@@ -70,7 +106,7 @@ const stuckJobs = await db.collection('jobs').countDocuments({
 // If stuckJobs > 0, these are DEAD. Report them prominently.
 ```
 
-### 5. Real Throughput (page-level verification)
+### 6. Real Throughput (page-level verification)
 
 ```javascript
 // Translation throughput - last 1h, 3h, 6h
@@ -92,7 +128,7 @@ for (const hours of [1, 3, 6]) {
 }
 ```
 
-### 6. Backfill-Specific Progress (when applicable)
+### 7. Backfill-Specific Progress (when applicable)
 
 For any named backfill operation (identified by `note` field on jobs), verify progress against actual pages:
 
@@ -114,7 +150,7 @@ for (const job of sampleJobs) {
 }
 ```
 
-### 7. ETA Calculation
+### 8. ETA Calculation
 
 ```javascript
 // Only use VERIFIED throughput (page-level, not job-level)
@@ -131,7 +167,7 @@ const remaining = activeJobs
 const etaHours = hourlyRate > 0 ? remaining / hourlyRate : Infinity;
 ```
 
-### 8. Pause Status
+### 9. Pause Status
 
 ```javascript
 const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
@@ -145,15 +181,31 @@ Present results as a concise status report:
 
 ```
 Pipeline Status — [timestamp]
+Dashboard: https://sourcelibrary.org/analytics (Pipeline tab)
 
-Fully translated: X books (target: Y)
-Pipeline funnel: Z queued, W archiving, ... N complete
+Pipeline funnel: Z queued → W archiving → ... → N complete
+Fully translated: X books
+
+Enrichment coverage (of Y total books):
+  OCR:              X (Z%)
+  Translation:      X (Z%)
+  Metadata:         X (Z%)
+  FT Verification:  X (Z%)
+  Summary & Index:  X (Z%)
+  Chapters:         X (Z%)
+  Collections:      X (Z%)
+  Quality Score:    X (Z%)
+  Image Extraction: X (Z%)  |  Gallery: N images
+  Faceted Tags:     X (Z%)
+  Author Entities:  X (Z%)
+  Pipeline Complete: X (Z%)
 
 Active jobs:
   Translation (backfill): X jobs, Y/Z pages done [rate/hr, ETA]
   Translation (pipeline): X jobs, Y/Z pages done
   OCR: X jobs
-  Images: X jobs
+  Image Extraction: X jobs
+  ...
 
 STUCK JOBS: X jobs processing with 0 progress for >2h  ← only if > 0
 
@@ -162,8 +214,8 @@ Throughput (verified from pages):
   OCR: X/hr (1h), Y/hr (3h)
 
 Spot check (5 random processing jobs):
-  "Book Title" — 45/50 pages translated (job says 43/50) ✓
-  "Book Title" — 0/30 pages translated (job says 0/30) ⚠ STUCK
+  "Book Title" — 45/50 pages translated (job says 43/50)
+  "Book Title" — 0/30 pages translated (job says 0/30) STUCK
 
 Pauses: none (or list)
 ```
@@ -174,3 +226,5 @@ Pauses: none (or list)
 - **Throughput looks good but backfill isn't moving:** You're seeing pipeline cron throughput, not backfill. Filter by backfill book IDs.
 - **`pages_translated` stale:** `sync-page-counts` cron runs every 6h. For real-time count, query pages directly.
 - **Book.job lock prevents re-submission:** Clear with `$unset: { job: '' }` on affected books.
+- **Image extraction stuck:** Check if `images` phase is in `paused_phases`. Also check Lambda CloudWatch for image-extraction-processor errors.
+- **Enrichment coverage low for summaries/chapters:** These run via `enrich-books` cron, not Lambda. Check if that cron is healthy in cron_runs.

--- a/src/app/api/analytics/pipeline/route.ts
+++ b/src/app/api/analytics/pipeline/route.ts
@@ -88,6 +88,44 @@ export const GET = withAuth(async (request, session) => {
       ]).toArray(),
     ]);
 
+    // 6. Pipeline funnel (current book counts per status) + enrichment coverage
+    const [funnelResult, enrichmentResult, galleryCount] = await Promise.all([
+      db.collection('books').aggregate([
+        { $match: { 'pipeline_auto.status': { $exists: true } } },
+        { $group: { _id: '$pipeline_auto.status', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ]).toArray(),
+
+      db.collection('books').aggregate([
+        { $match: { status: { $ne: 'deleted' }, pages_count: { $gt: 0 } } },
+        { $group: {
+          _id: null,
+          total: { $sum: 1 },
+          has_ocr: { $sum: { $cond: [{ $gt: ['$pages_ocr', 0] }, 1, 0] } },
+          has_translation: { $sum: { $cond: [{ $gt: ['$pages_translated', 0] }, 1, 0] } },
+          has_metadata: { $sum: { $cond: [{ $ifNull: ['$ai_metadata.enriched_at', false] }, 1, 0] } },
+          has_ft_verification: { $sum: { $cond: [{ $ifNull: ['$translation_verification.verified_at', false] }, 1, 0] } },
+          has_summary: { $sum: { $cond: [{ $ifNull: ['$index.generatedAt', false] }, 1, 0] } },
+          has_chapters: { $sum: { $cond: [{ $ifNull: ['$chapters', false] }, 1, 0] } },
+          has_collections: { $sum: { $cond: [{ $ifNull: ['$collection_scores', false] }, 1, 0] } },
+          has_quality_score: { $sum: { $cond: [{ $ifNull: ['$quality_score', false] }, 1, 0] } },
+          has_faceted_tags: { $sum: { $cond: [{ $ifNull: ['$faceted_tags', false] }, 1, 0] } },
+          has_author_entity: { $sum: { $cond: [{ $ifNull: ['$author_entity_id', false] }, 1, 0] } },
+          pipeline_complete: { $sum: { $cond: [{ $eq: ['$pipeline_auto.status', 'complete'] }, 1, 0] } },
+        }},
+      ]).toArray(),
+
+      db.collection('gallery_images').estimatedDocumentCount(),
+    ]);
+
+    const funnel = Object.fromEntries(funnelResult.map((f: any) => [f._id, f.count]));
+    const enrichment = enrichmentResult[0] || {};
+
+    // Image extraction: count books that have at least one page with detected_images
+    const booksWithImages = await db.collection('pages').distinct('book_id', {
+      'detected_images.0': { $exists: true },
+    });
+
     // Compute velocity from snapshots (deltas between consecutive points)
     const velocity = computeVelocity(snapshots);
 
@@ -131,6 +169,23 @@ export const GET = withAuth(async (request, session) => {
         reason: d.decision?.reason,
         data: d.decision?.data,
       })),
+      funnel,
+      enrichmentCoverage: {
+        total: enrichment.total || 0,
+        ocr: enrichment.has_ocr || 0,
+        translation: enrichment.has_translation || 0,
+        metadata: enrichment.has_metadata || 0,
+        ftVerification: enrichment.has_ft_verification || 0,
+        summary: enrichment.has_summary || 0,
+        chapters: enrichment.has_chapters || 0,
+        collections: enrichment.has_collections || 0,
+        qualityScore: enrichment.has_quality_score || 0,
+        facetedTags: enrichment.has_faceted_tags || 0,
+        authorEntity: enrichment.has_author_entity || 0,
+        imageExtraction: booksWithImages.length,
+        galleryImages: galleryCount,
+        pipelineComplete: enrichment.pipeline_complete || 0,
+      },
       query: { hours },
     };
 

--- a/src/components/analytics/tabs/PipelineTab.tsx
+++ b/src/components/analytics/tabs/PipelineTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { Clock, AlertTriangle, XCircle, BarChart3 } from 'lucide-react';
+import { Clock, AlertTriangle, XCircle, BarChart3, Layers, Image } from 'lucide-react';
 import { analytics } from '@/lib/api-client';
 import { BookLoader } from '@/components/ui/BookLoader';
 import type { PipelineData } from '@/lib/api-client/types/analytics';
@@ -93,6 +93,126 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           </div>
         </div>
       </div>
+
+      {/* Pipeline Funnel */}
+      {pipelineData.funnel && Object.keys(pipelineData.funnel).length > 0 && (() => {
+        const statusOrder = [
+          'queued', 'archiving', 'archive_complete',
+          'ocr_submitted', 'ocr_complete',
+          'metadata_enriched', 'ft_verifying', 'ft_verified',
+          'translate_submitted', 'translate_complete',
+          'enriching', 'enriched', 'chapters', 'chapters_complete',
+          'images_submitted', 'images_complete',
+          'complete', 'needs_attention', 'failed',
+        ];
+        const sorted = statusOrder
+          .filter(s => pipelineData.funnel![s])
+          .map(s => ({ status: s, count: pipelineData.funnel![s] }));
+        // Add any statuses not in our known list
+        for (const [status, count] of Object.entries(pipelineData.funnel!)) {
+          if (!statusOrder.includes(status)) sorted.push({ status, count });
+        }
+        const maxCount = Math.max(...sorted.map(s => s.count));
+
+        const statusColors: Record<string, string> = {
+          queued: '#94a3b8', archiving: '#94a3b8', archive_complete: '#94a3b8',
+          ocr_submitted: '#3b82f6', ocr_complete: '#3b82f6',
+          metadata_enriched: '#8b5cf6', ft_verifying: '#8b5cf6', ft_verified: '#8b5cf6',
+          translate_submitted: '#f59e0b', translate_complete: '#f59e0b',
+          enriching: '#10b981', enriched: '#10b981',
+          chapters: '#06b6d4', chapters_complete: '#06b6d4',
+          images_submitted: '#ec4899', images_complete: '#ec4899',
+          complete: '#16a34a',
+          needs_attention: '#dc2626', failed: '#dc2626',
+        };
+
+        return (
+          <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+            <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <Layers className="w-5 h-5" style={{ color: 'var(--accent-sage)' }} />
+              Pipeline Funnel
+            </h2>
+            <div className="space-y-1.5">
+              {sorted.map(({ status, count }) => (
+                <div key={status} className="flex items-center gap-3">
+                  <div className="w-40 text-xs font-medium truncate text-right" style={{ color: 'var(--text-muted)' }}>
+                    {status.replace(/_/g, ' ')}
+                  </div>
+                  <div className="flex-1 h-5 rounded-full overflow-hidden" style={{ background: 'var(--bg-warm)' }}>
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${Math.max(1, (count / maxCount) * 100)}%`,
+                        background: statusColors[status] || '#6b7280',
+                        opacity: 0.8,
+                      }}
+                    />
+                  </div>
+                  <div className="w-16 text-xs font-bold text-right" style={{ color: 'var(--text-secondary)' }}>
+                    {count.toLocaleString()}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* Enrichment Coverage */}
+      {pipelineData.enrichmentCoverage && (() => {
+        const cov = pipelineData.enrichmentCoverage;
+        const total = cov.total;
+        if (total === 0) return null;
+
+        const phases = [
+          { label: 'OCR', count: cov.ocr, color: '#3b82f6' },
+          { label: 'Translation', count: cov.translation, color: '#f59e0b' },
+          { label: 'Metadata Enrichment', count: cov.metadata, color: '#8b5cf6' },
+          { label: 'First-Translation Check', count: cov.ftVerification, color: '#a855f7' },
+          { label: 'Summary & Index', count: cov.summary, color: '#10b981' },
+          { label: 'Chapters', count: cov.chapters, color: '#06b6d4' },
+          { label: 'Collection Classification', count: cov.collections, color: '#0891b2' },
+          { label: 'Quality Score', count: cov.qualityScore, color: '#14b8a6' },
+          { label: 'Image Extraction', count: cov.imageExtraction, color: '#ec4899' },
+          { label: 'Faceted Tags', count: cov.facetedTags, color: '#f97316' },
+          { label: 'Author Entity Linking', count: cov.authorEntity, color: '#64748b' },
+          { label: 'Pipeline Complete', count: cov.pipelineComplete, color: '#16a34a' },
+        ];
+
+        return (
+          <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+            <h2 className="text-lg font-medium mb-1 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <Image className="w-5 h-5" style={{ color: 'var(--accent-violet)' }} />
+              Enrichment Coverage
+            </h2>
+            <p className="text-xs mb-4" style={{ color: 'var(--text-muted)' }}>
+              {total.toLocaleString()} books with pages &middot; {cov.galleryImages.toLocaleString()} gallery images
+            </p>
+            <div className="space-y-2.5">
+              {phases.map(({ label, count, color }) => {
+                const pct = Math.round((count / total) * 100);
+                return (
+                  <div key={label} className="flex items-center gap-3">
+                    <div className="w-44 text-xs font-medium text-right" style={{ color: 'var(--text-muted)' }}>
+                      {label}
+                    </div>
+                    <div className="flex-1 h-5 rounded-full overflow-hidden relative" style={{ background: 'var(--bg-warm)' }}>
+                      <div
+                        className="h-full rounded-full transition-all"
+                        style={{ width: `${Math.max(1, pct)}%`, background: color, opacity: 0.75 }}
+                      />
+                    </div>
+                    <div className="w-24 text-xs text-right" style={{ color: 'var(--text-secondary)' }}>
+                      <span className="font-bold">{count.toLocaleString()}</span>
+                      <span className="ml-1" style={{ color: 'var(--text-muted)' }}>({pct}%)</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })()}
 
       {/* OCR + Translation Velocity Chart */}
       {velocityChart && (

--- a/src/lib/api-client/types/analytics.ts
+++ b/src/lib/api-client/types/analytics.ts
@@ -228,6 +228,23 @@ export interface PipelineDecision {
   data?: unknown;
 }
 
+export interface EnrichmentCoverage {
+  total: number;
+  ocr: number;
+  translation: number;
+  metadata: number;
+  ftVerification: number;
+  summary: number;
+  chapters: number;
+  collections: number;
+  qualityScore: number;
+  facetedTags: number;
+  authorEntity: number;
+  imageExtraction: number;
+  galleryImages: number;
+  pipelineComplete: number;
+}
+
 export interface PipelineData {
   snapshots: PipelineSnapshot[];
   velocity: PipelineVelocity;
@@ -236,6 +253,8 @@ export interface PipelineData {
   needsAttention: PipelineAttentionBook[];
   recentErrors: PipelineError[];
   recentDecisions: PipelineDecision[];
+  funnel?: Record<string, number>;
+  enrichmentCoverage?: EnrichmentCoverage;
   query: { hours: number };
 }
 


### PR DESCRIPTION
## Summary
- Pipeline tab previously only showed OCR + translation velocity — now shows the full picture
- **Pipeline Funnel**: horizontal bar chart showing book counts at each of the 18 pipeline statuses (queued through complete)
- **Enrichment Coverage**: progress bars for all 12 enrichment phases — OCR, translation, metadata, FT verification, summaries, chapters, collection classification, quality scores, image extraction, faceted tags, author entity linking, plus gallery image count
- Updated `/progress` CLI skill to report on all phases too

## Test plan
- [ ] Visit preview deploy → Analytics → Pipeline tab
- [ ] Verify Pipeline Funnel section renders with status bars
- [ ] Verify Enrichment Coverage shows all 12 phases with percentages
- [ ] Existing velocity charts, cron health, stall detection still render
- [ ] Check that the API response includes `funnel` and `enrichmentCoverage` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)