### PR TITLE
Add inner_circle role for trusted collaborators

### DIFF
--- a/src/app/analytics/layout.tsx
+++ b/src/app/analytics/layout.tsx
@@ -1,12 +1,12 @@
-import { requireAdmin } from '@/lib/auth-helpers';
+import { requireInnerCircle } from '@/lib/auth-helpers';
 
 export default async function AnalyticsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // Server-side auth check - redirects if not admin
-  await requireAdmin();
+  // Server-side auth check - redirects if not admin or inner_circle
+  await requireInnerCircle();
 
   return <>{children}</>;
 }

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
-import { isAdmin } from '@/lib/auth-helpers';
+import { isInnerCircle } from '@/lib/auth-helpers';
 import { Book } from '@/lib/types';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
@@ -94,7 +94,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ArtworkPage({ params }: PageProps) {
-  const admin = await isAdmin();
+  const admin = await isInnerCircle();
   if (!admin) redirect('/');
 
   const { slug } = await params;

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { notFound, redirect } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
-import { isAdmin } from '@/lib/auth-helpers';
+import { isInnerCircle } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -94,7 +94,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ArtistPage({ params }: PageProps) {
-  const admin = await isAdmin();
+  const admin = await isInnerCircle();
   if (!admin) redirect('/');
 
   const { slug } = await params;

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { redirect } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
-import { isAdmin } from '@/lib/auth-helpers';
+import { isInnerCircle } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -40,7 +40,7 @@ async function getData() {
 }
 
 export default async function ArtworkLandingPage() {
-  const admin = await isAdmin();
+  const admin = await isInnerCircle();
   if (!admin) redirect('/');
 
   const { collections, totalCount } = await getData();

--- a/src/app/experiments/layout.tsx
+++ b/src/app/experiments/layout.tsx
@@ -1,13 +1,13 @@
 import { Suspense } from 'react';
-import { requireAdmin } from '@/lib/auth-helpers';
+import { requireInnerCircle } from '@/lib/auth-helpers';
 
 export default async function ExperimentsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // Server-side auth check - redirects if not admin
-  await requireAdmin();
+  // Server-side auth check - redirects if not admin or inner_circle
+  await requireInnerCircle();
 
   return <Suspense>{children}</Suspense>;
 }

--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -51,7 +51,8 @@ export default function ImageDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { data: session } = useSession();
-  const isAdmin = (session?.user as any)?.role === 'admin';
+  const userRole = (session?.user as any)?.role;
+  const isAdmin = userRole === 'admin' || userRole === 'inner_circle';
   const [imageId, setImageId] = useState<string | null>(null);
   const [data, setData] = useState<GalleryImageDetail | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/app/jobs/layout.tsx
+++ b/src/app/jobs/layout.tsx
@@ -1,12 +1,12 @@
-import { requireAdmin } from '@/lib/auth-helpers';
+import { requireInnerCircle } from '@/lib/auth-helpers';
 
 export default async function JobsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // Server-side auth check - redirects if not admin
-  await requireAdmin();
+  // Server-side auth check - redirects if not admin or inner_circle
+  await requireInnerCircle();
 
   return <>{children}</>;
 }

--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -5,16 +5,17 @@ import { useSession } from 'next-auth/react';
 interface AuthCheckProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
-  /** Require a specific role. 'admin' = whitelist only. Default: any authenticated user. */
-  role?: 'admin' | 'reader';
+  /** Require a specific role. 'admin' = admin only. 'inner_circle' = admin or inner_circle. Default: any authenticated user. */
+  role?: 'admin' | 'inner_circle' | 'reader';
 }
 
 /**
  * Client component that conditionally renders children based on auth status and role.
  *
  * @example
- * <AuthCheck>              // Any logged-in user
- * <AuthCheck role="admin"> // Admin-only (whitelist)
+ * <AuthCheck>                      // Any logged-in user
+ * <AuthCheck role="inner_circle">  // Admin or inner circle
+ * <AuthCheck role="admin">         // Admin-only (whitelist)
  */
 export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
   const { data: session, status } = useSession();
