### PR TITLE
Raise maxDuration/maxTimeMS for ISR pages

### DIFF
--- a/src/app/about/processing/page.tsx
+++ b/src/app/about/processing/page.tsx
@@ -10,8 +10,9 @@ export const metadata: Metadata = {
   alternates: { canonical: '/about/processing' },
 };
 
-// ISR: rebuild every 6 hours
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
+export const maxDuration = 60;
 
 /* ── Data fetching ── */
 
@@ -20,7 +21,7 @@ async function getStats() {
     const db = await getDb();
     const books = db.collection('books');
 
-    const maxTimeMS = 10000;
+    const maxTimeMS = 45000;
     const [totalBooks, visibleBooks, pageAgg, languages, sources, funnel] =
       await Promise.all([
         books.countDocuments({}, { maxTimeMS }),

--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -6,8 +6,9 @@ import { notFound } from 'next/navigation';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
-// ISR: rebuild daily. Generate on demand (not at build time) to avoid MongoDB timeouts.
+// ISR: rebuild daily. Allow 60s for first-hit generation.
 export const revalidate = 86400;
+export const maxDuration = 60;
 export const dynamicParams = true;
 
 export function generateStaticParams() {
@@ -57,7 +58,7 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
       },
     },
     { $sort: { _id: 1 } },
-  ], { maxTimeMS: 10000 }).toArray();
+  ], { maxTimeMS: 45000 }).toArray();
 
   return (
     <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -6,8 +6,9 @@ import { notFound } from 'next/navigation';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
-// ISR: rebuild daily. These pages are nearly static.
+// ISR: rebuild daily. Allow 60s for first-hit generation.
 export const revalidate = 86400;
+export const maxDuration = 60;
 export const dynamicParams = true;
 
 export function generateStaticParams() {
@@ -72,7 +73,7 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
         published: 1,
       },
     },
