### PR TITLE
Park books after 200-page translation chunk

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2486,7 +2486,8 @@ async function run() {
           console.log('  SKIP: at in-flight cap, waiting for existing translations to complete');
         }
 
-        const readyForTranslate = effectiveLimit > 0 ? await db.collection('books').aggregate([
+        // Fresh books first (never translated), then re-queue partially-translated books
+        const freshBooks = effectiveLimit > 0 ? await db.collection('books').aggregate([
           // PAUSED: BPH books excluded pending split quality audit (#523)
           { $match: { 'pipeline_auto.status': { $in: ['metadata_enriched', 'ft_verified'] }, 'image_source.provider': { $ne: 'bph' } } },
           { $addFields: { _latinFirst: { $cond: [{ $eq: ['$language', 'Latin'] }, 0, 1] } } },
@@ -2494,6 +2495,22 @@ async function run() {
           { $project: { id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 } },
           { $limit: effectiveLimit }
         ]).toArray() : [];
+
+        // If no fresh books, re-queue partially-translated books for their next chunk
+        let partialBooks = [];
+        if (freshBooks.length === 0 && effectiveLimit > 0) {
+          partialBooks = await db.collection('books')
+            .find({ 'pipeline_auto.status': 'translate_partial', 'image_source.provider': { $ne: 'bph' } })
+            .project({ id: 1, title: 1, pages_count: 1, language: 1, 'pipeline_auto.retry_count': 1, 'image_source.provider': 1 })
+            .sort({ pages_translated: 1 }) // least-translated first
+            .limit(effectiveLimit)
+            .toArray();
+          if (partialBooks.length > 0) {
+            console.log(`  No fresh books — re-queuing ${partialBooks.length} partially-translated books`);
+          }
+        }
+
+        const readyForTranslate = [...freshBooks, ...partialBooks];
 
         console.log(`  Books ready for translation: ${readyForTranslate.length}`);
 

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -597,7 +597,18 @@ async function processBook(db, book, job, globalCounter) {
       bookId: book.id,
     });
   } else {
-    console.log(`  [${label}] Progress — ${translated} this run (${newCompleted}/${job.progress.total} total)`);
+    // Park this book — it got its 200-page chunk, let other books go first.
+    // Status moves to translate_partial so it's no longer picked up as translate_submitted.
+    await db.collection('books').updateOne(
+      { id: book.id },
+      { $set: {
+        'pipeline_auto.status': 'translate_partial',
+        pages_translated: newCompleted,
+        updated_at: new Date(),
+        last_translation_at: new Date(),
+      }},
+    );
+    console.log(`  [${label}] Parked — ${translated} this run (${newCompleted}/${job.progress.total} total), moving to translate_partial`);
   }
 
   return { translated, failed, completed: isComplete ? 1 : 0, inputTokens: totalInputTokens, outputTokens: totalOutputTokens };
@@ -699,19 +710,12 @@ async function main() {
     }
   }
 
-  // Find books — fresh books first (pages_translated: 0).
-  // Fresh books all hit the 200-page cap at ~the same time, minimizing convoy waste.
+  // Find books in translate_submitted — each book gets up to 200 pages then gets parked.
+  // Only pick books that haven't been translated yet (fresh) to maximize breadth.
   const proj = { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, job: 1, image_source: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1 };
-  const fresh = await db.collection('books')
-    .find({ 'pipeline_auto.status': 'translate_submitted', $or: [{ pages_translated: 0 }, { pages_translated: { $exists: false } }] })
+  const books = await db.collection('books')
+    .find({ 'pipeline_auto.status': 'translate_submitted' })
     .project(proj).limit(CONCURRENCY).toArray();
-  let books = fresh;
-  if (fresh.length < CONCURRENCY) {
-    const rest = await db.collection('books')
-      .find({ 'pipeline_auto.status': 'translate_submitted', pages_translated: { $gt: 0 } })
-      .project(proj).limit(CONCURRENCY - fresh.length).toArray();
-    books = [...fresh, ...rest];
-  }
 
   if (books.length === 0) {
     console.log('[TRANSLATE] No books to translate');


### PR DESCRIPTION
## Summary
- After translating 200 pages, books are parked as `translate_partial` instead of staying in `translate_submitted`
- Fresh (untranslated) books always get priority — all 4,180 queued books get their first 200 pages before any big book gets seconds
- When no fresh books remain, partial books are re-queued (least-translated first)

## Impact
Currently 31 of 60 in-flight books have >200 pages remaining and monopolize worker slots. This change ensures breadth-first translation across the entire queue.

## Test plan
- [ ] Deploy to Hetzner and monitor next translate-worker run
- [ ] Verify books with >200 pages get parked as `translate_partial`
- [ ] Verify fresh books continue to be dispatched
- [ ] Check cron_runs log for "Parked" and "translate_partial" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)