### PR TITLE
Consolidate navbar: shared Logo + SiteHeader on all pages

### DIFF
--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, Book as BookIcon } from 'lucide-react';
+import { Book as BookIcon } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { notFound, redirect } from 'next/navigation';
 import { bookUrl, authorSlug } from '@/lib/slugify';
@@ -193,18 +194,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-5xl mx-auto px-4 py-4">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Library
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Browse - Source Library',
@@ -21,14 +22,9 @@ const CENTURIES = [
 
 export default function BrowsePage() {
   return (
-    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
-      <Link href="/" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-        </svg>
-        Home
-      </Link>
-
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
       <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
         Browse the Collection
       </h1>
@@ -94,5 +90,6 @@ export default function BrowsePage() {
         </div>
       </section>
     </div>
+    </>
   );
 }

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { ArrowLeft, BookOpen, ChevronRight } from 'lucide-react';
+import { BookOpen, ChevronRight } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { LIBRARY_CATEGORIES, CategoryWithCount } from '@/app/api/categories/route';
 
@@ -57,18 +58,7 @@ export default async function CategoriesPage() {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-5xl mx-auto px-4 py-4">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Back to Library
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Metadata } from 'next';
-import { BookOpen, Images, ArrowLeft, Library } from 'lucide-react';
+import { ArrowLeft, BookOpen, Images, Library } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import CollectionSchema from '@/components/seo/CollectionSchema';
@@ -490,6 +491,7 @@ export default async function CollectionDetailPage({ params }: Props) {
 
   return (
     <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
       <CollectionSchema
         slug={id}
         name={collection.name}

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { getDb } from '@/lib/mongodb';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = 21600;
@@ -64,22 +65,7 @@ export default async function ParticipatePage() {
 
   return (
     <div className="min-h-screen bg-cream">
-      {/* Nav */}
-      <header className="bg-white border-b border-border-light">
-        <div className="max-w-5xl mx-auto px-6 py-4">
-          <Link
-            href="/"
-            className="flex items-center gap-2 text-secondary hover:text-primary transition-colors"
-          >
-            <svg className="w-8 h-8" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1" />
-            </svg>
-            <span className="font-medium">Source Library</span>
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <section className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-20 md:py-28">

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -1,7 +1,7 @@
 import { getDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 import type { Metadata } from 'next';
@@ -129,17 +129,10 @@ export default async function CuratedCollectionsPage() {
 
   return (
     <div className="min-h-screen bg-cream">
+      <SiteHeader variant="light" />
       {/* Hero */}
       <div className="bg-warm border-b border-border-light">
         <div className="max-w-7xl mx-auto px-6 pt-8 pb-10 sm:pb-12">
-          <Link
-            href="/#library"
-            className="inline-flex items-center gap-2 text-sm text-muted hover:text-primary transition-colors mb-8"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Library
-          </Link>
-
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-primary font-semibold leading-tight mb-3 font-display">
             Curated Collections
           </h1>

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { likes } from '@/lib/api-client';
 
@@ -153,22 +154,7 @@ export default function FavoritesPage() {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Logo bar */}
-      <header className="bg-white border-b border-border-light">
-        <div className="max-w-5xl mx-auto px-6 py-4">
-          <Link
-            href="/"
-            className="flex items-center gap-2 text-secondary hover:text-primary transition-colors"
-          >
-            <svg className="w-8 h-8" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1" />
-            </svg>
-            <span className="font-medium">Source Library</span>
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Dark hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-16">

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { BookOpen, ArrowLeft, Images } from 'lucide-react';
+import { BookOpen, Images } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import CollectionBookCard from '@/components/CollectionBookCard';
@@ -185,18 +186,11 @@ export default async function LanguageDetailPage({ params, searchParams }: Props
 
   return (
     <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
       {/* Hero Section */}
       <div className="relative bg-dark overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-transparent" />
         <div className="relative max-w-7xl mx-auto px-6 pt-8 pb-12 sm:pb-16">
-          <Link
-            href="/languages"
-            className="inline-flex items-center gap-2 text-sm text-white/50 hover:text-white/80 transition-colors mb-8"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Languages
-          </Link>
-
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-semibold leading-tight mb-3 font-display">
             {langName}
           </h1>

--- a/src/app/reading-history/page.tsx
+++ b/src/app/reading-history/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, Clock, Eye, ArrowRight, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { readingHistory, type ReadingHistoryEntry } from '@/lib/api-client';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { bookUrl } from '@/lib/slugify';
@@ -85,22 +86,7 @@ export default function ReadingHistoryPage() {
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Logo bar */}
-      <header className="bg-white border-b border-border-light">
-        <div className="max-w-5xl mx-auto px-6 py-4">
-          <Link
-            href="/"
-            className="flex items-center gap-2 text-secondary hover:text-primary transition-colors"
-          >
-            <svg className="w-8 h-8" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="1" />
-              <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1" />
-            </svg>
-            <span className="font-medium">Source Library</span>
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Dark hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-16">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -10,6 +10,7 @@ import {
   ChevronLeft, ChevronRight, ArrowUpDown, ImageIcon, ChevronDown
 } from 'lucide-react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { useDebouncedCallback } from 'use-debounce';
 import { reportError } from '@/components/providers/ErrorReporter';
 import {
@@ -425,26 +426,7 @@ export default function SearchPage() {
 
   return (
     <div className="min-h-screen bg-cream">
-      {/* Header */}
-      <header className="bg-dark">
-        <div className="max-w-5xl mx-auto px-6 py-4">
-          <Link
-            href="/"
-            className="flex items-center gap-3"
-            aria-label="Source Library home"
-          >
-            <svg className="w-10 h-10 md:w-12 md:h-12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke="white" strokeWidth="1" />
-              <circle cx="12" cy="12" r="7" stroke="white" strokeWidth="1" />
-              <circle cx="12" cy="12" r="4" stroke="white" strokeWidth="1" />
-            </svg>
-            <span className="text-xl md:text-2xl uppercase tracking-wider text-white">
-              <span className="font-semibold text-white">Source</span>
-              <span className="font-light text-white">Library</span>
-            </span>
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="dark" />
 
       {/* Search Bar */}
       <div className="bg-white border-b border-border-light sticky top-0 z-10">

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 // TODO: Ask NAF for a Source Library-specific DonorPerfect form.
 // When available, replace this URL so donors see "Source Library" instead of the generic Embassy form.
@@ -51,15 +52,10 @@ const MEMBERSHIP_TIERS = [
 export default function SupportPage() {
   return (
     <div className="min-h-screen">
+      <SiteHeader variant="light" />
       {/* Header */}
       <section className="bg-gradient-to-b from-[#f6f3ee] to-white pt-8 pb-16 md:pt-12 md:pb-24">
         <div className="px-6 md:px-12 max-w-5xl mx-auto">
-          <Link href="/" className="inline-flex items-center gap-2 text-sm mb-10 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-            Back to library
-          </Link>
           <h1 className="text-3xl md:text-4xl lg:text-5xl text-stone-900 mb-6 leading-tight font-display">
             Support Source Library
           </h1>

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { signIn, useSession } from 'next-auth/react';
 import { recordLoadingMetric } from '@/lib/analytics';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
-import UserMenu from '@/components/layout/UserMenu';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 function HeroSignUp() {
   const [email, setEmail] = useState('');
@@ -122,21 +122,7 @@ export default function HeroSection() {
       <div className="absolute inset-0 bg-black/40 z-0" />
 
       {/* Header */}
-      <header className="relative z-50 flex items-center justify-between px-6 md:px-12 py-4">
-        <Link href="/" className="text-white flex items-center gap-3" aria-label="Source Library home">
-          <svg className="w-10 h-10 md:w-12 md:h-12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" stroke="white" strokeWidth="1" />
-            <circle cx="12" cy="12" r="7" stroke="white" strokeWidth="1" />
-            <circle cx="12" cy="12" r="4" stroke="white" strokeWidth="1" />
-          </svg>
-          <span className="text-xl md:text-2xl uppercase tracking-wider text-white">
-            <span className="font-semibold text-white">Source</span>
-            <span className="font-light text-white">Library</span>
-            <sup className="text-[0.6em] font-light tracking-normal normal-case ml-1 opacity-80 relative -top-[0.5em]">Beta</sup>
-          </span>
-        </Link>
-        <UserMenu variant="hero" />
-      </header>
+      <SiteHeader variant="transparent" />
 
       {/* Hero Content */}
       <div className="relative z-10 h-full flex items-center">

--- a/src/components/layout/Logo.tsx
+++ b/src/components/layout/Logo.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+
+interface LogoProps {
+  /** White text/stroke for dark backgrounds */
+  white?: boolean;
+  /** Compact sizing for tight headers (reader, breadcrumb rows) */
+  compact?: boolean;
+  /** Extra-compact: icon only on mobile, text on sm+ (used in reader header) */
+  mini?: boolean;
+}
+
+export default function Logo({ white, compact, mini }: LogoProps) {
+  const strokeColor = white ? 'white' : 'currentColor';
+
+  const iconSize = mini
+    ? 'w-6 h-6'
+    : compact
+      ? 'w-8 h-8'
+      : 'w-10 h-10 md:w-12 md:h-12';
+
+  const textSize = mini
+    ? 'text-sm'
+    : compact
+      ? 'text-lg'
+      : 'text-xl md:text-2xl';
+
+  return (
+    <Link
+      href="/"
+      className={`inline-flex items-center ${mini ? 'gap-1.5' : 'gap-3'} ${
+        white
+          ? 'text-white hover:opacity-80'
+          : 'text-primary hover:text-secondary'
+      } transition-colors`}
+      aria-label="Source Library home"
+    >
+      <svg
+        className={iconSize}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" stroke={strokeColor} strokeWidth="1" />
+        <circle cx="12" cy="12" r="7" stroke={strokeColor} strokeWidth="1" />
+        <circle cx="12" cy="12" r="4" stroke={strokeColor} strokeWidth="1" />
+      </svg>
+      <span
+        className={`${textSize} uppercase tracking-wider ${mini ? 'hidden sm:inline' : ''}`}
+      >
+        <span className="font-semibold">Source</span>
+        <span className="font-light">Library</span>
+        {!mini && (
+          <sup className="text-[0.6em] font-light tracking-normal normal-case ml-1 opacity-80 relative -top-[0.5em]">
+            Beta
+          </sup>
+        )}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Logo from './Logo';
 import UserMenu from './UserMenu';
 
 interface Breadcrumb {
@@ -17,35 +18,6 @@ interface SiteHeaderProps {
   sticky?: boolean;
   /** Additional className for the header element */
   className?: string;
-}
-
-function Logo({ white, compact }: { white?: boolean; compact?: boolean }) {
-  const strokeColor = white ? 'white' : 'currentColor';
-  return (
-    <Link
-      href="/"
-      className={`inline-flex items-center gap-3 ${
-        white
-          ? 'text-white hover:opacity-80'
-          : 'text-primary hover:text-secondary'
-      } transition-colors`}
-      aria-label="Source Library home"
-    >
-      <svg
-        className={compact ? 'w-8 h-8' : 'w-10 h-10 md:w-12 md:h-12'}
-        viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="10" stroke={strokeColor} strokeWidth="1" />
-        <circle cx="12" cy="12" r="7" stroke={strokeColor} strokeWidth="1" />
-        <circle cx="12" cy="12" r="4" stroke={strokeColor} strokeWidth="1" />
-      </svg>
-      <span className={`${compact ? 'text-lg' : 'text-xl md:text-2xl'} uppercase tracking-wider`}>
-        <span className="font-semibold">Source</span>
-        <span className="font-light">Library</span>
-        <sup className="text-[0.6em] font-light tracking-normal normal-case ml-1 opacity-80 relative -top-[0.5em]">Beta</sup>
-      </span>
-    </Link>
-  );
 }
 
 export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, className = '' }: SiteHeaderProps) {

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { toast } from 'sonner';
+import Logo from '@/components/layout/Logo';
 import RevisionHistory from '@/components/reader/RevisionHistory';
 import {
   Loader2,
@@ -846,17 +847,7 @@ export default function TranslationEditor({
           {/* Row 1: Back + Title ... Chapter Nav ... Page Navigator */}
           <div className="flex items-center justify-between gap-2 relative">
             <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
-              <a href="/" className="inline-flex items-center gap-1.5 shrink-0 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-primary)' }} aria-label="Source Library home">
-                <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1" />
-                  <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="1" />
-                  <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1" />
-                </svg>
-                <span className="hidden sm:inline text-sm uppercase tracking-wider">
-                  <span className="font-semibold">Source</span>
-                  <span className="font-light">Library</span>
-                </span>
-              </a>
+              <Logo mini />
               <span className="text-sm shrink-0" style={{ color: 'var(--text-muted)' }} aria-hidden="true">/</span>
               <a href={`/book/${book.id}`} className="min-w-0 hover:opacity-70 transition-opacity">
                 <h1 className="text-sm sm:text-base font-medium truncate" style={{ color: 'var(--text-primary)' }}>
@@ -1632,17 +1623,7 @@ export default function TranslationEditor({
         {/* Row 1: Back, Title, Navigation */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
-            <a href="/" className="inline-flex items-center gap-1.5 shrink-0 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-primary)' }} aria-label="Source Library home">
-              <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="1" />
-                <circle cx="12" cy="12" r="7" stroke="currentColor" strokeWidth="1" />
-                <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1" />
-              </svg>
-              <span className="hidden sm:inline text-sm uppercase tracking-wider">
-                <span className="font-semibold">Source</span>
-                <span className="font-light">Library</span>
-              </span>
-            </a>
+            <Logo mini />
             <span className="text-sm shrink-0" style={{ color: 'var(--text-muted)' }} aria-hidden="true">/</span>
             <a href={`/book/${book.id}`} className="min-w-0 hover:opacity-70 transition-opacity">
               <h1 className="text-base sm:text-xl font-medium truncate" style={{ color: 'var(--text-primary)' }}>


### PR DESCRIPTION
## Summary
- Extracts `Logo` into a shared component, replacing 3 duplicate SVG+text implementations (SiteHeader, HeroSection, TranslationEditor)
- Refactors HeroSection to use `SiteHeader variant="transparent"` instead of an inline header
- Replaces inline logo SVGs in TranslationEditor (read + edit modes) with the shared `Logo` component
- Adds `SiteHeader` to 11 user-facing pages that had either ad-hoc back-links or no navbar at all: browse, search, favorites, reading-history, categories, collections/[id], author/[name], support, contribute, curated, languages/[code]

**Net: -100 lines** (96 added, 194 removed)

Closes #233

## Test plan
- [ ] Homepage hero still shows transparent header with logo + user menu
- [ ] Book reader (TranslationEditor) shows compact logo in both read and edit modes
- [ ] Browse, search, favorites, categories pages now have consistent SiteHeader
- [ ] Collection detail pages show dark SiteHeader above hero
- [ ] No layout shift or visual regression on content pages that already used SiteHeader

🤖 Generated with [Claude Code](https://claude.com/claude-code)