### PR TITLE
Navbar batch 2: SiteHeader on 13 more pages

### DIFF
--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { authorSlug } from '@/lib/slugify';
 import { notFound } from 'next/navigation';
@@ -69,14 +70,9 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
-      <Link href="/browse" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-        </svg>
-        Browse
-      </Link>
-
+    <>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Browse', href: '/browse' }]} />
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
       <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
         Authors: {l}
       </h1>
@@ -127,5 +123,6 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
         </p>
       )}
     </div>
+    </>
   );
 }

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { bookUrl } from '@/lib/slugify';
 import { notFound } from 'next/navigation';
@@ -83,14 +84,9 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
-      <Link href="/browse" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-        </svg>
-        Browse
-      </Link>
-
+    <>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Browse', href: '/browse' }]} />
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
       <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
         Titles: {l}
       </h1>
@@ -143,5 +139,6 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
         </p>
       )}
     </div>
+    </>
   );
 }

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { bookUrl } from '@/lib/slugify';
 import { notFound } from 'next/navigation';
@@ -92,14 +93,9 @@ export default async function BrowseYearsPage({ params }: PageProps) {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
-      <Link href="/browse" className="inline-flex items-center gap-2 text-sm mb-8 hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-        </svg>
-        Browse
-      </Link>
-
+    <>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Browse', href: '/browse' }]} />
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
       <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
         {p.label}
       </h1>
@@ -152,5 +148,6 @@ export default async function BrowseYearsPage({ params }: PageProps) {
         </p>
       )}
     </div>
+    </>
   );
 }

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, BookOpen, Book as BookIcon } from 'lucide-react';
+import { BookOpen, Book as BookIcon } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { LIBRARY_CATEGORIES } from '@/app/api/categories/route';
 import { notFound } from 'next/navigation';
@@ -97,18 +98,7 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
           author: b.author,
         }))}
       />
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-5xl mx-auto px-4 py-4">
-          <Link
-            href="/categories"
-            className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            All Categories
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">

