### PR TITLE
Auto-deploy to Hetzner on worker/cron changes

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -1,0 +1,25 @@
+name: Deploy to Hetzner
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/workers/**'
+      - 'scripts/crons/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Pull latest on Hetzner
+        uses: appleboy/ssh-action@v1
+        with:
+          host: 46.224.122.120
+          username: root
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          script: |
+            cd /root/sourcelibrary
+            git fetch origin main
+            git reset --hard origin/main


### PR DESCRIPTION
## Summary
- GitHub Action triggers on push to `main` when `scripts/workers/**` or `scripts/crons/**` change
- SSHs to Hetzner and pulls latest via `appleboy/ssh-action`
- Dedicated deploy key added to Hetzner + `HETZNER_SSH_KEY` secret set

No more manual `ssh root@... git pull` after merging pipeline changes.

## Test plan
- [ ] Merge this PR, then merge any worker change — check Actions tab for successful run
- [ ] Verify Hetzner is on latest commit after action runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)