### PR TITLE
Sync Hetzner production patches + fix OCR split guard

### DIFF
--- a/.claude/docs/pipeline.md
+++ b/.claude/docs/pipeline.md
@@ -31,7 +31,7 @@ Every step is independent and idempotent. Books can enter at any stage and be re
 
 The pipeline is orchestrated from **Hetzner** (`scripts/workers/pipeline-orchestrator.mjs`, every 2 min). Translation runs on a separate Hetzner worker (`translate-worker.mjs`, every 2 min). Batch OCR results are collected by `batch-collector.mjs` (every 10 min). See `pipeline-architecture.md` for the full cron schedule and infrastructure map.
 
-**Legacy:** The Vercel crons (`post-import-pipeline`, `enrich-books`) still exist in `_archived/` and can be re-enabled. The Hetzner orchestrator consolidated both into a single script with all phases.
+**Legacy:** The Vercel crons (`post-import-pipeline`, `enrich-books`) still exist in `_archived/` but are no longer active. The Hetzner orchestrator (`pipeline-orchestrator.mjs`) handles phases 0-5 and 8+. A separate Hetzner worker (`enrich-worker.mjs`, every 5 min) handles phases 6-7 (summary+index, chapters) with direct Gemini calls. The `cron_runs` collection logs from both — orchestrator runs log as `archive-bulk`, enrich runs have their own entries.
 
 Each book has a `pipeline_auto` object tracking its state.
 
@@ -57,10 +57,10 @@ Any state can transition to `failed` on persistent errors (after 3 retries). Spe
 | `ft_verified` | First-translation verification complete (or skipped for English books) | Pipeline cron Phase 3.7 |
 | `translate_submitted` | Translation job created, Hetzner worker picks up | Orchestrator Phase 4 |
 | `translate_complete` | Translation finished | Pipeline cron Phase 5 |
-| `enriching` | Summary + index generation in progress | enrich-books cron Phase 1 |
-| `enriched` | Summary + index complete | enrich-books cron Phase 1 |
-| `chapters` | Chapter extraction in progress | enrich-books cron Phase 2 |
-| `chapters_complete` | Chapters extracted (or skipped for short books) | enrich-books cron Phase 2 |
+| `summarizing` | Summary + index generation in progress | Hetzner `enrich-worker.mjs` Phase 6 |
+| `summary_indexed` | Summary + index complete | Hetzner `enrich-worker.mjs` Phase 6 |
+| `chapters` | Chapter extraction in progress | Hetzner `enrich-worker.mjs` Phase 7 |
+| `chapters_complete` | Chapters extracted (or skipped for short books) | Hetzner `enrich-worker.mjs` Phase 7 |
 | `images_submitted` | Image extraction job queued to Lambda | Pipeline cron (priority pass) |
 | `images_complete` | All pages scanned for illustrations | Pipeline cron (priority pass) |
 | `complete` | Fully processed | Pipeline cron (priority pass) |

--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -290,4 +290,4 @@ Pauses: none (or list)
 - **`pages_translated` stale:** `sync-page-counts` cron runs every 6h. For real-time count, query pages directly.
 - **Book.job lock prevents re-submission:** Clear with `$unset: { job: '' }` on affected books.
 - **Image extraction stuck:** Check if `images` phase is in `paused_phases`. Also check Lambda CloudWatch for image-extraction-processor errors.
-- **Enrichment coverage low for summaries/chapters:** These run via `enrich-books` cron, not Lambda. Check if that cron is healthy in cron_runs.
+- **Enrichment coverage low for summaries/chapters:** These run via Hetzner `enrich-worker.mjs` (every 5 min, flock `/tmp/sl-enrich.lock`). Check `tail /var/log/sourcelibrary/enrich.log` on Hetzner, NOT the old Vercel `enrich-books` cron (deprecated since ~March 2026).

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -13,9 +13,9 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | Archiving | **Hetzner** (`archive-ocr.mjs`, `archive-bulk.mjs`) | Downloads → Cloudflare R2 |
 | Preview OCR (25 pages) | **Lambda** via SQS | Fast preview path, still active |
 | Image extraction | **Lambda** via SQS | Still active (Phase 8) |
