### PR TITLE
Search warming + timeline ISR + retry on cold start

### DIFF
--- a/src/app/api/cron/warm/route.ts
+++ b/src/app/api/cron/warm/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+export const maxDuration = 15;
+export const preferredRegion = 'fra1';
+
+/**
+ * Warm up critical Vercel serverless functions by calling them.
+ * Prevents cold-start delays for user-facing search and API routes.
+ * Runs every 5 minutes via Vercel cron.
+ */
+export async function GET() {
+  const baseUrl = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'https://sourcelibrary.org';
+
+  const endpoints = [
+    '/api/search/unified?q=test&limit=1',
+    '/api/books/search?q=test&limit=1',
+    '/api/search?q=test&limit=1',
+  ];
+
+  const results: { endpoint: string; status: number; ms: number }[] = [];
+
+  for (const endpoint of endpoints) {
+    const t = Date.now();
+    try {
+      const res = await fetch(`${baseUrl}${endpoint}`, {
+        headers: { 'X-Warm-Ping': '1' },
+        signal: AbortSignal.timeout(10000),
+      });
+      results.push({ endpoint, status: res.status, ms: Date.now() - t });
+    } catch {
+      results.push({ endpoint, status: 0, ms: Date.now() - t });
+    }
+  }
+
+  return NextResponse.json({ warmed: results.length, results });
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -216,7 +216,16 @@ export default function SearchPage() {
           setBookResults(bookData.results || []);
           setBookTotal(bookData.total || 0);
           setLoading(false); // Show results as soon as books arrive
-        }).catch(() => {});
+        }).catch(async () => {
+          // First attempt failed (likely cold start) — retry once
+          try {
+            const retryData = await searchApi.search(q, { ...bookFilters, search_content: 'true' });
+            setBookResults(retryData.results || []);
+            setBookTotal(retryData.total || 0);
+          } catch {
+            // Both attempts failed — finally block will clear loading
+          }
+        });
         searchApi.index(q, {}).then(indexData => {
           setIndexResults((indexData.results || []).slice(0, PREVIEW_INDEX));
           setIndexTotal(indexData.total || 0);

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -5,7 +5,7 @@ import TimelineClient from './TimelineClient';
 import type { Metadata } from 'next';
 import type { TimelineOverview, DecadeBucket } from '@/lib/api-client/types/timeline';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 300; // 5 minutes — timeline data changes rarely
 export const maxDuration = 30;
 
 export const metadata: Metadata = {

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
     {
       "path": "/api/cron/daily-pipeline-report",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/warm",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Warm cron** (`/api/cron/warm`, every 5min): pings search API endpoints to prevent Vercel cold starts. First user to search no longer sees "No results found" while functions boot.
- **Timeline ISR**: switched from `force-dynamic` to `revalidate: 300`. Timeline aggregation was running on every page load — now cached 5min like the homepage.
- **Search retry**: if book search API fails (cold start timeout), retries once automatically. User sees spinner instead of false "No results."

## Context
E2E tests showed `/api/books/search` consistently timing out (60s), and the search page showing "No results found" for Ficino on cold starts. Atlas Search itself is fast (327ms) — the bottleneck is Vercel function cold start + MongoDB connection time (~5s).

## Test plan
- [ ] Verify `/api/cron/warm` responds with warmed endpoint list
- [ ] Verify `/timeline` loads from cache (check response headers for `x-nextjs-cache: HIT`)
- [ ] Search for "Ficino" after deploy — should return results without delay
- [ ] Run `npm run test:e2e` against preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)