### PR TITLE
Fix BookPagesSection stats bar showing truncated counts

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -737,11 +737,11 @@ async function BookInfo({ id }: { id: string }) {
           if (membersOnlyUntil && new Date(membersOnlyUntil) > new Date()) {
             return (
               <EarlyAccessGate membersOnlyUntil={membersOnlyUntil}>
-                <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />
+                <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} totalPagesOcr={book.pages_ocr} totalPagesTranslated={book.pages_translated} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />
               </EarlyAccessGate>
             );
           }
-          return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
+          return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} totalPagesOcr={book.pages_ocr} totalPagesTranslated={book.pages_translated} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
         })()}
         <AuthCheck role="admin">
           <BookHistory bookId={book.id} />

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -20,12 +20,14 @@ interface BookPagesSectionProps {
   bookTitle?: string;
   pages: Page[];
   totalPageCount?: number;
+  totalPagesOcr?: number;
+  totalPagesTranslated?: number;
   displayBrightness?: number;
 }
 
 const PAGES_PER_LOAD = 24; // 2 rows on 12-col grid
 
-export default function BookPagesSection({ bookId, bookTitle, pages: initialPages, totalPageCount, displayBrightness }: BookPagesSectionProps) {
+export default function BookPagesSection({ bookId, bookTitle, pages: initialPages, totalPageCount, totalPagesOcr, totalPagesTranslated, displayBrightness }: BookPagesSectionProps) {
   const [pages, setPages] = useState(initialPages);
   const [allPagesFetched, setAllPagesFetched] = useState(
     !totalPageCount || initialPages.length >= totalPageCount
@@ -126,10 +128,9 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
 
   const lastSelectedIndexRef = useRef<number | null>(null);
 
-  // Calculate stats (check updated_at since data is excluded from projection)
-  // When only a partial page set was SSR'd, these are approximate until all pages load
-  const pagesWithOcr = pages.filter(p => p.ocr?.updated_at).length;
-  const pagesWithTranslation = pages.filter(p => p.translation?.updated_at).length;
+  // Use book-level cached counts when available (page array may be truncated to first 100)
+  const pagesWithOcr = totalPagesOcr ?? pages.filter(p => p.ocr?.updated_at).length;
+  const pagesWithTranslation = totalPagesTranslated ?? pages.filter(p => p.translation?.updated_at).length;
   const totalPages = totalPageCount || pages.length;
 
   // Calculate last activity dates


### PR DESCRIPTION
## Summary
Follow-up to #443. BookPagesSection was the component actually rendering the wrong "100 OCR / 89 translated" numbers. It computed stats from the truncated page array. Now takes `totalPagesOcr` and `totalPagesTranslated` props from book-level cached counts.

## Test plan
- [x] Type check passes
- [ ] Verify stats bar on Fludd Amphitheatrum shows 310/344

🤖 Generated with [Claude Code](https://claude.com/claude-code)