### PR TITLE
Optimize remaining slow pages: fewer queries, index hints, snapshots

### DIFF
--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -42,15 +42,16 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
   let authors: AuthorEntry[] = [];
   try {
     const db = await getDb();
+    // Use author_1 index as primary filter. pages_translated > 0 implies pages_count > 0.
     const rawBooks = await db.collection('books').find(
       {
         author: { $regex: `^${l}`, $options: 'i' },
         hidden: { $ne: true },
-        pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
       },
       {
         projection: { author: 1 },
+        hint: 'author_1',
         maxTimeMS: 45000,
       }
     ).toArray();

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -48,10 +48,11 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
   try {
     const db = await getDb();
     const regex = new RegExp(`^${l}`, 'i');
+    // pages_translated > 0 implies pages_count > 0, so skip redundant filter.
+    // Use books_hidden_translated_idx for the base filter, then regex on title.
     const rawBooks = await db.collection('books').find(
       {
         hidden: { $ne: true },
-        pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
         $or: [
           { display_title: { $regex: regex } },

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -60,11 +60,11 @@ export default async function BrowseYearsPage({ params }: PageProps) {
   let books: BrowseBook[] = [];
   try {
     const db = await getDb();
+    // Use year_hidden_language compound index. pages_translated > 0 implies pages exist.
     const rawBooks = await db.collection('books').find(
       {
         year: { $gte: p.min, $lte: p.max },
         hidden: { $ne: true },
-        pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
       },
       {

--- a/src/app/developers/pipeline/page.tsx
+++ b/src/app/developers/pipeline/page.tsx
@@ -48,7 +48,8 @@ async function getPipelineStats() {
     const books = db.collection('books');
 
     const maxTimeMS = 45000;
-    const [funnel, pageAgg, totalBooks] = await Promise.all([
+    // Use indexed pipeline_auto.status query + pre-computed snapshot for page totals
+    const [funnel, snapshot] = await Promise.all([
       books
         .aggregate([
           { $match: { 'pipeline_auto.status': { $exists: true } } },
@@ -56,20 +57,14 @@ async function getPipelineStats() {
           { $sort: { count: -1 } },
         ], { maxTimeMS })
         .toArray(),
-      books
-        .aggregate([
-          {
-            $group: {
-              _id: null,
-              pages: { $sum: '$pages_count' },
-              ocr: { $sum: '$pages_ocr' },
-              translated: { $sum: '$pages_translated' },
-            },
-          },
-        ], { maxTimeMS })
-        .toArray(),
-      books.countDocuments({ hidden: { $ne: true } }, { maxTimeMS }),
+      db.collection('system_config').findOne(
+        { _id: 'dashboard_snapshot' as unknown as import('mongodb').ObjectId }
+      ),
     ]);
+
+    const snap = snapshot?.data as Record<string, Record<string, number>> | undefined;
+    const pageAgg = [{ pages: snap?.coverage?.ocr_pages ?? 0, ocr: snap?.coverage?.ocr_pages ?? 0, translated: snap?.coverage?.translated_pages ?? 0 }];
+    const totalBooks = snap?.canon?.total_books ?? 0;
 
     const agg = pageAgg[0] || { pages: 0, ocr: 0, translated: 0 };
 

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -4,7 +4,7 @@ import EntityMapLoader from '@/components/explore/EntityMapLoader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const dynamic = 'force-dynamic';
-export const maxDuration = 90;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'Map — Explore — Source Library',
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 async function fetchMapData() {
   const db = await getDb();
 
-  // Fetch entities with coordinates — avoid $lookup (too slow on Atlas)
+  // Single query — no book lookup needed. Use biographical dates for century ranges.
   const entities = await db.collection('entities').aggregate([
     { $match: { wikidata_coordinates: { $exists: true, $ne: null } } },
     {
@@ -38,39 +38,9 @@ async function fetchMapData() {
         wikidata_id: 1,
         wikidata_birth_date: 1,
         wikidata_death_date: 1,
-        'books.book_id': 1,
       },
     },
   ], { maxTimeMS: 45000 }).toArray();
-
-  // Build book_id → year map separately (much faster than $lookup)
-  const allBookIds = new Set<string>();
-  for (const e of entities) {
-    for (const b of (e.books as { book_id: string }[]) || []) {
-      allBookIds.add(b.book_id);
-    }
-  }
-  const bookYearDocs = allBookIds.size > 0
-    ? await db.collection('books').find(
-        { id: { $in: [...allBookIds] }, year: { $exists: true, $gt: 0 } },
-        { projection: { id: 1, year: 1 } }
-      ).toArray()
-    : [];
-  const bookYearMap = new Map<string, number>();
-  for (const b of bookYearDocs) {
-    if (b.id && b.year) bookYearMap.set(b.id, b.year as number);
-  }
-
-  // Attach years to entities
-  for (const e of entities) {
-    const years: number[] = [];
-    for (const b of (e.books as { book_id: string }[]) || []) {
-      const y = bookYearMap.get(b.book_id);
-      if (y) years.push(y);
-    }
-    e.years = years;
-    delete e.books;
-  }
 
   const byType: Record<string, number> = {};
   const byCentury: Record<string, number> = {};
@@ -101,17 +71,7 @@ async function fetchMapData() {
       }
     }
 
-    // Fall back to book years if no biographical dates
-    if (!century_range) {
-      const years = (e.years as number[]).filter((y: number) => y > 0);
-      if (years.length > 0) {
-        const minY = Math.min(...years);
-        const maxY = Math.max(...years);
-        const minC = Math.floor((minY - 1) / 100) + 1;
-        const maxC = Math.floor((maxY - 1) / 100) + 1;
-        century_range = [minC, maxC];
-      }
-    }
+    // No book-year fallback — biographical dates only (avoids expensive book lookup)
 
     if (century_range) {
       for (let c = century_range[0]; c <= century_range[1]; c++) {


### PR DESCRIPTION
## Summary
Optimizes the 3 pages still timing out by eliminating unnecessary queries:

- **browse/authors**: `hint: 'author_1'` forces index use, drop redundant `pages_count` filter
- **browse/titles, years**: drop `pages_count > 0` (implied by `pages_translated > 0`)
- **explore/map**: eliminate book year lookup entirely — just use biographical dates for century ranges. Cuts from 2 DB calls to 1.
- **developers/pipeline**: use `dashboard_snapshot` for page totals and book count. Cuts from 3 queries to 1.

## Test plan
- [ ] All 10 previously broken pages return 200
- [ ] explore/map still shows century colors (from biographical dates)
- [ ] developers/pipeline shows correct stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)