### PR TITLE
Archive workers: find books by pages, not pipeline status

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -295,13 +295,13 @@ async function main() {
   await client.connect();
   const db = client.db('bookstore');
 
-  // Find IA books in archiving status with unarchived pages
+  // Find IA books with pages that may need archiving (regardless of pipeline status).
   // Priority: first translations > non-English > English
   const ENGLISH_VARIANTS = ['english', 'eng', 'en'];
   const iaBooks = await db.collection('books')
     .aggregate([
       { $match: {
-        'pipeline_auto.status': 'archiving',
+        pages_count: { $gt: 0 },
         'archive_metadata.blocked': { $ne: true },
         $or: [
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -199,25 +199,25 @@ async function main() {
   let processed = 0;
   const domainStats = {};
 
-  // Strategy: query books in archiving status, then fetch their unarchived pages.
-  // This avoids a full scan of the 9.5M pages collection.
+  // Strategy: find books with pages that need archiving, regardless of pipeline status.
+  // Books move through pipeline stages even if archiving isn't complete.
   // Exclude e-rara (blocked on Hetzner IPs, archived locally via launchd on Mac)
   // and internet_archive (handled by archive-bulk.mjs via JP2 zip download).
   const books = await db.collection('books')
     .find(
       {
-        'pipeline_auto.status': 'archiving',
+        pages_count: { $gt: 0 },
         'archive_metadata.blocked': { $ne: true },
         'image_source.provider': { $nin: ['e-rara', 'internet_archive'] },
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )
-    .limit(200)
+    .limit(500)
     .maxTimeMS(30_000)
     .toArray();
 
   if (books.length === 0) {
-    console.log(`[archive-ocr] No books in archiving status`);
+    console.log(`[archive-ocr] No books with pages found`);
     await client.close();
     return;
   }


### PR DESCRIPTION
## Summary
Both archive workers were finding 0 books to process because they filtered on `pipeline_auto.status: 'archiving'` — but the orchestrator advanced all books past that status overnight. Now queries any book with `pages_count > 0` regardless of pipeline stage.

## Test plan
- [ ] Deploy to Hetzner, verify workers find books and archive pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)