### PR TITLE
Fix silent navigation failure on DB timeout

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -66,7 +66,7 @@ export async function GET(
     const sortObj = sortMap[sort] || sortMap.year_asc;
 
     const projection = {
-      _id: 0, id: 1, title: 1, display_title: 1, author: 1, year: 1,
+      _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1,
       language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1,
       photo: 1, categories: 1, thumbnail: 1, thumbnail_blob: 1, published: 1, read_count: 1,
     };

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -73,7 +73,12 @@ async function getArtwork(slug: string) {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const data = await getArtwork(slug);
+  let data: Awaited<ReturnType<typeof getArtwork>>;
+  try {
+    data = await getArtwork(slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
   if (!data) return { title: 'Not Found' };
   const { artwork } = data;
   return {

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -78,7 +78,12 @@ async function getArtist(slug: string) {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const data = await getArtist(slug);
+  let data: Awaited<ReturnType<typeof getArtist>>;
+  try {
+    data = await getArtist(slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
   if (!data) return { title: 'Not Found' };
   return {
     title: `${data.name} — Source Library Visual Art`,

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -178,13 +178,18 @@ async function getAuthorBooks(authorName: string, entityId: string | null): Prom
 
 export async function generateMetadata({ params }: AuthorPageProps): Promise<Metadata> {
   const { name } = await params;
-  const decoded = decodeURIComponent(name);
-  const isOldFormat = decoded !== name;
-  const db = await getDb();
-  const resolved = isOldFormat
-    ? { authorName: decoded, entity: null, entityId: null }
-    : await resolveAuthor(db, name);
-  const authorName = resolved?.authorName || name.replace(/-/g, ' ');
+  let authorName: string;
+  try {
+    const decoded = decodeURIComponent(name);
+    const isOldFormat = decoded !== name;
+    const db = await getDb();
+    const resolved = isOldFormat
+      ? { authorName: decoded, entity: null, entityId: null }
+      : await resolveAuthor(db, name);
+    authorName = resolved?.authorName || name.replace(/-/g, ' ');
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   return {
     title: `${authorName} — Source Library`,

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -83,7 +83,14 @@ async function getBookForMetadata(id: string): Promise<Book | null> {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const book = await getBookForMetadata(id);
+  let book: Book | null;
+  try {
+    book = await getBookForMetadata(id);
+  } catch {
+    // DB timeout or other error — return minimal metadata so navigation doesn't silently fail.
+    // The page component's own error handling will show the user a friendly message.
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   if (!book) {
     return { title: 'Book Not Found - Source Library', robots: { index: false, follow: false } };

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -123,7 +123,12 @@ export const getEntity = cache(async (name: string) => {
 export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
   const { name } = await params;
   const decodedName = decodeURIComponent(name);
-  const entity = await getEntity(decodedName);
+  let entity;
+  try {
+    entity = await getEntity(decodedName);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   const typeLabels: Record<string, string> = {
     person: 'Person',

--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -101,7 +101,12 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
-  const data = await getImageData(id);
+  let data;
+  try {
+    data = await getImageData(id);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   // Normalize ID to use - separator for canonical URLs
   const urlSafeId = decodeURIComponent(id).replace(/:(\d+)$/, '-$1');

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -29,13 +29,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { code } = await params;
   const langName = decodeLanguageSlug(code);
 
-  const db = await getDb();
-  const count = await db.collection('books').countDocuments({
-    language: langName,
-    status: { $ne: 'deleted' },
-    hidden: { $ne: true },
-    pages_count: { $gt: 0 },
-  });
+  let count: number;
+  try {
+    const db = await getDb();
+    count = await db.collection('books').countDocuments({
+      language: langName,
+      status: { $ne: 'deleted' },
+      hidden: { $ne: true },
+      pages_count: { $gt: 0 },
+    });
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   if (count === 0) return { title: 'Language Not Found - Source Library' };
 

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -26,7 +26,12 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
-  const partner = getPartnerBySlug(slug);
+  let partner: ReturnType<typeof getPartnerBySlug>;
+  try {
+    partner = getPartnerBySlug(slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   if (!partner) {
     return { title: 'Library Not Found - Source Library' };

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -15,11 +15,16 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const db = await getDb();
-  const session = await db.collection('curator_sessions').findOne(
-    { id },
-    { projection: { title: 1, themes: 1, date: 1 } }
-  );
+  let session;
+  try {
+    const db = await getDb();
+    session = await db.collection('curator_sessions').findOne(
+      { id },
+      { projection: { title: 1, themes: 1, date: 1 } }
+    );
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
 
   if (!session) return { title: 'Session Not Found' };
 

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -12,7 +12,12 @@ interface Props {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { number } = await params;
-  const ep = await getEpisodeData(parseInt(number));
+  let ep;
+  try {
+    ep = await getEpisodeData(parseInt(number));
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
   if (!ep) return { title: 'Episode Not Found - SHWEP Reading Room' };
   return {
     title: `${ep.title} - SHWEP Reading Room`,

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -75,12 +75,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   // Fall back to old cluster slug
-  const db = await getDb();
-  const allClusters = await db.collection('books').aggregate([
-    { $match: { hidden: { $ne: true }, 'taxonomy.cluster': { $exists: true, $ne: null } } },
-    { $group: { _id: '$taxonomy.cluster' } },
-  ]).toArray();
-  const match = allClusters.find((c) => topicSlug(c._id) === slug);
+  let match;
+  try {
+    const db = await getDb();
+    const allClusters = await db.collection('books').aggregate([
+      { $match: { hidden: { $ne: true }, 'taxonomy.cluster': { $exists: true, $ne: null } } },
+      { $group: { _id: '$taxonomy.cluster' } },
+    ]).toArray();
+    match = allClusters.find((c) => topicSlug(c._id) === slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
   if (!match) return { title: 'Topic Not Found - Source Library' };
 
   return {

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -42,7 +42,12 @@ function workTitle(workId: string): string {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const editions = await getWorkEditions(id);
+  let editions: Awaited<ReturnType<typeof getWorkEditions>>;
+  try {
+    editions = await getWorkEditions(id);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
   if (editions.length === 0) return { title: 'Work Not Found' };
 
   const title = workTitle(id);


### PR DESCRIPTION
## Summary
- **Root cause:** `generateMetadata` in 12 of 15 dynamic pages had no try/catch. When Atlas is slow, the DB call throws, which crashes Next.js client-side navigation silently — the user clicks a link and nothing happens.
- Wrapped all `generateMetadata` functions in try/catch, returning minimal fallback metadata on error. Navigation now proceeds to the page's error boundary or "Temporarily Unavailable" message instead of silently failing.
- Added `slug` to the collection API projection so books fetched via "See All" get friendly URLs instead of hex IDs.

## Files changed (13)
All `generateMetadata` across: book, author, artwork, artwork/artist, languages, libraries, work, shwep, topics, research, encyclopedia, gallery/image pages + collection API route.

## Test plan
- [ ] Click book links on collection pages — should navigate (showing error boundary if DB is slow, not silent failure)
- [ ] Test "See All" on a collection — book links should use slug URLs
- [ ] Verify pages still render correctly when DB is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)