### PR TITLE
Route non-BPH books to gemini-3.1-flash-lite for OCR/translation

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -36,7 +36,13 @@ const SQS_IMAGE_EXTRACTION_QUEUE_URL = process.env.SQS_PAGE_IMAGE_EXTRACTION_QUE
 
 // Gemini Batch API config (for direct OCR submission, bypassing Vercel)
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
-const OCR_MODEL = 'gemini-3-flash-preview';
+const OCR_MODEL_FLASH = 'gemini-3-flash-preview';
+const OCR_MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+function getOcrModelForBook(book) {
+  if (book?.image_source?.provider === 'bph') return OCR_MODEL_FLASH;
+  return OCR_MODEL_LITE;
+}
+const OCR_MODEL = OCR_MODEL_FLASH; // Legacy fallback for recitation retry path
 const OCR_PROMPT_VERSION = 'v5.2026-02';
 const OCR_INLINE_BATCH_SIZE = 20;  // Pages per inline batch (base64 in body, ~20MB limit)
 const OCR_FILE_BATCH_SIZE = 150;   // Pages per file-based batch (JSONL uploaded to File API)
@@ -246,7 +252,13 @@ function hashString(str) {
   return hash.toString(16);
 }
 
-const TRANSLATE_MODEL = 'gemini-3-flash-preview';
+const TRANSLATE_MODEL_FLASH = 'gemini-3-flash-preview';
+const TRANSLATE_MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+function getTranslateModelForBook(book) {
+  if (book?.image_source?.provider === 'bph') return TRANSLATE_MODEL_FLASH;
+  return TRANSLATE_MODEL_LITE;
+}
+const TRANSLATE_MODEL = TRANSLATE_MODEL_FLASH; // Legacy fallback
 const TRANSLATE_PROMPT_VERSION = 'v5.2026-02';
 const TRANSLITERATION_MODEL = 'gemini-3.1-flash-lite-preview';
 const TRANSLITERATION_PROMPT = `You are a scholarly transliterator. Convert the following text to Latin characters using standard academic Romanization conventions.
@@ -827,7 +839,7 @@ async function getOcrPromptFromDb(db) {
  * A 300-page book now uses 2 batch jobs instead of 15.
  */
 async function submitOcrDirectly(db, book, { modelOverride } = {}) {
-  const ocrModel = modelOverride || OCR_MODEL;
+  const ocrModel = modelOverride || getOcrModelForBook(book);
   // Guard: check for existing active batch_jobs for this book
   const activeBatchForBook = await db.collection('batch_jobs').countDocuments({
     book_id: book.id,

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -25,7 +25,12 @@ const CONCURRENCY = 15;          // Max books translating simultaneously
 const PAGES_PER_RUN = 5000;      // Global page cap per run (prevent runaway costs)
 const MAX_CONSECUTIVE_ERRORS = 5; // Per-book error threshold before giving up
 const RATE_LIMIT_BACKOFF_MS = 15000;
-const MODEL = 'gemini-3-flash-preview';
+const MODEL_FLASH = 'gemini-3-flash-preview';
+const MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+function getModelForBook(book) {
+  if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
+  return MODEL_LITE;
+}
 const PROMPT_VERSION = 'v6';
 
 // ── Gemini API keys ──
@@ -128,7 +133,8 @@ async function translatePage(db, page, book, prevTranslation) {
   }
 
   const ai = getClient();
-  const model = ai.getGenerativeModel({ model: MODEL });
+  const selectedModel = getModelForBook(book);
+  const model = ai.getGenerativeModel({ model: selectedModel });
   const start = Date.now();
   const result = await model.generateContent(prompt);
   const durationMs = Date.now() - start;
@@ -237,7 +243,7 @@ async function processBook(db, book, job, globalCounter) {
               data: result.text,
               content_hash: contentHash(result.text),
               language: 'English',
-              model: MODEL,
+              model: getModelForBook(book),
               updated_at: new Date(),
               source: 'ai',
               prompt_version: PROMPT_VERSION,
@@ -252,7 +258,7 @@ async function processBook(db, book, job, globalCounter) {
       await db.collection('gemini_usage').insertOne({
         type: 'translation',
         mode: 'realtime',
-        model: MODEL,
+        model: getModelForBook(book),
         book_id: book.id,
         page_ids: [page.id],
         input_tokens: result.inputTokens,
@@ -296,7 +302,7 @@ async function processBook(db, book, job, globalCounter) {
         await db.collection('gemini_usage').insertOne({
           type: 'translation',
           mode: 'realtime',
-          model: MODEL,
+          model: getModelForBook(book),
           book_id: book.id,
           page_ids: [page.id],
           input_tokens: 0,

--- a/src/app/api/jobs/queue-books/route.ts
+++ b/src/app/api/jobs/queue-books/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { nanoid } from 'nanoid';
-import { DEFAULT_MODEL } from '@/lib/types/ai-models';
+import { getModelForBook } from '@/lib/types/ai-models';
 import type { JobStatus, JobType } from '@/lib/types/job';
 import { enqueuePagesForJob } from '@/lib/queue-utils';
 import { withAuth } from '@/lib/auth-helpers';
@@ -105,7 +105,7 @@ export const POST = withAuth(async (request, session) => {
       config: {
         page_ids: pageIds,
         custom_prompt: customPrompt,
-        model: DEFAULT_MODEL,
+        model: getModelForBook(book as { image_source?: { provider?: string } }),
         language: book.language || "auto-detect"
       },
       initiated_by: 'user',

--- a/src/lib/types/ai-models.ts
+++ b/src/lib/types/ai-models.ts
@@ -1,11 +1,25 @@
 // Available Gemini models for processing
 export const GEMINI_MODELS = [
-  { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Latest Model - Best Quality (Recommended)' },
-  { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Previous Generation - Lower Cost' },
+  { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Best Quality - Use for BPH and complex content' },
+  { id: 'gemini-3.1-flash-lite-preview', name: 'Gemini 3.1 Flash Lite', description: 'Cost-Efficient - 50% cheaper, comparable quality' },
 ] as const;
 
-// Default model for single-page realtime operations (best quality)
+// Full-quality model (BPH books, complex scripts, image extraction)
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
+
+// Cost-efficient model for standard OCR and translation
+export const DEFAULT_LITE_MODEL = 'gemini-3.1-flash-lite-preview';
 
 // Default model for batch operations (50% cheaper via Batch API)
 export const DEFAULT_BATCH_MODEL = 'gemini-3-flash-preview';
+
+/**
+ * Select the appropriate model for a book's OCR/translation.
+ * BPH books get full flash; everything else gets flash-lite.
+ */
+export function getModelForBook(book: { image_source?: { provider?: string } } | null): string {
+  if (book?.image_source?.provider === 'bph') {
+    return DEFAULT_MODEL;
+  }
+  return DEFAULT_LITE_MODEL;
+}


### PR DESCRIPTION
## Summary
- Routes all non-BPH books to `gemini-3.1-flash-lite-preview` for OCR and translation (~50% cost savings)
- BPH books (`image_source.provider === 'bph'`) continue using `gemini-3-flash-preview`
- Translation prompt v9 created in DB with few-shot `<term>`/`<gloss>` examples to improve annotation density on lite model

## A/B Test Results (production prompts, 6 languages, 3 samples each)

**OCR:** 90.4% similarity (lite) vs 91.8% (flash) — 49% cost savings
**Translation:** 90.9% similarity (lite) vs 88.6% (flash) — 56% cost savings
**Cost per 100 pages:** $1.04 (flash) → $0.49 (lite)

Non-Latin scripts tested: Sanskrit (-3.7pp), Chinese (-2.2pp), Hebrew (-10.5pp on handwritten manuscripts).

## Data Provenance
- Model name recorded on every page: `ocr.model` and `translation.model`
- Model name logged to `gemini_usage` collection per API call
- Every page processed with lite will have `gemini-3.1-flash-lite-preview` in its metadata

## Test plan
- [ ] Merge and deploy
- [ ] Run a few books through OCR and translation
- [ ] Spot-check quality on the translated pages vs existing flash translations
- [ ] Monitor `gemini_usage` collection for cost per page

🤖 Generated with [Claude Code](https://claude.com/claude-code)