### PR TITLE
Fix E2E test: duplicate language-metadata testid

### DIFF
--- a/e2e/book-detail.spec.ts
+++ b/e2e/book-detail.spec.ts
@@ -19,7 +19,7 @@ test.describe('Book Detail', () => {
   test('language metadata is visible', async ({ page }) => {
     // Wait for page to fully load beyond Suspense boundary
     await expect(page.getByRole('heading', { name: /The Hermetic Museum/i })).toBeVisible();
-    await expect(page.getByTestId('language-metadata')).toContainText(BOOK.language);
+    await expect(page.getByTestId('language-metadata').first()).toContainText(BOOK.language);
   });
 
   test('pages grid loads with links', async ({ page }) => {


### PR DESCRIPTION
One-line fix — use `.first()` to resolve Playwright strict mode violation when two elements share the same testid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)