### PR TITLE
Paginate book pages SSR to fix large book timeouts

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -63,11 +63,15 @@ export async function GET(
     }
 
     const bookId = (book.id || book._id?.toString()) as string;
-    const pages = await db.collection('pages')
+    const pageOffset = parseInt(searchParams.get('pageOffset') || '0');
+    const pageLimit = parseInt(searchParams.get('pageLimit') || '0'); // 0 = all (backwards-compat)
+    let cursor = db.collection('pages')
       .find({ book_id: bookId })
       .project(projection)
-      .sort({ page_number: 1 })
-      .toArray();
+      .sort({ page_number: 1 });
+    if (pageOffset > 0) cursor = cursor.skip(pageOffset);
+    if (pageLimit > 0) cursor = cursor.limit(pageLimit);
+    const pages = await cursor.toArray();
 
     const cacheControl = includeFull
       ? 'private, no-cache'

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -202,6 +202,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
         maxTimeMS: 5000,
       })
       .sort({ page_number: 1 })
+      .limit(100)
       .toArray(),
     db.collection('books').estimatedDocumentCount().catch(() => 1200),
     db.collection('gallery_images').countDocuments(
@@ -740,11 +741,11 @@ async function BookInfo({ id }: { id: string }) {
           if (membersOnlyUntil && new Date(membersOnlyUntil) > new Date()) {
             return (
               <EarlyAccessGate membersOnlyUntil={membersOnlyUntil}>
-                <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />
+                <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />
               </EarlyAccessGate>
             );
           }
-          return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
+          return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
         })()}
         <AuthCheck role="admin">
           <BookHistory bookId={book.id} />

--- a/src/components/book/AuthorCrossReference.tsx
+++ b/src/components/book/AuthorCrossReference.tsx
@@ -49,19 +49,24 @@ export default async function AuthorCrossReference({ author, currentBookId, cont
             resource_type: 1, thumbnail: 1, thumbnail_blob: 1,
             commons_width: 1, commons_height: 1,
           },
+          maxTimeMS: 3000,
         },
       )
       .sort({ published: 1 })
       .limit(12)
-      .toArray();
+      .toArray()
+      .catch((): never[] => []);
 
     if (artworks.length === 0) return null;
 
     const items = JSON.parse(JSON.stringify(artworks)) as CrossRefItem[];
-    const totalCount = await db.collection('books').countDocuments({
-      author: { $regex: `^${escaped}$`, $options: 'i' },
-      resource_type: { $in: VISUAL_TYPES },
-    });
+    const totalCount = await db.collection('books').countDocuments(
+      {
+        author: { $regex: `^${escaped}$`, $options: 'i' },
+        resource_type: { $in: VISUAL_TYPES },
+      },
+      { maxTimeMS: 3000 },
+    ).catch(() => artworks.length);
 
     return (
       <div className="card p-6 sm:p-8">
@@ -123,11 +128,13 @@ export default async function AuthorCrossReference({ author, currentBookId, cont
           language: 1, thumbnail: 1, thumbnail_blob: 1,
           pages_translated: 1,
         },
+        maxTimeMS: 3000,
       },
     )
     .sort({ published: 1 })
     .limit(8)
-    .toArray();
+    .toArray()
+    .catch((): never[] => []);
 
   // Also try "Surname, Firstname" format if author is "Firstname Surname"
   if (books.length === 0 && !author.includes(',')) {
@@ -149,11 +156,13 @@ export default async function AuthorCrossReference({ author, currentBookId, cont
               language: 1, thumbnail: 1, thumbnail_blob: 1,
               pages_translated: 1,
             },
+            maxTimeMS: 3000,
           },
         )
         .sort({ published: 1 })
         .limit(8)
-        .toArray();
+        .toArray()
+        .catch((): never[] => []);
 
       if (altBooks.length === 0) return null;
       const items = JSON.parse(JSON.stringify(altBooks)) as CrossRefItem[];

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -19,13 +19,18 @@ interface BookPagesSectionProps {
   bookId: string;
   bookTitle?: string;
   pages: Page[];
+  totalPageCount?: number;
   displayBrightness?: number;
 }
 
 const PAGES_PER_LOAD = 24; // 2 rows on 12-col grid
 
