### PR TITLE
Gate artwork pages to admin-only

### DIFF
--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -1,13 +1,13 @@
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
+import { isAdmin } from '@/lib/auth-helpers';
 import { Book } from '@/lib/types';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
 
-export const revalidate = 3600;
+export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
-export async function generateStaticParams() { return []; }
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -92,6 +92,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ArtworkPage({ params }: PageProps) {
+  const admin = await isAdmin();
+  if (!admin) redirect('/');
+
   const { slug } = await params;
   const data = await getArtwork(slug);
   if (!data) notFound();

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -1,14 +1,14 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
+import { isAdmin } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const revalidate = 3600;
+export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
-export async function generateStaticParams() { return []; }
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -92,6 +92,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ArtistPage({ params }: PageProps) {
+  const admin = await isAdmin();
+  if (!admin) redirect('/');
+
   const { slug } = await params;
   const data = await getArtist(slug);
   if (!data) notFound();

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
+import { redirect } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
+import { isAdmin } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -69,6 +71,9 @@ async function getData() {
 }
 
 export default async function ArtworkLandingPage() {
+  const admin = await isAdmin();
+  if (!admin) redirect('/');
+
   const { collections, artists, totalCount } = await getData();
 
   return (


### PR DESCRIPTION
## Summary
- All `/artwork/*` routes now require admin session — non-admins redirect to `/`
- Prevents the timeout error from affecting regular users while artwork feature is in development
- Switched all artwork routes from ISR (`revalidate = 3600`) to `force-dynamic` to avoid prerender timeouts

## Files changed
- `src/app/artwork/page.tsx` — landing page
- `src/app/artwork/[slug]/page.tsx` — individual artwork
- `src/app/artwork/artist/[slug]/page.tsx` — artist page

## Test plan
- [ ] Non-admin visiting /artwork gets redirected to /
- [ ] Admin visiting /artwork sees collections and artists
- [ ] No build errors (ISR prerender removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)