### PR TITLE
Raise categories + topics maxDuration to 90s

### DIFF
--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -6,7 +6,7 @@ import { LIBRARY_CATEGORIES, CategoryWithCount } from '@/app/api/categories/rout
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
-export const maxDuration = 60;
+export const maxDuration = 90;
 
 export const metadata: Metadata = {
   title: 'Browse by Category — Source Library',

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -7,7 +7,7 @@ import { FACETS, DOMAIN_GROUPS, facetDbField } from '@/lib/taxonomy/faceted-voca
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
-export const maxDuration = 60;
+export const maxDuration = 90;
 
 export const metadata: Metadata = {
   title: 'Browse by Topic | Source Library',


### PR DESCRIPTION
ISR caches the result — 60-80s first-hit is acceptable.