### PR TITLE
Raise explore/map maxDuration to 90s

### DIFF
--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -4,7 +4,7 @@ import EntityMapLoader from '@/components/explore/EntityMapLoader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const dynamic = 'force-dynamic';
-export const maxDuration = 60;
+export const maxDuration = 90;
 
 export const metadata: Metadata = {
   title: 'Map — Explore — Source Library',


### PR DESCRIPTION
Last timeout page — entity+book join is the heaviest query. 60s isn't enough.