### PR TITLE
Fix gallery timeout: eliminate countDocuments

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -153,24 +153,29 @@ export async function GET(request: NextRequest) {
       ? { _id: 0, score: { $meta: 'textScore' } }
       : { _id: 0 };
 
-    // Run query and count in parallel.
-    // Use estimatedDocumentCount when filter is broad (no book/type/collection filters)
-    // to avoid expensive collection scans on Atlas.
-    const isBroadFilter = !bookId && !collectionBookIds && !libraryBookIds && !imageType
-      && !subjectFilter && !figureFilter && !symbolFilter && !searchQuery
-      && yearStart === null && yearEnd === null;
+    // countDocuments with compound filters takes 20s+ on Atlas (no covering index).
+    // Strategy: run find first, then only count if we need pagination info.
+    // For first page with full results, total = offset + items.length (or +1 if full page).
+    const items = await db.collection('gallery_images')
+      .find(filter, { projection })
+      .sort(sortOrder)
+      .skip(offset)
+      .limit(limit + 1) // fetch one extra to know if there are more
+      .toArray();
 
-    const [items, total] = await Promise.all([
-      db.collection('gallery_images')
-        .find(filter, { projection })
-        .sort(sortOrder)
-        .skip(offset)
-        .limit(limit)
-        .toArray(),
-      isBroadFilter
-        ? db.collection('gallery_images').estimatedDocumentCount()
-        : db.collection('gallery_images').countDocuments(filter),
-    ]);
+    const hasMore = items.length > limit;
+    if (hasMore) items.pop(); // remove the extra probe item
+
+    // Avoid countDocuments entirely — derive total from what we know
+    let total: number;
+    if (!hasMore && offset === 0) {
+      total = items.length; // we have everything
+    } else if (!hasMore) {
+      total = offset + items.length; // last page
+    } else {
+      // There are more results — use estimated count as approximation
+      total = await db.collection('gallery_images').estimatedDocumentCount();
+    }
 
     // Fetch like counts (and visitor's liked status) for these images
     const visitorId = searchParams.get('visitor_id');

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -62,13 +62,14 @@ async function fetchInitialGalleryData(): Promise<GalleryResponse> {
       book_hidden: { $ne: true },
     };
 
+    // countDocuments takes 20s+ on Atlas — skip it for SSR, use estimatedDocumentCount
     const [items, total, typesResult, subjectsResult, yearResult] = await Promise.all([
       db.collection('gallery_images')
         .find(filter, { projection: { _id: 0 } })
         .sort({ gallery_quality: -1, book_year: 1, book_id: 1, page_number: 1 })
         .limit(limit)
         .toArray(),
-      db.collection('gallery_images').countDocuments(filter),
+      db.collection('gallery_images').estimatedDocumentCount(),
       db.collection('gallery_images').aggregate([
         { $group: { _id: '$type' } },
         { $match: { _id: { $ne: null } } },


### PR DESCRIPTION
## Summary
- `countDocuments` with compound filter takes **20 seconds** on Atlas (69K gallery_images, no covering compound index)
- The `find` query itself is fast (231ms, 8 docs via index) — countDocuments is the sole bottleneck
- Fix: use `limit + 1` probe to detect pagination, derive total without counting. Fall back to `estimatedDocumentCount` (instant) when more pages exist
- Also fixes the SSR gallery page (`/gallery`) which had the same countDocuments call

## Diagnostics
```
find-sorted: 83ms (8 docs examined)
countDocs-default: 20.249s  <-- this kills the API
countDocs-broad: 1.988s
estimatedCount: 55ms
```

## Test plan
- [ ] https://sourcelibrary.org/gallery loads images (SSR)
- [ ] https://sourcelibrary.org/gallery/curate loads images
- [ ] Pagination still works on gallery API

🤖 Generated with [Claude Code](https://claude.com/claude-code)