### PR TITLE
Limit transliteration to Greek only, complete efm→bph migration

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -213,12 +213,10 @@ const SKIP_TRANSLATION_PAGE_TYPES = [
   'blank',
 ];
 
-// Non-Latin languages that need transliteration
+// Languages that get inline transliteration before translation.
+// Currently Greek only — other scripts are handled by the translator directly.
 const NON_LATIN_LANGUAGES = new Set([
-  'greek', 'hebrew', 'arabic', 'persian', 'ottoman turkish',
-  'syriac', 'chinese', 'japanese', 'korean', 'sanskrit',
-  'armenian', 'georgian', 'ethiopic', 'coptic', 'tibetan',
-  'russian', 'church slavonic',
+  'greek',
 ]);
 
 function isNonLatin(language) {


### PR DESCRIPTION
## Summary
- **Transliteration**: Reduced from 17 non-Latin languages to Greek only. Other scripts are handled by the translator. Prevents pipeline lock starvation (490-page Syriac book blocked pipeline for 13h).
- **efm→bph**: Migrated last 45 books in DB. Code already used 'bph' everywhere. Closes #371.

## Test plan
- [x] Type check passes
- [x] DB verified: 0 efm remaining, 1,282 bph
- [ ] Deploy to Hetzner (re-enable phase 3.7 with Greek-only set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)