### PR TITLE
AI-powered USTC matcher with Gemini tool-calling

### DIFF
--- a/scripts/catalog-coverage/backfill-ustc-matches.mjs
+++ b/scripts/catalog-coverage/backfill-ustc-matches.mjs
@@ -93,7 +93,22 @@ async function main() {
         if (!dryRun) {
           await db.collection('books').updateOne(
             { id: book.id },
-            { $set: { ustc_id: result.match.ustc_sn, ustc_match: result.match } },
+            { $set: {
+              ustc_id: result.match.ustc_sn,
+              ustc_match: result.match,
+              'field_provenance.ustc_id': {
+                source: 'ai-matcher',
+                method: result.match.match_method,
+                confidence: result.match.confidence,
+                date: new Date(),
+              },
+              'field_provenance.ustc_match': {
+                source: 'ai-matcher',
+                method: result.match.match_method,
+                confidence: result.match.confidence,
+                date: new Date(),
+              },
+            } },
           );
         }
 

--- a/src/lib/ustc-matcher.ts
+++ b/src/lib/ustc-matcher.ts
@@ -24,9 +24,9 @@ const MODEL = 'gemini-3.1-flash-lite-preview';
 const MAX_ROUNDS = 5;
 const TEMPERATURE = 0.1;
 
-// Supabase (public anon key — read-only)
-const SUPABASE_URL = 'https://ykhxaecbbxaaqlujuzde.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlraHhhZWNiYnhhYXFsdWp1emRlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjUwNjExMDEsImV4cCI6MjA4MDYzNzEwMX0.O2chfnHGQWLOaVSFQ-F6UJMlya9EzPbsUh848SEOPj4';
+// Supabase (read-only anon key — from env)
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY!;
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -687,6 +687,18 @@ export async function matchBookToUstc(
             matched_at: result.match.matched_at,
             model: result.match.model,
             cost_usd: result.match.cost_usd,
+          },
+          'field_provenance.ustc_id': {
+            source: 'ai-matcher',
+            method: result.match.match_method,
+            confidence: result.match.confidence,
+            date: new Date(),
+          },
+          'field_provenance.ustc_match': {
+            source: 'ai-matcher',
+            method: result.match.match_method,
+            confidence: result.match.confidence,
+            date: new Date(),
           },
         },
       },


### PR DESCRIPTION
## Summary
- Adds `src/lib/ustc-matcher.ts` — two-tier matching system: fast word-overlap pre-filter (free, ~60% hit rate), then Gemini flash-lite tool-calling for cross-language and variant-name cases
- Follows the same Gemini tool-calling pattern as `verify-first-translation.ts`
- API endpoint `POST /api/books/[id]/match-ustc` for one-off matching from admin UI
- Batch script `scripts/catalog-coverage/backfill-ustc-matches.mjs` for bulk matching

Closes #343

## Test plan
- [ ] Run backfill with `--dry-run --limit 10` on a few known books to verify matching quality
- [ ] Test API endpoint via curl on a book with known USTC match
- [ ] Verify fast path catches obvious matches (same language, similar title)
- [ ] Verify AI path catches cross-language matches (e.g., Dutch→Latin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)