### PR TITLE
Collection UX: hero link, gallery label, auto-expand catalog

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -549,7 +549,12 @@ export default async function CollectionDetailPage({ params }: Props) {
           )}
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-            <span>{total.toLocaleString('en-US')} {itemLabel}</span>
+            <a
+              href="#collection-all-books"
+              className="hover:text-white/80 transition-colors underline underline-offset-2 decoration-white/30"
+            >
+              {total.toLocaleString('en-US')} {itemLabel}
+            </a>
             {languages.length > 0 && (
               <>
                 <span className="w-px h-4 bg-white/20" />
@@ -634,6 +639,11 @@ export default async function CollectionDetailPage({ params }: Props) {
           )}
 
           {diverseGalleryImages.length > 0 && (
+            <div>
+              <h3 className="text-lg text-primary mb-3 font-display flex items-center gap-2">
+                <Images className="w-4 h-4 text-muted" />
+                Illustrations from the Collection
+              </h3>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4">
               {diverseGalleryImages.map((img: { pageId?: string; page_id?: string; bookId?: string; book_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
                 const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
@@ -677,6 +687,7 @@ export default async function CollectionDetailPage({ params }: Props) {
                 <Images className="w-7 h-7" />
                 <span className="text-xs font-medium">Browse gallery</span>
               </Link>
+            </div>
             </div>
           )}
         </div>

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -124,7 +124,8 @@ export default function CollectionAllBooks({
     }
   }, [collectionId]);
 
-  // Read URL params on mount (avoids useSearchParams SSR bailout)
+  // Auto-expand and fetch manifest on mount.
+  // Read URL params for deep-linked state (avoids useSearchParams SSR bailout).
   useEffect(() => {
     if (initializedRef.current) return;
     initializedRef.current = true;
@@ -135,7 +136,6 @@ export default function CollectionAllBooks({
     const urlPage = params.get('page');
     const urlView = params.get('view') as ViewMode | null;
     const storedView = getStoredView();
-    const hasParams = urlSort || urlPage || urlView;
 
     if (urlSort) setSort(urlSort);
     if (urlLang) setLanguage(urlLang);
@@ -143,10 +143,8 @@ export default function CollectionAllBooks({
     if (urlPage) setCurrentPage(parseInt(urlPage));
     setViewMode(urlView || storedView || sizeDefault);
 
-    if (hasParams) {
-      setExpanded(true);
-      fetchManifest();
-    }
+    setExpanded(true);
+    fetchManifest();
   }, [fetchManifest, sizeDefault]);
 
   // Client-side filter → sort → paginate (instant, no network)


### PR DESCRIPTION
## Summary
Follow-up to #573 (merged). Three UX improvements:

- **Hero "N books" is now a link** — clicking it scrolls to the catalog section. Makes the catalog discoverable without scrolling past all the curated content.
- **Image grid labeled** — "Illustrations from the Collection" heading above the gallery images. Previously unlabeled.
- **Catalog auto-expands** — the "All Books" section immediately expands and fetches the manifest on page load. No more hidden behind a "See all 774" card buried at the bottom.

## Test plan
- [ ] Visit a collection page — "629 books" in the hero should be an underlined link
- [ ] Click it — should smooth-scroll to the "All Books" section
- [ ] Image grid should have "Illustrations from the Collection" heading
- [ ] "All Books" section should show the full catalog view immediately (search bar, sort, view toggle) without needing to click anything
- [ ] Search should still be instant (type to filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)