@@ -27,8 +28,13 @@ export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
     return <>{fallback}</>;
   }
 
-  // If a specific role is required, check it
-  if (role && (session.user as any).role !== role) {
+  const userRole = (session.user as any).role;
+
+  if (role === 'admin' && userRole !== 'admin') {
+    return <>{fallback}</>;
+  }
+
+  if (role === 'inner_circle' && userRole !== 'admin' && userRole !== 'inner_circle') {
     return <>{fallback}</>;
   }
 

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -178,7 +178,7 @@ export default function BibliographicInfo({ book, pagesCount }: BibliographicInf
           {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           Bibliographic Info
         </button>
-        <AuthCheck role="admin">
+        <AuthCheck role="inner_circle">
           <button
             onClick={() => setShowEditModal(true)}
             className="flex items-center gap-1.5 text-sm text-accent-gold hover:text-accent-gold transition-colors"

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -548,7 +548,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
             lastOcrDate={lastOcrDate}
             lastTranslationDate={lastTranslationDate}
           />
-          <AuthCheck role="admin">
+          <AuthCheck role="inner_circle">
             <BookPagesActions
               bookId={bookId}
               batchMode={batchMode}

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -95,8 +95,8 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
 
   return (
     <>
-      {/* Cover Image - Clickable only for admin users */}
-      <AuthCheck role="admin"
+      {/* Cover Image - Clickable for admin and inner circle */}
+      <AuthCheck role="inner_circle"
         fallback={
           // Non-authenticated users see the cover image but cannot click
           <div className="w-32 sm:w-48 aspect-[3/4] relative rounded-lg overflow-hidden shadow-xl bg-stone-700">

--- a/src/components/book/PagesGrid.tsx
+++ b/src/components/book/PagesGrid.tsx
@@ -185,8 +185,8 @@ export default function PagesGrid({
                     )}
                   </div>
                 </a>
-                {/* Set as Cover button — admin only */}
-                <AuthCheck role="admin">
+                {/* Set as Cover button — admin and inner circle */}
+                <AuthCheck role="inner_circle">
                   <button
                     onClick={(e) => {
                       e.preventDefault();

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1019,8 +1019,8 @@ export default function TranslationEditor({
               </div>
 
 
-              {/* Mode Toggle - admin only */}
-              <AuthCheck role="admin">
+              {/* Mode Toggle - admin and inner circle */}
+              <AuthCheck role="inner_circle">
                 <div className="flex items-center rounded-lg p-0.5 sm:p-1" style={{ background: 'var(--bg-warm)' }}>
                   <button
                     onClick={() => setMode('read')}

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -38,11 +38,35 @@ export async function requireAdmin(): Promise<Session> {
 }
 
 /**
+ * Require inner_circle or admin role in server components
+ */
+export async function requireInnerCircle(): Promise<Session> {
+  const session = await getSession();
+  if (!session?.user) {
+    redirect('/auth/signin');
+  }
+  const role = (session.user as any).role;
+  if (role !== 'admin' && role !== 'inner_circle') {
+    redirect('/unauthorized');
+  }
+  return session;
+}
+
+/**
  * Check if current user is an admin
  */
 export async function isAdmin(): Promise<boolean> {
   const session = await getSession();
   return (session?.user as any)?.role === 'admin';
+}
+
+/**
+ * Check if current user is inner_circle or admin
+ */
+export async function isInnerCircle(): Promise<boolean> {
+  const session = await getSession();
+  const role = (session?.user as any)?.role;
+  return role === 'admin' || role === 'inner_circle';
 }
 
 /**
@@ -116,6 +140,43 @@ export async function resolveIdentity(request: NextRequest): Promise<ResolvedIde
   }
 
   return null;
+}
+
+/**
+ * Wrapper for API routes requiring inner_circle or admin role.
+ * Returns 401 if not authenticated, 403 if not inner_circle/admin.
+ */
+export function withInnerCircleAuth(
+  handler: (request: NextRequest, session: Session, context?: any) => Promise<NextResponse>
+): (request: NextRequest, context?: any) => Promise<NextResponse> {
+  return async (request: NextRequest, context?: any) => {
+    // Check for CRON_SECRET bearer token (internal service-to-service calls)
+    const cronSecret = process.env.CRON_SECRET;
+    const authHeader = request.headers.get('authorization');
+    if (cronSecret && authHeader === `Bearer ${cronSecret}`) {
+      const cronSession: Session = {
+        user: { name: 'Pipeline Cron', email: 'cron@sourcelibrary.org', role: 'admin' } as any,
+        expires: new Date(Date.now() + 3600000).toISOString(),
+      };
+      return handler(request, cronSession, context);
+    }
+
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'Unauthorized - Authentication required' },
+        { status: 401 }
+      );
+    }
+    const role = (session.user as any).role;
+    if (role !== 'admin' && role !== 'inner_circle') {
+      return NextResponse.json(
+        { error: 'Forbidden - Inner circle access required' },
+        { status: 403 }
+      );
+    }
+    return handler(request, session, context);
+  };
 }
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -66,19 +66,22 @@ const WELCOME_HTML = `
 </div>
 `;
 
-// Helper: check if user is in the admin whitelist
-async function isAdminUser(email: string): Promise<boolean> {
+// Helper: check user role from admin_users whitelist
+// Returns 'admin', 'inner_circle', or null
+async function getUserRole(email: string): Promise<'admin' | 'inner_circle' | null> {
   try {
     const client = await clientPromise;
     const db = client.db(dbName);
-    const admin = await db.collection('admin_users').findOne({
+    const entry = await db.collection('admin_users').findOne({
       email: email.toLowerCase(),
       active: true,
     });
-    return !!admin;
+    if (!entry) return null;
+    // Default to 'admin' for existing entries without a role field (backward compat)
+    return entry.role === 'inner_circle' ? 'inner_circle' : 'admin';
   } catch (error) {
-    console.error('[auth] Error checking admin status:', error);
-    return false;
+    console.error('[auth] Error checking user role:', error);
+    return null;
   }
 }
 
@@ -200,7 +203,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.id = user.id;
         // Check admin status on first sign-in
         if (user.email) {
-          token.role = (await isAdminUser(user.email)) ? 'admin' : 'reader';
+          token.role = (await getUserRole(user.email)) || 'reader';
         } else {
           token.role = 'reader';
         }


### PR DESCRIPTION
## Summary
- Adds `inner_circle` role between `admin` and `reader` for trusted collaborators
- Inner circle users see edit buttons (translation editor read/edit toggle, cover picker, bibliographic editing, gallery metadata) and can access analytics, experiments, jobs, artwork pages
- Admin-only routes (`/admin/*`, pipeline control, imports, destructive ops) remain unchanged
- Data model: `admin_users.role` field defaults to `'admin'` for backward compat

Closes #550

## To add a user
```js
db.admin_users.insertOne({ email: "user@example.com", active: true, role: "inner_circle" })
```

## Files changed (15)
- `src/lib/auth.ts` — `getUserRole()` returns role string instead of boolean
- `src/lib/auth-helpers.ts` — `requireInnerCircle()`, `withInnerCircleAuth()`, `isInnerCircle()`
- `src/components/auth/AuthCheck.tsx` — supports `role="inner_circle"`
- 3 layout files — `requireAdmin` → `requireInnerCircle`
- 6 components — `AuthCheck role="admin"` → `role="inner_circle"`
- 3 artwork pages — `isAdmin` → `isInnerCircle`

## Test plan
- [ ] Existing admin users still see all controls
- [ ] Add a test `inner_circle` user to `admin_users` and verify they see edit buttons on book pages
- [ ] Verify inner_circle user cannot access `/admin/*` routes
- [ ] Verify regular readers still see no edit controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)