-| Metadata enrichment | **Vercel API** (called from Hetzner) | HTTP fetch to `/api/books/[id]/verify-metadata` |
-| Summary + Index | **Vercel API** (called from Hetzner) | HTTP fetch to `/api/books/[id]/index` |
-| Chapter extraction | **Vercel API** (called from Hetzner) | HTTP fetch to `/api/books/[id]/extract-chapters` |
+| Metadata enrichment | **Hetzner** (orchestrator Phase 3.5) | HTTP fetch to Vercel `/api/books/[id]/verify-metadata` |
+| Summary + Index | **Hetzner** (`enrich-worker.mjs`) | Direct Gemini calls, every 5 min, 30 books/run |
+| Chapter extraction | **Hetzner** (`enrich-worker.mjs`) | Direct Gemini calls, runs after summary+index |
 | Lightweight crons | **Vercel** | social-post, health-check, daily-report, warm |
 | e-rara archiving | **Local Mac** via launchd | Hetzner IPs blocked by e-rara |
 

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -324,7 +324,7 @@ function getTranslateModelForBook(book) {
   return TRANSLATE_MODEL_LITE;
 }
 const TRANSLATE_MODEL = TRANSLATE_MODEL_FLASH; // Legacy fallback
-const TRANSLATE_PROMPT_VERSION = 'v5.2026-02';
+const TRANSLATE_PROMPT_VERSION = 'v10';
 const TRANSLITERATION_MODEL = 'gemini-3.1-flash-lite-preview';
 const TRANSLITERATION_PROMPT = `You are a scholarly transliterator. Convert the following text to Latin characters using standard academic Romanization conventions.
 
@@ -431,37 +431,58 @@ const TRANSLATION_PROMPT = `You are translating a manuscript transcription into 
 - <column-break/> markers — preserve exactly as-is between translated columns
 - Line breaks and paragraph structure
 
-**Inline annotations (visible to readers):**
-- <note>X</note> — interpretive notes for readers
+**Inline annotations (XML tags — toggleable by reader):**
+- <note>X</note> — interpretive notes, interpolated clarifications
+- <term>X</term> — technical/foreign terms kept in transliteration
+- <gloss>X</gloss> — definition immediately after a <term> tag; also translate interlinear annotations
 - <margin>X</margin> — translate and keep marginal notes
-- <gloss>X</gloss> — translate interlinear annotations
-- <insert>X</insert> — translate later additions (inline only)
-- <unclear>X</unclear> — illegible readings
-- <term>X</term> — technical vocabulary with explanation
+- <insert>X</insert> — translate later additions
+- <unclear>X</unclear> — preserve uncertain readings from OCR
 
 **Metadata tags (hidden from readers):**
 - <meta>X</meta> for translator notes that should be hidden (e.g., continuity with previous page)
 
 **Do NOT use:**
-- Code blocks or backticks - this is prose
+- Bare [square brackets] for interpolations — use <note>...</note> instead
+- Bare (parenthetical glosses) after terms — use <term>word</term> <gloss>meaning</gloss> instead
+- Code blocks or backticks — this is prose
 
 **IMPORTANT - Translate ALL languages to English:**
-The source text may contain phrases in multiple languages (Latin, Greek, Hebrew, etc.). You MUST translate EVERYTHING to English:
+The source text may contain phrases in multiple languages (Latin, Greek, Hebrew, Sanskrit, Arabic, etc.). You MUST translate EVERYTHING to English:
 - Latin quotes embedded in German → translate to English
-- Greek phrases → translate to English
-- Hebrew or Aramaic terms → translate to English
+- Greek, Hebrew, Aramaic phrases → translate to English
+- Sanskrit, Prakrit, Pali, Arabic text → translate to English
+- Text in non-Latin scripts (Devanagari, Chinese, Arabic, etc.) → provide English translation immediately after
 - ANY non-English text → translate to English
 Use <note>original: "..."</note> to preserve important original phrases for scholars, but the main text must be fully readable in English without knowing other languages.
