### PR TITLE
Hide OCR/translation stats from public users

### DIFF
--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -538,17 +538,17 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
 
   return (
     <div className="space-y-6">
-      {/* Stats Bar & Actions */}
-      <div className="bg-white rounded-xl border border-stone-200 p-4">
-        <div className="flex items-center justify-between">
-          <BookPagesStats
-            pagesWithOcr={pagesWithOcr}
-            pagesWithTranslation={pagesWithTranslation}
-            totalPages={totalPages}
-            lastOcrDate={lastOcrDate}
-            lastTranslationDate={lastTranslationDate}
-          />
-          <AuthCheck role="inner_circle">
+      {/* Stats Bar & Actions — inner_circle only */}
+      <AuthCheck role="inner_circle">
+        <div className="bg-white rounded-xl border border-stone-200 p-4">
+          <div className="flex items-center justify-between">
+            <BookPagesStats
+              pagesWithOcr={pagesWithOcr}
+              pagesWithTranslation={pagesWithTranslation}
+              totalPages={totalPages}
+              lastOcrDate={lastOcrDate}
+              lastTranslationDate={lastTranslationDate}
+            />
             <BookPagesActions
               bookId={bookId}
               batchMode={batchMode}
@@ -565,9 +565,9 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
               onExitReorder={exitReorderMode}
               onSaveOrder={savePageOrder}
             />
-          </AuthCheck>
+          </div>
         </div>
-      </div>
+      </AuthCheck>
 
       {/* Job Status Banner */}
       {currentJob && (


### PR DESCRIPTION
## Summary
- Wraps the entire stats bar (OCR count, translation count, batch action buttons) in `AuthCheck role="inner_circle"` so regular visitors don't see internal processing metrics on the book detail page
- The white container is fully hidden for public users — no empty box left behind

## Test plan
- [ ] Visit a book page as a logged-out user — stats bar should not appear
- [ ] Visit as inner_circle or admin — stats bar visible as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)