### PR TITLE
Cache timeline overview to fix 30s timeout

### DIFF
--- a/scripts/seed-timeline-filters.mjs
+++ b/scripts/seed-timeline-filters.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 /**
- * Seed system_config.timeline_filters with pre-computed language and collection lists.
- * Run periodically or after large imports. Avoids slow distinct() queries at request time.
+ * Seed system_config with pre-computed timeline data:
+ *   - timeline_filters: language and collection lists for filter dropdowns
+ *   - timeline_overview: full decade buckets with language breakdown + summary stats
+ *
+ * Run periodically or after large imports. Avoids 30-80s aggregations at request time.
  *
  * Usage: set -a; source .env.production.local; set +a; node scripts/seed-timeline-filters.mjs
  */
@@ -15,23 +18,80 @@ const client = new MongoClient(uri);
 try {
   await client.connect();
   const db = client.db('bookstore');
-  const filter = { hidden: { $ne: true }, year: { $exists: true, $ne: null } };
+  const baseFilter = { hidden: { $ne: true }, year: { $exists: true, $ne: null } };
 
+  // 1. Filters
   console.log('Fetching distinct languages...');
-  const languages = (await db.collection('books').distinct('language', filter)).filter(Boolean).sort();
+  const languages = (await db.collection('books').distinct('language', baseFilter)).filter(Boolean).sort();
 
   console.log('Fetching distinct categories...');
-  const collections = (await db.collection('books').distinct('categories', filter)).filter(Boolean).sort();
-
-  const data = { languages, collections };
+  const collections = (await db.collection('books').distinct('categories', baseFilter)).filter(Boolean).sort();
 
   await db.collection('system_config').updateOne(
     { _id: 'timeline_filters' },
-    { $set: { data, updated_at: new Date() } },
+    { $set: { data: { languages, collections }, updated_at: new Date() } },
     { upsert: true },
   );
+  console.log(`Cached ${languages.length} languages, ${collections.length} collections into timeline_filters`);
 
-  console.log(`Cached ${languages.length} languages, ${collections.length} collections into system_config.timeline_filters`);
+  // 2. Overview (decade buckets)
+  console.log('Computing decade buckets...');
+  const rawDecades = await db.collection('books').aggregate([
+    { $match: baseFilter },
+    {
+      $group: {
+        _id: { $multiply: [{ $floor: { $divide: ['$year', 10] } }, 10] },
+        count: { $sum: 1 },
+        languages: { $push: '$language' },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+
+  const decades = rawDecades.map(d => {
+    const langCounts = {};
+    for (const lang of d.languages) {
+      const key = lang || 'Unknown';
+      langCounts[key] = (langCounts[key] || 0) + 1;
+    }
+    const langs = Object.entries(langCounts)
+      .map(([lang, count]) => ({ lang, count }))
+      .sort((a, b) => b.count - a.count);
+    return { decade: d._id, count: d.count, languages: langs };
+  });
+
+  const total = decades.reduce((sum, d) => sum + d.count, 0);
+  const allYears = decades.map(d => d.decade);
+  const yearRange = {
+    min: allYears.length ? allYears[0] : 0,
+    max: allYears.length ? allYears[allYears.length - 1] + 9 : 0,
+  };
+
+  const globalLangCounts = {};
+  for (const d of decades) {
+    for (const l of d.languages) {
+      globalLangCounts[l.lang] = (globalLangCounts[l.lang] || 0) + l.count;
+    }
+  }
+  const topLanguages = Object.entries(globalLangCounts)
+    .map(([lang, count]) => ({ lang, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const overview = {
+    decades,
+    summary: { total, yearRange, topLanguages },
+    filters: {
+      languages: languages.filter(Boolean).sort(),
+      collections: collections.filter(Boolean).sort(),
+    },
+  };
+
+  await db.collection('system_config').updateOne(
+    { _id: 'timeline_overview' },
+    { $set: { data: overview, updated_at: new Date() } },
+    { upsert: true },
+  );
+  console.log(`Cached ${decades.length} decades, ${total} books into timeline_overview`);
 } finally {
   await client.close();
 }

--- a/src/app/api/books/timeline/route.ts
+++ b/src/app/api/books/timeline/route.ts
@@ -67,7 +67,16 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ decade: decadeNum, books: mapped, total, offset });
     }
 
-    // Overview mode: decade buckets with language breakdown
+    // Overview mode — read pre-computed snapshot from system_config (live agg takes 30-80s)
+    const cached = await db.collection('system_config')
+      .findOne({ _id: 'timeline_overview' } as any)
+      .catch(() => null);
+
+    if (cached?.data) {
+      return NextResponse.json(cached.data);
+    }
+
+    // Fallback: compute live (will likely timeout on Atlas, but try)
     const pipeline = [
       { $match: baseMatch },
       {
@@ -80,9 +89,8 @@ export async function GET(request: NextRequest) {
       { $sort: { _id: 1 as const } },
     ];
 
-    const rawDecades = await db.collection('books').aggregate(pipeline, { maxTimeMS: 10000 }).toArray();
+    const rawDecades = await db.collection('books').aggregate(pipeline, { maxTimeMS: 15000 }).toArray();
 
-    // Build decade buckets with language breakdown
     const decades = rawDecades.map(d => {
       const langCounts: Record<string, number> = {};
       for (const lang of d.languages) {
@@ -92,11 +100,9 @@ export async function GET(request: NextRequest) {
       const languages = Object.entries(langCounts)
         .map(([lang, count]) => ({ lang, count }))
         .sort((a, b) => b.count - a.count);
-
       return { decade: d._id, count: d.count, languages };
     });
 
-    // Summary stats
     const total = decades.reduce((sum, d) => sum + d.count, 0);
     const allYears = decades.map(d => d.decade);
     const yearRange = {
@@ -104,7 +110,6 @@ export async function GET(request: NextRequest) {
       max: allYears.length ? allYears[allYears.length - 1] + 9 : 0,
     };
 
-    // Top languages across all decades
     const globalLangCounts: Record<string, number> = {};
     for (const d of decades) {
       for (const l of d.languages) {
@@ -115,29 +120,13 @@ export async function GET(request: NextRequest) {
       .map(([lang, count]) => ({ lang, count }))
       .sort((a, b) => b.count - a.count);
 
-    // Filter options — read from cache, fall back to computing from decade results
-    let languages: string[];
-    let collections: string[];
-
+    // Read filter options from cache
     const cachedFilters = await db.collection('system_config')
       .findOne({ _id: 'timeline_filters' } as any)
       .catch(() => null);
 
-    if (cachedFilters?.data) {
-      languages = cachedFilters.data.languages || [];
-      collections = cachedFilters.data.collections || [];
-    } else {
-      // Derive languages from the decade data we already computed (free)
-      const langSet = new Set<string>();
-      for (const d of rawDecades) {
-        for (const lang of d.languages) {
-          if (lang) langSet.add(lang);
-        }
-      }
-      languages = [...langSet];
-      // Collections require a separate query — skip if no cache to avoid timeout
-      collections = [];
-    }
+    const languages = cachedFilters?.data?.languages || [];
+    const collections = cachedFilters?.data?.collections || [];
 
     return NextResponse.json({
       decades,


### PR DESCRIPTION
## Summary
- Timeline API overview mode was 500ing on every request — the `$group` aggregation across all books takes 30-80s, exceeding Vercel's 30s limit
- Now reads from `system_config.timeline_overview` cache first, falls back to live computation
- Updated `seed-timeline-filters.mjs` to also compute the full overview (decade buckets + summary stats)
- Cache seeded: 87 languages, 792 collections, all decade buckets

## Context
Part of fixing the 6 E2E test failures found in the Playwright smoke suite. Previous PR #400 fixed search API (regex fallback) and libraries page (ISR). This PR fixes the timeline API.

## Test plan
- [ ] `curl 'https://sourcelibrary-v2.vercel.app/api/books/timeline?limit=1'` returns 200
- [ ] Timeline page loads at https://sourcelibrary.org/timeline
- [ ] Drill-down mode still works: `?decade=1500` returns books

🤖 Generated with [Claude Code](https://claude.com/claude-code)