### PR TITLE
Include split_checked in Phase 2 projection

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2082,7 +2082,7 @@ async function run() {
               },
             }},
             { $sort: { _priority: 1, hidden: 1 } },
-            { $project: { id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1 } },
+            { $project: { id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.split_checked': 1 } },
             { $limit: ocrLimit },
           ])
           .toArray();
@@ -2145,7 +2145,7 @@ async function run() {
             },
           }},
           { $sort: { _priority: 1, hidden: 1 } },
-          { $project: { id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1 } },
+          { $project: { id: 1, title: 1, pages_count: 1, 'pipeline_auto.retry_count': 1, 'pipeline_auto.recitation_retry': 1, 'pipeline_auto.split_checked': 1 } },
           { $limit: ocrLimit },
         ])
         .toArray() : [];


### PR DESCRIPTION
The unsplit guard checks `book.pipeline_auto.split_checked` but the Phase 2 aggregation didn't project it — always undefined, so every portrait book was rejected.

One-line fix: add `'pipeline_auto.split_checked': 1` to both preview and full pass projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)