### PR TITLE
Fix archive workers: remove $lookup timeout, skip 401'd IA books

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -270,6 +270,18 @@ async function processBook(book, db) {
   } catch (err) {
     console.log(`  [ERROR] ${book.title?.slice(0, 50)}: ${err.message?.slice(0, 100)}`);
     stats.booksFailed++;
+
+    // Mark 401/403 books so we don't retry them every 10 minutes
+    if (err.message?.includes('HTTP 401') || err.message?.includes('HTTP 403')) {
+      await db.collection('books').updateOne(
+        { id: book.id },
+        { $set: {
+          'archive_metadata.blocked': true,
+          'archive_metadata.blocked_at': new Date(),
+          'archive_metadata.blocked_reason': err.message.slice(0, 200),
+        }}
+      );
+    }
   } finally {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
   }
@@ -290,6 +302,7 @@ async function main() {
     .aggregate([
       { $match: {
         'pipeline_auto.status': 'archiving',
+        'archive_metadata.blocked': { $ne: true },
         $or: [
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
           { 'image_source.provider': 'internet_archive' },

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -201,16 +201,8 @@ async function main() {
     ],
   };
 
-  // Use estimatedDocumentCount for speed, exact count is too slow on 2.65M pages
-  const totalNeeding = await db.collection('pages').countDocuments(query, { maxTimeMS: 30_000 }).catch(() => -1);
-
-  if (totalNeeding === 0) {
-    console.log(`[archive-ocr] No pages need archiving`);
-    await client.close();
-    return;
-  }
-
-  console.log(`[archive-ocr] ~${totalNeeding} pages need archiving (processing up to ${MAX_PAGES})`);
+  // Skip expensive count — just fetch pages and check if any returned
+  console.log(`[archive-ocr] Looking for unarchived pages (up to ${MAX_PAGES})...`);
   console.log(`[archive-ocr] Per-domain rate limits: ${Object.entries(DOMAIN_RATE_LIMITS).filter(([k]) => k !== '_default').map(([k, v]) => `${k}:${v}/s`).join(', ')}`);
 
   let archived = 0;
@@ -219,37 +211,23 @@ async function main() {
   let processed = 0;
   const domainStats = {};
 
-  // Fetch pages with book-level priority: first translations > non-English > English
-  const ENGLISH_VARIANTS = ['english', 'eng', 'en'];
+  // Simple find — no $lookup. The priority aggregation was timing out on Atlas
+  // with 9.5M pages. Just grab unarchived pages directly.
   const pages = await db.collection('pages')
-    .aggregate([
-      { $match: query },
-      { $limit: MAX_PAGES * 2 }, // Over-fetch to allow priority sorting
-      { $lookup: {
-        from: 'books',
-        let: { bid: '$book_id' },
-        pipeline: [
-          { $match: { $expr: { $eq: ['$id', '$$bid'] } } },
-          { $project: { is_first_translation: 1, language: 1 } },
-        ],
-        as: '_book',
-      }},
-      { $addFields: {
-        _priority: {
-          $switch: {
-            branches: [
-              { case: { $eq: [{ $arrayElemAt: ['$_book.is_first_translation', 0] }, true] }, then: 0 },
-              { case: { $in: [{ $toLower: { $ifNull: [{ $arrayElemAt: ['$_book.language', 0] }, ''] } }, ENGLISH_VARIANTS] }, then: 2 },
-            ],
-            default: 1,
-          },
-        },
-      }},
-      { $sort: { _priority: 1 } },
-      { $limit: MAX_PAGES },
-      { $project: { _id: 1, book_id: 1, page_number: 1, photo: 1 } },
-    ], { maxTimeMS: 120_000 })
+    .find(query, {
+      projection: { _id: 1, book_id: 1, page_number: 1, photo: 1 },
+      limit: MAX_PAGES,
+    })
+    .maxTimeMS(60_000)
     .toArray();
+
+  if (pages.length === 0) {
+    console.log(`[archive-ocr] No pages need archiving`);
+    await client.close();
+    return;
+  }
+
+  console.log(`[archive-ocr] Found ${pages.length} pages to archive`);
 
   // Group by domain with per-domain cap
   const byDomain = {};
@@ -297,7 +275,7 @@ async function main() {
 
   const duration = ((Date.now() - start) / 1000).toFixed(1);
   const mb = (totalBytes / (1024 * 1024)).toFixed(1);
-  console.log(`[archive-ocr] Done in ${duration}s: ${archived} archived (${mb} MB), ${failed} failed, ${totalNeeding - processed} remaining`);
+  console.log(`[archive-ocr] Done in ${duration}s: ${archived} archived (${mb} MB), ${failed} failed`);
   console.log(`[archive-ocr] Per-domain: ${Object.entries(domainStats).map(([d, s]) => `${d}:${s.ok}ok/${s.fail}fail`).join(', ')}`);
 
   // Log to cron_runs for monitoring
@@ -308,7 +286,7 @@ async function main() {
     finished_at: new Date(),
     duration_ms: Date.now() - start,
     status: failed === 0 ? 'success' : 'partial',
-    actions: { archived, failed, bytes: totalBytes, remaining: totalNeeding - processed, domainStats },
+    actions: { archived, failed, bytes: totalBytes, domainStats },
   });
 
   await client.close();


### PR DESCRIPTION
## Summary
- **archive-ocr.mjs**: Replace `$lookup` aggregation (joining 9.5M pages to books for priority sorting) with a simple `find()`. The aggregation was timing out on every single run, making the non-IA archive worker completely non-functional.
- **archive-bulk.mjs**: Mark IA books that return HTTP 401/403 with `archive_metadata.blocked` so they aren't retried every 10 minutes. Skip blocked books in the query.

## Context
Both archive workers on Hetzner were broken:
- archive-ocr: every run hit `MaxTimeMSExpired` on the priority-sorting aggregation
- archive-bulk: 576 HTTP 401 errors logged, wasting time retrying restricted IA items

## Test plan
- [ ] Deploy to Hetzner and check logs after next cron cycle
- [ ] Verify archive-ocr completes and archives pages
- [ ] Verify archive-bulk skips blocked books

🤖 Generated with [Claude Code](https://claude.com/claude-code)