### PR TITLE
Pipeline observability: auto-resume stale pauses, audit logging, 40-book concurrency

### DIFF
--- a/.claude/docs/pipeline-architecture.md
+++ b/.claude/docs/pipeline-architecture.md
@@ -236,7 +236,7 @@ $0.0017/page (measured from `gemini_usage`: $354 / 211K pages over 7 days)
 4. Calls Gemini directly -- model: `gemini-3-flash-preview` (BPH) or `gemini-3.1-flash-lite-preview` (others)
 5. Writes translation directly to `pages` collection
 6. Rotates API keys on rate limits (up to 11 keys)
-7. Concurrency: 20 books simultaneously, 8,000 page cap per run
+7. Concurrency: 40 books simultaneously, 8,000 page cap per run
 
 ### Legacy Lambda Path (Fallback)
 

--- a/.claude/docs/pipeline.md
+++ b/.claude/docs/pipeline.md
@@ -300,7 +300,7 @@ The old Vercel-based `post-import-pipeline` cron also had OCR routing with Lambd
 - Translates pages sequentially per book (context continuity via previous page lookup)
 - Calls Gemini API directly — no SQS, no Lambda
 - Model routing: `gemini-3-flash-preview` for BPH, `gemini-3.1-flash-lite-preview` for all others
-- Concurrency: 20 books simultaneously, 8,000 page cap per run, 40 in-flight book cap
+- Concurrency: 40 books simultaneously, 8,000 page cap per run, 40 in-flight book cap
 - API key rotation on rate limits (up to 11 keys)
 
 ### Fallback Path: Lambda + SQS FIFO

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -8,7 +8,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 |-----------|-------|-----|
 | Pipeline orchestrator | **Hetzner** (`pipeline-orchestrator.mjs`) | All phases, every 2 min |
 | Full-book OCR | **Hetzner → Gemini Batch API** | Direct submission, 50% cost discount |
-| Translation | **Hetzner** (`translate-worker.mjs`) | Direct Gemini calls, 20 concurrent books |
+| Translation | **Hetzner** (`translate-worker.mjs`) | Direct Gemini calls, 40 concurrent books |
 | Batch result collection | **Hetzner** (`batch-collector.mjs`) | Polls Gemini API every 10 min |
 | Archiving | **Hetzner** (`archive-ocr.mjs`, `archive-bulk.mjs`) | Downloads → Cloudflare R2 |
 | Preview OCR (25 pages) | **Lambda** via SQS | Fast preview path, still active |
@@ -36,22 +36,28 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 - **Resume:** `POST /api/admin/emergency-stop?resume=true`
 - **Selective pause:** `paused_phases: ['ocr','translation','images']`
 - **Adaptive limits:** `GET/PATCH /api/admin/adaptive-limits`
