### PR TITLE
Fix ISR build failure: protect topics page DB call

### DIFF
--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -117,7 +117,10 @@ async function fetchFacetCounts(): Promise<{ groups: FacetGroup[]; totalBooks: n
 }
 
 export default async function TopicsPage() {
-  const { groups, totalBooks } = await fetchFacetCounts();
+  const { groups, totalBooks } = await fetchFacetCounts().catch((err) => {
+    console.error('Facet counts fetch failed:', err);
+    return { groups: [] as FacetGroup[], totalBooks: 0 };
+  });
 
   return (
     <ContentPageLayout


### PR DESCRIPTION
## Summary
- `topics/page.tsx` had an unprotected `fetchFacetCounts()` call that crashes when MongoDB is unavailable during Vercel's build step
- Added `.catch()` at the call site (same pattern already used in `languages/page.tsx`)
- This was causing **all production deploys to fail** since the ISR conversion in #413

## Test plan
- [ ] Verify Vercel preview build succeeds
- [ ] Verify /topics loads with real data after ISR revalidation
- [ ] Verify /search?first_translation=true and /search?has_translation=true return results (blocked by build failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)