### PR TITLE
Add chapter text materialization for AI reading

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -220,6 +220,7 @@ export async function getBook(args: { book_id: string }) {
 
 export async function getBookText(args: {
   book_id: string;
+  chapter?: number;
   content?: string;
   from?: number;
   to?: number;
@@ -227,6 +228,7 @@ export async function getBookText(args: {
   include_metadata?: boolean;
 }) {
   const params = new URLSearchParams();
+  if (args.chapter !== undefined) params.set("chapter", String(args.chapter));
   if (args.content) params.set("content", args.content);
   if (args.from !== undefined) params.set("from", String(args.from));
   if (args.to !== undefined) params.set("to", String(args.to));

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -182,13 +182,17 @@ const TOOLS: Tool[] = [
   {
     name: "get_book_text",
     description:
-      "READ A BOOK — start here. Returns 50+ pages of text (OCR and/or translations) in a single call, each with a citation URL. Use page ranges (from/to) for focused reading. This is the primary tool for reading and analyzing book content.",
+      "READ A BOOK — start here. Preferred: use 'chapter' param to read one chapter at a time (includes page markers like [Page 42] for citation). Or use page ranges (from/to) for focused reading. Call get_book first to see the chapter list.",
     inputSchema: {
       type: "object" as const,
       properties: {
         book_id: {
           type: "string",
           description: "The book ID",
+        },
+        chapter: {
+          type: "number",
+          description: "Chapter index (0-based). Returns the full chapter text with embedded [Page N] markers for citation. Preferred over from/to for reading.",
         },
         content: {
           type: "string",
@@ -197,16 +201,16 @@ const TOOLS: Tool[] = [
         },
         from: {
           type: "number",
-          description: "Start page number (inclusive)",
+          description: "Start page number (inclusive). Use chapter param instead when possible.",
         },
         to: {
           type: "number",
-          description: "End page number (inclusive)",
+          description: "End page number (inclusive). Use chapter param instead when possible.",
         },
         format: {
           type: "string",
           enum: ["json", "plain"],
-          description: "Response format: 'json' (structured with per-page URLs, default) or 'plain' (concatenated text with page markers)",
+          description: "Response format: 'json' (structured, default) or 'plain' (concatenated text with page markers)",
         },
         include_metadata: {
           type: "boolean",

--- a/scripts/backfill-chapter-texts.mjs
+++ b/scripts/backfill-chapter-texts.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Backfill chapter texts for all books that have chapters extracted
+ * but no materialized chapter_texts yet.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/backfill-chapter-texts.mjs [--limit N] [--book-id ID]
+ */
+
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const limitArg = args.includes('--limit') ? parseInt(args[args.indexOf('--limit') + 1]) : 0;
+const bookIdArg = args.includes('--book-id') ? args[args.indexOf('--book-id') + 1] : null;
+
+const client = new MongoClient(MONGODB_URI);
+
+function computeEndPages(chapters, totalPages) {
+  for (let i = 0; i < chapters.length; i++) {
+    if (i < chapters.length - 1) {
+      chapters[i].endPage = chapters[i + 1].pageNumber - 1;
+    } else {
+      chapters[i].endPage = totalPages;
+    }
+  }
+  return chapters;
+}
+
+async function materializeBook(db, book) {
+  const chapters = computeEndPages(book.chapters, book.pages_count || 0);
+
+  const pages = await db.collection('pages')
+    .find(
+      { book_id: book.id },
+      { projection: { page_number: 1, 'ocr.data': 1, 'translation.data': 1 } },
+    )
+    .sort({ page_number: 1 })
+    .toArray();
+
+  const pageMap = new Map();
+  for (const p of pages) {
+    pageMap.set(p.page_number, {
+      ocr: p.ocr?.data || undefined,
+      translation: p.translation?.data || undefined,
+    });
+  }
+
+  const docs = [];
+  let totalTokens = 0;
+
+  for (let i = 0; i < chapters.length; i++) {
+    const ch = chapters[i];
+    const startPage = ch.pageNumber;
+    const endPage = ch.endPage || book.pages_count || 0;
+    const translationParts = [];
+    const ocrParts = [];
+
+    // Start with chapter header for structural context
+    const chapterLabel = ch.titleEn
+      ? `# ${ch.title}\n## ${ch.titleEn}`
+      : `# ${ch.title}`;
+    translationParts.push(chapterLabel);
+    ocrParts.push(`# ${ch.title}`);
+
+    for (let pn = startPage; pn <= endPage; pn++) {
+      const page = pageMap.get(pn);
+      if (!page) continue;
+      const marker = `[Page ${pn}]`;
+      if (page.translation) {
+        translationParts.push(`${marker}\n${page.translation}`);
+      } else if (page.ocr) {
+        translationParts.push(`${marker}\n${page.ocr}`);
+      }
+      if (page.ocr) {
+        ocrParts.push(`${marker}\n${page.ocr}`);
+      }
+    }
+
+    const text = translationParts.join('\n\n');
+    const ocrText = ocrParts.join('\n\n');
+    const tokenEstimate = Math.round(text.length / 4);
+    totalTokens += tokenEstimate;
+
+    docs.push({
+      book_id: book.id,
+      chapter_index: i,
+      title: ch.title,
+      titleEn: ch.titleEn,
+      level: ch.level,
+      pageStart: startPage,
+      pageEnd: endPage,
+      text,
+      ocr_text: ocrText || undefined,
+      token_estimate: tokenEstimate,
+      materialized_at: new Date(),
+    });
+  }
+
+  await db.collection('chapter_texts').deleteMany({ book_id: book.id });
+  if (docs.length > 0) {
+    await db.collection('chapter_texts').insertMany(docs);
+  }
+
+  // Update book with endPages
+  await db.collection('books').updateOne(
+    { id: book.id },
+    { $set: { chapters, chapter_texts_at: new Date() } },
+  );
+
+  return { chapters: docs.length, totalTokens };
+}
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+
+  // Ensure index on chapter_texts
+  await db.collection('chapter_texts').createIndex({ book_id: 1, chapter_index: 1 });
+
+  // Find books with chapters but no materialized text
+  const filter = {
+    'chapters.0': { $exists: true },
+    ...(bookIdArg ? { id: bookIdArg } : { chapter_texts_at: { $exists: false } }),
+  };
+
+  const cursor = db.collection('books')
+    .find(filter, { projection: { id: 1, title: 1, chapters: 1, pages_count: 1 } })
+    .sort({ pages_count: -1 });
+
+  if (limitArg > 0) cursor.limit(limitArg);
+
+  const books = await cursor.toArray();
+  console.log(`Found ${books.length} books to materialize`);
+
+  let done = 0;
+  let totalChapters = 0;
+  let totalTokens = 0;
+
+  for (const book of books) {
+    try {
+      const result = await materializeBook(db, book);
+      totalChapters += result.chapters;
+      totalTokens += result.totalTokens;
+      done++;
+      if (done % 50 === 0 || done === books.length) {
+        console.log(`  ${done}/${books.length} — ${totalChapters} chapters, ~${Math.round(totalTokens / 1000)}K tokens`);
+      }
+    } catch (err) {
+      console.error(`  Error on ${book.id} (${book.title}): ${err.message}`);
+    }
+  }
+
+  console.log(`\nDone: ${done} books, ${totalChapters} chapters, ~${Math.round(totalTokens / 1000)}K tokens total`);
+  await client.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/books/[id]/chat/route.ts
+++ b/src/app/api/books/[id]/chat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getGeminiClient } from '@/lib/gemini-client';
 import { withAuth } from '@/lib/auth-helpers';
+import { getChapterTexts } from '@/lib/chapter-text';
 import { z } from 'zod';
 
 // Validation schema for chat messages
@@ -121,7 +122,56 @@ async function searchBookPages(
   return scoredPages.slice(0, limit).map(sp => sp.page);
 }
 
-// Build context from book data with RAG-based page retrieval
+// Search chapter texts for relevant content using keyword matching
+async function searchChapterTexts(
+  bookId: string,
+  query: string,
+  limit: number = 3,
+): Promise<Array<{ index: number; title: string; titleEn?: string; pageStart: number; pageEnd: number; text: string; score: number }>> {
+  const db = await getDb();
+  const chapters = await getChapterTexts(db, bookId);
+  if (chapters.length === 0) return [];
+
+  const keywords = extractKeywords(query);
+  if (keywords.length === 0) {
+    // No keywords — return first chapter
+    return chapters.slice(0, 1).map(ct => ({
+      index: ct.chapter_index,
+      title: ct.title,
+      titleEn: ct.titleEn,
+      pageStart: ct.pageStart,
+      pageEnd: ct.pageEnd,
+      text: ct.text,
+      score: 0,
+    }));
+  }
+
+  // Score each chapter by keyword density
+  const scored = chapters.map(ct => {
+    const text = ct.text.toLowerCase();
+    let score = 0;
+    for (const kw of keywords) {
+      const matches = (text.match(new RegExp(kw, 'gi')) || []).length;
+      score += matches;
+    }
+    return {
+      index: ct.chapter_index,
+      title: ct.title,
+      titleEn: ct.titleEn,
+      pageStart: ct.pageStart,
+      pageEnd: ct.pageEnd,
+      text: ct.text,
+      score,
+    };
+  });
+
+  return scored
+    .filter(s => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+// Build context from book data — prefers chapter-level retrieval, falls back to page-level
 async function buildBookContext(
   bookId: string,
   userQuery: string
@@ -131,10 +181,8 @@ async function buildBookContext(
   const book = await db.collection('books').findOne({ id: bookId }) as unknown as BookData | null;
   if (!book) throw new Error('Book not found');
 
-  // Get total page count for reference
   const totalPages = book.pages_count || 0;
 
-  // Build context string with book info
   let context = `# Book Information
 Title: ${book.display_title || book.title}
 Author: ${book.author || 'Unknown'}
@@ -142,7 +190,6 @@ Language: ${book.language || 'Unknown'}
 Total Pages: ${totalPages}
 `;
 
-  // Add summary if available
   if (book.index?.bookSummary?.abstract) {
     context += `\n## Summary\n${book.index.bookSummary.abstract}\n`;
   }
@@ -151,24 +198,40 @@ Total Pages: ${totalPages}
     context += `\n## Detailed Overview\n${book.index.bookSummary.detailed}\n`;
   }
 
-  // Use RAG to find relevant pages based on the user's query
-  const relevantPages = await searchBookPages(bookId, userQuery, 15);
+  // Try chapter-level retrieval first (better context, includes page markers for citation)
+  const relevantChapters = await searchChapterTexts(bookId, userQuery, 3);
 
-  if (relevantPages.length > 0) {
-    context += `\n## Relevant Pages (based on your question)\n`;
-    context += `The following pages from the book are most relevant to your question:\n`;
+  if (relevantChapters.length > 0) {
+    context += `\n## Relevant Chapters\n`;
+    // Budget: ~80K chars total for chapter text to stay within model limits
+    let charBudget = 80000;
+    for (const ch of relevantChapters) {
+      const title = ch.titleEn || ch.title;
+      context += `\n### ${title} (pages ${ch.pageStart}–${ch.pageEnd})\n`;
+      if (ch.text.length <= charBudget) {
+        context += ch.text + '\n';
+        charBudget -= ch.text.length;
+      } else {
+        context += ch.text.substring(0, charBudget) + '\n...(truncated)\n';
+        break;
+      }
+    }
+  } else {
+    // Fall back to page-level search (no chapter texts materialized)
+    const relevantPages = await searchBookPages(bookId, userQuery, 15);
 
-    // Sort by page number for readability
-    relevantPages.sort((a, b) => a.page_number - b.page_number);
+    if (relevantPages.length > 0) {
+      context += `\n## Relevant Pages (based on your question)\n`;
+      relevantPages.sort((a, b) => a.page_number - b.page_number);
 
-    for (const page of relevantPages) {
-      const cleaned = cleanText(page.translation?.data || '');
-      if (cleaned.length > 50) {
-        // Include full page content (up to 2000 chars per page)
-        const content = cleaned.length > 2000
-          ? cleaned.substring(0, 2000) + '...'
-          : cleaned;
-        context += `\n### Page ${page.page_number}\n${content}\n`;
+      for (const page of relevantPages) {
+        const cleaned = cleanText(page.translation?.data || '');
+        if (cleaned.length > 50) {
+          const content = cleaned.length > 2000
+            ? cleaned.substring(0, 2000) + '...'
+            : cleaned;
+          context += `\n### Page ${page.page_number}\n${content}\n`;
+        }
       }
     }
   }

--- a/src/app/api/books/[id]/materialize-chapters/route.ts
+++ b/src/app/api/books/[id]/materialize-chapters/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { materializeChapterTexts } from '@/lib/chapter-text';
+import { withAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 60;
+
+/**
+ * POST /api/books/[id]/materialize-chapters
+ *
+ * Concatenates page text into chapter-sized chunks and stores them
+ * in the `chapter_texts` collection. Requires chapters to be extracted first.
+ */
+export const POST = withAuth(async (request, session, context) => {
+  try {
+    const { id } = await context.params;
+    const db = await getDb();
+
+    const book = await db.collection('books').findOne(
+      { id },
+      { projection: { chapters: 1, title: 1 } },
+    );
+    if (!book) {
+      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+    }
+    if (!book.chapters?.length) {
+      return NextResponse.json({ error: 'No chapters extracted yet. Run extract-chapters first.' }, { status: 400 });
+    }
+
+    const result = await materializeChapterTexts(db, id);
+
+    return NextResponse.json({
+      success: true,
+      book_id: id,
+      title: book.title,
+      ...result,
+    });
+  } catch (error) {
+    console.error('Error materializing chapters:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to materialize chapters' },
+      { status: 500 },
+    );
+  }
+});

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { isBot, isTrustedBot, isBotAccessible, botGateResponse } from '@/lib/bot-gate';
+import { getChapterTexts } from '@/lib/chapter-text';
 
 export const maxDuration = 30;
 
@@ -15,6 +16,7 @@ export const maxDuration = 30;
  *   content=ocr|translation|both (default: both)
  *   from=N  — start page number (inclusive)
  *   to=N    — end page number (inclusive)
+ *   chapter=N — return chapter N (0-indexed). Overrides from/to.
  *   format=json|plain (default: json)
  *   include_metadata=true — include page-level OCR/translation metadata
  */
@@ -29,6 +31,7 @@ export async function GET(
     const content = searchParams.get('content') || 'both';
     const fromPage = searchParams.get('from') ? parseInt(searchParams.get('from')!) : undefined;
     const toPage = searchParams.get('to') ? parseInt(searchParams.get('to')!) : undefined;
+    const chapterParam = searchParams.get('chapter');
     const format = searchParams.get('format') || 'json';
     const includeMetadata = searchParams.get('include_metadata') === 'true';
 
@@ -66,6 +69,70 @@ export async function GET(
         botGateResponse({ ...book, ...fullBook, id: resolvedBookId }),
         { status: 200, headers: { 'Cache-Control': 'public, max-age=3600' } }
       );
+    }
+
+    // Chapter mode: return pre-materialized chapter text
+    if (chapterParam !== null) {
+      const chapterIndex = parseInt(chapterParam);
+      if (isNaN(chapterIndex) || chapterIndex < 0) {
+        return NextResponse.json({ error: 'chapter must be a non-negative integer' }, { status: 400 });
+      }
+
+      const chapterTexts = await getChapterTexts(db, resolvedBookId, chapterIndex);
+
+      if (chapterTexts.length === 0) {
+        // Fall back: check if chapters exist but aren't materialized yet
+        const bookWithChapters = await db.collection('books').findOne(
+          { id: resolvedBookId },
+          { projection: { chapters: 1 } },
+        );
+        if (bookWithChapters?.chapters?.[chapterIndex]) {
+          return NextResponse.json({
+            error: 'Chapter exists but text not yet materialized. Run POST /api/books/{id}/materialize-chapters first.',
+            chapter: bookWithChapters.chapters[chapterIndex],
+          }, { status: 404 });
+        }
+        return NextResponse.json({ error: 'Chapter not found' }, { status: 404 });
+      }
+
+      const ct = chapterTexts[0];
+      if (format === 'plain') {
+        const header = [
+          `# ${book.display_title || book.title}`,
+          `# ${book.author} (${book.published || 'n.d.'})`,
+          `# Chapter ${chapterIndex}: ${ct.titleEn || ct.title}`,
+          `# Pages ${ct.pageStart}–${ct.pageEnd}`,
+          `# Source: https://sourcelibrary.org/book/${resolvedBookId}`,
+          '',
+          content === 'ocr' ? (ct.ocr_text || ct.text) : ct.text,
+        ].join('\n');
+
+        return new Response(header, {
+          headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'public, max-age=3600' },
+        });
+      }
+
+      return NextResponse.json({
+        book: {
+          id: resolvedBookId,
+          title: book.display_title || book.title,
+          author: book.author,
+          url: `https://sourcelibrary.org/book/${resolvedBookId}`,
+        },
+        chapter: {
+          index: ct.chapter_index,
+          title: ct.title,
+          titleEn: ct.titleEn,
+          level: ct.level,
+          pageStart: ct.pageStart,
+          pageEnd: ct.pageEnd,
+          token_estimate: ct.token_estimate,
+          text: content === 'ocr' ? (ct.ocr_text || ct.text) : ct.text,
+          ...(content === 'both' && ct.ocr_text ? { ocr_text: ct.ocr_text } : {}),
+        },
+      }, {
+        headers: { 'Cache-Control': 'public, max-age=3600' },
+      });
     }
 
     // Build page query

--- a/src/app/api/cron/enrich-books/route.ts
+++ b/src/app/api/cron/enrich-books/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { verifyCronAuth } from '@/lib/cron-auth';
 import { extractChaptersForBook } from '@/lib/chapter-extraction';
+import { materializeChapterTexts } from '@/lib/chapter-text';
 import { scoreBookQuality } from '@/lib/quality-scoring';
 import { scoreBookAlignment } from '@/lib/semantic-alignment';
 import { scoreCollectionRelevance } from '@/lib/collection-relevance';
@@ -227,6 +228,8 @@ export async function GET(request: NextRequest) {
           );
 
           await extractChaptersForBook(db, book.id);
+          // Materialize chapter text (concatenate pages into chapter chunks)
+          await materializeChapterTexts(db, book.id);
 
           await db.collection('books').updateOne(
             { id: book.id },

--- a/src/lib/chapter-extraction.ts
+++ b/src/lib/chapter-extraction.ts
@@ -15,6 +15,7 @@ import { getGeminiClient } from '@/lib/gemini-client';
 import { logGeminiCall } from '@/lib/gemini-logger';
 import { DEFAULT_MODEL } from '@/lib/types';
 import { MODEL_PRICING } from '@/lib/ai';
+import { computeEndPages } from '@/lib/chapter-text';
 import type { Chapter } from '@/lib/types';
 
 interface RawHeading {
@@ -312,6 +313,9 @@ export async function extractChaptersForBook(
   }
 
   chapters.sort((a, b) => a.pageNumber - b.pageNumber);
+
+  // Compute endPage for each chapter
+  computeEndPages(chapters, pages.length);
 
   // Save to book
   await db.collection('books').updateOne(

--- a/src/lib/chapter-text.ts
+++ b/src/lib/chapter-text.ts
@@ -1,0 +1,178 @@
+/**
+ * Chapter Text Materialization
+ *
+ * Concatenates page-level text into chapter-sized chunks for AI reading,
+ * search, and RAG. Chapters are the optimal unit for LLM comprehension
+ * (~10K-50K tokens vs ~300-500 per page).
+ *
+ * Source of truth remains the `pages` collection. Chapter texts are derived
+ * and stored in `chapter_texts` for fast retrieval.
+ */
+
+import type { Db } from 'mongodb';
+import type { Chapter } from '@/lib/types';
+
+export interface ChapterText {
+  book_id: string;
+  chapter_index: number;
+  title: string;
+  titleEn?: string;
+  level: number;
+  pageStart: number;
+  pageEnd: number;
+  text: string;           // Concatenated translation (or OCR fallback)
+  ocr_text?: string;      // Concatenated original language text
+  token_estimate: number; // Rough token count (~4 chars/token)
+  materialized_at: Date;
+}
+
+/**
+ * Compute endPage for each chapter based on the next chapter's start page.
+ * Mutates the chapters array in place and returns it.
+ */
+export function computeEndPages(chapters: Chapter[], totalPages: number): Chapter[] {
+  for (let i = 0; i < chapters.length; i++) {
+    if (i < chapters.length - 1) {
+      chapters[i].endPage = chapters[i + 1].pageNumber - 1;
+    } else {
+      chapters[i].endPage = totalPages;
+    }
+  }
+  return chapters;
+}
+
+/**
+ * Materialize chapter texts for a single book.
+ * Fetches page text, concatenates by chapter boundaries, and upserts
+ * into the `chapter_texts` collection.
+ *
+ * @returns Number of chapters materialized
+ */
+export async function materializeChapterTexts(
+  db: Db,
+  bookId: string,
+): Promise<{ chapters: number; totalTokens: number }> {
+  const book = await db.collection('books').findOne(
+    { id: bookId },
+    { projection: { chapters: 1, pages_count: 1 } },
+  );
+
+  if (!book?.chapters?.length) {
+    return { chapters: 0, totalTokens: 0 };
+  }
+
+  const chapters: Chapter[] = book.chapters;
+  const totalPages = book.pages_count || 0;
+  computeEndPages(chapters, totalPages);
+
+  // Fetch all pages with text in one query
+  const pages = await db.collection('pages')
+    .find(
+      { book_id: bookId },
+      { projection: { page_number: 1, 'ocr.data': 1, 'translation.data': 1 } },
+    )
+    .sort({ page_number: 1 })
+    .toArray();
+
+  // Index pages by page_number for fast lookup
+  const pageMap = new Map<number, { ocr?: string; translation?: string }>();
+  for (const p of pages) {
+    pageMap.set(p.page_number, {
+      ocr: p.ocr?.data || undefined,
+      translation: p.translation?.data || undefined,
+    });
+  }
+
+  const docs: ChapterText[] = [];
+  let totalTokens = 0;
+
+  for (let i = 0; i < chapters.length; i++) {
+    const ch = chapters[i];
+    const startPage = ch.pageNumber;
+    const endPage = ch.endPage || totalPages;
+
+    const translationParts: string[] = [];
+    const ocrParts: string[] = [];
+
+    // Start with chapter header for structural context
+    const chapterLabel = ch.titleEn
+      ? `# ${ch.title}\n## ${ch.titleEn}`
+      : `# ${ch.title}`;
+    translationParts.push(chapterLabel);
+    ocrParts.push(`# ${ch.title}`);
+
+    for (let pn = startPage; pn <= endPage; pn++) {
+      const page = pageMap.get(pn);
+      if (!page) continue;
+
+      // Embed page markers so readers can cite specific pages
+      const marker = `[Page ${pn}]`;
+
+      if (page.translation) {
+        translationParts.push(`${marker}\n${page.translation}`);
+      } else if (page.ocr) {
+        translationParts.push(`${marker}\n${page.ocr}`);
+      }
+
+      if (page.ocr) {
+        ocrParts.push(`${marker}\n${page.ocr}`);
+      }
+    }
+
+    const text = translationParts.join('\n\n');
+    const ocrText = ocrParts.join('\n\n');
+    const tokenEstimate = Math.round(text.length / 4);
+    totalTokens += tokenEstimate;
+
+    docs.push({
+      book_id: bookId,
+      chapter_index: i,
+      title: ch.title,
+      titleEn: ch.titleEn,
+      level: ch.level,
+      pageStart: startPage,
+      pageEnd: endPage,
+      text,
+      ocr_text: ocrText || undefined,
+      token_estimate: tokenEstimate,
+      materialized_at: new Date(),
+    });
+  }
+
+  // Upsert: delete old chapter texts for this book, insert new ones
+  await db.collection('chapter_texts').deleteMany({ book_id: bookId });
+  if (docs.length > 0) {
+    await db.collection('chapter_texts').insertMany(docs);
+  }
+
+  // Update book with endPages and materialization timestamp
+  await db.collection('books').updateOne(
+    { id: bookId },
+    {
+      $set: {
+        chapters: chapters,
+        chapter_texts_at: new Date(),
+      },
+    },
+  );
+
+  return { chapters: docs.length, totalTokens };
+}
+
+/**
+ * Get chapter texts for a book, optionally filtered by chapter index.
+ */
+export async function getChapterTexts(
+  db: Db,
+  bookId: string,
+  chapterIndex?: number,
+): Promise<ChapterText[]> {
+  const filter: Record<string, unknown> = { book_id: bookId };
+  if (chapterIndex !== undefined) {
+    filter.chapter_index = chapterIndex;
+  }
+  return db.collection('chapter_texts')
+    .find(filter)
+    .sort({ chapter_index: 1 })
+    .toArray() as unknown as ChapterText[];
+}

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -282,6 +282,7 @@ export interface Chapter {
   titleEn?: string;    // English translation of title
   pageId: string;
   pageNumber: number;
+  endPage?: number;    // Last page of this chapter (computed from next chapter's start)
   level: number;  // 1 = top-level division, 2 = major chapter, 3 = sub-chapter
   confidence?: 'high' | 'medium' | 'low'; // AI's confidence in this chapter boundary
 }


### PR DESCRIPTION
## Summary

- Pages (~300-500 tokens each) are too small for AI comprehension. Chapters (~10K-50K tokens) are the optimal reading unit.
- New `chapter_texts` collection stores concatenated page text per chapter, with embedded `[Page N]` markers for citation and chapter titles as headers.
- Text API, MCP server, and chat RAG all upgraded to support chapter-level retrieval.
- Pipeline auto-materializes after chapter extraction. Backfill script included.

## What changed

| File | Change |
|------|--------|
| `src/lib/chapter-text.ts` | New library: materialize, query, compute endPages |
| `src/lib/types/book.ts` | `Chapter.endPage` field added |
| `src/lib/chapter-extraction.ts` | Computes endPage on extraction |
| `src/app/api/books/[id]/text/route.ts` | `?chapter=N` param for chapter text |
| `src/app/api/books/[id]/materialize-chapters/route.ts` | New POST endpoint |
| `src/app/api/books/[id]/chat/route.ts` | RAG searches chapters first, falls back to pages |
| `src/app/api/cron/enrich-books/route.ts` | Auto-materialize in pipeline |
| `mcp-server/src/{api,index}.ts` | `chapter` param on `get_book_text` |
| `scripts/backfill-chapter-texts.mjs` | Backfill for existing books |

## Test plan

- [ ] Run backfill on a few books: `node scripts/backfill-chapter-texts.mjs --limit 5`
- [ ] Verify `chapter_texts` collection populated with correct page ranges
- [ ] Test `/api/books/{id}/text?chapter=0` returns chapter text with page markers
- [ ] Test chat endpoint uses chapter context when available
- [ ] Verify pipeline still works end-to-end (chapter extraction → materialization)

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)