+
+**Image descriptions from OCR:**
+If the OCR contains <image-desc>...</image-desc>, translate the description and wrap the ENTIRE paragraph in <note>...</note>. Image descriptions are editorial content, not original text — they must be toggleable. Do NOT leave image description prose untagged. Example:
+  OCR: <image-desc>A woodcut of a pelican feeding her young</image-desc>
+  Translation: <note>A woodcut depicts a pelican feeding her young from her own breast, a symbol of self-sacrifice in alchemical tradition.</note>
 
 **Instructions:**
 1. Start with <meta>...</meta> if noting continuity with previous page (hidden from readers).
 2. Mirror the source layout - headings, paragraphs, tables, centered text.
 3. Translate ALL text including <margin>, <insert>, <gloss> - keep the XML tags.
 4. Translate embedded Latin/Greek/Hebrew phrases to English, noting originals when significant.
-5. Add <note>...</note> inline to explain historical references or difficult phrases.
-6. Style: warm museum label - explain rather than assume knowledge.
-7. Preserve the voice and spirit of the original.
-8. END with <summary>...</summary> and <keywords>...</keywords> for indexing.
+5. For foreign terms kept in transliteration: <term>Chesed</term> <gloss>Mercy/Loving-kindness</gloss>
+
+**Examples of annotated translation:**
+- "He composed a very worthy book On the World and Religion <note>original: "De Seculo, & Religione"</note>; one On Fate and Fortune <note>original: "De Fato, & Fortuna"</note>; and another On Law and Medicine <note>original: "Della Legge, e della Medicina"</note>."
+- "The <term>prima materia</term> <gloss>first matter</gloss> must be purified through <term>calcination</term> <gloss>heating to powder</gloss> before the <term>opus</term> <gloss>the Great Work</gloss> can proceed."
+- "According to the <term>Sefer Yetzirah</term> <gloss>Book of Formation</gloss>, the ten <term>sefirot</term> <gloss>divine emanations</gloss> correspond to the paths of wisdom."
+6. For interpolated clarifications: <note>from the aspect of the secret</note>
+7. Add <note>...</note> inline to explain historical references or difficult phrases.
+8. Style: warm museum label - explain rather than assume knowledge.
+9. Preserve the voice and spirit of the original.
+8. Wrap ALL image/illustration descriptions in <note>...</note> — readers can toggle these off.
+9. END with <summary>...</summary> and <keywords>...</keywords> for indexing.
+
+**Writing style for summaries and notes:**
+- Never use em-dashes (—). Use commas, colons, semicolons, or separate sentences.
+- Avoid: "delves into", "rich tapestry", "fascinating exploration", "sheds light on", "comprehensive", "intricate", "nuanced", "multifaceted", "offers a window into".
+- Use short, direct sentences. Scholarly but accessible.
 
 **Source language:** {source_language}
 **Target language:** {target_language}
@@ -470,7 +491,7 @@ Use <note>original: "..."</note> to preserve important original phrases for scho
 [translated text]
 
 <summary>1-2 sentence summary of this page's main content and significance</summary>
-<keywords>key concepts, names, themes in English — for indexing</keywords>`;
+<keywords>key concepts, names, themes in English, for indexing</keywords>`;
 
 const ENGLISH_MODERNIZATION_PROMPT = `You are modernizing Early Modern English text into clear, accessible Modern English.
 
@@ -1132,9 +1153,11 @@ async function submitOcrDirectly(db, book, { modelOverride } = {}) {
 
   // Guard: skip pages that are unsplit spreads (have no crop but book needs splitting)
   // These would send two-page images to OCR, producing garbled results
+  // BUT: if the book was already split_checked, it passed Phase 1.25 and was determined
+  // to be portrait/single-page — no crop data expected, safe to OCR as-is.
   const unsplitPages = pages.filter(p => !p.crop && !p.cropped_photo);
-  if (unsplitPages.length > 0 && unsplitPages.length === pages.length) {
-    // All pages are unsplit — book probably needs split detection first
+  if (unsplitPages.length > 0 && unsplitPages.length === pages.length && !book.pipeline_auto?.split_checked) {
+    // All pages are unsplit AND book hasn't been through split detection
     console.log(`    WARNING: All ${pages.length} pages lack crop data — possible unsplit spreads, skipping OCR (#523)`);
     return { submitted: 0, jobName: null, alreadyDone: false, skippedUnsplit: true };
   }

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -39,7 +39,7 @@ function getModelForBook(book) {
   if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
   return MODEL_LITE;
 }