-export default function BookPagesSection({ bookId, bookTitle, pages: initialPages, displayBrightness }: BookPagesSectionProps) {
+export default function BookPagesSection({ bookId, bookTitle, pages: initialPages, totalPageCount, displayBrightness }: BookPagesSectionProps) {
   const [pages, setPages] = useState(initialPages);
+  const [allPagesFetched, setAllPagesFetched] = useState(
+    !totalPageCount || initialPages.length >= totalPageCount
+  );
+  const [fetchingMore, setFetchingMore] = useState(false);
   const [batchMode, setBatchMode] = useState(false);
   const [reorderMode, setReorderMode] = useState(false);
   const [selectedPages, setSelectedPages] = useState<Set<string>>(new Set());
@@ -36,10 +41,34 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
   const [overwriteMode, setOverwriteMode] = useState(false); // Force re-process pages that already have data
   const [visibleCount, setVisibleCount] = useState(PAGES_PER_LOAD); // Pagination
 
+  // Fetch remaining pages from API when SSR only sent a partial set
+  const fetchRemainingPages = useCallback(async () => {
+    if (allPagesFetched || fetchingMore) return;
+    setFetchingMore(true);
+    try {
+      const res = await fetch(`/api/books/${bookId}?pageOffset=${pages.length}&pageLimit=0`);
+      if (!res.ok) throw new Error('Failed to fetch');
+      const data = await res.json();
+      if (data.pages?.length) {
+        setPages(prev => [...prev, ...data.pages]);
+      }
+      setAllPagesFetched(true);
+    } catch (error) {
+      console.error('Failed to fetch remaining pages:', error);
+    } finally {
+      setFetchingMore(false);
+    }
+  }, [bookId, pages.length, allPagesFetched, fetchingMore]);
+
   // Load more pages manually via button click (no auto-scroll)
   const handleLoadMore = useCallback(() => {
-    setVisibleCount(prev => Math.min(prev + PAGES_PER_LOAD, pages.length));
-  }, [pages.length]);
+    const nextVisible = Math.min(visibleCount + PAGES_PER_LOAD, totalPageCount || pages.length);
+    // If we're about to show more than we have, fetch the rest first
+    if (nextVisible > pages.length && !allPagesFetched) {
+      fetchRemainingPages();
+    }
+    setVisibleCount(nextVisible);
+  }, [visibleCount, pages.length, totalPageCount, allPagesFetched, fetchRemainingPages]);
 
   // Reorder mode state
   const [draggedPageId, setDraggedPageId] = useState<string | null>(null);
@@ -58,6 +87,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
       const book = await books.get(bookId);
       if ('pages' in book && book.pages) {
         setPages(book.pages);
+        setAllPagesFetched(true);
       }
     } catch (error) {
       console.error('Failed to refresh pages:', error);
@@ -97,9 +127,10 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
   const lastSelectedIndexRef = useRef<number | null>(null);
 
   // Calculate stats (check updated_at since data is excluded from projection)
+  // When only a partial page set was SSR'd, these are approximate until all pages load
   const pagesWithOcr = pages.filter(p => p.ocr?.updated_at).length;
   const pagesWithTranslation = pages.filter(p => p.translation?.updated_at).length;
-  const totalPages = pages.length;
+  const totalPages = totalPageCount || pages.length;
 
   // Calculate last activity dates
   const lastOcrDate = pages
@@ -210,7 +241,10 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
     }
   }, [pages]);
 
