### PR TITLE
archive-ocr: exclude e-rara/IA, focus on other IIIF sources

### DIFF
--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -201,9 +201,15 @@ async function main() {
 
   // Strategy: query books in archiving status, then fetch their unarchived pages.
   // This avoids a full scan of the 9.5M pages collection.
+  // Exclude e-rara (blocked on Hetzner IPs, archived locally via launchd on Mac)
+  // and internet_archive (handled by archive-bulk.mjs via JP2 zip download).
   const books = await db.collection('books')
     .find(
-      { 'pipeline_auto.status': 'archiving', 'archive_metadata.blocked': { $ne: true } },
+      {
+        'pipeline_auto.status': 'archiving',
+        'archive_metadata.blocked': { $ne: true },
+        'image_source.provider': { $nin: ['e-rara', 'internet_archive'] },
+      },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )
     .limit(200)


### PR DESCRIPTION
## Summary
- Exclude e-rara (403 on Hetzner IPs, archived locally) and internet_archive (handled by archive-bulk.mjs JP2 downloads) from the archive-ocr worker
- This worker now focuses on MDZ, Gallica, Bodleian, Vatican, Cambridge, and other IIIF providers

## Test plan
- [ ] Deploy to Hetzner, verify cron runs without e-rara 403 spam
- [ ] Verify other domains get archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)