### PR TITLE
Complete visible:true migration — zero $ne filters remaining

### DIFF
--- a/src/app/api/admin/book-collections/[slug]/gallery/route.ts
+++ b/src/app/api/admin/book-collections/[slug]/gallery/route.ts
@@ -21,7 +21,7 @@ export const GET = withAuth(async (req: NextRequest, _session: Session, context?
 
     // Get all book IDs in this collection
     const books = await db.collection('books').find(
-      { collections: slug, visible: true, status: { $ne: 'deleted' } },
+      { collections: slug, visible: true },
       { projection: { _id: 0, id: { $ifNull: ['$id', { $toString: '$_id' }] }, slug: 1 } }
     ).toArray();
 
@@ -101,7 +101,7 @@ export const POST = withAuth(async (req: NextRequest, _session: Session, context
 
     // Get all book IDs in this collection
     const books = await db.collection('books').find(
-      { collections: slug, visible: true, status: { $ne: 'deleted' } },
+      { collections: slug, visible: true },
       { projection: { _id: 0, id: { $ifNull: ['$id', { $toString: '$_id' }] }, slug: 1 } }
     ).toArray();
     const bookIds = books.map(b => b.id);

--- a/src/app/api/admin/seed-collections/route.ts
+++ b/src/app/api/admin/seed-collections/route.ts
@@ -489,7 +489,7 @@ async function seedThematicCollections(
     // Find all book IDs in this collection
     const bookDocs = await db.collection('books')
       .find(
-        { collections: bc.slug, status: { $ne: 'deleted' }, visible: true },
+        { collections: bc.slug, visible: true },
         { projection: { id: 1 } },
       )
       .toArray();

--- a/src/app/api/admin/sync-gallery-images/route.ts
+++ b/src/app/api/admin/sync-gallery-images/route.ts
@@ -50,7 +50,7 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
       // Lookup book info
       { $lookup: { from: 'books', localField: 'book_id', foreignField: 'id', as: 'book' } },
       { $unwind: { path: '$book', preserveNullAndEmptyArrays: true } },
-      { $match: { 'book.hidden': { $ne: true } } },
+      { $match: { 'book.visible': true } },
 
       // Strip to needed fields before unwind
       {

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -45,7 +45,6 @@ export async function GET(
       ? { collections: id, resource_type: { $exists: true } }
       : {
           collections: id,
-          status: { $ne: 'deleted' },
           visible: true,
           pages_count: { $gt: 0 },
           pages_translated: { $gt: 0 },
@@ -136,7 +135,7 @@ export async function GET(
         .find(
           isArtCollection
             ? { collections: id, resource_type: { $exists: true } }
-            : { collections: id, status: { $ne: 'deleted' }, visible: true, pages_translated: { $gt: 0 } },
+            : { collections: id, visible: true, pages_translated: { $gt: 0 } },
           { projection: highlightProjection },
         )
         .sort(isArtCollection ? { title: 1 } : { quality_score: -1, read_count: -1, pages_translated: -1 })

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -95,7 +95,6 @@ export const PATCH = withAuth(async (request) => {
       // Update book_count on collection (same filter as detail page)
       const bookCount = await db.collection('books').countDocuments({
         collections: slug,
-        status: { $ne: 'deleted' },
         visible: true,
         pages_count: { $gt: 0 },
       });
@@ -173,7 +172,6 @@ export const POST = withAuth(async (request) => {
     // Count visible books (same filter as detail page)
     const bookCount = await db.collection('books').countDocuments({
       collections: slug,
-      status: { $ne: 'deleted' },
       visible: true,
       pages_count: { $gt: 0 },
     });

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -90,7 +90,7 @@ export async function GET(request: NextRequest) {
     if (collectionSlug) {
       collectionBookIds = await db.collection('books').distinct('id', {
         collections: collectionSlug,
-        status: { $ne: 'deleted' },
+        visible: true,
       }) as string[];
     }
 
@@ -99,7 +99,7 @@ export async function GET(request: NextRequest) {
     if (libraryFilter) {
       libraryBookIds = await db.collection('books').distinct('id', {
         'image_source.provider': libraryFilter,
-        status: { $ne: 'deleted' },
+        visible: true,
       }) as string[];
     }
 
@@ -482,7 +482,7 @@ async function legacyGalleryQuery(db: Awaited<ReturnType<typeof getDb>>, searchP
 
   pipeline.push({ $lookup: { from: 'books', localField: 'book_id', foreignField: 'id', as: 'book' } });
   pipeline.push({ $unwind: { path: '$book', preserveNullAndEmptyArrays: true } });
-  pipeline.push({ $match: { 'book.hidden': { $ne: true } } });
+  pipeline.push({ $match: { 'book.visible': true } });
 
   if (yearStart !== null || yearEnd !== null) {
     const yearMatch: Record<string, unknown> = {};

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -55,7 +55,7 @@ async function getTraditions(): Promise<{ traditions: TraditionCollection[]; tot
       const scriptureCount = await db.collection('books').countDocuments({
         collections: t.slug,
         'sacred_text_type.type': { $in: ['scripture', 'canonical_commentary', 'liturgical'] },
-        status: { $ne: 'deleted' },
+        visible: true,
         pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
       });
@@ -65,7 +65,7 @@ async function getTraditions(): Promise<{ traditions: TraditionCollection[]; tot
 
       // Try gallery images first
       const traditionBooks = await db.collection('books')
-        .find({ collections: t.slug, status: { $ne: 'deleted' } }, { projection: { id: 1 } })
+        .find({ collections: t.slug, visible: true }, { projection: { id: 1 } })
         .limit(50)
         .toArray();
       const bookIds = traditionBooks.map(b => b.id);

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -35,7 +35,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const db = await getDb();
     count = await db.collection('books').countDocuments({
       language: langName,
-      status: { $ne: 'deleted' },
       visible: true,
       pages_count: { $gt: 0 },
     });
@@ -87,7 +86,6 @@ async function fetchLanguageData(langName: string, sort: string, offset: number,
 
   const baseFilter: Record<string, unknown> = {
     language: langName,
-    status: { $ne: 'deleted' },
     visible: true,
     pages_count: { $gt: 0 },
   };

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -37,7 +37,6 @@ async function fetchLanguageStats(): Promise<{ languages: LanguageStats[]; total
   const langAgg = await db.collection('books').aggregate([
     {
       $match: {
-        status: { $ne: 'deleted' },
         visible: true,
         pages_count: { $gt: 0 },
         language: { $exists: true, $nin: [null, ''] },

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -80,7 +80,6 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
 
   const filter: Record<string, unknown> = {
     'image_source.provider': providerKey,
-    status: { $ne: 'deleted' },
     visible: true,
     pages_count: { $gt: 0 },
     pages_translated: { $gt: 0 },
@@ -110,7 +109,6 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
   // Get all unique languages for this provider (unfiltered by language/search, but exclude hidden)
   const langFilter = {
     'image_source.provider': providerKey,
-    status: { $ne: 'deleted' },
     visible: true,
     pages_count: { $gt: 0 },
     pages_translated: { $gt: 0 },

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -38,7 +38,7 @@ async function fetchProviderStats(): Promise<ProviderStats[]> {
     {
       $match: {
         'image_source.provider': { $exists: true, $nin: ['user_upload', 'other', 'library', 'iiif'] },
-        status: { $ne: 'deleted' },
+        visible: true,
         pages_count: { $gt: 0 },
         pages_translated: { $gt: 0 },
       },
@@ -105,7 +105,7 @@ async function fetchContributingLibraries(): Promise<ContributingLibrary[]> {
     {
       $match: {
         'image_source.contributing_library': { $exists: true, $nin: [null, ''] },
-        status: { $ne: 'deleted' },
+        visible: true,
         pages_count: { $gt: 0 },
       },
     },


### PR DESCRIPTION
## Summary
Replace all remaining `hidden:{$ne:true}` and `status:{$ne:'deleted'}` with `visible:true` across 11 files. After this + PR #594, the codebase has **zero negative equality filters** on the books collection (excluding archived routes).

Also migrates 2 gallery aggregation pipelines from `book.hidden:{$ne:true}` to `book.visible:true`.

**11 files, -20/+12 lines.**

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)