### PR TITLE
Translate-worker daemon mode: continuous slot-fill for 10k+/hr

### DIFF
--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -699,12 +699,19 @@ async function main() {
     }
   }
 
-  // Find books with active translation jobs
-  const books = await db.collection('books')
-    .find({ 'pipeline_auto.status': 'translate_submitted' })
-    .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1 })
-    .limit(CONCURRENCY)
-    .toArray();
+  // Find books — fresh books first (pages_translated: 0).
+  // Fresh books all hit the 200-page cap at ~the same time, minimizing convoy waste.
+  const proj = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1 };
+  const fresh = await db.collection('books')
+    .find({ 'pipeline_auto.status': 'translate_submitted', $or: [{ pages_translated: 0 }, { pages_translated: { $exists: false } }] })
+    .project(proj).limit(CONCURRENCY).toArray();
+  let books = fresh;
+  if (fresh.length < CONCURRENCY) {
+    const rest = await db.collection('books')
+      .find({ 'pipeline_auto.status': 'translate_submitted', pages_translated: { $gt: 0 } })
+      .project(proj).limit(CONCURRENCY - fresh.length).toArray();
+    books = [...fresh, ...rest];
+  }
 
   if (books.length === 0) {
     console.log('[TRANSLATE] No books to translate');


### PR DESCRIPTION
## Summary
- Converts translate-worker from **cron batch-and-exit** to a **long-running daemon** with continuous slot-fill
- When a book finishes translation, the next one is picked up immediately — no 2-min cron gap, no idle slots while the slowest book completes
- `--once` flag preserves legacy cron behavior for safe rollback
- Systemd service file for Hetzner deployment
- Per-book page cap (200) removed in daemon mode — no longer needed since slots refill independently

## Why
The batch model wastes ~50% of wall-clock time in idle gaps (waiting for slowest book, cron intervals). At 40 concurrent books, this alone should double sustained throughput from ~5-7k/hr to 10k+/hr.

## Architecture
```
OLD: cron fires → grab 40 books → translate all → wait for slowest → exit → 2min gap → repeat
NEW: daemon starts → fill 40 slots → as each finishes → immediately fill slot → never idle
```

## Deployment
```bash
# On Hetzner:
git pull
# Stop the old cron-based worker
crontab -l | sed 's|^.*/translate-worker.mjs.*|# &|' | crontab -
# Kill any running cron instance
pkill -f 'translate-worker.mjs' || true
# Install and start the daemon
cp infrastructure/translate-worker.service /etc/systemd/system/
systemctl daemon-reload
systemctl enable --now translate-worker
# Verify
journalctl -u translate-worker -f
```

## Rollback
```bash
systemctl stop translate-worker
# Uncomment cron line in crontab, or run manually:
cd /root/sourcelibrary && node scripts/workers/translate-worker.mjs --once
```

## Test plan
- [ ] Verify `--once` mode still works (backward compatible)
- [ ] Deploy daemon on Hetzner, monitor throughput
- [ ] Confirm graceful shutdown (SIGTERM drains in-flight books)
- [ ] Check cron_runs logging every 5min
- [ ] Monitor sustained throughput target: 10k+/hr

🤖 Generated with [Claude Code](https://claude.com/claude-code)