### PR TITLE
Graceful fallback for categories/topics: maxTimeMS < maxDuration

### DIFF
--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -6,7 +6,7 @@ import { LIBRARY_CATEGORIES, CategoryWithCount } from '@/app/api/categories/rout
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
-export const maxDuration = 90;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'Browse by Category — Source Library',
@@ -27,7 +27,7 @@ async function getCategoriesWithCounts(): Promise<CategoryWithCount[]> {
       { $match: { hidden: { $ne: true }, categories: { $exists: true } } },
       { $unwind: '$categories' },
       { $group: { _id: '$categories', count: { $sum: 1 } } },
-    ], { maxTimeMS: 50000, hint: 'categories_1' }).toArray();
+    ], { maxTimeMS: 30000, hint: 'categories_1' }).toArray();
 
     for (const item of categoryCounts) {
       countMap.set(item._id as string, item.count as number);

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -7,7 +7,7 @@ import { FACETS, DOMAIN_GROUPS, facetDbField } from '@/lib/taxonomy/faceted-voca
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
-export const maxDuration = 90;
+export const maxDuration = 60;
 
 export const metadata: Metadata = {
   title: 'Browse by Topic | Source Library',
@@ -35,7 +35,7 @@ interface FacetGroup {
 
 async function fetchFacetCounts(): Promise<{ groups: FacetGroup[]; totalBooks: number }> {
   const db = await getDb();
-  const maxTimeMS = 50000;
+  const maxTimeMS = 30000;
   const baseMatch = { faceted_tags: { $exists: true }, hidden: { $ne: true } };
 
   // Single $facet aggregation — one collection scan for all 6 facets


### PR DESCRIPTION
maxTimeMS 30s ensures MongoDB throws before Vercel's 60s function timeout. try/catch renders with zero counts → 200 instead of 504.