### PR TITLE
SEO: fix soft 404s, expand sitemap coverage

### DIFF
--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -79,7 +79,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
-  if (!data) return { title: 'Not Found' };
+  if (!data) return { title: 'Not Found', robots: { index: false, follow: true } };
   const { artwork } = data;
   return {
     title: `${artwork.display_title || artwork.title} — ${artwork.author} — Source Library`,

--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -113,21 +113,8 @@ export async function generateMetadata({
 
   if (!data) {
     return {
-      title: 'Image | Source Library',
-      description: 'Explore historical illustrations from early modern texts.',
-      alternates: {
-        canonical: `/gallery/image/${urlSafeId}`,
-      },
-      openGraph: {
-        title: 'Image',
-        description: 'Explore historical illustrations from early modern texts.',
-        siteName: 'Source Library',
-      },
-      twitter: {
-        card: 'summary_large_image',
-        title: 'Image',
-        description: 'Explore historical illustrations from early modern texts.',
-      },
+      title: 'Image Not Found | Source Library',
+      robots: { index: false, follow: true },
     };
   }
 

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -42,7 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
 
-  if (count === 0) return { title: 'Language Not Found - Source Library' };
+  if (count === 0) return { title: 'Language Not Found - Source Library', robots: { index: false, follow: true } };
 
   const description = `Browse ${count} ${langName} texts in Source Library — digitized and translated from original manuscripts and early printed books.`;
 

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   if (!partner) {
-    return { title: 'Library Not Found - Source Library' };
+    return { title: 'Library Not Found - Source Library', robots: { index: false, follow: true } };
   }
 
   const description = `Browse books digitized by ${partner.name} on Source Library. ${partner.description.slice(0, 120)}...`;

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
-  if (!ep) return { title: 'Episode Not Found - SHWEP Reading Room' };
+  if (!ep) return { title: 'Episode Not Found - SHWEP Reading Room', robots: { index: false, follow: true } };
   return {
     title: `${ep.title} - SHWEP Reading Room`,
     description: ep.description || `Primary sources discussed in SHWEP episode ${ep.number}.`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -198,11 +198,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         };
       });
 
-    // Encyclopedia entities — only substantial entries to focus crawl budget
-    // Raised threshold from 5→20 books: 7,780 entities at ≥5 overwhelmed crawl budget
-    // and most were too thin to index (just a name + book list)
+    // Encyclopedia entities — include entries with descriptions (useful content for search)
+    // Previously threshold was 20 books — too aggressive, hid entities like Hermeticism/Neoplatonism.
+    // Now: ≥5 books AND must have a description (filters out thin stubs).
     const entities = await db.collection('entities').find(
-      { book_count: { $gte: 20 }, description: { $exists: true, $ne: '' } },
+      { book_count: { $gte: 5 }, description: { $exists: true, $ne: '' } },
       { projection: { name: 1, updated_at: 1, book_count: 1 } }
     ).toArray();
 
@@ -249,9 +249,50 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.5,
     }));
 
-    // NOTE: /read and /guide pages removed from sitemap to improve indexing.
-    // For a new domain, focus on book landing pages only.
-    // Individual page URLs also removed — can be discovered via internal links.
+    // Language pages — aggregate distinct languages with enough content
+    const languages = await db.collection('books').aggregate([
+      { $match: { hidden: { $ne: true }, pages_count: { $gt: 0 }, language: { $exists: true, $ne: null } } },
+      { $group: { _id: '$language', count: { $sum: 1 } } },
+      { $match: { count: { $gte: 5 } } },
+    ]).toArray();
+
+    const languagePages: MetadataRoute.Sitemap = languages.map((lang) => ({
+      url: `${baseUrl}/languages/${(lang._id as string).toLowerCase().replace(/\s+/g, '-')}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.5,
+    }));
+
+    // Gallery images — unique historical illustrations with rich metadata
+    // Only include images with museum descriptions (well-curated content)
+    const galleryImages = await db.collection('pages').aggregate([
+      { $match: { 'detected_images': { $exists: true, $ne: [] } } },
+      { $unwind: { path: '$detected_images', includeArrayIndex: 'img_idx' } },
+      { $match: { 'detected_images.museum_description': { $exists: true, $ne: '' } } },
+      { $project: { id: 1, img_idx: 1 } },
+      { $limit: 2000 },
+    ]).toArray();
+
+    const galleryPages: MetadataRoute.Sitemap = galleryImages.map((img) => ({
+      url: `${baseUrl}/gallery/image/${img.id}-${img.img_idx}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.4,
+    }));
+
+    // Work pages — multi-edition comparison pages
+    const works = await db.collection('books').aggregate([
+      { $match: { work_id: { $exists: true, $ne: null }, hidden: { $ne: true } } },
+      { $group: { _id: '$work_id', count: { $sum: 1 } } },
+      { $match: { count: { $gte: 2 } } },
+    ]).toArray();
+
+    const workPages: MetadataRoute.Sitemap = works.map((w) => ({
+      url: `${baseUrl}/work/${w._id}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.5,
+    }));
 
     return [
       ...staticPages,
@@ -262,6 +303,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       ...entityPages,
       ...collectionPages,
       ...libraryPages,
+      ...languagePages,
+      ...galleryPages,
+      ...workPages,
     ];
   } catch (error) {
     console.error('Error generating sitemap:', error);

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -86,7 +86,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
-  if (!match) return { title: 'Topic Not Found - Source Library' };
+  if (!match) return { title: 'Topic Not Found - Source Library', robots: { index: false, follow: true } };
 
   return {
     title: `${match._id} | Source Library`,

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
-  if (editions.length === 0) return { title: 'Work Not Found' };
+  if (editions.length === 0) return { title: 'Work Not Found', robots: { index: false, follow: true } };
 
   const title = workTitle(id);
   const libraries = new Set(editions.map(e => (e as unknown as { image_source?: { provider_name?: string } }).image_source?.provider_name).filter(Boolean));


### PR DESCRIPTION
## Summary
- **Fix soft 404s**: 7 page types were returning 200 status with generic "Not Found" titles but no `noindex` tag — Google indexed them as thin content (496 soft 404s in GSC). Now all not-found responses include `robots: { index: false, follow: true }`.
- **Expand sitemap**: Encyclopedia threshold lowered from ≥20 to ≥5 books (with description required), gallery images with museum descriptions added (~2K pages), language pages and work/edition pages added.
- **Net effect**: Fewer junk pages indexed, more valuable content discoverable.

## Files changed
- `src/app/gallery/image/[id]/layout.tsx` — noindex on not-found
- `src/app/libraries/[slug]/page.tsx` — noindex on not-found  
- `src/app/languages/[code]/page.tsx` — noindex on not-found
- `src/app/artwork/[slug]/page.tsx` — noindex on not-found
- `src/app/topics/[slug]/page.tsx` — noindex on not-found
- `src/app/shwep/[number]/page.tsx` — noindex on not-found
- `src/app/work/[id]/page.tsx` — noindex on not-found
- `src/app/sitemap.ts` — expanded coverage

## Test plan
- [ ] Verify sitemap.xml loads without error (check `/sitemap.xml`)
- [ ] Spot-check a gallery image page has proper metadata (not noindex)
- [ ] Spot-check a missing gallery image returns noindex
- [ ] Check GSC after deploy — soft 404 count should start decreasing
- [ ] Verify encyclopedia entities with 5-19 books now appear in sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)