-- **`paused: true` doesn't stop Lambda workers or Hetzner translate-worker.** Must CANCEL jobs in MongoDB for actual load reduction.
+- **`paused: true` is respected by Hetzner workers** (orchestrator, translate-worker, enrich-worker). Workers auto-resume stale pauses after 30min if DB is healthy (<500ms findOne). Phase-specific pauses are always respected.
+- **Audit log:** All pause/unpause events logged to `processing_control_log` collection (action, timestamp, source, detail).
+- To force-stop Lambda workers: must CANCEL jobs in MongoDB (Lambda doesn't check pause flag).
 
 ## Concurrency Limits
 
 - MongoDB Atlas saturates at ~40 concurrent Lambda jobs (global backpressure limit)
 - Per-phase maximums: OCR 20, translation 30 (in-flight cap 40 books), images 50
-- Translate-worker runs 20 concurrent books, 8000 pages/run cap
+- Translate-worker runs 40 concurrent books, 8000 pages/run cap
 - Tested higher (2026-03-26): `global_active_max` 50, `translate_lambda_max` 50 — Atlas stayed healthy. Adaptive system will auto-dial back if needed (ensure `locked: false`).
 
 ## Critical Rules
 
 - NEVER use Gemini Batch API for translation — lacks cross-page context. Use `translate-worker.mjs` (Hetzner) or Lambda FIFO (fallback).
+- **Translation prompt source of truth is the DB `prompts` collection** (type: 'translation', is_default: true). Both workers read it once per run and cache. Never hardcode prompts in worker files. To update the prompt, update the DB — no code deploy needed.
 - **Any Hetzner worker that writes to `pages` must also update the parent book's cached counters** (`pages_ocr`, `pages_translated`, `pages_archived`). Vercel API routes do this via shared helpers, but standalone Hetzner scripts bypass them. See #497.
 - Any script overwriting `ocr.data` or `translation.data` MUST call `createRevision(pageId, field, jobId?)` first
+- **Never patch Hetzner without committing to git.** Local-only patches cause drift that's invisible to other devs and future sessions. Apply fixes in git first, then `git pull` on Hetzner.
+- **Health grading uses DB latency only** (findMs, countMs), not job count. Job count stopped correlating with DB load when translation moved to Hetzner. See lesson 2026-03-30.
 - Summary/Index generation: ALWAYS use `gemini-3-flash-preview` (per CLAUDE.md)
 - Stale Vercel connection pools after DB recovery → redeploy to reset
+- **All Hetzner workers log to `cron_runs`** with their `cron` field name (not `name`). Workers: `hetzner-translate-worker`, `pipeline-orchestrator-worker`, `hetzner-enrich-worker`. Query: `db.collection('cron_runs').find({ cron: '...' }).sort({ timestamp: -1 })`.
 
 ## Lessons Learned
 

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -1210,7 +1210,23 @@ async function main() {
   await client.connect();
   const db = client.db('bookstore');
 
+  const startTime = Date.now();
   console.log(`[ENRICH] ${new Date().toISOString()} — phase=${phaseArg}, dry-run=${DRY_RUN}`);
+
+  // Check pause status
+  const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
+  if (control?.paused || control?.paused_phases?.includes('enrichment')) {
+    const reason = control?.paused ? 'pipeline paused' : 'enrichment phase paused';
+    console.log(`[ENRICH] ${reason}, exiting`);
+    await db.collection('cron_runs').insertOne({
+      cron: 'hetzner-enrich-worker', timestamp: new Date(),
+      duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+      actions: { skip_reason: reason }, errors: [], error_count: 0,
+      summary: `skipped: ${reason}`,
+    }).catch(() => {});
+    await client.close();
+    return;
+  }
 
   let enriched = 0;
   let chaptersExtracted = 0;
@@ -1312,11 +1328,23 @@ async function main() {
   }
 
   // Summary
-  console.log(`\n[ENRICH] Done — enriched=${enriched}, chapters=${chaptersExtracted}, errors=${errors.length}`);
+  const durationMs = Date.now() - startTime;
+  console.log(`\n[ENRICH] Done — enriched=${enriched}, chapters=${chaptersExtracted}, errors=${errors.length}, ${(durationMs/1000).toFixed(0)}s`);
   if (errors.length > 0) {
     console.log('  Errors:');
     for (const err of errors.slice(0, 10)) console.log(`    ${err}`);
   }
+
+  await db.collection('cron_runs').insertOne({
+    cron: 'hetzner-enrich-worker', timestamp: new Date(),
+    duration_ms: durationMs,
+    status: errors.length > 0 ? 'completed_with_errors' : 'success',
+    failed: false,
+    actions: { enriched, chapters_extracted: chaptersExtracted },
+    errors: errors.slice(0, 20).map(msg => ({ message: msg, timestamp: new Date() })),
+    error_count: errors.length,
+    summary: `E:${enriched} C:${chaptersExtracted} err:${errors.length}`,
+  }).catch(() => {});
 
   await client.close();
 }

--- a/scripts/workers/enrichment-snapshot.mjs
+++ b/scripts/workers/enrichment-snapshot.mjs
@@ -96,6 +96,18 @@ async function run() {
   // 8. Pause status
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
 
+  // 9. Stall detection — flag when translation throughput is 0 but jobs exist
+  const translationActive = active_jobs.some(j => j._id.type === 'translation');
+  const translationStalled = translationActive && throughput.translation_1h === 0;
+  if (translationStalled) {
+    console.log(`[enrichment-snapshot] WARNING: Translation stalled — active jobs exist but 0 pages translated in 1h`);
+    await db.collection('processing_control_log').insertOne({
+      action: 'stall_detected', timestamp: new Date(), source: 'enrichment-snapshot',
+      detail: `translation_1h=0 with ${active_jobs.filter(j => j._id.type === 'translation').reduce((s, j) => s + j.count, 0)} active translation jobs`,
+      paused: control?.paused || false,
+    }).catch(() => {});
+  }
+
   // Write snapshot
   const snapshot = {
     _id: 'enrichment_snapshot',
@@ -138,6 +150,7 @@ async function run() {
     throughput,
     paused: control?.paused || false,
     paused_phases: control?.paused_phases || [],
+    translation_stalled: translationStalled,
   };
 
   await db.collection('system_config').replaceOne(

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1271,12 +1271,53 @@ async function run() {
   await client.connect();
   const db = client.db('bookstore');
 
-  // Emergency stop check
+  // Emergency stop check — with auto-resume for stale pauses
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
   if (control?.paused) {
-    console.log('[pipeline-orchestrator] PAUSED by emergency stop. Exiting.');
-    await client.close();
-    return;
+    const pauseAgeMs = control.paused_at ? Date.now() - new Date(control.paused_at).getTime() : Infinity;
+    const STALE_PAUSE_MS = 30 * 60 * 1000; // 30 minutes
+
+    // Auto-resume if pause is stale and DB is responsive
+    if (pauseAgeMs > STALE_PAUSE_MS) {
+      const probeStart = Date.now();
+      await db.collection('books').findOne({ pages_count: { $gt: 0 } });
+      const findMs = Date.now() - probeStart;
+
+      if (findMs < 500) {
+        console.log(`[pipeline-orchestrator] Auto-resuming stale pause (${Math.round(pauseAgeMs / 60000)}min old, DB ${findMs}ms). Original paused_by: ${control.paused_by}`);
+        await db.collection('system_config').updateOne(
+          { _id: 'processing_control' },
+          { $set: { paused: false, unpaused_at: new Date(), unpaused_by: `auto-resume: stale pause (${Math.round(pauseAgeMs / 60000)}min), DB healthy (${findMs}ms)` } }
+        );
+        await db.collection('processing_control_log').insertOne({
+          action: 'auto_resume', timestamp: new Date(), source: 'pipeline-orchestrator',
+          detail: `Stale pause auto-cleared after ${Math.round(pauseAgeMs / 60000)}min. DB findOne: ${findMs}ms. Original: ${control.paused_by}`,
+        }).catch(() => {});
+        // Continue execution — don't return
+      } else {
+        console.log(`[pipeline-orchestrator] Pause is stale (${Math.round(pauseAgeMs / 60000)}min) but DB slow (${findMs}ms). Staying paused.`);
+        await db.collection('cron_runs').insertOne({
+          cron: 'pipeline-orchestrator-worker', timestamp: new Date(),
+          duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+          actions: { skip_reason: 'pipeline paused (stale but DB slow)', paused_by: control.paused_by, paused_at: control.paused_at, db_find_ms: findMs },
+          errors: [], error_count: 0,
+          summary: `skipped: paused (stale ${Math.round(pauseAgeMs / 60000)}min, DB ${findMs}ms)`,
+        }).catch(() => {});
+        await client.close();
+        return;
+      }
+    } else {
+      console.log(`[pipeline-orchestrator] PAUSED (${Math.round(pauseAgeMs / 60000)}min ago by ${control.paused_by}). Exiting.`);
+      await db.collection('cron_runs').insertOne({
+        cron: 'pipeline-orchestrator-worker', timestamp: new Date(),
+        duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+        actions: { skip_reason: 'pipeline paused', paused_by: control.paused_by, paused_at: control.paused_at },
+        errors: [], error_count: 0,
+        summary: `skipped: pipeline paused (by ${control.paused_by || 'unknown'}, ${Math.round(pauseAgeMs / 60000)}min ago)`,
+      }).catch(() => {});
+      await client.close();
+      return;
+    }
   }
 
   // DB health probe — adjusts submission limits based on Atlas load

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -26,7 +26,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { createHash } from 'crypto';
 
 // ── Config ──
-const CONCURRENCY = 20;          // Max books translating simultaneously
+const CONCURRENCY = 40;          // Max books translating simultaneously
 const PAGES_PER_RUN = 8000;      // Global page cap per run (prevent runaway costs)
 const MAX_CONSECUTIVE_ERRORS = 5; // Per-book error threshold before giving up
 const RATE_LIMIT_BACKOFF_MS = 15000;
@@ -99,7 +99,7 @@ const MIN_OCR_CHARS_FOR_BATCH = 200;
 // ── MongoDB ──
 const client = new MongoClient(process.env.MONGODB_URI, {
   serverSelectionTimeoutMS: 10000,
-  maxPoolSize: CONCURRENCY + 5,
+  maxPoolSize: CONCURRENCY + 10,
 });
 
 // ── Sanitize translation tags (matches src/lib/sanitize-translation-tags.ts) ──
@@ -638,12 +638,65 @@ async function main() {
   await client.connect();
   const db = client.db('bookstore');
 
-  // Check pause status
+  // Check pause status — with auto-resume for stale global pauses
   const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
-  if (control?.paused || control?.paused_phases?.includes('translation')) {
-    console.log('[TRANSLATE] Pipeline paused, exiting');
-    await client.close();
-    return;
+  const translationPhasePaused = control?.paused_phases?.includes('translation');
+  if (control?.paused || translationPhasePaused) {
+    // Phase-specific pauses are always respected (intentional)
+    if (translationPhasePaused) {
+      console.log('[TRANSLATE] Translation phase paused, exiting');
+      await db.collection('cron_runs').insertOne({
+        cron: 'hetzner-translate-worker', timestamp: new Date(),
+        duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+        pages_saved: 0, actions: { books_processed: 0, skip_reason: 'translation phase paused' },
+        errors: [], error_count: 0, summary: 'skipped: translation phase paused',
+      }).catch(() => {});
+      await client.close();
+      return;
+    }
+
+    // Global pause: auto-resume if stale (>30min) and DB is healthy
+    const pauseAgeMs = control.paused_at ? Date.now() - new Date(control.paused_at).getTime() : Infinity;
+    const STALE_PAUSE_MS = 30 * 60 * 1000;
+
+    if (pauseAgeMs > STALE_PAUSE_MS) {
+      const probeStart = Date.now();
+      await db.collection('books').findOne({ pages_count: { $gt: 0 } });
+      const findMs = Date.now() - probeStart;
+
+      if (findMs < 500) {
+        console.log(`[TRANSLATE] Auto-resuming stale pause (${Math.round(pauseAgeMs / 60000)}min old, DB ${findMs}ms)`);
+        await db.collection('system_config').updateOne(
+          { _id: 'processing_control' },
+          { $set: { paused: false, unpaused_at: new Date(), unpaused_by: `auto-resume: translate-worker (${Math.round(pauseAgeMs / 60000)}min stale, DB ${findMs}ms)` } }
+        );
+        await db.collection('processing_control_log').insertOne({
+          action: 'auto_resume', timestamp: new Date(), source: 'translate-worker',
+          detail: `Stale pause auto-cleared after ${Math.round(pauseAgeMs / 60000)}min. DB: ${findMs}ms. Original: ${control.paused_by}`,
+        }).catch(() => {});
+        // Continue — don't return
+      } else {
+        console.log(`[TRANSLATE] Stale pause but DB slow (${findMs}ms), staying paused`);
+        await db.collection('cron_runs').insertOne({
+          cron: 'hetzner-translate-worker', timestamp: new Date(),
+          duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+          pages_saved: 0, actions: { books_processed: 0, skip_reason: 'pipeline paused (DB slow)', db_find_ms: findMs },
+          errors: [], error_count: 0, summary: `skipped: paused (stale but DB ${findMs}ms)`,
+        }).catch(() => {});
+        await client.close();
+        return;
+      }
+    } else {
+      console.log(`[TRANSLATE] Pipeline paused (${Math.round(pauseAgeMs / 60000)}min ago), exiting`);
+      await db.collection('cron_runs').insertOne({
+        cron: 'hetzner-translate-worker', timestamp: new Date(),
+        duration_ms: Date.now() - startTime, status: 'skipped', failed: false,
+        pages_saved: 0, actions: { books_processed: 0, skip_reason: 'pipeline paused' },
+        errors: [], error_count: 0, summary: `skipped: pipeline paused (${Math.round(pauseAgeMs / 60000)}min ago)`,
+      }).catch(() => {});
+      await client.close();
+      return;
+    }
   }
 
   // Find books with active translation jobs

--- a/src/app/api/admin/emergency-stop/route.ts
+++ b/src/app/api/admin/emergency-stop/route.ts
@@ -31,8 +31,11 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
   if (resume) {
     await db.collection('system_config').updateOne(
       { _id: 'processing_control' as any },
-      { $set: { paused: false, paused_phases: [], resumed_at: new Date() } },
+      { $set: { paused: false, paused_phases: [], resumed_at: new Date(), resumed_by: 'emergency-stop-api' } },
     );
+    await db.collection('processing_control_log').insertOne({
+      action: 'resume', timestamp: new Date(), source: 'emergency-stop-api',
+    });
     return NextResponse.json({ success: true, action: 'resumed' });
   }
 
@@ -123,6 +126,11 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
       { $set: pauseUpdate },
       { upsert: true }
     );
+    await db.collection('processing_control_log').insertOne({
+      action: 'pause', timestamp: new Date(), source: 'emergency-stop-api',
+      reason: 'emergency stop', paused_phases: pausedPhases || 'all',
+      jobs_cancelled: activeJobCount, batch_jobs_cancelled: activeBatchCount,
+    });
   }
 
   // 5. Purge SQS AI queues (unless skipped or dry run)


### PR DESCRIPTION
## Summary
- **Auto-resume stale pauses**: Orchestrator and translate-worker now auto-resume global pauses older than 30min if DB health is good (<500ms findOne). Phase-specific pauses are always respected. This prevents indefinite stalls from abandoned Claude Code sessions.
- **Cron logging when skipped**: All three Hetzner workers (orchestrator, translate-worker, enrich-worker) now log to `cron_runs` when they skip due to pause, with the reason and who paused. Previously translate-worker and orchestrator exited silently.
- **Audit log**: All pause/unpause events logged to new `processing_control_log` collection (action, timestamp, source, detail). Emergency-stop API route also logs.
- **Stall detection**: Enrichment snapshot flags `translation_stalled: true` when active jobs exist but 0 pages translated in 1h, and writes to `processing_control_log`.
- **Translation concurrency 20→40 books**: Targeting 10k pages/hr throughput.
- **Enrich-worker**: Added pause checking (had none) and cron_runs logging on completion.
- Docs updated: pipeline-ops.md, pipeline.md, pipeline-architecture.md

## Context
Today a Claude Code session paused the pipeline at 07:58 UTC and cancelled 17 active translation jobs (3,377 pages wasted). The translate-worker silently respected the pause for 90+ minutes with zero logging. No other session could tell what happened or why throughput was 0.

## Test plan
- [ ] Deploy to Hetzner (`git pull` + verify cron runs)
- [ ] Pause pipeline manually, confirm workers log `skipped` to `cron_runs`
- [ ] Wait >30min, confirm auto-resume kicks in
- [ ] Check `processing_control_log` collection for audit entries
- [ ] Monitor translation throughput at new 40-book concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)