### PR TITLE
Fix zero counts on timeline/libraries, update email, drop CC0

### DIFF
--- a/src/app/api/volunteer/route.ts
+++ b/src/app/api/volunteer/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
 
     await db.collection('volunteers').insertOne(doc);
 
-    // TODO: Send email notification to derek@ancientwisdomtrust.org on new submissions
+    // TODO: Send email notification to derek@sourcelibrary.org on new submissions
     // Options: Resend API, or a simple webhook to Slack/Discord
 
     return NextResponse.json({ ok: true });

--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -423,7 +423,7 @@ export default function BetaLandingPage() {
               <a href="mailto:press@sourcelibrary.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
                 Press
               </a>
-              <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
+              <a href="mailto:derek@sourcelibrary.org" className="text-accent-gold/60 hover:text-accent-gold transition-colors">
                 Contact
               </a>
             </div>

--- a/src/app/blog/autonomous-agents/page.tsx
+++ b/src/app/blog/autonomous-agents/page.tsx
@@ -482,7 +482,7 @@ export default function AutonomousAgentsPage() {
 
         <p className="text-secondary leading-relaxed mb-12">
           Source Library is a project of the{' '}
-          <a href="https://www.ancientwisdomtrust.org" className="text-accent-rust hover:underline">Ancient Wisdom Trust</a>, affiliated with the{' '}
+          <a href="https://www.sourcelibrary.org" className="text-accent-rust hover:underline">Ancient Wisdom Trust</a>, affiliated with the{' '}
           <a href="https://embassyofthefreemind.com" className="text-accent-rust hover:underline">Embassy of the Free Mind</a> (Bibliotheca Philosophica Hermetica) in Amsterdam.
         </p>
 

--- a/src/app/blog/counting-the-gap/page.tsx
+++ b/src/app/blog/counting-the-gap/page.tsx
@@ -231,7 +231,7 @@ export default function CountingTheGapPage() {
             All data and code is open source at{' '}
             <a href="https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2" className="text-accent-rust hover:text-accent-rust underline">github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2</a>.
             If you know of a translation we missed, please reach out &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/first-translation-methodology/page.tsx
+++ b/src/app/blog/first-translation-methodology/page.tsx
@@ -452,8 +452,8 @@ export default function FirstTranslationMethodologyPage() {
 
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed">
-            Source Library is a project of the Embassy of the Free Mind. Everything in the collection is CC0 public domain. Corrections and feedback are welcome &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            Source Library is a project of the Embassy of the Free Mind. Corrections and feedback are welcome &mdash;{' '}
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/first-translations/page.tsx
+++ b/src/app/blog/first-translations/page.tsx
@@ -438,8 +438,8 @@ export default function FirstTranslationsPage() {
         {/* === Footer === */}
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed font-body">
-            Source Library is a project of the Embassy of the Free Mind. Everything in the collection is CC0 public domain. If you are a scholar who can improve any of these translations, or if you know of a prior English translation we missed, please reach out &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            Source Library is a project of the Embassy of the Free Mind. If you are a scholar who can improve any of these translations, or if you know of a prior English translation we missed, please reach out &mdash;{' '}
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/mcp-server/page.tsx
+++ b/src/app/blog/mcp-server/page.tsx
@@ -184,7 +184,7 @@ export default function McpServerPage() {
         </ul>
 
         <p className="text-secondary leading-relaxed mb-8">
-          Every book has been OCR&apos;d from the original page images and translated to English by AI, with the original language always preserved alongside for verification. Published editions carry DOIs via Zenodo. Everything is CC0 public domain.
+          Every book has been OCR&apos;d from the original page images and translated to English by AI, with the original language always preserved alongside for verification. Published editions carry DOIs via Zenodo.
         </p>
 
         <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
@@ -268,8 +268,8 @@ export default function McpServerPage() {
 
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed">
-            Source Library is a project of the Embassy of the Free Mind. Everything in the collection is CC0 public domain. If you use it for research, we&apos;d love to hear about it &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            Source Library is a project of the Embassy of the Free Mind. If you use it for research, we&apos;d love to hear about it &mdash;{' '}
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/origin-story/page.tsx
+++ b/src/app/blog/origin-story/page.tsx
@@ -262,8 +262,8 @@ export default function OriginStoryPage() {
         {/* === Footer === */}
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed font-body">
-            Source Library is a project of the Embassy of the Free Mind. The collection is CC0 public domain. If you want to help translate the Renaissance, or if you have leads on untranslated texts that belong in the collection, reach out &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            Source Library is a project of the Embassy of the Free Mind. If you want to help translate the Renaissance, or if you have leads on untranslated texts that belong in the collection, reach out &mdash;{' '}
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/translation-rate/page.tsx
+++ b/src/app/blog/translation-rate/page.tsx
@@ -450,7 +450,7 @@ export default function TranslationRatePage() {
             (1.57M records). Analysis scripts are in{' '}
             <a href="https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2" className="text-accent-rust hover:text-accent-rust underline">our repo</a>.
             If you know of translation catalogs we&apos;re missing, please reach out &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/blog/untranslated-renaissance/page.tsx
+++ b/src/app/blog/untranslated-renaissance/page.tsx
@@ -436,8 +436,8 @@ export default function UntranslatedRenaissancePage() {
         {/* === Footer === */}
         <div className="border-t border-border-light pt-8 mt-16">
           <p className="text-secondary text-sm leading-relaxed font-body">
-            Source Library is a project of the Embassy of the Free Mind. The collection is CC0 public domain. If you know of a translation we missed, or if you can improve one of ours, please reach out &mdash;{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:text-accent-rust underline">derek@ancientwisdomtrust.org</a>.
+            Source Library is a project of the Embassy of the Free Mind. If you know of a translation we missed, or if you can improve one of ours, please reach out &mdash;{' '}
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:text-accent-rust underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </article>

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -233,7 +233,7 @@ export default async function ParticipatePage() {
             </p>
           </Link>
 
-          <a href="mailto:derek@ancientwisdomtrust.org?subject=Study group idea" className="group p-4 rounded-xl bg-white border border-border-light hover:border-accent-violet/40 hover:shadow-sm transition-all text-center">
+          <a href="mailto:derek@sourcelibrary.org?subject=Study group idea" className="group p-4 rounded-xl bg-white border border-border-light hover:border-accent-violet/40 hover:shadow-sm transition-all text-center">
             <div className="w-9 h-9 mx-auto mb-2 rounded-lg bg-accent-violet/10 flex items-center justify-center">
               <svg className="w-5 h-5 text-accent-violet" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
@@ -326,10 +326,10 @@ export default async function ParticipatePage() {
           </p>
           <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
             <a
-              href="mailto:derek@ancientwisdomtrust.org"
+              href="mailto:derek@sourcelibrary.org"
               className="inline-flex items-center gap-2 text-lg text-primary font-medium hover:text-accent-rust transition-colors"
             >
-              derek@ancientwisdomtrust.org
+              derek@sourcelibrary.org
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
@@ -351,7 +351,7 @@ export default async function ParticipatePage() {
       <footer className="border-t border-border-light">
         <div className="max-w-5xl mx-auto px-6 py-8">
           <p className="text-muted text-sm leading-relaxed">
-            Everything here is CC0 public domain. No paywalls, no login walls. AI translations are first drafts &mdash; the originals are always preserved alongside them. Published editions carry DOIs via Zenodo, so your contributions become citable scholarship.
+            No paywalls, no login walls. AI translations are first drafts &mdash; the originals are always preserved alongside them. Published editions carry DOIs via Zenodo, so your contributions become citable scholarship.
           </p>
         </div>
       </footer>

--- a/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
+++ b/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
@@ -316,10 +316,10 @@ export function WikipediaPlaybook({ posts }: { posts: TalkPagePost[] }) {
       <div className="text-sm text-muted text-center pb-8">
         Questions? Contact{' '}
         <a
-          href="mailto:derek@ancientwisdomtrust.org"
+          href="mailto:derek@sourcelibrary.org"
           className="text-accent-rust hover:underline"
         >
-          derek@ancientwisdomtrust.org
+          derek@sourcelibrary.org
         </a>
       </div>
     </div>

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -56,7 +56,7 @@ async function fetchProviderStats(): Promise<ProviderStats[]> {
     { $project: { count: 1, languages: 1, sampleIds: { $slice: ['$sampleIds', 3] } } },
   ];
 
-  const results = await db.collection('books').aggregate(pipeline, { maxTimeMS: 25000 }).toArray();
+  const results = await db.collection('books').aggregate(pipeline, { maxTimeMS: 45000 }).toArray();
 
   // Fetch one hero gallery image per provider (small $in query)
   const allBookIds = results.flatMap(r => (r.sampleIds as string[]));
@@ -116,7 +116,7 @@ async function fetchContributingLibraries(): Promise<ContributingLibrary[]> {
       },
     },
     { $sort: { count: -1 as const } },
-  ], { maxTimeMS: 25000 }).toArray();
+  ], { maxTimeMS: 45000 }).toArray();
 
   // Filter out entries that duplicate a digital source name (e.g. "Internet Archive")
   const digitalNames = new Set(Object.values(LIBRARY_PARTNERS).map(p => p.name.toLowerCase()));

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -96,7 +96,7 @@ export default function PrivacyPage() {
           <h2 className="text-lg font-medium mt-8 mb-3" style={{ color: 'var(--text-primary)' }}>Contact</h2>
           <p>
             Privacy questions? Contact us at{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="underline">derek@ancientwisdomtrust.org</a>.
+            <a href="mailto:derek@sourcelibrary.org" className="underline">derek@sourcelibrary.org</a>.
           </p>
         </div>
       </main>

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -299,7 +299,7 @@ export default function RoadmapPage() {
           </p>
           <div className="flex flex-wrap gap-4">
             <a
-              href="mailto:derek@ancientwisdomtrust.org"
+              href="mailto:derek@sourcelibrary.org"
               className="inline-flex items-center gap-2 bg-accent-rust hover:bg-accent-gold/80 text-white px-6 py-3 rounded-lg font-medium transition-colors"
             >
               <BookOpen className="w-5 h-5" />

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 // When available, replace this URL so donors see "Source Library" instead of the generic Embassy form.
 const DONORPERFECT_URL = 'https://form-renderer-app.donorperfect.io/give/naf/embassyofthefreemind';
 
-const CONTACT_EMAIL = 'derek@ancientwisdomtrust.org';
+const CONTACT_EMAIL = 'derek@sourcelibrary.org';
 
 const MEMBERSHIP_TIERS = [
   {
@@ -227,7 +227,7 @@ export default function SupportPage() {
               },
               {
                 title: 'Open Access for Everyone',
-                text: 'Everything we produce — scans, OCR text, translations — is released under CC0 public domain. No paywalls, no restrictions. Wisdom belongs to everyone, and your support keeps it that way.',
+                text: 'Everything we produce — scans, OCR text, translations — is open access. No paywalls, no restrictions. Wisdom belongs to everyone, and your support keeps it that way.',
               },
               {
                 title: 'Enriching AI with Ancient Knowledge',

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -130,8 +130,8 @@ export default function TermsPage() {
           </p>
           <p className="text-secondary">
             <strong>Contact us:</strong>{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:underline">
-              derek@ancientwisdomtrust.org
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
+              derek@sourcelibrary.org
             </a>
           </p>
         </section>
@@ -219,8 +219,8 @@ export default function TermsPage() {
           </h2>
           <p className="text-secondary">
             Questions about these terms or interested in a partnership?{' '}
-            <a href="mailto:derek@ancientwisdomtrust.org" className="text-accent-rust hover:underline">
-              derek@ancientwisdomtrust.org
+            <a href="mailto:derek@sourcelibrary.org" className="text-accent-rust hover:underline">
+              derek@sourcelibrary.org
             </a>
           </p>
         </section>

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -14,15 +14,28 @@ export const metadata: Metadata = {
 };
 
 async function fetchTimelineData(): Promise<TimelineOverview> {
+  const empty: TimelineOverview = {
+    decades: [],
+    summary: { total: 0, yearRange: { min: 0, max: 0 }, topLanguages: [] },
+    filters: { languages: [], collections: [] },
+  };
+
   try {
     const db = await getDb();
 
+    // Try pre-computed cache first (seeded by scripts/seed-timeline-filters.mjs)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cached = await db.collection('system_config').findOne({ _id: 'timeline_overview' } as any);
+    if (cached && cached.data?.decades?.length > 0) {
+      return cached.data as TimelineOverview;
+    }
+
+    // Fallback: live aggregation with generous timeout
     const baseMatch = {
       year: { $exists: true, $ne: null },
       hidden: { $ne: true },
     };
 
-    // Single aggregation: group by decade+language, then reshape
     const pipeline = [
       { $match: baseMatch },
       { $project: { year: 1, language: { $ifNull: ['$language', 'Unknown'] } } },
@@ -47,7 +60,7 @@ async function fetchTimelineData(): Promise<TimelineOverview> {
     ];
 
     const [rawDecades, languages] = await Promise.all([
-      db.collection('books').aggregate(pipeline, { maxTimeMS: 10000 }).toArray(),
+      db.collection('books').aggregate(pipeline, { maxTimeMS: 45000 }).toArray(),
       db.collection('books').distinct('language', baseMatch),
     ]);
 
@@ -84,11 +97,7 @@ async function fetchTimelineData(): Promise<TimelineOverview> {
     };
   } catch (err) {
     console.error('Timeline data fetch failed:', err);
-    return {
-      decades: [],
-      summary: { total: 0, yearRange: { min: 0, max: 0 }, topLanguages: [] },
-      filters: { languages: [], collections: [] },
-    };
+    return empty;
   }
 }
 

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1992,12 +1992,10 @@ export default function TranslationEditor({
 
       </div>
 
-      {/* CC0 Footer */}
+      {/* Footer */}
       <div className="px-4 py-1.5 flex items-center justify-center gap-2 text-xs" style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', borderTop: '1px solid var(--border-light)' }}>
-        <span>CC0 Public Domain</span>
-        <span>•</span>
-        <a href="mailto:derek@ancientwisdomtrust.org" className="hover:underline" style={{ color: 'var(--accent-rust)' }}>
-          derek@ancientwisdomtrust.org
+        <a href="mailto:derek@sourcelibrary.org" className="hover:underline" style={{ color: 'var(--accent-rust)' }}>
+          derek@sourcelibrary.org
         </a>
       </div>
 

--- a/src/lib/api-client/images.ts
+++ b/src/lib/api-client/images.ts
@@ -26,7 +26,7 @@
  */
 
 // Polite User-Agent for external library servers
-const USER_AGENT = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)';
+const USER_AGENT = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org)';
 
 /**
  * Fetch an image from a URL and return it as a Buffer


### PR DESCRIPTION
## Summary
- **Timeline page**: reads from `system_config` cache first (seeded by `seed-timeline-filters.mjs`), falls back to live aggregation with 45s timeout (was 10s which silently timed out on Atlas, returning 0)
- **Libraries page**: increased aggregation timeout from 25s to 45s
- **Email**: replaced `derek@ancientwisdomtrust.org` with `derek@sourcelibrary.org` across 16 files
- **CC0**: removed "CC0 public domain" claims from public-facing pages (contribute, support, blog footers, translation editor)

## Test plan
- [ ] Visit https://sourcelibrary.org/timeline — should show non-zero text count
- [ ] Visit https://sourcelibrary.org/libraries — should show non-zero book/platform/institution counts
- [ ] Check footer email on /contribute, /support, /terms, /privacy — should be derek@sourcelibrary.org
- [ ] Verify no CC0 text on /contribute, /support, blog posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)