--- a/src/app/contribute/volunteer/page.tsx
+++ b/src/app/contribute/volunteer/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 import VolunteerForm from '@/components/contribute/VolunteerForm';
 
 export const metadata: Metadata = {
@@ -13,20 +13,7 @@ export const metadata: Metadata = {
 export default function VolunteerPage() {
   return (
     <div className="min-h-screen bg-cream">
-      {/* Nav */}
-      <header className="bg-white border-b border-border-light">
-        <div className="max-w-2xl mx-auto px-6 py-4">
-          <Link
-            href="/contribute"
-            className="flex items-center gap-2 text-secondary hover:text-primary transition-colors"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
-            </svg>
-            Back to Participate
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       <div className="max-w-2xl mx-auto px-6 py-12 md:py-16">
         <h1 className="font-serif text-3xl md:text-4xl text-primary mb-3">

--- a/src/app/encyclopedia/[name]/page.tsx
+++ b/src/app/encyclopedia/[name]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, User, MapPin, Lightbulb, ExternalLink } from 'lucide-react';
+import { User, MapPin, Lightbulb, ExternalLink } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { ENTITY_TYPE_STYLES, ENTITY_TYPE_LABELS, type EntityType } from '@/lib/style-constants';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { getEntity, getSharedBooks } from './layout';
@@ -51,18 +52,7 @@ export default async function EntityDetailPage({
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-5xl mx-auto px-4 py-4">
-          <Link
-            href="/encyclopedia"
-            className="inline-flex items-center gap-2 text-stone-600 hover:text-stone-900"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Back to Encyclopedia
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-12">

--- a/src/app/encyclopedia/page.tsx
+++ b/src/app/encyclopedia/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { User, MapPin, Lightbulb, BookOpen, ArrowRight, Search, ChevronLeft, ChevronRight } from 'lucide-react';
 import { getDb } from '@/lib/mongodb';
 import type { Sort } from 'mongodb';
@@ -166,14 +167,7 @@ export default async function EncyclopediaPage({
 
   return (
     <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white border-b border-stone-200">
-        <div className="max-w-7xl mx-auto px-4 py-4">
-          <Link href="/" className="text-stone-600 hover:text-stone-900 text-sm">
-            &larr; Back to Library
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-12">

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Image as ImageIcon, Layers } from 'lucide-react';
+import { Image as ImageIcon, Layers } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import CollectionImageCard, { CollectionImageProps } from './CollectionImageCard';
 
@@ -104,26 +105,7 @@ export default async function CollectionDetailPage({ params }: PageProps) {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
-      {/* Header */}
-      <header className="bg-stone-900 text-white py-4">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between">
-            <Link href="/gallery/collections" className="flex items-center gap-2 text-stone-400 hover:text-white transition-colors">
-              <ArrowLeft className="w-5 h-5" />
-              <span>Collections</span>
-            </Link>
-            <div className="flex items-center gap-3">
-              <div className="text-right">
-                <h1 className="text-lg font-serif">{data.title}</h1>
-                <p className="text-stone-400 text-xs">
-                  {data.imageCount} {data.imageCount === 1 ? 'image' : 'images'}
-                </p>
-              </div>
-              <Layers className="w-6 h-6 text-accent-gold" />
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Collection description */}

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowLeft, Image as ImageIcon, Layers } from 'lucide-react';
+import { Image as ImageIcon, Layers } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 
 export const revalidate = 600;
@@ -92,26 +93,7 @@ export default async function CollectionsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
-      {/* Header */}
-      <header className="bg-stone-900 text-white py-4">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between">
-            <Link href="/gallery" className="flex items-center gap-2 text-stone-400 hover:text-white transition-colors">
-              <ArrowLeft className="w-5 h-5" />
-              <span>Gallery</span>
-            </Link>
-            <div className="flex items-center gap-3">
-              <div className="text-right">
-                <h1 className="text-lg font-serif">Collections</h1>
-                <p className="text-stone-400 text-xs">
-                  {collections.length} curated collections
-                </p>
-              </div>
-              <Layers className="w-6 h-6 text-accent-gold" />
-            </div>
-          </div>
-        </div>
-      </header>
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Intro */}

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { BookOpen, ExternalLink, Images, ArrowLeft, Library } from 'lucide-react';
+import { BookOpen, ExternalLink, Images, Library } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import { getPartnerBySlug, getAllPartnerSlugs } from '@/lib/library-partners';
@@ -209,19 +210,12 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
 
   return (
     <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
       {/* Hero Section */}
       <div className="relative bg-dark overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-transparent" />
 
         <div className="relative max-w-7xl mx-auto px-6 pt-8 pb-12 sm:pb-16">
-          <Link
-            href="/libraries"
-            className="inline-flex items-center gap-2 text-sm text-white/50 hover:text-white/80 transition-colors mb-8"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Libraries
-          </Link>
-
           <h1
             className="text-4xl sm:text-5xl md:text-6xl text-white font-semibold leading-tight mb-3 font-display"
           >

--- a/src/app/press/page.tsx
+++ b/src/app/press/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Press - Source Library',
@@ -64,8 +65,9 @@ const SOURCE_LIBRARIES = [
 export default function PressPage() {
   return (
     <div className="min-h-screen bg-white">
-      {/* Header */}
-      <header className="bg-stone-900 text-white py-16 md:py-24">
+      <SiteHeader variant="dark" />
+      {/* Hero */}
+      <div className="bg-stone-900 text-white py-16 md:py-24">
         <div className="max-w-5xl mx-auto px-6 md:px-12">
           <p className="text-accent-gold text-sm tracking-[0.2em] uppercase mb-4">
             Press
@@ -80,7 +82,7 @@ export default function PressPage() {
             AI-powered translations of thousands of rare historical texts, freely available online.
           </p>
         </div>
-      </header>
+      </div>
 
       <div className="max-w-5xl mx-auto px-6 md:px-12 py-16 space-y-16">
         {/* Launch Press Release */}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy - Source Library',
@@ -10,13 +10,7 @@ export const metadata: Metadata = {
 export default function PrivacyPage() {
   return (
     <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
-      <header className="border-b" style={{ background: 'var(--bg-white)', borderColor: 'var(--border-light)' }}>
-        <div className="max-w-2xl mx-auto px-6 py-4">
-          <Link href="/" className="text-sm hover:opacity-70 transition-opacity" style={{ color: 'var(--text-muted)' }}>
-            &larr; Back to Source Library
-          </Link>
-        </div>
-      </header>
+      <SiteHeader variant="light" />
       <main className="max-w-2xl mx-auto px-6 py-12">
         <h1 className="text-3xl font-medium mb-8" style={{ color: 'var(--text-primary)' }}>
           Privacy Policy

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -2,7 +2,8 @@ import { getDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Metadata } from 'next';
-import { BookOpen, ArrowLeft } from 'lucide-react';
+import { BookOpen } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
 import { notFound } from 'next/navigation';
 import { bookUrl } from '@/lib/slugify';
 import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
@@ -320,17 +321,10 @@ export default async function TopicDetailPage({ params }: Props) {
 
     return (
       <div className="min-h-screen bg-cream">
+        <SiteHeader variant="dark" />
         {/* Hero */}
         <div className="bg-gradient-to-b from-[#2a1f17] to-[#1a1612] text-white">
           <div className="max-w-5xl mx-auto px-6 pt-8 pb-12">
-            <Link
-              href="/topics"
-              className="inline-flex items-center gap-2 text-sm text-white/50 hover:text-white/80 transition-colors mb-8"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Browse
-            </Link>
-
             <p className="text-sm text-white/40 mb-2">{data.facet.label}</p>
             <h1 className="text-3xl sm:text-4xl md:text-5xl text-white font-semibold leading-tight mb-3 font-display">
               {data.value.label}
@@ -433,16 +427,9 @@ export default async function TopicDetailPage({ params }: Props) {
 
   return (
     <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
       <div className="bg-gradient-to-b from-[#2a1f17] to-[#1a1612] text-white">
         <div className="max-w-5xl mx-auto px-6 pt-8 pb-12">
-          <Link
-            href="/topics/clusters"
-            className="inline-flex items-center gap-2 text-sm text-white/50 hover:text-white/80 transition-colors mb-8"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            All Clusters
-          </Link>
-
           <h1 className="text-3xl sm:text-4xl md:text-5xl text-white font-semibold leading-tight mb-3 font-display">
             {clusterName}
           </h1>


### PR DESCRIPTION
## Summary
Continues #233 navbar consolidation (batch 1 was #570).

Adds `SiteHeader` to 13 more user-facing pages, replacing inline back-links and ad-hoc headers:
- Browse sub-pages (authors, titles, years) — with "Browse" breadcrumb
- Categories/[id], encyclopedia index + detail pages
- Libraries/[slug], privacy, press
- Contribute/volunteer, topics/[slug] (facet + cluster routes)
- Gallery collections + gallery collection detail — with "Gallery" breadcrumb

**Net: -107 lines** (45 added, 152 removed)

## Test plan
- [ ] `/browse/titles/A` shows SiteHeader with "Browse" breadcrumb
- [ ] `/categories/alchemy` shows light SiteHeader
- [ ] `/encyclopedia` and `/encyclopedia/Hermes` show light SiteHeader
- [ ] `/libraries/bph` shows dark SiteHeader above hero
- [ ] `/privacy` shows light SiteHeader
- [ ] `/press` shows dark SiteHeader above branded hero
- [ ] `/gallery/collections` shows dark SiteHeader with "Gallery" breadcrumb

🤖 Generated with [Claude Code](https://claude.com/claude-code)