### PR TITLE
Fix unbalanced search bar padding on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -749,7 +749,7 @@ export default async function HomePage() {
                 type="text"
                 name="q"
                 placeholder="Search the collection..."
-                className="w-full pl-12 pr-4 py-3.5 bg-white border border-stone-200 rounded-full text-stone-900 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-rust/20 focus:border-accent-rust shadow-sm"
+                className="w-full pl-12 pr-12 py-3.5 bg-white border border-stone-200 rounded-full text-stone-900 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-rust/20 focus:border-accent-rust shadow-sm"
               />
             </form>
           </div>


### PR DESCRIPTION
## Summary
- Changed `pr-4` to `pr-12` on the home page search input to match the left padding (`pl-12`), centering the placeholder text in the pill

## Test plan
- [ ] Search bar placeholder text appears visually centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)