### PR TITLE
Fix homepage logo alignment and collections display

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -33,7 +33,7 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
     <header
       className={`${variantClasses} ${sticky ? 'sticky top-0 z-20' : ''} ${className}`}
     >
-      <div className="flex items-center justify-between px-6 md:px-12 max-w-[var(--container-wide)] mx-auto">
+      <div className={`flex items-center justify-between px-6 md:px-12 ${variant !== 'transparent' ? 'max-w-[var(--container-wide)] mx-auto' : ''}`}>
         <div className="flex items-center gap-3">
           <Logo white={isWhiteText} compact={!!breadcrumbs} />
           {breadcrumbs?.map((crumb) => (


### PR DESCRIPTION
## Summary
- Fix logo misalignment on homepage: the navbar consolidation (b681fce9) added `max-w-[var(--container-wide)]` to the transparent SiteHeader variant, misaligning it with the hero text. Transparent variant now skips the container constraint since it sits inside HeroSection's own layout.
- Fix collections not showing: the `visible:true` migration (0bb19ad7) only backfilled the `books` collection. Ran DB backfill for `collections` (188 docs) and `gallery_images` (37,974 docs).

## Test plan
- [ ] Verify logo aligns with hero text on wide screens
- [ ] Verify homepage collections section renders
- [ ] Verify collection showcase images appear
- [ ] Verify non-homepage SiteHeader still has container constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)