-const PROMPT_VERSION = 'v6';
+const PROMPT_VERSION = 'v10';
 
 // ── Gemini API keys ──
 const API_KEYS = [
@@ -62,18 +62,82 @@ function rotateKey() {
   console.log(`[TRANSLATE] Rotated to API key ${(currentKeyIndex % API_KEYS.length) + 1}/${API_KEYS.length}`);
 }
 
-// ── Translation prompt (matches src/lib/ai.ts performTranslation) ──
-const TRANSLATION_PROMPT = `You are a scholarly translator producing publication-quality English translations of historical texts.
+// ── Translation prompt (DB v10 — synced 2026-03-29) ──
+const TRANSLATION_PROMPT = `You are translating a manuscript transcription into accessible English.
 
-**Your task:** Translate the following text from {source_language} to English.
+**Input:** The OCR transcription and (if available) the previous page's translation for continuity.
 
-**Guidelines:**
-- Produce a faithful, readable English translation
-- Preserve the structure and meaning of the original
-- Use appropriate scholarly English for the period and genre
-- Preserve any XML-like tags in the text (e.g., <margin>, <gloss>, <unclear>)
-- Do NOT add commentary, notes, or explanations — just the translation
-- If the text is already in English, modernize archaic spelling and grammar`;
+**Output:** A readable English translation that preserves the markdown formatting from the OCR.
+
+**Preserve from OCR:**
+- Heading levels (# ## ###) - keep the same hierarchy
+- **Bold** and *italic* formatting
+- Tables - recreate them in the translation
+- Centered text (->text<-)
+- <column-break/> markers — preserve exactly as-is between translated columns
+- Line breaks and paragraph structure
+
+**Inline annotations (XML tags — toggleable by reader):**
+- <note>X</note> — interpretive notes, interpolated clarifications
+- <term>X</term> — technical/foreign terms kept in transliteration
+- <gloss>X</gloss> — definition immediately after a <term> tag; also translate interlinear annotations
+- <margin>X</margin> — translate and keep marginal notes
+- <insert>X</insert> — translate later additions
+- <unclear>X</unclear> — preserve uncertain readings from OCR
+
+**Metadata tags (hidden from readers):**
+- <meta>X</meta> for translator notes that should be hidden (e.g., continuity with previous page)
+
+**Do NOT use:**
+- Bare [square brackets] for interpolations — use <note>...</note> instead
+- Bare (parenthetical glosses) after terms — use <term>word</term> <gloss>meaning</gloss> instead
+- Code blocks or backticks — this is prose
+
+**IMPORTANT - Translate ALL languages to English:**
+The source text may contain phrases in multiple languages (Latin, Greek, Hebrew, Sanskrit, Arabic, etc.). You MUST translate EVERYTHING to English:
+- Latin quotes embedded in German → translate to English
+- Greek, Hebrew, Aramaic phrases → translate to English
+- Sanskrit, Prakrit, Pali, Arabic text → translate to English
+- Text in non-Latin scripts (Devanagari, Chinese, Arabic, etc.) → provide English translation immediately after
+- ANY non-English text → translate to English
+Use <note>original: "..."</note> to preserve important original phrases for scholars, but the main text must be fully readable in English without knowing other languages.
+
+**Image descriptions from OCR:**
+If the OCR contains <image-desc>...</image-desc>, translate the description and wrap the ENTIRE paragraph in <note>...</note>. Image descriptions are editorial content, not original text — they must be toggleable. Do NOT leave image description prose untagged. Example:
+  OCR: <image-desc>A woodcut of a pelican feeding her young</image-desc>
+  Translation: <note>A woodcut depicts a pelican feeding her young from her own breast, a symbol of self-sacrifice in alchemical tradition.</note>
+
+**Instructions:**
+1. Start with <meta>...</meta> if noting continuity with previous page (hidden from readers).
+2. Mirror the source layout - headings, paragraphs, tables, centered text.
+3. Translate ALL text including <margin>, <insert>, <gloss> - keep the XML tags.
+4. Translate embedded Latin/Greek/Hebrew phrases to English, noting originals when significant.
+5. For foreign terms kept in transliteration: <term>Chesed</term> <gloss>Mercy/Loving-kindness</gloss>
+
+**Examples of annotated translation:**
+- "He composed a very worthy book On the World and Religion <note>original: "De Seculo, & Religione"</note>; one On Fate and Fortune <note>original: "De Fato, & Fortuna"</note>; and another On Law and Medicine <note>original: "Della Legge, e della Medicina"</note>."
+- "The <term>prima materia</term> <gloss>first matter</gloss> must be purified through <term>calcination</term> <gloss>heating to powder</gloss> before the <term>opus</term> <gloss>the Great Work</gloss> can proceed."
+- "According to the <term>Sefer Yetzirah</term> <gloss>Book of Formation</gloss>, the ten <term>sefirot</term> <gloss>divine emanations</gloss> correspond to the paths of wisdom."
+6. For interpolated clarifications: <note>from the aspect of the secret</note>
+7. Add <note>...</note> inline to explain historical references or difficult phrases.
+8. Style: warm museum label - explain rather than assume knowledge.
+9. Preserve the voice and spirit of the original.
+8. Wrap ALL image/illustration descriptions in <note>...</note> — readers can toggle these off.
+9. END with <summary>...</summary> and <keywords>...</keywords> for indexing.
+
+**Writing style for summaries and notes:**
+- Never use em-dashes (—). Use commas, colons, semicolons, or separate sentences.
+- Avoid: "delves into", "rich tapestry", "fascinating exploration", "sheds light on", "comprehensive", "intricate", "nuanced", "multifaceted", "offers a window into".
+- Use short, direct sentences. Scholarly but accessible.
+
+**Source language:** {source_language}
+**Target language:** {target_language}
+
+**Final output format:**
+[translated text]
+
+<summary>1-2 sentence summary of this page's main content and significance</summary>
+<keywords>key concepts, names, themes in English, for indexing</keywords>`;
 
 const ENGLISH_MODERNIZATION_PROMPT = `You are a scholarly editor modernizing Early Modern English texts for contemporary readers.
 


### PR DESCRIPTION
## Summary
- **Translation prompt v10** — term/gloss XML tags, image-desc handling, expanded language coverage (Sanskrit, Arabic, Devanagari, etc.), few-shot examples, writing style guide. This is what's been running in production on Hetzner since ~Mar 29 but was never committed.
- **OCR split guard fix** — 7,283 books were stuck at `archive_complete` because the per-page crop guard rejected portrait/single-page books even after Phase 1.25 confirmed they don't need splitting. Guard now checks `book.pipeline_auto.split_checked` before rejecting. (#523)
- **Doc corrections** — enrichment runs on Hetzner `enrich-worker.mjs` (not deprecated Vercel `enrich-books` cron). Pipeline states corrected (`summarizing`/`summary_indexed` not `enriching`/`enriched`). Progress skill updated.

## Why
Hetzner had diverged from git for weeks. Translation prompt v10 was running in production but invisible to version control. The OCR bug was blocking thousands of books silently. Docs were pointing to dead infrastructure.

## Test plan
- [x] OCR fix already live on Hetzner and verified — next Phase 2 cycle will pick up the 7,283 ready books
- [ ] Verify prompt text matches what's in the DB `prompts` collection (v10)
- [ ] After merge, `git pull` on Hetzner to eliminate remaining divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)