-  ], { maxTimeMS: 10000 }).toArray();
+  ], { maxTimeMS: 45000 }).toArray();
 
   return (
     <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -17,8 +17,9 @@ const PERIODS: Record<string, { label: string; min: number; max: number }> = {
 
 const PERIOD_SLUGS = Object.keys(PERIODS);
 
-// ISR: rebuild daily.
+// ISR: rebuild daily. Allow 60s for first-hit generation.
 export const revalidate = 86400;
+export const maxDuration = 60;
 export const dynamicParams = true;
 
 export function generateStaticParams() {
@@ -82,7 +83,7 @@ export default async function BrowseYearsPage({ params }: PageProps) {
         _pub_year: '$year',
       },
     },
-  ], { maxTimeMS: 10000 }).toArray();
+  ], { maxTimeMS: 45000 }).toArray();
 
   return (
     <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -4,9 +4,9 @@ import { getDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { CenturyChart } from './DataCharts';
 
-// ISR: rebuild every 6 hours (public data changes slowly)
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'The Collection — Source Library',
@@ -184,7 +184,7 @@ async function fetchLibraryData(showAdmin: boolean): Promise<LibraryData> {
   const visible = { hidden: { $ne: true } };
   const filter = showAdmin ? {} : visible;
 
-  const maxTimeMS = 15000;
+  const maxTimeMS = 45000;
 
   // Base queries (always run)
   const baseQueries = [
@@ -292,8 +292,8 @@ async function fetchLibraryData(showAdmin: boolean): Promise<LibraryData> {
     books.countDocuments({ 'chapters.0': { $exists: true } }, { maxTimeMS }),
     books.countDocuments({ 'source_work_dates.0': { $exists: true } }, { maxTimeMS }),
     db.collection('editions').estimatedDocumentCount(),
-    books.aggregate(buildCoverageTiers('pages_ocr'), { maxTimeMS: 20000 }).toArray(),
-    books.aggregate(buildCoverageTiers('pages_translated'), { maxTimeMS: 20000 }).toArray(),
+    books.aggregate(buildCoverageTiers('pages_ocr'), { maxTimeMS: 45000 }).toArray(),
+    books.aggregate(buildCoverageTiers('pages_translated'), { maxTimeMS: 45000 }).toArray(),
     books.countDocuments({ $or: [{ pages_count: 0 }, { pages_count: { $exists: false } }] }, { maxTimeMS }),
   ]);
 

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -3,9 +3,9 @@ import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { getDb } from '@/lib/mongodb';
 
-// ISR: rebuild every 6 hours
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
-export const maxDuration = 15;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'Dataset — Source Library',
@@ -28,7 +28,7 @@ async function fetchDatasetStats() {
   const books = db.collection('books');
   const visible = { hidden: { $ne: true } };
 
-  const maxTimeMS = 10000;
+  const maxTimeMS = 45000;
   const [totalBooks, pageTotalsAgg, languagesAgg] = await Promise.all([
     books.countDocuments(visible, { maxTimeMS }),
     books

--- a/src/app/developers/pipeline/page.tsx
+++ b/src/app/developers/pipeline/page.tsx
@@ -11,8 +11,9 @@ export const metadata: Metadata = {
   alternates: { canonical: '/developers/pipeline' },
 };
 
-// ISR: rebuild every 6 hours
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
+export const maxDuration = 60;
 
 /* ── Data fetching ── */
 
@@ -46,7 +47,7 @@ async function getPipelineStats() {
     const db = await getDb();
     const books = db.collection('books');
 
-    const maxTimeMS = 10000;
+    const maxTimeMS = 45000;
     const [funnel, pageAgg, totalBooks] = await Promise.all([
       books
         .aggregate([

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from 'next';
 import { getDb } from '@/lib/mongodb';
 import EntityMapLoader from '@/components/explore/EntityMapLoader';
 
-// ISR: rebuild every 6 hours (entity data changes slowly)
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'Map — Explore — Source Library',
@@ -40,7 +41,7 @@ async function fetchMapData() {
         'books.book_id': 1,
       },
     },
-  ], { maxTimeMS: 10000 }).toArray();
+  ], { maxTimeMS: 45000 }).toArray();
 
   // Build book_id → year map separately (much faster than $lookup)
   const allBookIds = new Set<string>();

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from 'next';
 import { getDb } from '@/lib/mongodb';
 import TimelineLoader from '@/components/explore/TimelineLoader';
 
-// ISR: rebuild every 6 hours (entity data changes slowly)
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'Timeline — Explore — Source Library',
@@ -71,7 +72,7 @@ async function fetchTimelineData() {
           'books.book_id': 1,
         },
       },
-    ], { maxTimeMS: 10000 })
+    ], { maxTimeMS: 45000 })
     .toArray();
 
   // Build book_id → language map from books collection

--- a/src/app/shwep/page.tsx
+++ b/src/app/shwep/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from 'next';
 import { getShwepIndexData } from './shwep-data';
 import ShwepClient from './ShwepClient';
 
-// ISR: rebuild every 6 hours
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'SHWEP Reading Room - Source Library',

--- a/src/app/shwep/shwep-data.ts
+++ b/src/app/shwep/shwep-data.ts
@@ -106,7 +106,7 @@ async function fetchMatchedBooks(db: any): Promise<Map<string, MatchedBook>> {
         thumbnail: 1, thumbnail_blob: 1,
         'reading_summary.overview': 1, 'index.bookSummary.brief': 1, summary: 1,
       },
-      maxTimeMS: 10000,
+      maxTimeMS: 45000,
     }
   ).toArray();
 
@@ -197,7 +197,7 @@ export async function getShwepIndexData(): Promise<ShwepIndexData> {
   }
 
   // Get total books count efficiently
-  const totalBooks = await db.collection('books').countDocuments({ deleted: { $ne: true } }, { maxTimeMS: 10000 });
+  const totalBooks = await db.collection('books').countDocuments({ deleted: { $ne: true } }, { maxTimeMS: 45000 });
 
   return {
     periods: reversedPeriods,


### PR DESCRIPTION
## Summary
Follow-up to #508. The 10s `maxTimeMS` was too aggressive — Atlas queries take 30-40s on cold ISR generation. Since ISR caches the result for 6-24h, a one-time slow generation is acceptable.

- Raised `maxTimeMS` from 10s to 45s on all queries
- Added `maxDuration = 60` to all affected pages (Vercel function timeout)
- ISR ensures subsequent requests are instant from cache

## Test plan
- [ ] All 10 previously broken pages return 200 on first hit (may take 30-40s)
- [ ] Second hit is instant (served from ISR cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)