### PR TITLE
Fix batch OCR stale timeout and add failure rate alerting

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -341,8 +341,9 @@ async function processOneJob(db, job) {
     };
 
   } else if (state === 'JOB_STATE_PENDING' || state === 'JOB_STATE_RUNNING') {
-    // Check for stale jobs — if PENDING for >6 hours with no progress, cancel and let orchestrator retry
-    const STALE_HOURS = 6;
+    // Check for stale jobs — if PENDING for >24 hours with no progress, cancel and let orchestrator retry
+    // Note: Flash Lite batches routinely take 8-9h. Previous 6h timeout was killing valid jobs.
+    const STALE_HOURS = 24;
     const jobAge = (Date.now() - new Date(job.created_at).getTime()) / 3600000;
     if (state === 'JOB_STATE_PENDING' && jobAge > STALE_HOURS) {
       console.log(`  Stale PENDING job (${jobAge.toFixed(1)}h old): ${job.job_name || job.gemini_job_name} — cancelling`);

--- a/scripts/workers/pipeline-health-alert.mjs
+++ b/scripts/workers/pipeline-health-alert.mjs
@@ -102,18 +102,42 @@ async function run() {
     }
   }
 
-  // 3. Check for stale batch jobs
+  // 3. Check for stale batch jobs (>24h is the actual stale threshold now)
+  const twentyFourHoursAgo = new Date(now - 24 * 60 * 60 * 1000);
   const staleBatchJobs = await db.collection('batch_jobs').countDocuments({
     status: { $in: ['pending', 'processing'] },
-    created_at: { $lt: sixHoursAgo },
+    created_at: { $lt: twentyFourHoursAgo },
   });
 
   if (staleBatchJobs > 0) {
     alerts.push({
       level: 'warning',
       check: 'stale_batch_jobs',
-      message: `${staleBatchJobs} batch jobs stuck for >6h.`,
+      message: `${staleBatchJobs} batch jobs stuck for >24h.`,
     });
+  }
+
+  // 3b. Batch failure rate — alert if >50% failing in last 24h
+  const recentFailed = await db.collection('batch_jobs').countDocuments({
+    status: 'failed',
+    job_name: { $exists: true },
+    created_at: { $gte: oneDayAgo },
+  });
+  const recentTotal = await db.collection('batch_jobs').countDocuments({
+    job_name: { $exists: true },
+    created_at: { $gte: oneDayAgo },
+  });
+  if (recentTotal >= 10) {
+    const failRate = recentFailed / recentTotal;
+    if (failRate > 0.5) {
+      alerts.push({
+        level: 'critical',
+        check: 'batch_failure_rate',
+        message: `Batch failure rate ${(failRate * 100).toFixed(0)}% (${recentFailed}/${recentTotal} in 24h). Possible API quota exhaustion or outage.`,
+      });
+    } else {
+      console.log(`[health] Batch failure rate: ${(failRate * 100).toFixed(0)}% (${recentFailed}/${recentTotal} in 24h)`);
+    }
   }
 
   // 4. Check for books stuck in ocr_submitted
@@ -222,6 +246,44 @@ async function run() {
       },
       { upsert: true },
     );
+
+    // Email critical alerts via Resend (with 4h cooldown)
+    const hasCritical = alerts.some(a => a.level === 'critical');
+    if (hasCritical && process.env.RESEND_API_KEY) {
+      const COOLDOWN_MS = 4 * 60 * 60 * 1000;
+      const lastAlert = await db.collection('system_config').findOne({ _id: 'pipeline_alert_state' });
+      const elapsed = lastAlert?.last_sent_at ? (Date.now() - new Date(lastAlert.last_sent_at).getTime()) : Infinity;
+      if (elapsed >= COOLDOWN_MS) {
+        try {
+          const { Resend } = await import('resend');
+          const resend = new Resend(process.env.RESEND_API_KEY);
+          const criticalAlerts = alerts.filter(a => a.level === 'critical');
+          await resend.emails.send({
+            from: 'Source Library <noreply@sourcelibrary.org>',
+            to: process.env.ALERT_EMAIL || 'derek@sourcelibrary.org',
+            subject: `[PIPELINE] ${criticalAlerts.map(a => a.check).join(', ')}`,
+            html: [
+              '<h2>Pipeline Health Alert</h2>',
+              `<p><strong>Time:</strong> ${now.toISOString()}</p>`,
+              '<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse">',
+              '<tr><th>Check</th><th>Level</th><th>Detail</th></tr>',
+              ...alerts.map(a => `<tr><td>${a.check}</td><td style="color:${a.level === 'critical' ? 'red' : 'orange'}">${a.level}</td><td>${a.message}</td></tr>`),
+              '</table>',
+            ].join('\n'),
+          });
+          await db.collection('system_config').updateOne(
+            { _id: 'pipeline_alert_state' },
+            { $set: { last_sent_at: new Date(), last_alerts: criticalAlerts } },
+            { upsert: true },
+          );
+          console.log('[health] Email alert sent');
+        } catch (emailErr) {
+          console.error('[health] Email alert failed:', emailErr.message);
+        }
+      } else {
+        console.log(`[health] Email cooldown: ${((COOLDOWN_MS - elapsed) / 3600000).toFixed(1)}h remaining`);
+      }
+    }
   } else {
     console.log('\n[health] All checks passed');
     await db.collection('system_config').updateOne(

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -889,10 +889,11 @@ function shouldRun(phase) {
 // ── Gemini Batch API helpers (direct OCR submission, no Vercel) ──
 
 // All keys for rotation — try each until one works (batch jobs are per-key)
+// KEY_2 moved to end: frequently quota-exhausted, let healthy keys go first
 const GEMINI_BATCH_KEYS = [
-  process.env.GEMINI_API_KEY_2,       // Prefer KEY_2 for batch (separate quota pool)
   process.env.GEMINI_API_KEY_TIER3,
   process.env.GEMINI_API_KEY,
+  process.env.GEMINI_API_KEY_2,
 ].filter(k => !!k);
 
 function getGeminiApiKey(keyIndex = 0) {


### PR DESCRIPTION
## Summary
- **Increased stale timeout from 6h to 24h** — Flash Lite batches take 8-9h to process, the 6h timeout was cancelling valid jobs (2,525 jobs killed in 5 days, ~10K pages lost progress)
- **Reordered API key rotation** — KEY_2 (quota-exhausted) moved to end, healthy keys tried first
- **Added batch failure rate alert** — triggers when >50% of batch jobs fail in 24h
- **Added email notification** for critical pipeline alerts via Resend (4h cooldown)

## Root cause
`gemini-3.1-flash-lite-preview` batch jobs routinely take 8-9h. The stale checker was cancelling them at 6h, marking them as failed. The orchestrator then resubmitted, creating a cycle of submit → cancel → resubmit with near-zero throughput since March 25.

## Test plan
- [ ] Deploy to Hetzner and verify batch-collector uses 24h stale threshold
- [ ] Confirm pipeline-orchestrator tries TIER3/KEY before KEY_2
- [ ] Monitor batch failure rate after deploy — should drop from 93% to near 0%
- [ ] Verify email alert fires on next health check if failure rate remains high

🤖 Generated with [Claude Code](https://claude.com/claude-code)