### PR TITLE
Image extraction: skip decoratives, save ~36% cost

### DIFF
--- a/src/lib/image-extraction.ts
+++ b/src/lib/image-extraction.ts
@@ -6,7 +6,7 @@
 import Replicate from 'replicate';
 import { images } from '@/lib/api-client';
 
-export const IMAGE_EXTRACTION_PROMPT = `You are a museum curator analyzing a historical book page scan. Create rich metadata for each illustration.
+export const IMAGE_EXTRACTION_PROMPT = `You are a museum curator analyzing a historical book page scan. Extract only significant illustrations — skip decorative elements like ornaments, borders, printer's marks, and initials.
 
 BOUNDING BOX (0.0-1.0 normalized coordinates):
 - x: LEFT edge (0=left, 1=right), y: TOP edge (0=top, 1=bottom)
@@ -18,17 +18,21 @@ IMAGE TYPES (use these exactly):
 - woodcut: Bold relief print lines
 - engraving: Fine detailed intaglio lines, crosshatching
 - portrait: Depiction of a person
-- frontispiece: Decorative title page
+- frontispiece: Decorative title page illustration
 - musical_score: Sheet music, notation, fugues (NOT "table")
 - diagram: Technical/scientific illustration
 - symbol: Alchemical, astrological symbols
-- decorative: Ornaments, borders, initials
 - map: Geographic representation
 
-For each illustration return:
+SKIP these — do NOT include them:
+- Page ornaments, borders, decorative initials, printer's devices
+- Marbled papers, blank frames, ruled lines
+- Any element that is purely decorative with no intellectual content
+
+For each significant illustration return:
 {
   "description": "Brief factual description",
-  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|decorative|map",
+  "type": "emblem|woodcut|engraving|portrait|frontispiece|musical_score|diagram|symbol|map",
   "bbox": { "x": 0.15, "y": 0.25, "width": 0.70, "height": 0.45 },
   "confidence": 0.95,
   "gallery_quality": 0.85,
@@ -47,13 +51,11 @@ GALLERY QUALITY (0.0-1.0):
 - 0.9-1.0: Exceptional emblems, portraits, allegorical scenes with figures
 - 0.8-0.9: Illustrations with people/figures
 - 0.6-0.8: Good illustrations without people
-- 0.4-0.6: Musical scores, standard decorative elements
-- 0.2-0.4: Page ornaments, borders
-- 0.0-0.2: Marbled papers, blank frames
+- 0.4-0.6: Musical scores, alchemical symbols
 
 MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer sees and its significance.
 
-Return ONLY a valid JSON array. If no illustrations, return: []`;
+Return ONLY a valid JSON array. If no significant illustrations, return: []`;
 
 export interface ImageMetadata {
   subjects?: string[];


### PR DESCRIPTION
## Summary
- Updated extraction prompt to explicitly skip decorative elements (ornaments, borders, initials, printer's devices)
- Decoratives were 25,455 of 69,746 gallery images (36%) with avg quality 0.38 — not gallery-worthy
- Saves ~36% on output tokens and gallery storage

## Context
- Flash-lite (3.1) tested for cost savings but bbox accuracy was poor compared to 3-flash-preview
- Detection uses archived_photo (full-res R2 copy) when available; gallery stores bbox for render-time cropping
- Gallery already filters `gallery_quality < 0.5` so most decoratives were excluded from display, but still cost tokens to detect

## Test plan
- [ ] Verify extraction still finds real illustrations (emblems, engravings, diagrams)
- [ ] Verify decorative elements no longer appear in new extractions
- [ ] Lambda needs redeploy after merge: `npm run lambda:prepare && aws lambda update-function-code ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)