### PR TITLE
Fix translation model routing: use lite for non-BPH books

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2021,7 +2021,7 @@ async function run() {
           { $match: { 'pipeline_auto.status': { $in: ['metadata_enriched', 'ft_verified'] } } },
           { $addFields: { _latinFirst: { $cond: [{ $eq: ['$language', 'Latin'] }, 0, 1] } } },
           { $sort: { _latinFirst: 1, is_first_translation: -1, hidden: 1 } },
-          { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1 } },
+          { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
           { $limit: effectiveLimit }
         ]).toArray() : [];
 
@@ -2071,7 +2071,7 @@ async function run() {
               progress: { total: pageIds.length, completed: 0, failed: 0 },
               config: {
                 page_ids: pageIds,
-                model: 'gemini-3-flash-preview',
+                model: getTranslateModelForBook(book),
                 language: book.language || 'auto-detect',
               },
               initiated_by: 'pipeline_orchestrator',

--- a/src/workers/translation-processor-logic.ts
+++ b/src/workers/translation-processor-logic.ts
@@ -2,7 +2,7 @@ import { getDb } from '@/lib/mongodb';
 import type { PageProcessingMessage } from '@/lib/types/sqs';
 import type { TranslationWriteResult, GeminiUsagePayload } from '@/lib/types/sqs';
 import { performTranslation } from '@/lib/ai';
-import { DEFAULT_MODEL, PROMPT_VERSION } from '@/lib/types';
+import { DEFAULT_MODEL, PROMPT_VERSION, getModelForBook } from '@/lib/types';
 import { SKIP_TRANSLATION_PAGE_TYPES, extractPageType } from '@/lib/types/prompts/defaults';
 import { classifyError } from '@/lib/errors';
 import { extractTranslationMetadata, propagateOcrWarnings } from '@/lib/translation-metadata';
@@ -84,7 +84,7 @@ export async function processTranslationPage(message: PageProcessingMessage) {
   // Fetch book metadata for translation context (title, author, year)
   const bookDoc = await db.collection('books').findOne(
     { id: bookId },
-    { projection: { title: 1, display_title: 1, author: 1, year: 1, published: 1 } }
+    { projection: { title: 1, display_title: 1, author: 1, year: 1, published: 1, 'image_source.provider': 1 } }
   );
   const bookContext = bookDoc ? {
     title: bookDoc.display_title || bookDoc.title,
@@ -161,7 +161,7 @@ export async function processTranslationPage(message: PageProcessingMessage) {
     }
   }
 
-  const modelId = job.config.model || DEFAULT_MODEL;
+  const modelId = job.config.model || getModelForBook(bookDoc as { image_source?: { provider?: string } } | null) || DEFAULT_MODEL;
   const startTime = Date.now();
 
   // Snapshot manually-edited content before overwriting


### PR DESCRIPTION
## Summary

- Pipeline orchestrator was hardcoding `gemini-3-flash-preview` for all translation jobs (line 2074) instead of calling `getTranslateModelForBook(book)` which routes non-BPH books to the 3x cheaper `gemini-3.1-flash-lite-preview`
- Lambda translation worker fallback also defaulted to flash instead of checking the book's provider
- In the last 3 days: 176,485 pages translated with flash ($579) vs only 3,916 with lite ($5.42) — the function existed but was never called

## Changes

**`pipeline-orchestrator.mjs`:**
- Add `image_source.provider` to Phase 4 book projection so the model router can check BPH status
- Replace hardcoded `'gemini-3-flash-preview'` with `getTranslateModelForBook(book)` in job creation

**`translation-processor-logic.ts`:**
- Import `getModelForBook` and add `image_source.provider` to book projection
- Use `getModelForBook(bookDoc)` as fallback when `job.config.model` is not set

## Impact

~$400 savings per 3 days at current translation volume (~180K pages/3d). Non-BPH books (97%+ of volume) will use lite model going forward.

## Test plan

- [ ] Verify new translation jobs get `gemini-3.1-flash-lite-preview` in `job.config.model`
- [ ] Verify BPH books still get `gemini-3-flash-preview`
- [ ] Monitor `gemini_usage` model distribution after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)