### PR TITLE
Replace hidden:$ne:true with visible:true across codebase

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -169,7 +169,7 @@ async function probeDbHealth(db) {
   try {
     const t3 = Date.now();
     await db.collection('books').find(
-      { hidden: { $ne: true }, pages_count: { $gt: 0 } }
+      { visible: true, pages_count: { $gt: 0 } }
     ).sort({ created_at: -1 }).limit(10).project({ _id: 1 }).toArray();
     browseMs = Date.now() - t3;
   } catch {

--- a/src/app/about/processing/page.tsx
+++ b/src/app/about/processing/page.tsx
@@ -25,7 +25,7 @@ async function getStats() {
     const [totalBooks, visibleBooks, pageAgg, languages, sources, funnel] =
       await Promise.all([
         books.countDocuments({}, { maxTimeMS }),
-        books.countDocuments({ hidden: { $ne: true } }, { maxTimeMS }),
+        books.countDocuments({ visible: true }, { maxTimeMS }),
         books
           .aggregate([
             {
@@ -40,7 +40,7 @@ async function getStats() {
           .toArray(),
         books
           .aggregate([
-            { $match: { hidden: { $ne: true }, language: { $exists: true, $ne: 'Unknown' } } },
+            { $match: { visible: true, language: { $exists: true, $ne: 'Unknown' } } },
             { $group: { _id: '$language', count: { $sum: 1 } } },
             { $sort: { count: -1 } },
             { $limit: 10 },
@@ -48,7 +48,7 @@ async function getStats() {
           .toArray(),
         books
           .aggregate([
-            { $match: { hidden: { $ne: true }, 'image_source.provider_name': { $exists: true } } },
+            { $match: { visible: true, 'image_source.provider_name': { $exists: true } } },
             { $group: { _id: '$image_source.provider_name', count: { $sum: 1 } } },
             { $sort: { count: -1 } },
             { $limit: 8 },

--- a/src/app/api/_archived/admin/ensure-indexes/route.ts
+++ b/src/app/api/_archived/admin/ensure-indexes/route.ts
@@ -243,7 +243,7 @@ export const POST = withAuth(async (request, session) => {
     }
 
     // Books - recently translated sort (homepage, library default sort)
-    // Query: { hidden: { $ne: true }, pages_translated: { $gt: 0 }, last_translation_at: { $exists: true } }
+    // Query: { visible: true, pages_translated: { $gt: 0 }, last_translation_at: { $exists: true } }
     try {
       await db.collection('books').createIndex(
         { last_translation_at: -1 },
@@ -258,7 +258,7 @@ export const POST = withAuth(async (request, session) => {
     }
 
     // Books - translated book count (homepage stat)
-    // Query: { hidden: { $ne: true }, pages_translated: { $gt: 0 } }
+    // Query: { visible: true, pages_translated: { $gt: 0 } }
     try {
       await db.collection('books').createIndex(
         { pages_translated: 1, hidden: 1 },
@@ -331,7 +331,7 @@ export const POST = withAuth(async (request, session) => {
     }
 
     // Books - compound index for filtered search (language + category + hidden)
-    // Query: { $text: ..., hidden: { $ne: true }, language: ..., categories: ... }
+    // Query: { $text: ..., visible: true, language: ..., categories: ... }
     try {
       await db.collection('books').createIndex(
         { hidden: 1, language: 1, categories: 1 },

--- a/src/app/api/admin/book-collections/[slug]/gallery/route.ts
+++ b/src/app/api/admin/book-collections/[slug]/gallery/route.ts
@@ -21,7 +21,7 @@ export const GET = withAuth(async (req: NextRequest, _session: Session, context?
 
     // Get all book IDs in this collection
     const books = await db.collection('books').find(
-      { collections: slug, hidden: { $ne: true }, status: { $ne: 'deleted' } },
+      { collections: slug, visible: true, status: { $ne: 'deleted' } },
       { projection: { _id: 0, id: { $ifNull: ['$id', { $toString: '$_id' }] }, slug: 1 } }
     ).toArray();
 
@@ -101,7 +101,7 @@ export const POST = withAuth(async (req: NextRequest, _session: Session, context
 
     // Get all book IDs in this collection
     const books = await db.collection('books').find(
-      { collections: slug, hidden: { $ne: true }, status: { $ne: 'deleted' } },
+      { collections: slug, visible: true, status: { $ne: 'deleted' } },
       { projection: { _id: 0, id: { $ifNull: ['$id', { $toString: '$_id' }] }, slug: 1 } }
     ).toArray();
     const bookIds = books.map(b => b.id);

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -8,7 +8,7 @@ const STALE_AFTER_MS = 15 * 60 * 1000;
 
 async function computeSnapshot(db: any) {
   const books = db.collection('books');
-  const notHidden = { hidden: { $ne: true } };
+  const notHidden = { visible: true };
 
   // Use simple countDocuments — each one is fast with proper filters
   // Run in two batches to avoid overwhelming cold connections

--- a/src/app/api/admin/duplicates/route.ts
+++ b/src/app/api/admin/duplicates/route.ts
@@ -86,7 +86,7 @@ export const GET = withAdminAuth(async (request) => {
 
   const db = await getDb();
   const books = await db.collection('books').find(
-    { hidden: { $ne: true } },
+    { visible: true },
     { projection: {
       id: 1, title: 1, author: 1, slug: 1,
       normalized_title: 1, normalized_author: 1,
@@ -243,9 +243,9 @@ export const POST = withAdminAuth(async (request) => {
   const now = new Date();
 
   const result = await db.collection('books').updateMany(
-    { id: { $in: bookIds }, hidden: { $ne: true } },
+    { id: { $in: bookIds }, visible: true },
     { $set: {
-      hidden: true,
+      hidden: true, visible: false,
       hidden_reason: 'duplicate',
       hidden_at: now,
       ...(keeperId ? { duplicate_of: keeperId } : {}),

--- a/src/app/api/admin/revalidate-authors/route.ts
+++ b/src/app/api/admin/revalidate-authors/route.ts
@@ -24,7 +24,7 @@ export const POST = withAdminAuth(async (request) => {
 
   // Get distinct authors from visible books
   const authors: string[] = await db.collection('books').distinct('author', {
-    hidden: { $ne: true },
+    visible: true,
     author: { $exists: true, $ne: null, $nin: ['Unknown', 'Anonymous', 'Various'] },
   });
 

--- a/src/app/api/admin/seed-collections/route.ts
+++ b/src/app/api/admin/seed-collections/route.ts
@@ -489,7 +489,7 @@ async function seedThematicCollections(
     // Find all book IDs in this collection
     const bookDocs = await db.collection('books')
       .find(
-        { collections: bc.slug, status: { $ne: 'deleted' }, hidden: { $ne: true } },
+        { collections: bc.slug, status: { $ne: 'deleted' }, visible: true },
         { projection: { id: 1 } },
       )
       .toArray();

--- a/src/app/api/analytics/canon/route.ts
+++ b/src/app/api/analytics/canon/route.ts
@@ -39,7 +39,7 @@ export const GET = withAuth(async () => {
     ] = await Promise.all([
       // 1. Overall totals
       db.collection('books').aggregate([
-        { $match: { hidden: { $ne: true } } },
+        { $match: { visible: true } },
         {
           $group: {
             _id: null,
@@ -54,7 +54,7 @@ export const GET = withAuth(async () => {
       // 2. Books that are "readable" — >=90% of translatable pages translated
       //    Denominator: pages_ocr - pages_blank (blank pages don't need translation)
       db.collection('books').countDocuments({
-        hidden: { $ne: true },
+        visible: true,
         pages_ocr: { $gte: 1 },
         $expr: {
           $gte: [
@@ -68,7 +68,7 @@ export const GET = withAuth(async () => {
       db.collection('books').aggregate([
         {
           $match: {
-            hidden: { $ne: true },
+            visible: true,
             is_first_translation: true,
           },
         },
@@ -96,7 +96,7 @@ export const GET = withAuth(async () => {
 
       // 4. Breakdown by original language
       db.collection('books').aggregate([
-        { $match: { hidden: { $ne: true }, pages_count: { $gte: 1 } } },
+        { $match: { visible: true, pages_count: { $gte: 1 } } },
         {
           $group: {
             _id: { $ifNull: ['$language', 'Unknown'] },
@@ -125,7 +125,7 @@ export const GET = withAuth(async () => {
 
       // 5. Breakdown by collection (top traditions)
       db.collection('books').aggregate([
-        { $match: { hidden: { $ne: true }, collections: { $exists: true, $ne: [] } } },
+        { $match: { visible: true, collections: { $exists: true, $ne: [] } } },
         { $unwind: '$collections' },
         {
           $group: {
@@ -153,7 +153,7 @@ export const GET = withAuth(async () => {
 
       // 6. Recently completed translations (last 30 days, by pipeline completion)
       db.collection('books').find({
-        hidden: { $ne: true },
+        visible: true,
         'pipeline_auto.status': 'complete',
         'pipeline_auto.completed_at': { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) },
         language: { $nin: ['English', 'english'] },

--- a/src/app/api/analytics/stats/route.ts
+++ b/src/app/api/analytics/stats/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
     // Uses cached pages_translated from books instead of scanning 916k pages
     const [bookStats, totalBooks, totalPages] = await Promise.all([
       db.collection('books').aggregate([
-        { $match: { hidden: { $ne: true } } },
+        { $match: { visible: true } },
         { $group: {
           _id: null,
           totalReads: { $sum: '$read_count' },
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
           pagesTranslated: { $sum: { $ifNull: ['$pages_translated', 0] } },
         } }
       ]).toArray(),
-      db.collection('books').countDocuments({ hidden: { $ne: true } }),
+      db.collection('books').countDocuments({ visible: true }),
       db.collection('pages').estimatedDocumentCount(),
     ]);
     const pagesTranslated = bookStats[0]?.pagesTranslated || 0;

--- a/src/app/api/books/[id]/visibility/route.ts
+++ b/src/app/api/books/[id]/visibility/route.ts
@@ -30,6 +30,7 @@ export const POST = withAdminAuth(async (
 
     const update: Record<string, unknown> = {
       hidden,
+      visible: !hidden,
       updated_at: new Date(),
     };
 

--- a/src/app/api/books/facets/route.ts
+++ b/src/app/api/books/facets/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
   // Build MongoDB query from facet filters
   const query: Record<string, unknown> = {
     'faceted_tags': { $exists: true },
-    hidden: { $ne: true },
+    visible: true,
   };
 
   const activeFilters: Record<string, string[]> = {};

--- a/src/app/api/books/library/route.ts
+++ b/src/app/api/books/library/route.ts
@@ -86,7 +86,7 @@ export async function GET(request: NextRequest) {
       ];
     } else {
       const matchConditions: Record<string, unknown>[] = [
-        { hidden: { $ne: true } },
+        { visible: true },
         { pages_count: { $gt: 0 } },
       ];
       if (language) matchConditions.push({ language });

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
     // NEVER $lookup to the pages collection (9.5M docs) on a hot path.
     const books = await db.collection('books')
       .find(
-        { hidden: { $ne: true } },
+        { visible: true },
         {
           projection: {
             _id: 0, id: 1, title: 1, display_title: 1, author: 1, language: 1,

--- a/src/app/api/books/search/route.ts
+++ b/src/app/api/books/search/route.ts
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
       // Fallback: regex search (skip countDocuments — it's a full collection scan)
       const queryRegex = new RegExp(escapeRegex(query), 'i');
       const filter = {
-        hidden: { $ne: true },
+        visible: true,
         pages_count: { $gt: 0 },
         $or: [
           { title: queryRegex },

--- a/src/app/api/books/timeline/route.ts
+++ b/src/app/api/books/timeline/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     // Base filter: has year, not hidden
     const baseMatch: Record<string, unknown> = {
       year: { $exists: true, $ne: null },
-      hidden: { $ne: true },
+      visible: true,
     };
     if (language) baseMatch.language = language;
     if (collection) baseMatch.categories = collection;

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -206,7 +206,7 @@ export async function GET() {
 
     // Get category counts from books
     const categoryCounts = await db.collection('books').aggregate([
-      { $match: { hidden: { $ne: true } } },
+      { $match: { visible: true } },
       { $unwind: '$categories' },
       { $group: { _id: '$categories', count: { $sum: 1 } } },
     ]).toArray();

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -46,7 +46,7 @@ export async function GET(
       : {
           collections: id,
           status: { $ne: 'deleted' },
-          hidden: { $ne: true },
+          visible: true,
           pages_count: { $gt: 0 },
           pages_translated: { $gt: 0 },
         };
@@ -136,7 +136,7 @@ export async function GET(
         .find(
           isArtCollection
             ? { collections: id, resource_type: { $exists: true } }
-            : { collections: id, status: { $ne: 'deleted' }, hidden: { $ne: true }, pages_translated: { $gt: 0 } },
+            : { collections: id, status: { $ne: 'deleted' }, visible: true, pages_translated: { $gt: 0 } },
           { projection: highlightProjection },
         )
         .sort(isArtCollection ? { title: 1 } : { quality_score: -1, read_count: -1, pages_translated: -1 })

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -96,7 +96,7 @@ export const PATCH = withAuth(async (request) => {
       const bookCount = await db.collection('books').countDocuments({
         collections: slug,
         status: { $ne: 'deleted' },
-        hidden: { $ne: true },
+        visible: true,
         pages_count: { $gt: 0 },
       });
       updates.book_count = bookCount;
@@ -174,7 +174,7 @@ export const POST = withAuth(async (request) => {
     const bookCount = await db.collection('books').countDocuments({
       collections: slug,
       status: { $ne: 'deleted' },
-      hidden: { $ne: true },
+      visible: true,
       pages_count: { $gt: 0 },
     });
 

--- a/src/app/api/cron/_archived/post-import-pipeline/route.ts
+++ b/src/app/api/cron/_archived/post-import-pipeline/route.ts
@@ -2089,7 +2089,7 @@ export async function GET(request: NextRequest) {
           translated: { $sum: { $ifNull: ['$pages_translated', 0] } },
         }}],
         canon: [
-          { $match: { hidden: { $ne: true } } },
+          { $match: { visible: true } },
           { $group: {
             _id: null,
             visible_books: { $sum: 1 },

--- a/src/app/api/cron/_archived/sync-page-counts/route.ts
+++ b/src/app/api/cron/_archived/sync-page-counts/route.ts
@@ -182,7 +182,7 @@ export async function GET(request: NextRequest) {
       const liveCount = await db.collection('books').countDocuments({
         collections: col.slug,
         status: { $ne: 'deleted' },
-        hidden: { $ne: true },
+        visible: true,
         pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
       });

--- a/src/app/api/cron/daily-pipeline-report/route.ts
+++ b/src/app/api/cron/daily-pipeline-report/route.ts
@@ -27,7 +27,7 @@ export async function GET() {
     const dayStart = new Date(`${dateStr}T00:00:00Z`);
     const dayEnd = new Date(`${dateStr}T23:59:59.999Z`);
 
-    const vis = { hidden: { $ne: true } };
+    const vis = { visible: true };
 
     // ── Collection state (from book-level caches) — single pass ──
     const [collectionState] = await books.aggregate([

--- a/src/app/api/dataset/v1/books/route.ts
+++ b/src/app/api/dataset/v1/books/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
   }
 
   const db = await getDb();
-  const filter: any = { hidden: { $ne: true } };
+  const filter: any = { visible: true };
   if (language) filter.language = language;
   if (cluster) filter['taxonomy.cluster'] = cluster;
   if (fromYear || toYear) {

--- a/src/app/api/dataset/v1/pages/route.ts
+++ b/src/app/api/dataset/v1/pages/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
   const db = await getDb();
 
   // Build book filter
-  const bookFilter: any = { hidden: { $ne: true } };
+  const bookFilter: any = { visible: true };
   if (language) bookFilter.language = language;
   if (cluster) bookFilter['taxonomy.cluster'] = cluster;
   if (fromYear || toYear) {

--- a/src/app/api/dataset/v1/stats/route.ts
+++ b/src/app/api/dataset/v1/stats/route.ts
@@ -13,7 +13,7 @@ export const maxDuration = 15;
 export async function GET() {
   const db = await getDb();
   const books = db.collection('books');
-  const visible = { hidden: { $ne: true } };
+  const visible = { visible: true };
 
   const [
     totalBooks,

--- a/src/app/api/explore/stats/route.ts
+++ b/src/app/api/explore/stats/route.ts
@@ -59,7 +59,7 @@ export async function GET() {
       }),
 
       // Total books
-      db.collection('books').countDocuments({ hidden: { $ne: true } }),
+      db.collection('books').countDocuments({ visible: true }),
 
       // Type distribution
       db.collection('entities').aggregate([

--- a/src/app/api/feed/books/route.ts
+++ b/src/app/api/feed/books/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
   const db = await getDb();
 
   const books = await db.collection('books')
-    .find({ hidden: { $ne: true }, pages_translated: { $gt: 0 } })
+    .find({ visible: true, pages_translated: { $gt: 0 } })
     .sort({ created_at: -1 })
     .limit(50)
     .project({

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest) {
     // Build query filter
     const filter: Record<string, unknown> = {
       gallery_quality: { $gte: minQuality },
-      book_hidden: { $ne: true },
+      book_visible: true,
     };
 
     // Book diversity: limit to top N images per book (unless filtering by single book or showing all)

--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -270,7 +270,7 @@ export const POST = withAuth(async (request, session) => {
         access_date: new Date(),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ image_source: { provider: 'e-rara', identifier: numericId, iiif_manifest: manifestUrl } }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -182,7 +182,7 @@ export const POST = withAuth(async (request, session) => {
         access_date: new Date(),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ gallica_ark: ark }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -195,7 +195,7 @@ export const POST = withAuth(async (request, session) => {
         access_date: new Date(),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ ia_identifier, google_books_id }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -223,7 +223,7 @@ export const POST = withAuth(async (request, session) => {
       },
       page_count_source: pageCountSource,
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ ia_identifier }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -405,7 +405,7 @@ export const POST = withAuth(async (request, session) => {
         ...(shelfmark ? { shelfmark } : {}),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ image_source: { provider: 'iiif', iiif_manifest: manifest_url } }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -266,7 +266,7 @@ export const POST = withAuth(async (request, session) => {
         ...(start_page || end_page ? { page_range: `${startIdx + 1}-${endIdx}` } : {}),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ image_source: { provider: 'loc', identifier: lccn } }),
       normalized_title: normalizeTitle(bookTitle),
       normalized_author: normalizeAuthor(bookAuthor),

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -224,7 +224,7 @@ export const POST = withAuth(async (request, session) => {
         access_date: new Date(),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ mdz_id: normalizedId }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -231,7 +231,7 @@ export const POST = withAuth(async (request) => {
       ...(catalog_metadata ? { catalog_metadata } : {}),
       page_count_source: 'pdf_extraction',
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ image_source: { provider, identifier: identifier || undefined, pdf_url } }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -105,7 +105,7 @@ export const POST = withAuth(async (request, session) => {
       pageCount: pageFiles.length,
       pages_count: pageFiles.length,
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       created_at: new Date(),
       updated_at: new Date()
     };

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -248,7 +248,7 @@ export const POST = withAuth(async (request, session) => {
         access_date: new Date(),
       },
       status: 'draft',
-      hidden: true,
+      hidden: true, visible: false,
       source_fingerprint: sourceFingerprint({ image_source: { provider: 'wellcome', identifier: work_id, iiif_manifest: manifestUrl } }),
       normalized_title: normalizeTitle(title),
       normalized_author: normalizeAuthor(author),

--- a/src/app/api/nde/dataset/route.ts
+++ b/src/app/api/nde/dataset/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
   const books = db.collection('books');
 
   // Live stats for the BPH subset
-  const bphFilter = { 'image_source.provider': 'bph', hidden: { $ne: true } };
+  const bphFilter = { 'image_source.provider': 'bph', visible: true };
 
   const [totalBooks, pageTotalsAgg] = await Promise.all([
     books.countDocuments(bphFilter),

--- a/src/app/api/search/index/route.ts
+++ b/src/app/api/search/index/route.ts
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
       ? db.collection('books').aggregate([
           { $match: {
               'index.generatedAt': { $exists: true },
-              hidden: { $ne: true },
+              visible: true,
               pages_count: { $gt: 0 },
               $or: termTypes.map(t => ({ [`${t.field}.term`]: queryRegex }))
             }
@@ -105,7 +105,7 @@ export async function GET(request: NextRequest) {
       ? db.collection('books').aggregate([
           { $match: {
               'index.generatedAt': { $exists: true },
-              hidden: { $ne: true },
+              visible: true,
               pages_count: { $gt: 0 },
               'index.sectionSummaries.quotes.text': queryRegex
             }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -82,7 +82,7 @@ export async function GET(request: NextRequest) {
 
     // Helper: build common book-level filters (language, category, year, etc.)
     function buildBookFilters(): Record<string, unknown> {
-      const filters: Record<string, unknown> = { hidden: { $ne: true }, pages_count: { $gt: 0 } };
+      const filters: Record<string, unknown> = { visible: true, pages_count: { $gt: 0 } };
       if (language) filters.language = language;
       if (category) filters.categories = category;
       if (dateFrom || dateTo) {
@@ -207,7 +207,7 @@ export async function GET(request: NextRequest) {
         if (bookId) {
           pageFilter.book_id = bookId;
         } else if (hasBookLevelFilters) {
-          const bookIdFilter: Record<string, unknown> = { hidden: { $ne: true } };
+          const bookIdFilter: Record<string, unknown> = { visible: true };
           if (language) bookIdFilter.language = language;
           if (category) bookIdFilter.categories = category;
           if (dateFrom || dateTo) {

--- a/src/app/api/search/suggest/route.ts
+++ b/src/app/api/search/suggest/route.ts
@@ -31,7 +31,7 @@ async function getVocabulary(): Promise<string[]> {
   // have no `index` field and are skipped in the index-terms loop.
   const books = await db.collection('books')
     .find(
-      { hidden: { $ne: true }, pages_count: { $gt: 0 } },
+      { visible: true, pages_count: { $gt: 0 } },
       {
         projection: { title: 1, display_title: 1, author: 1, 'index.concepts': 1, 'index.people': 1, 'index.places': 1, 'index.keyTerms': 1 },
         maxTimeMS: 8000,

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -117,7 +117,7 @@ async function searchBooks(db: any, query: string, queryRegex: RegExp, limit: nu
           { author: queryRegex },
           { 'reading_summary.overview': queryRegex },
         ],
-        hidden: { $ne: true },
+        visible: true,
         pages_count: { $gt: 0 },
       })
       .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, pages_ocr: 1, thumbnail: 1, thumbnail_blob: 1 })
@@ -143,7 +143,7 @@ async function searchBooks(db: any, query: string, queryRegex: RegExp, limit: nu
       const aliasBooks = await db.collection('books')
         .find({
           author_entity_id: entity._id.toString(),
-          hidden: { $ne: true },
+          visible: true,
           pages_count: { $gt: 0 },
         })
         .project({ id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, pages_ocr: 1, thumbnail: 1, thumbnail_blob: 1 })
@@ -238,7 +238,7 @@ async function searchIndex(db: any, query: string, limit: number) {
   if (results.length === 0 && query.length >= 4) {
     const books = await db.collection('books').find({
       'index.generatedAt': { $exists: true },
-      hidden: { $ne: true },
+      visible: true,
       $or: [
         { 'index.concepts.term': queryRegex },
         { 'index.people.term': queryRegex },

--- a/src/app/api/search/vocabulary/route.ts
+++ b/src/app/api/search/vocabulary/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
     const db = await getDb();
     const books = await db.collection('books')
       .find(
-        { hidden: { $ne: true }, pages_count: { $gt: 0 } },
+        { visible: true, pages_count: { $gt: 0 } },
         { projection: { title: 1, display_title: 1, author: 1 } }
       )
       .toArray();

--- a/src/app/api/taxonomy/hierarchy/route.ts
+++ b/src/app/api/taxonomy/hierarchy/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
 
     // Aggregate: group by cluster + subcluster, get counts and sample books
     const groups = await books.aggregate([
-      { $match: { taxonomy: { $exists: true }, hidden: { $ne: true } } },
+      { $match: { taxonomy: { $exists: true }, visible: true } },
       { $sort: { year: 1 } },
       {
         $group: {

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -37,7 +37,7 @@ async function getArtist(slug: string) {
       .toArray(),
     db.collection('books')
       .find(
-        { author: authorRegex, resource_type: { $exists: false }, hidden: { $ne: true } },
+        { author: authorRegex, resource_type: { $exists: false }, visible: true },
         { projection: {
           slug: 1, title: 1, display_title: 1, author: 1, published: 1,
           language: 1, thumbnail: 1, thumbnail_blob: 1, pages_translated: 1,
@@ -56,7 +56,7 @@ async function getArtist(slug: string) {
       const reversedEscaped = reversed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       allBooks = await db.collection('books')
         .find(
-          { author: { $regex: `^${reversedEscaped}$`, $options: 'i' }, resource_type: { $exists: false }, hidden: { $ne: true } },
+          { author: { $regex: `^${reversedEscaped}$`, $options: 'i' }, resource_type: { $exists: false }, visible: true },
           { projection: {
             slug: 1, title: 1, display_title: 1, author: 1, published: 1,
             language: 1, thumbnail: 1, thumbnail_blob: 1, pages_translated: 1,

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -29,7 +29,7 @@ async function getData() {
   // Only query the small collections table (19 docs) — fast and reliable.
   // Skip the expensive books aggregation that was causing timeouts.
   const collections = await db.collection('collections')
-    .find({ collection_type: 'visual_art', hidden: { $ne: true } })
+    .find({ collection_type: 'visual_art', visible: true })
     .sort({ order: 1 })
     .project({ _id: 0, slug: 1, name: 1, subtitle: 1, color: 1, book_count: 1, featured_images: 1 })
     .toArray() as ArtCollection[];

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -79,7 +79,7 @@ async function loadAuthorData(db: any, slug: string): Promise<{
     const guess = slug.split('-').map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
     // Verify this author exists with an exact match
     const check = await db.collection('books').findOne(
-      { author: guess, hidden: { $ne: true } },
+      { author: guess, visible: true },
       { projection: { _id: 1 } }
     );
     if (check) authorName = guess;
@@ -89,7 +89,7 @@ async function loadAuthorData(db: any, slug: string): Promise<{
 
   // Fetch books + entity in parallel
   const booksPromise = db.collection('books').find(
-    { author: authorName, hidden: { $ne: true } },
+    { author: authorName, visible: true },
     {
       projection: {
         _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -209,7 +209,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
     // Top 8 gallery images for preview row
     db.collection('gallery_images')
       .find(
-        { book_id: bookId, gallery_quality: { $gte: 0.7 }, book_hidden: { $ne: true } },
+        { book_id: bookId, gallery_quality: { $gte: 0.7 }, book_visible: true },
         { projection: { _id: 0, id: 1, extracted_url: 1, thumbnail_url: 1, image_url: 1, description: 1, type: 1, page_number: 1, gallery_quality: 1 }, maxTimeMS: 5000 },
       )
       .sort({ gallery_quality: -1 })
@@ -219,7 +219,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
     // Separate count query for accurate image count display
     db.collection('gallery_images')
       .countDocuments(
-        { book_id: bookId, gallery_quality: { $gte: 0.7 }, book_hidden: { $ne: true } },
+        { book_id: bookId, gallery_quality: { $gte: 0.7 }, book_visible: true },
         { maxTimeMS: 5000 },
       )
       .catch(() => 0),
@@ -227,7 +227,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
     book.collections?.length
       ? db.collection('collections')
           .find(
-            { slug: { $in: book.collections }, hidden: { $ne: true } },
+            { slug: { $in: book.collections }, visible: true },
             { projection: { _id: 0, slug: 1, name: 1, subtitle: 1, color: 1, book_count: 1, featured_images: 1 }, maxTimeMS: 5000 },
           )
           .sort({ order: 1 })

--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -47,7 +47,7 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
     const rawBooks = await db.collection('books').find(
       {
         author: { $regex: `^${l}`, $options: 'i' },
-        hidden: { $ne: true },
+        visible: true,
         pages_translated: { $gt: 0 },
       },
       {

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -53,7 +53,7 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
     // Use books_hidden_translated_idx for the base filter, then regex on title.
     const rawBooks = await db.collection('books').find(
       {
-        hidden: { $ne: true },
+        visible: true,
         pages_translated: { $gt: 0 },
         $or: [
           { display_title: { $regex: regex } },

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -65,7 +65,7 @@ export default async function BrowseYearsPage({ params }: PageProps) {
     const rawBooks = await db.collection('books').find(
       {
         year: { $gte: p.min, $lte: p.max },
-        hidden: { $ne: true },
+        visible: true,
         pages_translated: { $gt: 0 },
       },
       {

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -44,7 +44,7 @@ async function getCategoryBooks(id: string): Promise<Book[]> {
     const db = await getDb();
     // Use cached pages_translated on books — no $lookup against 9.5M pages collection
     const books = await db.collection('books').find(
-      { categories: id, hidden: { $ne: true }, pages_translated: { $gt: 0 } },
+      { categories: id, visible: true, pages_translated: { $gt: 0 } },
       { maxTimeMS: 30000 }
     )
     .project({ _id: 0, pages_array: 0 })

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -25,7 +25,7 @@ async function getCategoriesWithCounts(): Promise<CategoryWithCount[]> {
   try {
     const db = await getDb();
     const categoryCounts = await db.collection('books').aggregate([
-      { $match: { hidden: { $ne: true }, categories: { $exists: true } } },
+      { $match: { visible: true, categories: { $exists: true } } },
       { $unwind: '$categories' },
       { $group: { _id: '$categories', count: { $sum: 1 } } },
     ], { maxTimeMS: 30000, hint: 'categories_1' }).toArray();

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -208,7 +208,7 @@ async function fetchCollectionData(id: string) {
     : {
         collections: id,
         status: { $ne: 'deleted' },
-        hidden: { $ne: true },
+        visible: true,
         pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
       };
@@ -287,7 +287,7 @@ async function fetchCollectionData(id: string) {
           }
           // Fallback: dynamic query (before thematic collections are seeded)
           const bookDocs = await db.collection('books')
-            .find({ collections: id, status: { $ne: 'deleted' }, hidden: { $ne: true } }, { projection: { id: 1 }, maxTimeMS: 5000 })
+            .find({ collections: id, status: { $ne: 'deleted' }, visible: true }, { projection: { id: 1 }, maxTimeMS: 5000 })
             .toArray();
           const bookIds = bookDocs.map(d => d.id);
           if (bookIds.length === 0) return [];
@@ -331,7 +331,7 @@ async function fetchCollectionData(id: string) {
   // Fetch child collections if this is a parent collection
   const childCollections = await withTimeout(
     db.collection('collections')
-      .find({ parent: id, hidden: { $ne: true } })
+      .find({ parent: id, visible: true })
       .sort({ book_count: -1 })
       .project({ slug: 1, name: 1, subtitle: 1, book_count: 1, featured_images: 1 })
       .toArray(),

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -47,10 +47,10 @@ async function fetchCollections(): Promise<CollectionDoc[]> {
       parent: { $exists: false },
       type: { $ne: 'curated' },
       collection_type: { $ne: 'visual_art' },
-      hidden: { $ne: true },
+      visible: true,
     }).toArray(),
     db.collection('collections').aggregate<{ _id: string; count: number }>([
-      { $match: { parent: { $exists: true }, hidden: { $ne: true } } },
+      { $match: { parent: { $exists: true }, visible: true } },
       { $group: { _id: '$parent', count: { $sum: 1 } } },
     ]).toArray(),
   ]);
@@ -68,7 +68,7 @@ async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total:
   try {
     const db = await getDb();
     const pipeline = [
-      { $match: { year: { $exists: true, $ne: null }, hidden: { $ne: true } } },
+      { $match: { year: { $exists: true, $ne: null }, visible: true } },
       { $project: { year: 1, language: { $ifNull: ['$language', 'Unknown'] } } },
       {
         $group: {

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -44,7 +44,7 @@ async function getTraditions(): Promise<{ traditions: TraditionCollection[]; tot
 
   const traditions = await db
     .collection('collections')
-    .find({ parent: 'sacred-texts', hidden: { $ne: true } })
+    .find({ parent: 'sacred-texts', visible: true })
     .sort({ order: 1 })
     .toArray();
 

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -181,7 +181,7 @@ function extractTiers(
 async function fetchLibraryData(showAdmin: boolean): Promise<LibraryData> {
   const db = await getDb();
   const books = db.collection('books');
-  const visible = { hidden: { $ne: true } };
+  const visible = { visible: true };
   const filter = showAdmin ? {} : visible;
 
   const maxTimeMS = 45000;

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -28,7 +28,7 @@ async function fetchDatasetStats() {
 
   try {
     const books = db.collection('books');
-    const visible = { hidden: { $ne: true } };
+    const visible = { visible: true };
     const maxTimeMS = 45000;
 
     const [totalBooks, pageTotalsAgg, languagesAgg] = await Promise.all([

--- a/src/app/design-options/all-editorial/page.tsx
+++ b/src/app/design-options/all-editorial/page.tsx
@@ -38,7 +38,7 @@ async function getAllCollectionsWithBooks(): Promise<CollectionWithBooks[]> {
   const db = await getDb();
 
   const collections = await db.collection('collections').find(
-    { parent: { $exists: false }, type: { $ne: 'curated' }, hidden: { $ne: true }, book_count: { $gte: 5 } },
+    { parent: { $exists: false }, type: { $ne: 'curated' }, visible: true, book_count: { $gte: 5 } },
     { projection: { slug: 1, name: 1, subtitle: 1, description: 1, book_count: 1, featured_images: 1, curated_gallery: 1, highlighted_books: 1 } }
   ).sort({ book_count: -1 }).toArray();
 
@@ -66,7 +66,7 @@ async function getAllCollectionsWithBooks(): Promise<CollectionWithBooks[]> {
   // Batch-fetch all highlighted books in one query
   const highlightedBooks = allHighlightedIds.length > 0
     ? await db.collection('books').aggregate([
-        { $match: { $or: [{ id: { $in: allHighlightedIds } }, { _id: { $in: allHighlightedIds } }], hidden: { $ne: true }, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } } },
+        { $match: { $or: [{ id: { $in: allHighlightedIds } }, { _id: { $in: allHighlightedIds } }], visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } } },
         { $project: bookProjection },
       ], { maxTimeMS: 10000 }).toArray()
     : [];
@@ -111,7 +111,7 @@ async function getAllCollectionsWithBooks(): Promise<CollectionWithBooks[]> {
     if (books.length < 8) {
       const existingIds = new Set(books.map(b => b.id));
       const backfill = (await db.collection('books').aggregate([
-        { $match: { collections: slug, hidden: { $ne: true }, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, thumbnail_blob: { $exists: true, $ne: null } } },
+        { $match: { collections: slug, visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, thumbnail_blob: { $exists: true, $ne: null } } },
         { $sort: { read_count: -1 } },
         { $limit: 16 },
         { $project: bookProjection },

--- a/src/app/design-options/page.tsx
+++ b/src/app/design-options/page.tsx
@@ -68,7 +68,7 @@ async function getFeaturedCollection(): Promise<FeaturedCollectionItem | null> {
           book_count: { $gte: 10 },
           parent: { $exists: false },
           type: { $ne: 'curated' },
-          hidden: { $ne: true },
+          visible: true,
         },
       },
       { $sample: { size: 1 } },
@@ -107,7 +107,7 @@ async function getFeaturedCollection(): Promise<FeaturedCollectionItem | null> {
                 { id: { $in: highlightedIds } },
                 { _id: { $in: highlightedIds } },
               ],
-              hidden: { $ne: true },
+              visible: true,
               pages_count: { $gt: 0 },
               pages_translated: { $gt: 0 },
             },
@@ -129,7 +129,7 @@ async function getFeaturedCollection(): Promise<FeaturedCollectionItem | null> {
           {
             $match: {
               collections: col.slug,
-              hidden: { $ne: true },
+              visible: true,
               pages_count: { $gt: 0 },
               pages_translated: { $gt: 0 },
               thumbnail_blob: { $exists: true, $ne: null },
@@ -191,7 +191,7 @@ async function getMultipleFeaturedCollections(): Promise<FeaturedCollectionItem[
           book_count: { $gte: 10 },
           parent: { $exists: false },
           type: { $ne: 'curated' },
-          hidden: { $ne: true },
+          visible: true,
         },
       },
       { $sample: { size: 5 } },
@@ -210,7 +210,7 @@ async function getMultipleFeaturedCollections(): Promise<FeaturedCollectionItem[
   for (const col of collections) {
     // Get books for this collection
     const colBooks = (await db.collection('books').aggregate([
-      { $match: { collections: col.slug, hidden: { $ne: true }, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, thumbnail_blob: { $exists: true, $ne: null } } },
+      { $match: { collections: col.slug, visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, thumbnail_blob: { $exists: true, $ne: null } } },
       { $sort: { read_count: -1 } },
       { $limit: 10 },
       { $project: bookProjection },
@@ -243,7 +243,7 @@ async function getMultipleFeaturedCollections(): Promise<FeaturedCollectionItem[
 async function getCollectionSummaries(): Promise<CollectionSummary[]> {
   const db = await getDb();
   const docs = await db.collection('collections').find(
-    { parent: { $exists: false }, type: { $ne: 'curated' }, hidden: { $ne: true }, book_count: { $gte: 5 } },
+    { parent: { $exists: false }, type: { $ne: 'curated' }, visible: true, book_count: { $gte: 5 } },
     { projection: { _id: 0, slug: 1, name: 1, subtitle: 1, book_count: 1, featured_images: 1, languages: 1 } }
   ).limit(8).toArray();
 

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -47,7 +47,7 @@ async function fetchExploreStats() {
 
       // Books by century — fast aggregation on books collection
       db.collection('books').aggregate([
-        { $match: { year: { $exists: true, $gt: 0 }, hidden: { $ne: true } } },
+        { $match: { year: { $exists: true, $gt: 0 }, visible: true } },
         {
           $group: {
             _id: {

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -59,7 +59,7 @@ async function fetchInitialGalleryData(): Promise<GalleryResponse> {
     const filter = {
       gallery_quality: { $gte: minQuality },
       book_rank: { $lte: maxPerBook },
-      book_hidden: { $ne: true },
+      book_visible: true,
     };
 
     // Read pre-computed filters from system_config (subjects/year aggs take 20-40s on Atlas)

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     count = await db.collection('books').countDocuments({
       language: langName,
       status: { $ne: 'deleted' },
-      hidden: { $ne: true },
+      visible: true,
       pages_count: { $gt: 0 },
     });
   } catch {
@@ -88,7 +88,7 @@ async function fetchLanguageData(langName: string, sort: string, offset: number,
   const baseFilter: Record<string, unknown> = {
     language: langName,
     status: { $ne: 'deleted' },
-    hidden: { $ne: true },
+    visible: true,
     pages_count: { $gt: 0 },
   };
 
@@ -140,7 +140,7 @@ async function fetchLanguageData(langName: string, sort: string, offset: number,
           { $match: {
             book_id: { $in: sampleBookIds },
             gallery_quality: { $gte: 0.7 },
-            book_hidden: { $ne: true },
+            book_visible: true,
             type: { $nin: ['decorative', 'symbol', 'musical_score', 'exlibris', 'bookplate'] },
           }},
           { $sort: { gallery_quality: -1 } },

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -38,7 +38,7 @@ async function fetchLanguageStats(): Promise<{ languages: LanguageStats[]; total
     {
       $match: {
         status: { $ne: 'deleted' },
-        hidden: { $ne: true },
+        visible: true,
         pages_count: { $gt: 0 },
         language: { $exists: true, $nin: [null, ''] },
       },

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -81,7 +81,7 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
   const filter: Record<string, unknown> = {
     'image_source.provider': providerKey,
     status: { $ne: 'deleted' },
-    hidden: { $ne: true },
+    visible: true,
     pages_count: { $gt: 0 },
     pages_translated: { $gt: 0 },
   };
@@ -111,7 +111,7 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
   const langFilter = {
     'image_source.provider': providerKey,
     status: { $ne: 'deleted' },
-    hidden: { $ne: true },
+    visible: true,
     pages_count: { $gt: 0 },
     pages_translated: { $gt: 0 },
   };
@@ -143,7 +143,7 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
           { $match: {
             book_id: { $in: sampleBookIds },
             gallery_quality: { $gte: 0.7 },
-            book_hidden: { $ne: true },
+            book_visible: true,
             type: { $nin: ['decorative', 'symbol', 'musical_score', 'exlibris', 'bookplate'] },
           }},
           { $sort: { gallery_quality: -1 } },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ async function getFeaturedCollections() {
 
   // Pick 1 random collection with enough books for the editorial spread
   const collections = await db.collection('collections').aggregate([
-    { $match: { book_count: { $gte: 10 }, parent: { $exists: false }, type: { $ne: 'curated' }, collection_type: { $ne: 'visual_art' }, hidden: { $ne: true } } },
+    { $match: { book_count: { $gte: 10 }, parent: { $exists: false }, type: { $ne: 'curated' }, collection_type: { $ne: 'visual_art' }, visible: true } },
     { $sample: { size: 1 } },
   ]).toArray();
 
@@ -67,7 +67,7 @@ async function getFeaturedCollections() {
   // Fetch highlighted books by ID (these are curated, high-quality picks)
   const highlightedBooks = allHighlightedIds.length > 0
     ? await db.collection('books').aggregate([
-        { $match: { $or: [{ id: { $in: allHighlightedIds } }, { _id: { $in: allHighlightedIds } }], hidden: { $ne: true }, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } } },
+        { $match: { $or: [{ id: { $in: allHighlightedIds } }, { _id: { $in: allHighlightedIds } }], visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } } },
         { $project: bookProjection },
       ], { maxTimeMS: 8000 }).toArray()
     : [];
@@ -89,7 +89,7 @@ async function getFeaturedCollections() {
   if (slugsNeedingMore.length > 0) {
     const existingIds = new Set([...booksBySlug.values()].flat().map(b => b.id));
     const backfillBooks = await db.collection('books').aggregate([
-      { $match: { collections: { $in: slugsNeedingMore }, hidden: { $ne: true }, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, thumbnail_blob: { $exists: true, $ne: null } } },
+      { $match: { collections: { $in: slugsNeedingMore }, visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, thumbnail_blob: { $exists: true, $ne: null } } },
       { $sort: { read_count: -1 } },
       { $limit: slugsNeedingMore.length * 10 },
       { $project: bookProjection },
@@ -152,7 +152,7 @@ async function getFeaturedCollections() {
 
 async function getRemainingCollections(): Promise<CollectionForGrid[]> {
   const db = await getDb();
-  const docs = await db.collection('collections').find({ parent: { $exists: false }, type: { $ne: 'curated' }, hidden: { $ne: true }, 'highlighted_books.0': { $exists: true } }).toArray();
+  const docs = await db.collection('collections').find({ parent: { $exists: false }, type: { $ne: 'curated' }, visible: true, 'highlighted_books.0': { $exists: true } }).toArray();
 
   const result = docs.map(({ _id, ...rest }) => {
     const images = rest.featured_images || [];
@@ -193,7 +193,7 @@ async function getRemainingCollections(): Promise<CollectionForGrid[]> {
         {
           $match: {
             collections: { $in: missingSlugs },
-            hidden: { $ne: true },
+            visible: true,
             $or: [
               { thumbnail_blob: { $exists: true, $nin: [null, ''] } },
               { thumbnail: { $exists: true, $nin: [null, ''] } },
@@ -235,7 +235,7 @@ async function getDiscoverBooks(): Promise<Book[]> {
   // Over-sample to account for hidden/untranslated books being filtered out.
   const books = await db.collection('books').aggregate([
     { $sample: { size: 200 } },
-    { $match: { hidden: { $ne: true }, pages_translated: { $gte: 10 } } },
+    { $match: { visible: true, pages_translated: { $gte: 10 } } },
     { $limit: 10 },
     { $project: BOOK_PROJECTION },
   ], { maxTimeMS: 8000 }).toArray();
@@ -260,7 +260,7 @@ async function getCollectionShowcase() {
           { thumbnail_url: { $type: 'string', $gt: '' } },
           { extracted_url: { $type: 'string', $gt: '' } },
         ],
-        book_hidden: { $ne: true },
+        book_visible: true,
       },
     },
     { $limit: 40 },

--- a/src/app/research/translation-lag/page.tsx
+++ b/src/app/research/translation-lag/page.tsx
@@ -29,7 +29,7 @@ async function fetchLagData(): Promise<LagDataPoint[]> {
   const db = await getDb();
   const books = await db.collection('books').find(
     {
-      hidden: { $ne: true },
+      visible: true,
       deleted: { $ne: true },
       source_work_dates: { $elemMatch: { type: 'composition' } },
       year: { $exists: true, $ne: null },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -170,7 +170,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const [books, collections, libraries, languages, galleryImages, works] = await Promise.all([
       // Books
       db.collection('books').find(
-        { hidden: { $ne: true } },
+        { visible: true },
         {
           projection: { id: 1, slug: 1, updated_at: 1, pages_ocr: 1, pages_translated: 1, is_first_translation: 1, read_count: 1 },
           maxTimeMS: 8000,
@@ -179,7 +179,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
       // Collections
       db.collection('collections').find(
-        { hidden: { $ne: true } },
+        { visible: true },
         { projection: { slug: 1, updated_at: 1 }, maxTimeMS: 5000 }
       ).toArray(),
 
@@ -191,7 +191,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
       // Languages
       db.collection('books').aggregate([
-        { $match: { hidden: { $ne: true }, pages_count: { $gt: 0 }, language: { $exists: true, $ne: null } } },
+        { $match: { visible: true, pages_count: { $gt: 0 }, language: { $exists: true, $ne: null } } },
         { $group: { _id: '$language', count: { $sum: 1 } } },
         { $match: { count: { $gte: 5 } } },
       ], { maxTimeMS: 8000 }).toArray(),
@@ -207,7 +207,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
       // Works
       db.collection('books').aggregate([
-        { $match: { work_id: { $exists: true, $ne: null }, hidden: { $ne: true } } },
+        { $match: { work_id: { $exists: true, $ne: null }, visible: true } },
         { $group: { _id: '$work_id', count: { $sum: 1 } } },
         { $match: { count: { $gte: 2 } } },
       ], { maxTimeMS: 8000 }).toArray(),

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -33,7 +33,7 @@ async function fetchTimelineData(): Promise<TimelineOverview> {
     // Fallback: live aggregation with generous timeout
     const baseMatch = {
       year: { $exists: true, $ne: null },
-      hidden: { $ne: true },
+      visible: true,
     };
 
     const pipeline = [

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -81,7 +81,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   try {
     const db = await getDb();
     const allClusters = await db.collection('books').aggregate([
-      { $match: { hidden: { $ne: true }, 'taxonomy.cluster': { $exists: true, $ne: null } } },
+      { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
       { $group: { _id: '$taxonomy.cluster' } },
     ]).toArray();
     match = allClusters.find((c) => topicSlug(c._id) === slug);
@@ -111,7 +111,7 @@ async function fetchFacetData(facetId: string, valueId: string) {
 
   const dbField = facetDbField(facet);
   const query = {
-    hidden: { $ne: true },
+    visible: true,
     [`faceted_tags.${dbField}`]: valueId,
   };
 
@@ -204,7 +204,7 @@ async function fetchClusterData(slug: string) {
   const db = await getDb();
 
   const allClusters = await db.collection('books').aggregate([
-    { $match: { hidden: { $ne: true }, 'taxonomy.cluster': { $exists: true, $ne: null } } },
+    { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
     { $group: { _id: '$taxonomy.cluster', cluster_id: { $first: '$taxonomy.cluster_id' } } },
   ]).toArray();
 
@@ -214,7 +214,7 @@ async function fetchClusterData(slug: string) {
   const clusterName = match._id;
 
   const books = await db.collection('books')
-    .find({ hidden: { $ne: true }, 'taxonomy.cluster': clusterName }, {
+    .find({ visible: true, 'taxonomy.cluster': clusterName }, {
       projection: {
         _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, language: 1,
         pages_count: 1, pages_translated: 1, read_count: 1, thumbnail: 1, 'taxonomy.subcluster': 1,

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -38,7 +38,7 @@ async function fetchTopics(): Promise<{ topics: TopicSummary[]; totalBooks: numb
   const pipeline = [
     {
       $match: {
-        hidden: { $ne: true },
+        visible: true,
         'taxonomy.cluster': { $exists: true, $ne: null },
       },
     },

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -37,7 +37,7 @@ interface FacetGroup {
 async function fetchFacetCounts(): Promise<{ groups: FacetGroup[]; totalBooks: number }> {
   const db = await getDb();
   const maxTimeMS = 30000;
-  const baseMatch = { faceted_tags: { $exists: true }, hidden: { $ne: true } };
+  const baseMatch = { faceted_tags: { $exists: true }, visible: true };
 
   // Single $facet aggregation — one collection scan for all 6 facets
   const facetStages: Record<string, object[]> = {};
@@ -81,7 +81,7 @@ async function fetchDomainCrossTab(): Promise<Map<string, SubDomain[]>> {
   const db = await getDb();
   // Efficient: project array as two copies, unwind both, filter out self-pairs
   const results = await db.collection('books').aggregate([
-    { $match: { 'faceted_tags.knowledge_domain.1': { $exists: true }, hidden: { $ne: true } } },
+    { $match: { 'faceted_tags.knowledge_domain.1': { $exists: true }, visible: true } },
     { $project: { a: '$faceted_tags.knowledge_domain', b: '$faceted_tags.knowledge_domain' } },
     { $unwind: '$a' },
     { $unwind: '$b' },

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -18,7 +18,7 @@ interface PageProps {
 async function getWorkEditions(workId: string) {
   const db = await getDb();
   const editions = await db.collection('books').find(
-    { work_id: workId, hidden: { $ne: true } },
+    { work_id: workId, visible: true },
     {
       projection: {
         id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1,

--- a/src/components/book/RelatedEditions.tsx
+++ b/src/components/book/RelatedEditions.tsx
@@ -11,7 +11,7 @@ export default async function RelatedEditions({ bookId, workId }: RelatedEdition
   const db = await getDb();
 
   const related = await db.collection('books').find(
-    { work_id: workId, id: { $ne: bookId }, hidden: { $ne: true } },
+    { work_id: workId, id: { $ne: bookId }, visible: true },
     { projection: { 'image_source.provider_name': 1 }, maxTimeMS: 3000 }
   ).toArray().catch(() => []);
 

--- a/src/lib/adaptive-limits.ts
+++ b/src/lib/adaptive-limits.ts
@@ -197,7 +197,7 @@ export async function getAdaptiveLimits(
     // is writing heavily, even when findOne reports 14ms.
     timedQuery(() =>
       db.collection('books').find(
-        { hidden: { $ne: true }, pages_count: { $gt: 0 } }
+        { visible: true, pages_count: { $gt: 0 } }
       ).sort({ created_at: -1 }).limit(10).project({ _id: 1 }).toArray(),
       5000
     ),

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -166,7 +166,7 @@ export async function checkDuplicate(
   const fp = sourceFingerprint(book);
   if (fp) {
     const fpMatch = await db.collection('books').findOne(
-      { source_fingerprint: fp, hidden: { $ne: true } },
+      { source_fingerprint: fp, visible: true },
       { projection: { id: 1, title: 1 } }
     );
     if (fpMatch) {
@@ -190,7 +190,7 @@ export async function checkDuplicate(
       {
         normalized_title: normTitle,
         normalized_author: normAuthor,
-        hidden: { $ne: true },
+        visible: true,
       },
       { projection: { id: 1, title: 1 } }
     ).limit(5).toArray();
@@ -213,7 +213,7 @@ export async function checkDuplicate(
     const iiifMatch = await db.collection('books').findOne(
       {
         'image_source.iiif_manifest': book.image_source.iiif_manifest,
-        hidden: { $ne: true },
+        visible: true,
       },
       { projection: { id: 1, title: 1 } }
     );
@@ -301,7 +301,7 @@ export async function scanForDuplicates(db: Db): Promise<{
 }> {
   // Find duplicate fingerprints
   const fpDupes = await db.collection('books').aggregate([
-    { $match: { hidden: { $ne: true }, source_fingerprint: { $exists: true, $ne: null } } },
+    { $match: { visible: true, source_fingerprint: { $exists: true, $ne: null } } },
     { $group: {
       _id: '$source_fingerprint',
       count: { $sum: 1 },
@@ -315,7 +315,7 @@ export async function scanForDuplicates(db: Db): Promise<{
   // Find duplicate title+author combos
   const taDupes = await db.collection('books').aggregate([
     { $match: {
-      hidden: { $ne: true },
+      visible: true,
       normalized_title: { $exists: true, $nin: [null, ''] },
       // Exclude generic titles
       title: { $nin: ['Unknown', 'Untitled'] },

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -359,7 +359,7 @@ export async function importBookFromIIIF(
         : {}),
     },
     status: 'draft',
-    hidden: true,
+    hidden: true, visible: false,
     pipeline_auto: {
       status: 'queued',
       source: 'import',


### PR DESCRIPTION
## Summary

Closes #591, closes #593.

MongoDB can't use indexes for `$ne` queries. Every user-facing page was doing a full collection scan to exclude hidden books — the browse health probe took **52 seconds**, crashing the pipeline into critical mode.

**What changed:**
- Replaced `hidden: { $ne: true }` with `visible: true` in **65 source files** (122 occurrences)
- Updated all import routes to set `visible: false` alongside `hidden: true`
- Updated visibility toggle API (`/api/books/[id]/visibility`) to set both fields
- Updated pipeline orchestrator browse probe to use `visible: true`

**Already live in MongoDB (backfilled before this PR):**
- `visible: true` on 13,102 non-hidden books
- `visible: false` on 26,378 hidden books
- Compound indexes: `visible_created_at`, `visible_pages_created`, `visible_translated`

**Expected impact:** Browse probe goes from 52s → <100ms. All user-facing pages get faster filtered queries.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Homepage loads (uses `visible: true` for collection queries)
- [ ] `/collections` page loads
- [ ] `/browse/titles/A` loads
- [ ] Search works
- [ ] Book detail page loads
- [ ] Import a test book → verify it gets `hidden: true, visible: false`
- [ ] Pipeline orchestrator health probe runs fast after Hetzner deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)