### PR TITLE
Fix untitled slugs for CJK/Cyrillic books

### DIFF
--- a/src/lib/metadata-enrichment.ts
+++ b/src/lib/metadata-enrichment.ts
@@ -14,6 +14,7 @@ import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/ge
 import { logGeminiCall } from './gemini-logger';
 import { logAuditEvent } from './audit-logger';
 import { logMetadataChange } from './book-changelog';
+import { generateUniqueBookSlug } from './slugify';
 
 const MODEL = 'gemini-3-flash-preview';
 const MAX_OCR_PAGES = 25;
@@ -474,6 +475,20 @@ export async function enrichBookMetadata(
 
   // Write to DB
   await db.collection('books').updateOne({ id: bookId }, { $set: updates });
+
+  // Regenerate slug if display_title was just set and current slug is bad
+  if (updates.display_title) {
+    const currentSlug = (book.slug as string) || '';
+    if (!currentSlug || currentSlug === 'undefined' || currentSlug.startsWith('untitled')) {
+      const newSlug = await generateUniqueBookSlug(
+        db, book.title as string, (updates.author || book.author) as string, updates.display_title as string
+      );
+      if (newSlug !== currentSlug) {
+        await db.collection('books').updateOne({ id: bookId }, { $set: { slug: newSlug } });
+        changes.push({ field: 'slug', previous: currentSlug, new_value: newSlug });
+      }
+    }
+  }
 
   // Log to gemini_usage
   await logGeminiCall({


### PR DESCRIPTION
## Summary
- 297 books had `untitled-*` or `undefined` slugs because `slugifyText()` strips all non-ASCII characters, leaving CJK/Cyrillic titles empty
- **Backfill (already applied):** Translated 252 titles via Gemini → `display_title`, regenerated all 297 slugs. Zero untitled slugs remain.
- **Pipeline fix:** `metadata-enrichment.ts` now regenerates the slug when it sets `display_title` on a book with a bad slug. Prevents recurrence for future imports.

Example: `untitled-196` → `treatise-on-armament-technology-6` (武備志 Vol. 81)

## Test plan
- [x] Dry-run confirmed all 297 slugs look correct
- [x] Applied to production DB — 0 untitled slugs remaining
- [x] `tsc --noEmit` passes
- [ ] Verify a few book URLs work on next deploy (e.g. `/book/treatise-on-armament-technology-6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)