### PR TITLE
Add browse pages: titles, authors, years

### DIFF
--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -1,0 +1,122 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { getDb } from '@/lib/mongodb';
+import { authorSlug } from '@/lib/slugify';
+import { notFound } from 'next/navigation';
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+// ISR: rebuild daily.
+export const revalidate = 86400;
+export const dynamicParams = true;
+
+export function generateStaticParams() {
+  return LETTERS.map(letter => ({ letter }));
+}
+
+interface PageProps {
+  params: Promise<{ letter: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { letter } = await params;
+  const l = letter.toUpperCase();
+  return {
+    title: `Authors starting with ${l} - Source Library`,
+    description: `Browse all authors in Source Library whose names begin with the letter ${l}.`,
+    alternates: { canonical: `/browse/authors/${l}` },
+  };
+}
+
+interface AuthorEntry {
+  _id: string;
+  count: number;
+}
+
+export default async function BrowseAuthorsPage({ params }: PageProps) {
+  const { letter } = await params;
+  const l = letter.toUpperCase();
+  if (l.length !== 1 || !/[A-Z]/.test(l)) notFound();
+
+  const db = await getDb();
+
+  // Aggregate distinct authors with book counts, filtered to this letter
+  const authors = await db.collection('books').aggregate<AuthorEntry>([
+    {
+      $match: {
+        hidden: { $ne: true },
+        pages_count: { $gt: 0 },
+        pages_translated: { $gt: 0 },
+        author: { $regex: `^${l}`, $options: 'i' },
+      },
+    },
+    {
+      $group: {
+        _id: '$author',
+        count: { $sum: 1 },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ], { maxTimeMS: 15000 }).toArray();
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <Link href="/browse" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Browse
+      </Link>
+
+      <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+        Authors: {l}
+      </h1>
+      <p className="text-sm mb-8" style={{ color: 'var(--text-muted)' }}>
+        {authors.length.toLocaleString('en-US')} {authors.length === 1 ? 'author' : 'authors'}
+      </p>
+
+      {/* Letter nav */}
+      <div className="flex flex-wrap gap-1.5 mb-10">
+        {LETTERS.map(lt => (
+          <Link
+            key={lt}
+            href={`/browse/authors/${lt}`}
+            className={`w-8 h-8 flex items-center justify-center rounded text-xs font-medium transition-colors ${
+              lt === l ? 'text-white' : 'hover:opacity-70'
+            }`}
+            style={lt === l
+              ? { background: 'var(--text-primary)', color: '#fff' }
+              : { color: 'var(--text-muted)' }
+            }
+          >
+            {lt}
+          </Link>
+        ))}
+      </div>
+
+      {/* Author list */}
+      <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+        {authors.map(author => (
+          <Link
+            key={author._id}
+            href={`/author/${authorSlug(author._id)}`}
+            className="flex items-baseline justify-between py-3 hover:opacity-70 transition-opacity"
+          >
+            <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
+              {author._id}
+            </p>
+            <p className="text-xs tabular-nums" style={{ color: 'var(--text-muted)' }}>
+              {author.count} {author.count === 1 ? 'book' : 'books'}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      {authors.length === 0 && (
+        <p className="py-12 text-center" style={{ color: 'var(--text-muted)' }}>
+          No authors found starting with {l}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -1,0 +1,98 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Browse - Source Library',
+  description: 'Browse the Source Library collection alphabetically by title, author, or publication year.',
+  alternates: { canonical: '/browse' },
+};
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+const CENTURIES = [
+  { label: 'Ancient', slug: 'ancient', range: 'Before 500 CE' },
+  { label: 'Medieval', slug: 'medieval', range: '500–1400' },
+  { label: '15th century', slug: '1400s', range: '1400–1499' },
+  { label: '16th century', slug: '1500s', range: '1500–1599' },
+  { label: '17th century', slug: '1600s', range: '1600–1699' },
+  { label: '18th century', slug: '1700s', range: '1700–1799' },
+  { label: '19th century', slug: '1800s', range: '1800–1899' },
+  { label: '20th century', slug: '1900s', range: '1900–1930' },
+];
+
+export default function BrowsePage() {
+  return (
+    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <Link href="/" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Home
+      </Link>
+
+      <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+        Browse the Collection
+      </h1>
+      <p className="text-lg mb-12" style={{ color: 'var(--text-muted)' }}>
+        Pre-built indexes for browsing without search.
+      </p>
+
+      {/* By Title */}
+      <section className="mb-12">
+        <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+          By Title
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {LETTERS.map(letter => (
+            <Link
+              key={letter}
+              href={`/browse/titles/${letter}`}
+              className="w-10 h-10 flex items-center justify-center rounded-lg text-sm font-medium transition-colors hover:opacity-80"
+              style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-light)' }}
+            >
+              {letter}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* By Author */}
+      <section className="mb-12">
+        <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+          By Author
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {LETTERS.map(letter => (
+            <Link
+              key={letter}
+              href={`/browse/authors/${letter}`}
+              className="w-10 h-10 flex items-center justify-center rounded-lg text-sm font-medium transition-colors hover:opacity-80"
+              style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-light)' }}
+            >
+              {letter}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* By Period */}
+      <section className="mb-12">
+        <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+          By Period
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {CENTURIES.map(c => (
+            <Link
+              key={c.slug}
+              href={`/browse/years/${c.slug}`}
+              className="rounded-lg p-4 transition-colors hover:opacity-80"
+              style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
+            >
+              <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>{c.label}</p>
+              <p className="text-xs" style={{ color: 'var(--text-muted)' }}>{c.range}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -1,0 +1,142 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { getDb } from '@/lib/mongodb';
+import { bookUrl } from '@/lib/slugify';
+import { notFound } from 'next/navigation';
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+// ISR: rebuild daily. These pages are nearly static.
+export const revalidate = 86400;
+export const dynamicParams = true;
+
+export function generateStaticParams() {
+  return LETTERS.map(letter => ({ letter }));
+}
+
+interface PageProps {
+  params: Promise<{ letter: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { letter } = await params;
+  const l = letter.toUpperCase();
+  return {
+    title: `Books starting with ${l} - Source Library`,
+    description: `Browse all translated books in Source Library whose titles begin with the letter ${l}.`,
+    alternates: { canonical: `/browse/titles/${l}` },
+  };
+}
+
+interface BrowseBook {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  language: string;
+  published: string;
+}
+
+export default async function BrowseTitlesPage({ params }: PageProps) {
+  const { letter } = await params;
+  const l = letter.toUpperCase();
+  if (l.length !== 1 || !/[A-Z]/.test(l)) notFound();
+
+  const db = await getDb();
+  const books = await db.collection('books').aggregate<BrowseBook>([
+    {
+      $match: {
+        hidden: { $ne: true },
+        pages_count: { $gt: 0 },
+        pages_translated: { $gt: 0 },
+      },
+    },
+    {
+      $addFields: {
+        _sort_title: {
+          $toUpper: {
+            $substrCP: [{ $ifNull: ['$display_title', '$title'] }, 0, 1],
+          },
+        },
+      },
+    },
+    { $match: { _sort_title: l } },
+    { $sort: { display_title: 1, title: 1 } },
+    {
+      $project: {
+        _id: 0,
+        id: { $ifNull: ['$id', { $toString: '$_id' }] },
+        slug: 1,
+        title: 1,
+        display_title: 1,
+        author: 1,
+        language: 1,
+        published: 1,
+      },
+    },
+  ], { maxTimeMS: 15000 }).toArray();
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <Link href="/browse" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Browse
+      </Link>
+
+      <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+        Titles: {l}
+      </h1>
+      <p className="text-sm mb-8" style={{ color: 'var(--text-muted)' }}>
+        {books.length.toLocaleString('en-US')} {books.length === 1 ? 'book' : 'books'}
+      </p>
+
+      {/* Letter nav */}
+      <div className="flex flex-wrap gap-1.5 mb-10">
+        {LETTERS.map(lt => (
+          <Link
+            key={lt}
+            href={`/browse/titles/${lt}`}
+            className={`w-8 h-8 flex items-center justify-center rounded text-xs font-medium transition-colors ${
+              lt === l ? 'text-white' : 'hover:opacity-70'
+            }`}
+            style={lt === l
+              ? { background: 'var(--text-primary)', color: '#fff' }
+              : { color: 'var(--text-muted)' }
+            }
+          >
+            {lt}
+          </Link>
+        ))}
+      </div>
+
+      {/* Book list */}
+      <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+        {books.map(book => (
+          <Link
+            key={book.id}
+            href={bookUrl(book)}
+            className="block py-3 hover:opacity-70 transition-opacity"
+          >
+            <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
+              {book.display_title || book.title}
+            </p>
+            <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              {book.author}
+              {book.published ? ` · ${book.published}` : ''}
+              {book.language ? ` · ${book.language}` : ''}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      {books.length === 0 && (
+        <p className="py-12 text-center" style={{ color: 'var(--text-muted)' }}>
+          No books found starting with {l}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -1,0 +1,172 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { getDb } from '@/lib/mongodb';
+import { bookUrl } from '@/lib/slugify';
+import { notFound } from 'next/navigation';
+
+const PERIODS: Record<string, { label: string; min: number; max: number }> = {
+  ancient:   { label: 'Ancient (before 500 CE)', min: -9999, max: 499 },
+  medieval:  { label: 'Medieval (500–1400)', min: 500, max: 1399 },
+  '1400s':   { label: '15th Century (1400–1499)', min: 1400, max: 1499 },
+  '1500s':   { label: '16th Century (1500–1599)', min: 1500, max: 1599 },
+  '1600s':   { label: '17th Century (1600–1699)', min: 1600, max: 1699 },
+  '1700s':   { label: '18th Century (1700–1799)', min: 1700, max: 1799 },
+  '1800s':   { label: '19th Century (1800–1899)', min: 1800, max: 1899 },
+  '1900s':   { label: '20th Century (1900–1930)', min: 1900, max: 1930 },
+};
+
+const PERIOD_SLUGS = Object.keys(PERIODS);
+
+// ISR: rebuild daily.
+export const revalidate = 86400;
+export const dynamicParams = true;
+
+export function generateStaticParams() {
+  return PERIOD_SLUGS.map(period => ({ period }));
+}
+
+interface PageProps {
+  params: Promise<{ period: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { period } = await params;
+  const p = PERIODS[period];
+  if (!p) return { title: 'Not Found' };
+  return {
+    title: `${p.label} - Source Library`,
+    description: `Browse all translated books from the ${p.label.toLowerCase()} in Source Library.`,
+    alternates: { canonical: `/browse/years/${period}` },
+  };
+}
+
+interface BrowseBook {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  language: string;
+  published: string;
+  _pub_year: number;
+}
+
+export default async function BrowseYearsPage({ params }: PageProps) {
+  const { period } = await params;
+  const p = PERIODS[period];
+  if (!p) notFound();
+
+  const db = await getDb();
+
+  // published is stored as a string — parse to int for range filtering
+  const books = await db.collection('books').aggregate<BrowseBook>([
+    {
+      $match: {
+        hidden: { $ne: true },
+        pages_count: { $gt: 0 },
+        pages_translated: { $gt: 0 },
+        published: { $exists: true, $ne: '' },
+      },
+    },
+    {
+      $addFields: {
+        _pub_year: {
+          $convert: {
+            input: {
+              $replaceAll: {
+                input: { $replaceAll: { input: '$published', find: 'c.', replacement: '' } },
+                find: '?',
+                replacement: '',
+              },
+            },
+            to: 'int',
+            onError: null,
+            onNull: null,
+          },
+        },
+      },
+    },
+    {
+      $match: {
+        _pub_year: { $gte: p.min, $lte: p.max },
+      },
+    },
+    { $sort: { _pub_year: 1, title: 1 } },
+    {
+      $project: {
+        _id: 0,
+        id: { $ifNull: ['$id', { $toString: '$_id' }] },
+        slug: 1,
+        title: 1,
+        display_title: 1,
+        author: 1,
+        language: 1,
+        published: 1,
+        _pub_year: 1,
+      },
+    },
+  ], { maxTimeMS: 20000 }).toArray();
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <Link href="/browse" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+        </svg>
+        Browse
+      </Link>
+
+      <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+        {p.label}
+      </h1>
+      <p className="text-sm mb-8" style={{ color: 'var(--text-muted)' }}>
+        {books.length.toLocaleString('en-US')} {books.length === 1 ? 'book' : 'books'}
+      </p>
+
+      {/* Period nav */}
+      <div className="flex flex-wrap gap-2 mb-10">
+        {PERIOD_SLUGS.map(slug => (
+          <Link
+            key={slug}
+            href={`/browse/years/${slug}`}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              slug === period ? 'text-white' : 'hover:opacity-70'
+            }`}
+            style={slug === period
+              ? { background: 'var(--text-primary)', color: '#fff' }
+              : { background: 'var(--bg-warm)', color: 'var(--text-muted)', border: '1px solid var(--border-light)' }
+            }
+          >
+            {PERIODS[slug].label.split(' (')[0]}
+          </Link>
+        ))}
+      </div>
+
+      {/* Book list */}
+      <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+        {books.map(book => (
+          <Link
+            key={book.id}
+            href={bookUrl(book)}
+            className="block py-3 hover:opacity-70 transition-opacity"
+          >
+            <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
+              {book.display_title || book.title}
+            </p>
+            <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              {book.author}
+              {book.published ? ` · ${book.published}` : ''}
+              {book.language ? ` · ${book.language}` : ''}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      {books.length === 0 && (
+        <p className="py-12 text-center" style={{ color: 'var(--text-muted)' }}>
+          No books found for this period.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -747,7 +747,7 @@ export default async function HomePage() {
             <p className="text-stone-500 text-sm mb-8">
               {counts.totalBooks.toLocaleString('en-US')} books &middot; {counts.authorCount.toLocaleString('en-US')}+ authors &middot; {counts.languageCount}+ languages
             </p>
-            <form action="/search" method="get" className="relative max-w-lg mx-auto">
+            <form action="/search" method="get" className="relative max-w-lg mx-auto mb-6">
               <svg className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               </svg>
@@ -758,6 +758,14 @@ export default async function HomePage() {
                 className="w-full pl-12 pr-12 py-3.5 bg-white border border-stone-200 rounded-full text-stone-900 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-rust/20 focus:border-accent-rust shadow-sm"
               />
             </form>
+            <p className="text-stone-400 text-sm">
+              or browse by{' '}
+              <Link href="/browse/titles/A" className="text-stone-600 hover:text-accent-rust transition-colors underline underline-offset-2">title</Link>
+              {' '}&middot;{' '}
+              <Link href="/browse/authors/A" className="text-stone-600 hover:text-accent-rust transition-colors underline underline-offset-2">author</Link>
+              {' '}&middot;{' '}
+              <Link href="/browse/years/1500s" className="text-stone-600 hover:text-accent-rust transition-colors underline underline-offset-2">year</Link>
+            </p>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- New `/browse` index page with A-Z grids for titles and authors, plus period cards for years
- `/browse/titles/[A-Z]` — all translated books alphabetically by first letter of display title
- `/browse/authors/[A-Z]` — distinct authors with book counts, linked to author pages
- `/browse/years/[period]` — books grouped by century (ancient through 1930)
- All pages use ISR with 24h revalidation — built once, served as static HTML
- Home page search section now includes "or browse by title, author, year" links

## Test plan
- [ ] `/browse` renders A-Z grids and period cards
- [ ] `/browse/titles/A` shows books starting with A, sorted alphabetically
- [ ] `/browse/authors/M` shows authors starting with M with book counts
- [ ] `/browse/years/1500s` shows 16th century books sorted by year
- [ ] Letter/period nav works across all browse pages
- [ ] Book links go to correct book pages
- [ ] Author links go to correct author pages
- [ ] Home page "or browse by" links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)