### PR TITLE
Fix browse API timeout: split facet into parallel queries

### DIFF
--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -69,10 +69,9 @@ export async function GET(request: NextRequest) {
     const db = await getDb();
 
     // When a search term is present, use Atlas Search ($search must be first stage).
-    // Language, category, firstTranslation are pushed as Atlas Search filters.
-    // Collection is not in the search index so it stays as a post-$search $match.
     // When no search term, use a standard $match (cheaper for unfiltered browsing).
     let pipelineStart: Record<string, unknown>[];
+    let matchFilter: Record<string, unknown> | null = null;
 
     if (search.trim()) {
       pipelineStart = [
@@ -95,7 +94,8 @@ export async function GET(request: NextRequest) {
       if (library) matchConditions.push({ 'image_source.provider': library });
       if (firstTranslation) matchConditions.push({ is_first_translation: true });
       if (hasTranslation) matchConditions.push({ pages_translated: { $gt: 0 } });
-      pipelineStart = [{ $match: { $and: matchConditions } }];
+      matchFilter = { $and: matchConditions };
+      pipelineStart = [{ $match: matchFilter }];
     }
 
     const pipeline = [
@@ -133,45 +133,46 @@ export async function GET(request: NextRequest) {
         },
       },
       buildSortStage(sort, collection || undefined),
+      { $skip: skip },
+      { $limit: limit },
       {
-        $facet: {
-          books: [
-            { $skip: skip },
-            { $limit: limit },
-            {
-              $project: {
-                _id: 0,
-                id: 1,
-                slug: 1,
-                title: 1,
-                display_title: 1,
-                author: 1,
-                thumbnail: 1,
-                thumbnail_blob: 1,
-                language: 1,
-                published: 1,
-                pages_count: 1,
-                pages_ocr: 1,
-                pages_translated: 1,
-                translation_percent: 1,
-                is_first_translation: 1,
-                last_processed: 1,
-                last_translation_at: 1,
-              },
-            },
-          ],
-          total: [{ $count: 'count' }],
+        $project: {
+          _id: 0,
+          id: 1,
+          slug: 1,
+          title: 1,
+          display_title: 1,
+          author: 1,
+          thumbnail: 1,
+          thumbnail_blob: 1,
+          language: 1,
+          published: 1,
+          pages_count: 1,
+          pages_ocr: 1,
+          pages_translated: 1,
+          translation_percent: 1,
+          is_first_translation: 1,
+          last_processed: 1,
+          last_translation_at: 1,
         },
       },
     ];
 
-    const [result] = await db.collection('books').aggregate(pipeline, {
-      collation: { locale: 'en', strength: 1 },
-      maxTimeMS: 30000,
-    }).toArray();
-
-    const books = result.books || [];
-    const total = result.total[0]?.count || 0;
+    // Run results pipeline and count in parallel.
+    // For non-search queries, count uses a lightweight countDocuments (index-backed).
+    // For search queries, count uses a separate $search + $count pipeline.
+    const [books, total] = await Promise.all([
+      db.collection('books').aggregate(pipeline, {
+        collation: { locale: 'en', strength: 1 },
+        maxTimeMS: 15000,
+      }).toArray(),
+      matchFilter
+        ? db.collection('books').countDocuments(matchFilter, { maxTimeMS: 10000 }).catch(() => 0)
+        : db.collection('books').aggregate([
+            ...pipelineStart,
+            { $count: 'count' },
+          ], { maxTimeMS: 10000 }).toArray().then(r => r[0]?.count || 0).catch(() => 0),
+    ]);
 
     const responseData = JSON.stringify({ books, total });
 


### PR DESCRIPTION
## Summary

- The `/api/books/library` route used `$facet` to get results + count in one pipeline, which forced MongoDB to process ALL matching documents even when only 24 were needed
- Under Atlas cache pressure (see #561), this caused 5-minute timeouts on `/search?library=bph` and other browse pages
- Split into two parallel operations: results pipeline (can short-circuit at `$limit`) and separate `countDocuments` with graceful fallback

## What changed

One file: `src/app/api/books/library/route.ts`
- Replaced `$facet { books, total }` with `Promise.all([aggregate, countDocuments])`
- Count uses `maxTimeMS: 10000` with `.catch(() => 0)` so a slow count never blocks results
- Results pipeline uses `$skip`/`$limit` directly (no `$facet` wrapper)

## Context

Atlas has been severely degraded today (#561). Root causes:
1. `idx_translate_worker_pages` was indexing full OCR/translation text (19.6 GB index on 9.6M docs) — **dropped**
2. No `visible` index on books — **added**
3. No `image_source.provider` index — **added**
4. This `$facet` pattern forced full-collection processing — **this PR**

## Test plan

- [ ] Load https://sourcelibrary.org/search?library=bph — should load in <2s instead of timing out
- [ ] Load https://sourcelibrary.org/search (no filters) — browse should work
- [ ] Load category/collection pages
- [ ] Verify pagination still shows correct total count

🤖 Generated with [Claude Code](https://claude.com/claude-code)