### PR TITLE
Health probe: detect cache saturation with browse query

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -162,7 +162,21 @@ async function probeDbHealth(db) {
     countMs = 3000;
   }
 
-  // Signal 2: Active jobs
+  // Signal 2: User-facing query latency — tests the browse pattern that actual users hit.
+  // The pages-level probes above can report "healthy" (indexed findOne) while browse
+  // queries time out due to WiredTiger cache pressure from write amplification.
+  let browseMs = 0;
+  try {
+    const t3 = Date.now();
+    await db.collection('books').find(
+      { hidden: { $ne: true }, pages_count: { $gt: 0 } }
+    ).sort({ created_at: -1 }).limit(10).project({ _id: 1 }).toArray();
+    browseMs = Date.now() - t3;
+  } catch {
+    browseMs = 5000; // treat timeout as worst-case
+  }
+
+  // Signal 3: Active jobs
   try {
     activeJobs = await db.collection('jobs').countDocuments(
       { status: 'processing' },
@@ -176,12 +190,14 @@ async function probeDbHealth(db) {
   // Job count was a proxy for DB load but stopped correlating when translation
   // moved to Hetzner (jobs stay "processing" for hours without DB pressure).
   // If high job counts actually stress Atlas, latency metrics will catch it.
+  // browseMs catches the failure mode where indexed queries are fine but
+  // user-facing queries time out (WiredTiger cache saturation from writes).
   let grade = 'healthy';
-  if (findMs > 1000 || countMs > 1500) grade = 'critical';
-  else if (findMs > 300 || countMs > 500) grade = 'degraded';
+  if (findMs > 1000 || countMs > 1500 || browseMs > 5000) grade = 'critical';
+  else if (findMs > 300 || countMs > 500 || browseMs > 2000) grade = 'degraded';
 
   const duration = Date.now() - t0;
-  console.log(`[health] grade=${grade} find=${findMs}ms count=${countMs}ms jobs=${activeJobs} (probed in ${duration}ms)`);
+  console.log(`[health] grade=${grade} find=${findMs}ms count=${countMs}ms browse=${browseMs}ms jobs=${activeJobs} (probed in ${duration}ms)`);
 
   // Apply throttling
   if (grade === 'critical') {
@@ -275,6 +291,7 @@ async function probeDbHealth(db) {
           'health.grade': grade,
           'health.find_ms': findMs,
           'health.count_ms': countMs,
+          'health.browse_ms': browseMs,
           'health.active_jobs': activeJobs,
           'health.measured_at': new Date(),
           'health.source': 'hetzner-orchestrator',

--- a/src/lib/adaptive-limits.ts
+++ b/src/lib/adaptive-limits.ts
@@ -29,6 +29,7 @@ interface HealthState {
   grade: HealthGrade;
   find_ms: number;
   count_ms: number;
+  browse_ms: number;
   active_jobs: number;
   last_cron_duration_ms: number;
   sqs_combined_depth: number;
@@ -88,9 +89,9 @@ async function timedQuery(fn: () => Promise<unknown>, timeoutMs = 2500): Promise
 }
 
 /** Grade a single signal */
-function gradeLatency(findMs: number, countMs: number): HealthGrade {
-  if (findMs > 1000 || countMs > 1500) return 'critical';
-  if (findMs > 300 || countMs > 500) return 'degraded';
+function gradeLatency(findMs: number, countMs: number, browseMs = 0): HealthGrade {
+  if (findMs > 1000 || countMs > 1500 || browseMs > 5000) return 'critical';
+  if (findMs > 300 || countMs > 500 || browseMs > 2000) return 'degraded';
   return 'healthy';
 }
 
@@ -174,7 +175,7 @@ export async function getAdaptiveLimits(
     } catch { /* non-critical */ }
   }
 
-  const [findMs, countMs] = await Promise.all([
+  const [findMs, countMs, browseMs] = await Promise.all([
     sampleBookId
       ? timedQuery(() =>
           db.collection('pages').findOne(
@@ -191,6 +192,15 @@ export async function getAdaptiveLimits(
           )
         )
       : Promise.resolve(0),
+    // User-facing browse query — catches WiredTiger cache saturation that indexed
+    // page queries miss. This is the query pattern that times out when the pipeline
+    // is writing heavily, even when findOne reports 14ms.
+    timedQuery(() =>
+      db.collection('books').find(
+        { hidden: { $ne: true }, pages_count: { $gt: 0 } }
+      ).sort({ created_at: -1 }).limit(10).project({ _id: 1 }).toArray(),
+      5000
+    ),
   ]);
 
   // ── Signal 2: Active jobs ──
@@ -223,7 +233,7 @@ export async function getAdaptiveLimits(
 
   // ── Grade ──
   const grade = compositeGrade(
-    gradeLatency(findMs, countMs),
+    gradeLatency(findMs, countMs, browseMs),
     gradeJobs(activeJobs),
     gradeCronDuration(lastCronMs),
     sqsGrade,
@@ -242,6 +252,7 @@ export async function getAdaptiveLimits(
     grade,
     find_ms: findMs,
     count_ms: countMs,
+    browse_ms: browseMs,
     active_jobs: activeJobs,
     last_cron_duration_ms: lastCronMs,
     sqs_combined_depth: sqsCombined,
@@ -306,8 +317,8 @@ export async function getAdaptiveLimits(
 
   // Log decision
   if (logger && adjustment !== 'none') {
-    logger.decision('backpressure', `adaptive: ${adjustment} (grade=${grade}, find=${findMs}ms, count=${countMs}ms, jobs=${activeJobs}, cron=${lastCronMs}ms, sqs_ocr=${sqsOcrDepth}, sqs_translate=${sqsTranslateDepth}${jobsCancelled ? `, cancelled=${jobsCancelled}` : ''})`, {
-      grade, find_ms: findMs, count_ms: countMs, active_jobs: activeJobs, last_cron_duration_ms: lastCronMs,
+    logger.decision('backpressure', `adaptive: ${adjustment} (grade=${grade}, find=${findMs}ms, count=${countMs}ms, browse=${browseMs}ms, jobs=${activeJobs}, cron=${lastCronMs}ms, sqs_ocr=${sqsOcrDepth}, sqs_translate=${sqsTranslateDepth}${jobsCancelled ? `, cancelled=${jobsCancelled}` : ''})`, {
+      grade, find_ms: findMs, count_ms: countMs, browse_ms: browseMs, active_jobs: activeJobs, last_cron_duration_ms: lastCronMs,
       sqs_ocr_depth: sqsOcrDepth, sqs_translate_depth: sqsTranslateDepth, sqs_combined_depth: sqsCombined,
       jobs_cancelled: jobsCancelled, adjustment,
     });


### PR DESCRIPTION
## Summary

- Health probe now tests a user-facing browse query in addition to indexed page lookups
- This catches the failure mode from 2026-03-30 where the probe reported "healthy" (14ms findOne) while users experienced 5-minute timeouts
- Also dropped 3 unused pages indexes (`archived_photo`, `ocr.batch_job_id`, `translation.batch_job_id`) reducing write amplification ~20%

## What changed

**`src/lib/adaptive-limits.ts`** — Added `browse_ms` to HealthState interface and probe. Tests `books.find({hidden:{$ne:true}, pages_count:{$gt:0}}).sort({created_at:-1}).limit(10)`. Degraded at 2s, critical at 5s.

**`scripts/workers/pipeline-orchestrator.mjs`** — Same browse probe added to Hetzner orchestrator. Persists `health.browse_ms` alongside existing metrics.

## Why

On 2026-03-30, the probe said "healthy" while the site was unusable. Indexed point lookups (findOne by book_id) work fine under cache pressure because they touch few cache pages. But browse queries that need to scan even a small index are disk-bound when WiredTiger cache is full of dirty pages from pipeline writes. The new browse probe catches this.

## Test plan

- [ ] Deploy to Hetzner: `git pull` on the server
- [ ] Check `system_config.adaptive_limits.health.browse_ms` appears after next orchestrator run
- [ ] Verify probe doesn't add significant latency to orchestrator cycle (should be <100ms normally)

Part of #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)