### PR TITLE
Fix 3 user-facing routes timing out against Atlas

### DIFF
--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -4,35 +4,33 @@ import { ObjectId } from 'mongodb';
 import { Book } from '@/lib/types';
 import { withAuth } from '@/lib/auth-helpers';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '100', 10), 500);
+    const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10), 0);
+
     const db = await getDb();
 
-    // Get all books with page counts
-    const books = await db.collection('books').aggregate([
-      { $match: { hidden: { $ne: true } } },
-      {
-        $lookup: {
-          from: 'pages',
-          localField: 'id',
-          foreignField: 'book_id',
-          as: 'pages_array'
-        }
-      },
-      {
-        $addFields: {
-          pages_count: { $size: '$pages_array' }
-        }
-      },
-      {
-        $project: {
-          pages_array: 0
-        }
-      },
-      {
-        $sort: { created_at: -1 }
-      }
-    ], { maxTimeMS: 30000 }).toArray();
+    // pages_count is already cached on each book by the sync-page-counts cron.
+    // NEVER $lookup to the pages collection (9.5M docs) on a hot path.
+    const books = await db.collection('books')
+      .find(
+        { hidden: { $ne: true } },
+        {
+          projection: {
+            _id: 0, id: 1, title: 1, display_title: 1, author: 1, language: 1,
+            published: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1,
+            status: 1, slug: 1, thumbnail: 1, thumbnail_blob: 1, created_at: 1,
+            ia_identifier: 1, image_source: 1, collections: 1,
+          },
+          maxTimeMS: 8000,
+        },
+      )
+      .sort({ created_at: -1 })
+      .skip(offset)
+      .limit(limit)
+      .toArray();
 
     return NextResponse.json(books, {
       headers: {

--- a/src/app/api/search/suggest/route.ts
+++ b/src/app/api/search/suggest/route.ts
@@ -26,13 +26,16 @@ async function getVocabulary(): Promise<string[]> {
 
   const db = await getDb();
 
-  // Single query: titles/authors + index terms in one round trip.
+  // Only fetch books that have pages (skip catalog stubs — growing toward 100K).
   // Projection covers both use cases; books without an index simply
   // have no `index` field and are skipped in the index-terms loop.
   const books = await db.collection('books')
     .find(
-      { hidden: { $ne: true } },
-      { projection: { title: 1, display_title: 1, author: 1, 'index.concepts': 1, 'index.people': 1, 'index.places': 1, 'index.keyTerms': 1 } }
+      { hidden: { $ne: true }, pages_count: { $gt: 0 } },
+      {
+        projection: { title: 1, display_title: 1, author: 1, 'index.concepts': 1, 'index.people': 1, 'index.places': 1, 'index.keyTerms': 1 },
+        maxTimeMS: 8000,
+      },
     )
     .toArray();
 

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -241,7 +241,7 @@ async function fetchCollectionData(id: string) {
   const [books, highlights, galleryImages, mentionedBooks] = await Promise.all([
     withTimeout(
       db.collection('books')
-        .find(filter, { projection: { ...projection, collection_scores: 1 } })
+        .find(filter, { projection: { ...projection, collection_scores: 1 }, maxTimeMS: 8000 })
         .sort({ read_count: -1, title: 1 })
         .limit(COMPACT_LIMIT)
         .toArray()
@@ -287,7 +287,7 @@ async function fetchCollectionData(id: string) {
           }
           // Fallback: dynamic query (before thematic collections are seeded)
           const bookDocs = await db.collection('books')
-            .find({ collections: id, status: { $ne: 'deleted' }, hidden: { $ne: true } }, { projection: { id: 1 } })
+            .find({ collections: id, status: { $ne: 'deleted' }, hidden: { $ne: true } }, { projection: { id: 1 }, maxTimeMS: 5000 })
             .toArray();
           const bookIds = bookDocs.map(d => d.id);
           if (bookIds.length === 0) return [];


### PR DESCRIPTION
## Summary
- **`/api/books`**: Removed `$lookup` join to the 9.5M-row pages collection — `pages_count` is already cached on each book. Added pagination (`limit`/`offset` params), projection, and `maxTimeMS: 8000`.
- **`/api/search/suggest`**: Added `pages_count: { $gt: 0 }` filter to skip catalog stubs (growing toward 100K). Added `maxTimeMS: 8000`.
- **`/collections/[id]`**: Added `maxTimeMS: 8000` to main books query and gallery fallback so large collections fail fast instead of hanging.

## Context
E2E smoke test found these 3 routes timing out at 10s. Root causes:
1. `/api/books` was doing a `$lookup` to compute `pages_count` that's already a cached field
2. `/api/search/suggest` was loading all 5K+ books including empty catalog stubs on cache miss
3. `/collections/alchemy` (largest collection) had no query timeout, hanging on `$ne` filters

## Test plan
- [ ] `curl 'https://sourcelibrary.org/api/books?limit=5'` returns in <1s
- [ ] `curl 'https://sourcelibrary.org/api/search/suggest?q=paracelsus'` returns in <1s  
- [ ] Visit `/collections/alchemy` — loads without timeout
- [ ] Run `_tmp-e2e-smoke.mjs` — all 15 endpoints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)