### PR TITLE
Switch 3 timeout routes from hidden:$ne to visible:true

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -207,7 +207,6 @@ async function fetchCollectionData(id: string) {
     ? { collections: id, resource_type: { $exists: true } }
     : {
         collections: id,
-        status: { $ne: 'deleted' },
         visible: true,
         pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
@@ -260,7 +259,7 @@ async function fetchCollectionData(id: string) {
       ? withTimeout(
           db.collection('books')
             .find(
-              { id: { $in: curatedBookIds }, status: { $ne: 'deleted' } },
+              { id: { $in: curatedBookIds }, visible: true },
               { projection: { ...projection, is_first_translation: 1, 'translation_verification.disposition': 1 } },
             )
             .toArray(),
@@ -287,7 +286,7 @@ async function fetchCollectionData(id: string) {
           }
           // Fallback: dynamic query (before thematic collections are seeded)
           const bookDocs = await db.collection('books')
-            .find({ collections: id, status: { $ne: 'deleted' }, visible: true }, { projection: { id: 1 }, maxTimeMS: 5000 })
+            .find({ collections: id, visible: true }, { projection: { id: 1 }, maxTimeMS: 5000 })
             .toArray();
           const bookIds = bookDocs.map(d => d.id);
           if (bookIds.length === 0) return [];
@@ -404,7 +403,7 @@ async function fetchCollectionData(id: string) {
     if (allBookIds.size > 0) {
       const exBooks = await withTimeout(
         db.collection('books').find(
-          { id: { $in: [...allBookIds] }, status: { $ne: 'deleted' } },
+          { id: { $in: [...allBookIds] }, visible: true },
           { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, is_first_translation: 1, 'translation_verification.disposition': 1 } },
         ).toArray(),
         8000, [],


### PR DESCRIPTION
## Summary
- Replace `hidden: { $ne: true }` with `visible: true` in `/api/books`, `/api/search/suggest`, and `/collections/[id]`
- Also replaces `status: { $ne: 'deleted' }` with `visible: true` in collection page queries (visible is already false for deleted books)

## Context
Follow-up to #589. The `visible` field and `books_visible_created_idx` index were already backfilled during the Atlas crisis. The first PR added `maxTimeMS` and removed `$lookup` but kept the `$ne` filter pattern. This switches to positive equality matching which can use the index directly.

The remaining ~100 `hidden: { $ne: true }` occurrences across the codebase are tracked in #591.

## Test plan
- [ ] `curl 'https://sourcelibrary.org/api/books?limit=3'` returns in <1s
- [ ] `curl 'https://sourcelibrary.org/api/search/suggest?q=paracelsus'` returns in <1s
- [ ] `/collections/alchemy` loads without timeout
- [ ] Run e2e smoke test — all endpoints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)