### PR TITLE
Fix browse API timeout: filter catalog stubs

### DIFF
--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -84,7 +84,10 @@ export async function GET(request: NextRequest) {
         ...(library ? [{ $match: { 'image_source.provider': library } }] : []),
       ];
     } else {
-      const matchConditions: Record<string, unknown>[] = [{ hidden: { $ne: true } }];
+      const matchConditions: Record<string, unknown>[] = [
+        { hidden: { $ne: true } },
+        { pages_count: { $gt: 0 } },
+      ];
       if (language) matchConditions.push({ language });
       if (category) matchConditions.push({ categories: category });
       if (collection) matchConditions.push({ collections: collection });
@@ -186,6 +189,7 @@ export async function GET(request: NextRequest) {
 
     const [result] = await db.collection('books').aggregate(pipeline, {
       collation: { locale: 'en', strength: 1 },
+      maxTimeMS: 15000,
     }).toArray();
 
     const books = result.books || [];


### PR DESCRIPTION
## Summary
- The books collection grew from ~5K to 13K+ with catalog stubs (pages_count=0)
- Browse API aggregation was scanning all 13K through $facet + collation sort, causing 30s+ timeouts
- Added `pages_count > 0` to default match — catalog stubs shouldn't appear in browse results
- Added `maxTimeMS: 15000` safety net

This fixes /search?first_translation=true and /search?has_translation=true returning "no books found" (the API was timing out and the UI silently swallowed the error).

## Test plan
- [ ] Verify /search?first_translation=true shows results
- [ ] Verify /search?has_translation=true shows results  
- [ ] Verify default browse (no filters) still works
- [ ] Verify collection browse still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)