-  const selectAll = () => setSelectedPages(new Set(pages.map(p => p.id)));
+  const selectAll = () => {
+    if (!allPagesFetched) fetchRemainingPages();
+    setSelectedPages(new Set(pages.map(p => p.id)));
+  };
   const clearSelection = () => setSelectedPages(new Set());
 
   const exitBatchMode = () => {
@@ -518,7 +552,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
               savingOrder={savingOrder}
               pagesWithOcr={pagesWithOcr}
               pagesWithTranslation={pagesWithTranslation}
-              onBatchClick={() => setBatchMode(true)}
+              onBatchClick={() => { if (!allPagesFetched) fetchRemainingPages(); setBatchMode(true); }}
               onReorderClick={enterReorderMode}
               onExitBatch={exitBatchMode}
               onExitReorder={exitReorderMode}
@@ -603,6 +637,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
         onDragEnd={handleDragEnd}
         onLoadMore={handleLoadMore}
         getImageUrl={getImageUrl}
+        totalCount={totalPages}
       />
     </div>
   );

--- a/src/components/book/PagesGrid.tsx
+++ b/src/components/book/PagesGrid.tsx
@@ -32,6 +32,7 @@ interface PagesGridProps {
   selectedPages: Set<string>;
   settingCover: string | null;
   visibleCount: number;
+  totalCount?: number;
   draggedPageId: string | null;
   dragOverPageId: string | null;
   brightness?: number;
@@ -63,8 +64,10 @@ export default function PagesGrid({
   onDragOver,
   onDragEnd,
   onLoadMore,
-  getImageUrl
+  getImageUrl,
+  totalCount,
 }: PagesGridProps) {
+  const displayTotal = totalCount || pages.length;
   // CSS brightness filter — only apply when not default (1.0)
   const brightnessStyle = brightness && brightness !== 1.0
     ? { filter: `brightness(${brightness})` }
@@ -74,7 +77,7 @@ export default function PagesGrid({
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>Pages</h2>
         <span className="text-sm text-stone-500">
-          Showing {Math.min(visibleCount, pages.length)} of {pages.length}
+          Showing {Math.min(visibleCount, pages.length)} of {displayTotal}
         </span>
       </div>
 
@@ -209,14 +212,14 @@ export default function PagesGrid({
       )}
 
       {/* Load More */}
-      {visibleCount < pages.length && (
+      {visibleCount < displayTotal && (
         <div className="mt-6 text-center">
           <button
             onClick={onLoadMore}
             className="inline-flex items-center gap-2 px-6 py-2.5 bg-white border border-stone-300 text-stone-700 rounded-lg hover:bg-stone-50 hover:border-stone-400 transition-colors text-sm font-medium"
           >
             <RefreshCw className="w-4 h-4" />
-            Load more ({pages.length - visibleCount} remaining)
+            Load more ({displayTotal - visibleCount} remaining)
           </button>
         </div>
       )}

--- a/src/components/book/RelatedEditions.tsx
+++ b/src/components/book/RelatedEditions.tsx
@@ -12,8 +12,8 @@ export default async function RelatedEditions({ bookId, workId }: RelatedEdition
 
   const related = await db.collection('books').find(
     { work_id: workId, id: { $ne: bookId }, hidden: { $ne: true } },
-    { projection: { 'image_source.provider_name': 1 } }
-  ).toArray();
+    { projection: { 'image_source.provider_name': 1 }, maxTimeMS: 3000 }
+  ).toArray().catch(() => []);
 
   if (related.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- Book detail page was loading ALL pages in one SSR query (no limit). The Zohar (612 pages) was timing out at the 5s maxTimeMS.
- SSR now sends first 100 pages; client fetches the rest on demand when the user clicks "Load more" or enters batch mode.
- Added `pageOffset`/`pageLimit` params to `GET /api/books/[id]` for paginated fetching.
- PagesGrid shows the correct total (from `book.pages_count`) even with partial data.

## Test plan
- [ ] Visit a small book (<100 pages) — should work exactly as before
- [ ] Visit the Zohar (612 pages) — should load fast, show "Showing 24 of 612", "Load more" fetches next batch
- [ ] Batch mode on large book — entering batch mode auto-fetches all pages
- [ ] "Select all" on large book — fetches remaining pages then selects all

## Related
- PR #372 — generateMetadata error handling (merged)
- Issue #373 — dead-link health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)