### PR TITLE
Switch all page routes from force-dynamic to ISR

### DIFF
--- a/src/app/about/processing/page.tsx
+++ b/src/app/about/processing/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 };
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 60;
 export const maxDuration = 60;
 
 /* ── Data fetching ── */

--- a/src/app/about/progress/page.tsx
+++ b/src/app/about/progress/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   alternates: { canonical: '/about/progress' },
 };
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 60;
 
 // ── Data Loading ──────────────────────────────────────────────────────
 

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { Book } from '@/lib/types';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 
 interface PageProps {

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { isAdmin } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 
 interface PageProps {

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
   description: 'Renaissance paintings and prints cross-referenced with the philosophical texts that inspired them.',
 };
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface ArtCollection {
   slug: string;

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -35,7 +35,7 @@ interface AuthorEntity {
 
 // ISR: author pages are mostly static — revalidate weekly.
 // Use POST /api/admin/revalidate-authors to force refresh after changes.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return []; // All paths generated on demand via ISR

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -37,7 +37,7 @@ import { firstTranslationBadge, firstTranslationDescription } from '@/lib/first-
 import SiteHeader from '@/components/layout/SiteHeader';
 
 // ISR: rebuild at most every hour (requires no searchParams/headers() usage)
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 // Run SSR near the database to cut cross-region latency (~200ms RTT savings)
 export const preferredRegion = 'fra1';

--- a/src/app/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/page.tsx
@@ -5,7 +5,7 @@ import type { Book, Page } from '@/lib/types';
 import PageEditorClient from './PageEditorClient';
 
 // ISR: rebuild at most every hour (content changes infrequently)
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface PageProps {
   params: Promise<{ id: string; pageId: string }>;

--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from 'next/navigation';
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 // ISR: rebuild daily. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 export const dynamicParams = true;
 

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from 'next/navigation';
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 // ISR: rebuild daily. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 export const dynamicParams = true;
 

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -18,7 +18,7 @@ const PERIODS: Record<string, { label: string; min: number; max: number }> = {
 const PERIOD_SLUGS = Object.keys(PERIODS);
 
 // ISR: rebuild daily. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 export const dynamicParams = true;
 

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -24,7 +24,7 @@ interface Book {
 }
 
 // ISR: rebuild at most every hour
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return []; // All paths generated on demand via ISR

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -14,7 +14,7 @@ import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-uti
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 
 // ISR: rebuild at most every 10 minutes
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 export const maxDuration = 60;
 export async function generateStaticParams() {

--- a/src/app/collections/contemplative-traditions/page.tsx
+++ b/src/app/collections/contemplative-traditions/page.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, BookOpen } from 'lucide-react';
 import { getDb } from '@/lib/mongodb';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'The Contemplative Traditions - Source Library',

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -6,7 +6,7 @@ import { sortCollections } from '@/lib/collections-utils';
 import EraTimeline, { type DecadeBucket } from '@/components/collections/EraTimeline';
 import type { Metadata } from 'next';
 
-export const revalidate = 3600; // ISR: rebuild every hour
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Collections | Source Library',

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -7,7 +7,7 @@ import { getDb } from '@/lib/mongodb';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Sacred Texts - Source Library',

--- a/src/app/contribute/wikipedia/page.tsx
+++ b/src/app/contribute/wikipedia/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 };
 
 // Dynamic — DB queries are too slow for build-time prerendering
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 // Config: which books to feature and where to post
 const FEATURED_BOOKS: {

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -6,7 +6,7 @@ import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 import type { Metadata } from 'next';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Curated Collections | Source Library',

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -5,7 +5,7 @@ import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPag
 import { CenturyChart } from './DataCharts';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -4,7 +4,7 @@ import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPag
 import { getDb } from '@/lib/mongodb';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const revalidate = 21600;
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {

--- a/src/app/design-options/all-editorial/page.tsx
+++ b/src/app/design-options/all-editorial/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import { BookOpen, ArrowRight } from 'lucide-react';
 import { bookUrl } from '@/lib/slugify';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 
 interface FeaturedBook {

--- a/src/app/design-options/page.tsx
+++ b/src/app/design-options/page.tsx
@@ -11,7 +11,7 @@ import CollectionsShowcase, { type CollectionSummary } from '@/components/home/C
 import FeaturedCollectionNoon from './FeaturedCollectionNoon';
 import FeaturedCollection4pm from './FeaturedCollection4pm';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 
 // ---------- Data fetching (reuse home page pattern) ----------

--- a/src/app/developers/pipeline/page.tsx
+++ b/src/app/developers/pipeline/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 };
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 60;
 export const maxDuration = 60;
 
 /* ── Data fetching ── */

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -5,7 +5,7 @@ import { ObjectId } from 'mongodb';
 import EntitySchema from '@/components/seo/EntitySchema';
 
 // ISR: rebuild at most every 24 hours (entity data changes rarely)
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return []; // All paths generated on demand via ISR

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import EntityMapLoader from '@/components/explore/EntityMapLoader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -6,7 +6,7 @@ import ExploreNav from '@/components/explore/ExploreNav';
 import DataSources from '@/components/explore/DataSources';
 import { getDb } from '@/lib/mongodb';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 30;
 
 export const metadata: Metadata = {

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import TimelineLoader from '@/components/explore/TimelineLoader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {

--- a/src/app/ficino-society/members/page.tsx
+++ b/src/app/ficino-society/members/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: 'The circle of scholars and readers translating the Western esoteric tradition.',
 };
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface MemberProfile {
   name: string;

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, Image as ImageIcon, Layers } from 'lucide-react';
 import { getDb } from '@/lib/mongodb';
 import CollectionImageCard, { CollectionImageProps } from './CollectionImageCard';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { ArrowLeft, Image as ImageIcon, Layers } from 'lucide-react';
 import { getDb } from '@/lib/mongodb';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Curated Collections | Gallery | Source Library',

--- a/src/app/gallery/opengraph-image.tsx
+++ b/src/app/gallery/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { getDb } from '@/lib/mongodb';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const alt = 'Image Gallery - Source Library';
 export const size = {
   width: 1200,

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import type { Metadata } from 'next';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 30;
 
 export const metadata: Metadata = {

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -7,7 +7,7 @@ import ConversationView from '@/components/research/ConversationView';
 import type { CuratorSession, BookRef } from '@/lib/api-client/types/research';
 import Link from 'next/link';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface PageProps {
   params: Promise<{ id: string }>;

--- a/src/app/research/image-atlas/page.tsx
+++ b/src/app/research/image-atlas/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import ImageConstellationViz from '@/components/research/ImageConstellationViz';
 import dataRaw from '@/data/image-constellation.json';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Image Atlas — Source Library',

--- a/src/app/research/image-pixplot/page.tsx
+++ b/src/app/research/image-pixplot/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import ImagePixPlotViz from '@/components/research/ImagePixPlotViz';
 import dataRaw from '@/data/image-constellation.json';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Image PixPlot — Source Library',

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -5,7 +5,7 @@ import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPag
 import ResearchClient from '@/components/research/ResearchClient';
 import type { CuratorSessionListItem } from '@/lib/api-client/types/research';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Research Sessions - Source Library',

--- a/src/app/research/translation-lag/page.tsx
+++ b/src/app/research/translation-lag/page.tsx
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import TranslationLagViz from '@/components/research/TranslationLagViz';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 60;
 
 export const metadata: Metadata = {
   title: 'Translation Lag — Source Library Research',

--- a/src/app/shwep/[number]/page.tsx
+++ b/src/app/shwep/[number]/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { getEpisodeData, getAllEpisodeNumbers } from '../shwep-data';
 import type { MatchedBook } from '../shwep-data';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface Props {
   params: Promise<{ number: string }>;

--- a/src/app/shwep/page.tsx
+++ b/src/app/shwep/page.tsx
@@ -3,7 +3,7 @@ import { getShwepIndexData } from './shwep-data';
 import ShwepClient from './ShwepClient';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const maxDuration = 60;
 
 export const metadata: Metadata = {

--- a/src/app/taxonomy/page.tsx
+++ b/src/app/taxonomy/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   robots: 'noindex',
 };
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export default function TaxonomyPage() {
   return (

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from 'next/navigation';
 import { bookUrl } from '@/lib/slugify';
 import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 interface Props {
   params: Promise<{ slug: string }>;

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import type { Metadata } from 'next';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'AI-Discovered Topic Clusters | Source Library',

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 600;
 export const dynamicParams = true;
 export async function generateStaticParams() {
   return [];


### PR DESCRIPTION
## Summary
- Replaces `export const dynamic = 'force-dynamic'` with `export const revalidate` on all 43 page routes
- Public pages get 10-min ISR cache (`revalidate = 600`), admin/monitoring pages get 1-min (`revalidate = 60`)
- API routes are unchanged (keep `force-dynamic` for mutations/real-time)
- Fixes intermittent "Temporarily Unavailable" on collection pages when Atlas is slow under pipeline load

## Context
`force-dynamic` was added in 306a4681 to prevent MongoDB timeouts during SSG builds. But it makes *every* request hit the DB, so when Atlas is slow users get error pages. ISR is the right fix: pages are cached and revalidated in the background, so users always get a fast response.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Smoke tests pass after deploy (current failures on prod confirm the problem)
- [ ] Verify collection pages load instantly on second visit (ISR cache hit)
- [ ] Verify admin pages (pipeline dashboard, progress) still show fresh data within 1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)