### PR TITLE
Use find() over aggregate() for browse pages + raise maxDuration

### DIFF
--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -41,24 +41,29 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
 
   const db = await getDb();
 
-  // Aggregate distinct authors with book counts, filtered to this letter
-  const authors = await db.collection('books').aggregate<AuthorEntry>([
+  // Use find() + client-side grouping to avoid slow $group aggregation
+  const rawBooks = await db.collection('books').find(
     {
-      $match: {
-        hidden: { $ne: true },
-        pages_count: { $gt: 0 },
-        pages_translated: { $gt: 0 },
-        author: { $regex: `^${l}`, $options: 'i' },
-      },
+      author: { $regex: `^${l}`, $options: 'i' },
+      hidden: { $ne: true },
+      pages_count: { $gt: 0 },
+      pages_translated: { $gt: 0 },
     },
     {
-      $group: {
-        _id: '$author',
-        count: { $sum: 1 },
-      },
-    },
-    { $sort: { _id: 1 } },
-  ], { maxTimeMS: 45000 }).toArray();
+      projection: { author: 1 },
+      maxTimeMS: 45000,
+    }
+  ).toArray();
+
+  // Group by author in JS (much faster than $group on Atlas)
+  const authorCounts = new Map<string, number>();
+  for (const b of rawBooks) {
+    const a = b.author as string;
+    authorCounts.set(a, (authorCounts.get(a) || 0) + 1);
+  }
+  const authors: AuthorEntry[] = [...authorCounts.entries()]
+    .map(([name, count]) => ({ _id: name, count }))
+    .sort((a, b) => a._id.localeCompare(b._id));
 
   return (
     <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -46,34 +46,37 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
 
   const db = await getDb();
 
-  // Use $regex on title/display_title to avoid expensive $addFields on every document
+  // Use find() with regex prefix match on title
   const regex = new RegExp(`^${l}`, 'i');
-  const books = await db.collection('books').aggregate<BrowseBook>([
+  const rawBooks = await db.collection('books').find(
     {
-      $match: {
-        hidden: { $ne: true },
-        pages_count: { $gt: 0 },
-        pages_translated: { $gt: 0 },
-        $or: [
-          { display_title: { $regex: regex } },
-          { display_title: { $exists: false }, title: { $regex: regex } },
-        ],
-      },
+      hidden: { $ne: true },
+      pages_count: { $gt: 0 },
+      pages_translated: { $gt: 0 },
+      $or: [
+        { display_title: { $regex: regex } },
+        { display_title: { $exists: false }, title: { $regex: regex } },
+      ],
     },
-    { $sort: { display_title: 1, title: 1 } },
     {
-      $project: {
-        _id: 0,
-        id: { $ifNull: ['$id', { $toString: '$_id' }] },
-        slug: 1,
-        title: 1,
-        display_title: 1,
-        author: 1,
-        language: 1,
-        published: 1,
+      projection: {
+        id: 1, slug: 1, title: 1, display_title: 1,
+        author: 1, language: 1, published: 1,
       },
-    },
-  ], { maxTimeMS: 45000 }).toArray();
+      sort: { display_title: 1, title: 1 },
+      maxTimeMS: 45000,
+    }
+  ).toArray();
+
+  const books: BrowseBook[] = rawBooks.map(b => ({
+    id: (b.id as string) || b._id.toString(),
+    slug: b.slug as string | undefined,
+    title: b.title as string,
+    display_title: b.display_title as string | undefined,
+    author: b.author as string,
+    language: b.language as string,
+    published: b.published as string,
+  }));
 
   return (
     <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -59,31 +59,34 @@ export default async function BrowseYearsPage({ params }: PageProps) {
 
   const db = await getDb();
 
-  // Use the numeric `year` field (indexed) instead of parsing the string `published` field
-  const books = await db.collection('books').aggregate<BrowseBook>([
+  // Use find() with year_hidden_language compound index
+  const rawBooks = await db.collection('books').find(
     {
-      $match: {
-        hidden: { $ne: true },
-        pages_count: { $gt: 0 },
-        pages_translated: { $gt: 0 },
-        year: { $gte: p.min, $lte: p.max },
-      },
+      year: { $gte: p.min, $lte: p.max },
+      hidden: { $ne: true },
+      pages_count: { $gt: 0 },
+      pages_translated: { $gt: 0 },
     },
-    { $sort: { year: 1, title: 1 } },
     {
-      $project: {
-        _id: 0,
-        id: { $ifNull: ['$id', { $toString: '$_id' }] },
-        slug: 1,
-        title: 1,
-        display_title: 1,
-        author: 1,
-        language: 1,
-        published: 1,
-        _pub_year: '$year',
+      projection: {
+        id: 1, slug: 1, title: 1, display_title: 1,
+        author: 1, language: 1, published: 1, year: 1,
       },
-    },
-  ], { maxTimeMS: 45000 }).toArray();
+      sort: { year: 1, title: 1 },
+      maxTimeMS: 45000,
+    }
+  ).toArray();
+
+  const books: BrowseBook[] = rawBooks.map(b => ({
+    id: (b.id as string) || b._id.toString(),
+    slug: b.slug as string | undefined,
+    title: b.title as string,
+    display_title: b.display_title as string | undefined,
+    author: b.author as string,
+    language: b.language as string,
+    published: b.published as string,
+    _pub_year: b.year as number,
+  }));
 
   return (
     <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">

--- a/src/app/shwep/shwep-data.ts
+++ b/src/app/shwep/shwep-data.ts
@@ -197,7 +197,8 @@ export async function getShwepIndexData(): Promise<ShwepIndexData> {
   }
 
   // Get total books count efficiently
-  const totalBooks = await db.collection('books').countDocuments({ deleted: { $ne: true } }, { maxTimeMS: 45000 });
+  // Use estimatedDocumentCount (instant, metadata-based) instead of slow filtered countDocuments
+  const totalBooks = await db.collection('books').estimatedDocumentCount();
 
   return {
     periods: reversedPeriods,


### PR DESCRIPTION
## Summary
Follow-up to #508 and #512. Atlas aggregate() queries weren't using compound indexes efficiently, causing 30-40s timeouts even with maxTimeMS raised.

- **browse/years**: switched to `find()` to leverage `year_hidden_language` compound index
- **browse/titles**: switched to `find()` for better index coverage  
- **browse/authors**: `find()` + client-side grouping (much faster than `$group` on Atlas)
- **shwep**: `estimatedDocumentCount()` instead of filtered `countDocuments` scanning 28K docs
- All browse pages get `maxDuration = 60` for ISR first-hit

## Test plan
- [ ] All browse pages return 200 on first hit
- [ ] Second hit is instant from ISR cache
- [ ] SHWEP page loads without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)