### PR TITLE
fix: Amazonbot block + quote endpoint bot gating

### DIFF
--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
+import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -153,8 +154,19 @@ export async function GET(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
 
-    // Get the requested page (use book.id, not URL param, in case slug was used)
+    // Bot page gating: only allow quotes from the first 20% of pages
     const resolvedBookId = book.id;
+    if (isBot(request) && !isTrustedBot(request)) {
+      const maxPage = botMaxPage(book.pages_count || 0);
+      if (pageNumber > maxPage) {
+        return NextResponse.json({
+          error: `Page ${pageNumber} is beyond the bot-accessible range (pages 1–${maxPage}). Install the MCP server for full access: claude mcp add source-library -- npx -y @source-library/mcp-server`,
+          accessible_pages: maxPage,
+          partnership: 'https://sourcelibrary.org/llms.txt',
+        }, { status: 403 });
+      }
+    }
+
     const page = await db.collection('pages').findOne({
       book_id: resolvedBookId,
       page_number: pageNumber,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,7 +16,7 @@ const BLOCKED_BOT_PATTERNS = [
   'CCBot', 'Bytespider', 'Diffbot', 'Omgilibot', 'FacebookBot',
   'PetalBot', 'SemrushBot', 'AhrefsBot', 'MJ12bot', 'DotBot',
   'BLEXBot', 'DataForSeoBot', 'serpstatbot', 'Seekport',
-  'MegaIndex', 'Linguee', 'YandexBot',
+  'MegaIndex', 'Linguee', 'YandexBot', 'Amazonbot',
 ];
 
 const BLOCKED_BOT_RE = new RegExp(BLOCKED_BOT_PATTERNS.join('|'), 'i');


### PR DESCRIPTION
## Summary
- Add Amazonbot to `BLOCKED_BOT_PATTERNS` in proxy.ts for defense-in-depth (already blocked at Cloudflare WAF)
- Apply 20% page limit to `/api/books/[id]/quote` endpoint — bots can no longer iterate `page=1..N` to bypass the text API gating
- Added `CF_API_TOKEN` and `CF_ZONE_ID` to Vercel production env vars

## Test plan
- [ ] Verify quote endpoint returns 403 for bot UA requesting page beyond 20% limit
- [ ] Verify MCP server can still quote any page
- [ ] Confirm Amazonbot gets 403 from middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)