### PR TITLE
Log client-side API errors and auto-cancel stuck jobs

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,3 +1,5 @@
 /mcp-server
 astrologuy
 tools-standlone-gemini-page-split
+ocr-output
+.claude

--- a/scripts/workers/auto-cancel-stuck-jobs.mjs
+++ b/scripts/workers/auto-cancel-stuck-jobs.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 /**
- * Auto-cancel stuck jobs — jobs in 'processing' with 0 progress for >2 hours.
- * Clears the book.job lock so the pipeline can re-submit.
+ * Auto-cancel stuck jobs + site health check.
+ * - Cancels any job in 'processing' that hasn't been updated in 2+ hours.
+ * - Pings the browse API to detect DB saturation early.
+ * - Clears the book.job lock so the pipeline can re-submit.
  *
  * Run via Hetzner cron every 30 minutes:
  *   */30 * * * * cd /root/sourcelibrary && set -a && source .env.production.local && set +a && node scripts/workers/auto-cancel-stuck-jobs.mjs >> /tmp/auto-cancel.log 2>&1
@@ -9,7 +11,7 @@
 
 import { MongoClient } from 'mongodb';
 
-const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours no update = stuck
 
 async function main() {
   const mongo = new MongoClient(process.env.MONGODB_URI);
@@ -18,10 +20,13 @@ async function main() {
 
   const cutoff = new Date(Date.now() - STUCK_THRESHOLD_MS);
 
+  // Any processing job not updated in 2h is stuck — regardless of progress
   const stuckJobs = await db.collection('jobs').find({
     status: 'processing',
-    'progress.completed': 0,
-    created_at: { $lt: cutoff },
+    $or: [
+      { updated_at: { $lt: cutoff } },
+      { updated_at: { $exists: false }, created_at: { $lt: cutoff } },
+    ],
   }).toArray();
 
   if (stuckJobs.length === 0) {
@@ -37,7 +42,7 @@ async function main() {
 
     await db.collection('jobs').updateOne(
       { _id: job._id },
-      { $set: { status: 'cancelled', cancelled_at: new Date(), cancel_reason: `auto: stuck ${age}h with 0 progress` } }
+      { $set: { status: 'cancelled', cancelled_at: new Date(), cancel_reason: `auto: stuck ${age}h, no update since ${job.updated_at?.toISOString?.() || 'unknown'}` } }
     );
 
     if (job.book_id) {
@@ -52,4 +57,21 @@ async function main() {
   await mongo.close();
 }
 
-main().catch(err => { console.error(err); process.exit(1); });
+async function healthCheck() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch('https://sourcelibrary.org/api/books/library?limit=1', {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!res.ok) {
+      console.error(`[${new Date().toISOString()}] HEALTH CHECK FAILED: browse API returned ${res.status}`);
+    }
+  } catch (err) {
+    clearTimeout(timeout);
+    console.error(`[${new Date().toISOString()}] HEALTH CHECK FAILED: browse API unreachable — ${err.message}`);
+  }
+}
+
+Promise.all([main(), healthCheck()]).catch(err => { console.error(err); process.exit(1); });

--- a/src/app/admin/errors/page.tsx
+++ b/src/app/admin/errors/page.tsx
@@ -34,6 +34,8 @@ const SOURCE_LABELS: Record<string, string> = {
   'window.onerror': 'JS Error',
   'unhandledrejection': 'Promise',
   'react_error_boundary': 'React',
+  'search_browse': 'Browse API',
+  'search_query': 'Search API',
 };
 
 export default function AdminErrorsPage() {

--- a/src/app/api/errors/route.ts
+++ b/src/app/api/errors/route.ts
@@ -1,7 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 10;
+
+/**
+ * GET /api/errors — admin-only: list recent errors for inspection.
+ */
+export const GET = withAdminAuth(async (request) => {
+  try {
+    const limit = Math.min(parseInt(request.nextUrl.searchParams.get('limit') || '100'), 500);
+    const db = await getDb();
+    const errors = await db.collection('application_errors')
+      .find({})
+      .sort({ timestamp: -1 })
+      .limit(limit)
+      .toArray();
+    const total = await db.collection('application_errors').estimatedDocumentCount();
+    return NextResponse.json({ errors, total });
+  } catch (error) {
+    console.error('[errors] Failed to fetch errors:', error);
+    return NextResponse.json({ error: 'Failed to fetch errors' }, { status: 500 });
+  }
+});
 
 /**
  * POST /api/errors

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useDebouncedCallback } from 'use-debounce';
+import { reportError } from '@/components/providers/ErrorReporter';
 import {
   search as searchApi,
   gallery as galleryApi,
@@ -223,8 +224,11 @@ export default function SearchPage() {
             const retryData = await searchApi.search(q, { ...bookFilters, search_content: 'true' });
             setBookResults(retryData.results || []);
             setBookTotal(retryData.total || 0);
-          } catch {
-            // Both attempts failed — finally block will clear loading
+          } catch (retryErr) {
+            reportError({
+              message: `Search API failed (with retry): ${retryErr instanceof Error ? retryErr.message : String(retryErr)}`,
+              source: 'search_query',
+            });
           }
         });
         searchApi.index(q, {}).then(indexData => {
@@ -346,10 +350,14 @@ export default function SearchPage() {
       });
       setBrowseBooks(data.books || []);
       setBrowseTotal(data.total || 0);
-    } catch {
+    } catch (err) {
       setBrowseBooks([]);
       setBrowseTotal(0);
       setBrowseError(true);
+      reportError({
+        message: `Browse API failed: ${err instanceof Error ? err.message : String(err)}`,
+        source: 'search_browse',
+      });
     } finally {
       setBrowseLoading(false);
     }

--- a/src/components/providers/ErrorReporter.tsx
+++ b/src/components/providers/ErrorReporter.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useCallback } from 'react';
 import ErrorBoundary from './ErrorBoundary';
 
-function reportError(data: {
+export function reportError(data: {
   message: string;
   stack?: string;
   source: string;


### PR DESCRIPTION
## Summary
- Search page browse/query failures now report to `application_errors` collection (were silently swallowed — Mike hit this today with 101 stuck jobs saturating Atlas)
- Added GET handler to `/api/errors` so the admin errors page at `/admin/errors` actually loads data
- Broadened stuck job auto-cancel from "0 progress only" to "no update in 2h" — catches today's scenario
- Added site health check ping to the auto-cancel cron script
- Added `.claude` and `ocr-output` to `.vercelignore` (2.2GB worktrees were blocking CLI deploys)

## Test plan
- [ ] Visit `/search?library=bph` — should load BPH books (after deploy lands)
- [ ] Trigger a browse API error — check `/admin/errors` shows it
- [ ] Verify auto-cancel script runs on Hetzner: `cat /tmp/auto-cancel.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)