### PR TITLE
Pre-render 1200px display images to bypass /api/image proxy

### DIFF
--- a/scripts/migration/backfill-display-images.mjs
+++ b/scripts/migration/backfill-display-images.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Backfill display (1200px) and thumbnail (150px) variants for pages
+ * that already have archived_photo but no display_photo.
+ *
+ * Downloads full-res from R2, generates variants, uploads back to R2.
+ * R2 egress is free, so the only cost is CPU time + write ops.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/migration/backfill-display-images.mjs
+ *   node scripts/migration/backfill-display-images.mjs --limit=1000 --concurrency=8 --dry-run
+ */
+
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { generateDisplayVariants } from '../workers/lib/display-image.mjs';
+
+const args = process.argv.slice(2);
+const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
+const hasFlag = (name) => args.includes(`--${name}`);
+
+const LIMIT = parseInt(getArg('limit') || '50000', 10);
+const CONCURRENCY = parseInt(getArg('concurrency') || '10', 10);
+const DRY_RUN = hasFlag('dry-run');
+const BOOK_ID = getArg('book');  // Optional: backfill a single book
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID;
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY;
+const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+if (!MONGODB_URI) { console.error('Missing MONGODB_URI'); process.exit(1); }
+if (!R2_ACCOUNT_ID) { console.error('Missing R2_ACCOUNT_ID'); process.exit(1); }
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+});
+
+async function uploadToR2(key, buffer, contentType = 'image/jpeg') {
+  await s3.send(new PutObjectCommand({
+    Bucket: R2_BUCKET_NAME, Key: key, Body: buffer,
+    ContentType: contentType, CacheControl: 'public, max-age=86400',
+  }));
+  return `${R2_PUBLIC_URL}/${key}`;
+}
+
+async function downloadFromR2(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return Buffer.from(await res.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+const stats = {
+  processed: 0, succeeded: 0, failed: 0, skipped: 0,
+  bytesUploaded: 0, startTime: Date.now(),
+};
+
+async function processPage(page, db) {
+  try {
+    const fullResBuffer = await downloadFromR2(page.archived_photo);
+
+    if (DRY_RUN) {
+      stats.skipped++;
+      return;
+    }
+
+    const { display, thumb } = await generateDisplayVariants(fullResBuffer);
+
+    const num = String(page.page_number).padStart(4, '0');
+    const displayKey = `pages/${page.book_id}/${num}.jpg`;
+    const thumbKey = `pages/${page.book_id}/${num}-thumb.jpg`;
+
+    const displayUrl = await uploadToR2(displayKey, display);
+    const thumbUrl = await uploadToR2(thumbKey, thumb);
+
+    stats.bytesUploaded += display.length + thumb.length;
+
+    await db.collection('pages').updateOne(
+      { _id: page._id },
+      {
+        $set: {
+          display_photo: displayUrl,
+          thumbnail_blob: thumbUrl,
+          updated_at: new Date(),
+        }
+      }
+    );
+
+    stats.succeeded++;
+  } catch (err) {
+    stats.failed++;
+    if (stats.failed <= 20) {
+      console.error(`  FAIL page ${page.book_id}/${page.page_number}: ${err.message?.slice(0, 100)}`);
+    }
+  }
+}
+
+async function main() {
+  console.log(`[backfill-display] Display image backfill — limit=${LIMIT}, concurrency=${CONCURRENCY}${DRY_RUN ? ' (DRY RUN)' : ''}`);
+
+  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 5 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  // Find pages with archived_photo but no display_photo
+  const filter = {
+    archived_photo: { $exists: true, $regex: /^https:/ },
+    $or: [
+      { display_photo: { $exists: false } },
+      { display_photo: null },
+      { display_photo: '' },
+    ],
+    ...(BOOK_ID ? { book_id: BOOK_ID } : {}),
+  };
+
+  const total = await db.collection('pages').countDocuments(filter);
+  console.log(`[backfill-display] Found ${total.toLocaleString()} pages needing display variants`);
+
+  if (total === 0) {
+    await client.close();
+    return;
+  }
+
+  const pages = await db.collection('pages')
+    .find(filter, { projection: { _id: 1, book_id: 1, page_number: 1, archived_photo: 1 } })
+    .limit(LIMIT)
+    .toArray();
+
+  console.log(`[backfill-display] Processing ${pages.length.toLocaleString()} pages...`);
+
+  // Process with bounded concurrency
+  let idx = 0;
+  async function worker() {
+    while (idx < pages.length) {
+      const i = idx++;
+      if (i >= pages.length) break;
+      await processPage(pages[i], db);
+      stats.processed++;
+
+      if (stats.processed % 500 === 0) {
+        const elapsed = (Date.now() - stats.startTime) / 1000;
+        const rate = (stats.processed / elapsed).toFixed(1);
+        const mb = (stats.bytesUploaded / (1024 * 1024)).toFixed(0);
+        console.log(`  ${stats.processed.toLocaleString()}/${pages.length.toLocaleString()} — ${stats.succeeded} ok, ${stats.failed} fail — ${rate}/s — ${mb}MB uploaded`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, pages.length) }, () => worker()));
+
+  const elapsed = (Date.now() - stats.startTime) / 1000;
+  const rate = (stats.processed / elapsed).toFixed(1);
+  console.log(`\n[backfill-display] Done in ${Math.round(elapsed)}s`);
+  console.log(`  Processed: ${stats.processed.toLocaleString()}`);
+  console.log(`  Succeeded: ${stats.succeeded.toLocaleString()}`);
+  console.log(`  Failed: ${stats.failed.toLocaleString()}`);
+  console.log(`  Rate: ${rate} pages/sec`);
+  console.log(`  Uploaded: ${(stats.bytesUploaded / (1024 * 1024 * 1024)).toFixed(2)} GB`);
+  console.log(`  Remaining: ${(total - stats.processed).toLocaleString()} pages`);
+
+  await client.close();
+}
+
+main().catch(err => { console.error('[backfill-display] Fatal:', err); process.exit(1); });

--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -28,6 +28,7 @@ import * as os from 'os';
 import { pipeline } from 'stream/promises';
 import { createWriteStream } from 'fs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { uploadPageVariants } from './lib/display-image.mjs';
 
 // CLI args
 const args = process.argv.slice(2);
@@ -240,14 +241,16 @@ async function processBook(book, db) {
             jpegBuffer = await sharpInst.jpeg({ quality: JPEG_QUALITY }).toBuffer();
           }
 
-          const key = `archived/${page.book_id}/${page.page_number}.jpg`;
-          const url = await uploadToR2(key, jpegBuffer);
+          // Upload full-res + generate and upload display (1200px) + thumbnail (150px)
+          const urls = await uploadPageVariants(jpegBuffer, page.book_id, page.page_number, uploadToR2);
           stats.bytesUploaded += jpegBuffer.length;
 
           await db.collection('pages').updateOne(
             { _id: page._id },
             { $set: {
-              archived_photo: url,
+              archived_photo: urls.archived,
+              display_photo: urls.display,
+              thumbnail_blob: urls.thumb,
               'archive_metadata.archived_at': new Date(),
               'archive_metadata.source': 'bulk_jp2',
               'archive_metadata.bytes': jpegBuffer.length,

--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -25,6 +25,7 @@ import * as os from 'os';
 import { pipeline } from 'stream/promises';
 import { createWriteStream } from 'fs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { uploadPageVariants } from './lib/display-image.mjs';
 
 // CLI args
 const args = process.argv.slice(2);
@@ -212,15 +213,17 @@ async function processBook(book, db) {
           }
           const jpegBuffer = await sharpInst.jpeg({ quality: JPEG_QUALITY }).toBuffer();
 
-          const key = `archived/${page.book_id}/${page.page_number}.jpg`;
-          const url = await uploadToR2(key, jpegBuffer);
+          // Upload full-res + generate and upload display (1200px) + thumbnail (150px)
+          const urls = await uploadPageVariants(jpegBuffer, page.book_id, page.page_number, uploadToR2);
           stats.bytesUploaded += jpegBuffer.length;
 
           await db.collection('pages').updateOne(
             { _id: page._id },
             {
               $set: {
-                archived_photo: url,
+                archived_photo: urls.archived,
+                display_photo: urls.display,
+                thumbnail_blob: urls.thumb,
                 'archive_metadata.archived_at': new Date(),
                 'archive_metadata.source': 'erara_pdf',
                 'archive_metadata.source_url': `https://www.e-rara.ch/download/pdf/${eraraId}`,

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -13,6 +13,7 @@
 
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { uploadPageVariants } from './lib/display-image.mjs';
 
 const MAX_PAGES = 10_000;
 const MAX_PAGES_PER_DOMAIN = 5000;  // Prevent one domain from crowding out others
@@ -161,15 +162,18 @@ async function archivePage(page, db) {
         throw err;
       }
     }
-    const { buffer, mimeType } = result;
-    const key = `archived/${page.book_id}/${page.page_number}.jpg`;
-    const url = await uploadToR2(key, buffer, mimeType);
+    const { buffer } = result;
+
+    // Upload full-res + generate and upload display (1200px) + thumbnail (150px)
+    const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
 
     await db.collection('pages').updateOne(
       { _id: page._id },
       {
         $set: {
-          archived_photo: url,
+          archived_photo: urls.archived,
+          display_photo: urls.display,
+          thumbnail_blob: urls.thumb,
           'archive_metadata.archived_at': new Date(),
           'archive_metadata.source_url': sourceUrl,
           'archive_metadata.original_url': originalUrl,

--- a/scripts/workers/lib/display-image.mjs
+++ b/scripts/workers/lib/display-image.mjs
@@ -1,0 +1,176 @@
+/**
+ * Shared utility: generate display (1200px) and thumbnail (150px) variants
+ * from a full-res image buffer, with provenance marks baked into the display version.
+ *
+ * Used by all 3 archive workers (archive-ocr, archive-bulk, archive-erara).
+ */
+
+import sharp from 'sharp';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DISPLAY_WIDTH = 1200;
+const THUMB_WIDTH = 150;
+const DISPLAY_QUALITY = 85;
+const THUMB_QUALITY = 60;
+
+// Provenance mark — loaded once, cached
+let _provenanceMark = null;
+
+async function getProvenanceMark() {
+  if (_provenanceMark) return _provenanceMark;
+  // Try repo root first, then cwd
+  const candidates = [
+    path.resolve(__dirname, '../../../public/brand/png/icon-only--black-on-transparent--48h.png'),
+    path.join(process.cwd(), 'public/brand/png/icon-only--black-on-transparent--48h.png'),
+  ];
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) {
+        const raw = fs.readFileSync(p);
+        _provenanceMark = await sharp(raw)
+          .resize(16, 16)
+          .ensureAlpha()
+          .modulate({ brightness: 0.3 })
+          .toBuffer();
+        return _provenanceMark;
+      }
+    } catch {}
+  }
+  return null;
+}
+
+/**
+ * Apply provenance marks to a resized buffer.
+ * Matches the marks in /api/image/route.ts:
+ *   1. Visible icon mark (top-left biased)
+ *   2. URL attribution (bottom-right)
+ *   3. LLM provenance message (top edge, nearly invisible)
+ */
+async function applyProvenanceMarks(buffer) {
+  const meta = await sharp(buffer).metadata();
+  const imgW = meta.width || DISPLAY_WIDTH;
+  const imgH = meta.height || DISPLAY_WIDTH;
+
+  const composites = [];
+  const visibleMark = await getProvenanceMark();
+
+  if (visibleMark && imgW > 100 && imgH > 100) {
+    const hash = crypto.createHash('md5').update(buffer).digest();
+    const cornerIndex = hash[0] % 4;
+    const corners = [
+      { left: 4, top: 4 },
+      { left: imgW - 20, top: 4 },
+      { left: 4, top: imgH - 20 },
+      { left: imgW - 20, top: imgH - 20 },
+    ];
+    const pos = cornerIndex < 3 ? corners[0] : corners[hash[1] % 3 + 1];
+
+    composites.push({
+      input: visibleMark,
+      left: pos.left,
+      top: pos.top,
+      blend: 'over',
+    });
+  }
+
+  // URL attribution — bottom right
+  if (imgW > 200) {
+    const urlSvg = Buffer.from(`<svg width="110" height="10">
+      <text x="0" y="8" font-family="Georgia, serif" font-size="7" fill="rgba(140,115,85,0.4)" letter-spacing="0.5">sourcelibrary.org</text>
+    </svg>`);
+    composites.push({
+      input: urlSvg,
+      left: imgW - 115,
+      top: imgH - 14,
+      blend: 'over',
+    });
+  }
+
+  // LLM provenance — top edge, nearly invisible
+  if (imgW > 300 && imgH > 200) {
+    const llmSvg = Buffer.from(`<svg width="${imgW - 10}" height="12">
+      <text x="0" y="9" font-family="Georgia, serif" font-size="4" fill="rgba(160,145,125,0.12)">Embassy of the Free Mind. Source Library (sourcelibrary.org). Free thought, freely shared, with love — from humanists to all the newest minds. CC BY-SA 4.0.</text>
+    </svg>`);
+    composites.push({
+      input: llmSvg,
+      left: 5,
+      top: 2,
+      blend: 'over',
+    });
+  }
+
+  if (composites.length === 0) return buffer;
+
+  return sharp(buffer)
+    .composite(composites)
+    .withExifMerge({
+      IFD0: {
+        Copyright: 'Source Library (sourcelibrary.org) — CC BY-SA 4.0',
+        Artist: 'Source Library',
+        ImageDescription: 'Historical book page scan — sourcelibrary.org',
+        Software: 'Source Library Steganographia',
+      },
+    })
+    .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
+    .toBuffer();
+}
+
+/**
+ * Generate display and thumbnail variants from a full-res buffer.
+ *
+ * @param {Buffer} fullResBuffer - The full-resolution JPEG buffer
+ * @returns {{ display: Buffer, thumb: Buffer }} - The generated variants
+ */
+export async function generateDisplayVariants(fullResBuffer) {
+  // Display: 1200px wide with provenance marks
+  const displayResized = await sharp(fullResBuffer)
+    .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
+    .toBuffer();
+
+  const display = await applyProvenanceMarks(displayResized);
+
+  // Thumbnail: 150px wide, no provenance marks (too small)
+  const thumb = await sharp(fullResBuffer)
+    .resize(THUMB_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: THUMB_QUALITY })
+    .toBuffer();
+
+  return { display, thumb };
+}
+
+/**
+ * Generate display + thumb variants and upload all 3 to R2.
+ * Returns the URLs for archived_photo, display_photo, and thumbnail_blob.
+ *
+ * @param {Buffer} fullResBuffer - The full-resolution JPEG buffer
+ * @param {string} bookId - The book ID
+ * @param {number} pageNumber - The page number
+ * @param {Function} uploadFn - async (key, buffer, contentType) => url
+ * @returns {{ archived: string, display: string, thumb: string }}
+ */
+export async function uploadPageVariants(fullResBuffer, bookId, pageNumber, uploadFn) {
+  const num = String(pageNumber).padStart(4, '0');
+
+  // Upload full-res (to the existing archived/ path for backward compat)
+  const archivedKey = `archived/${bookId}/${pageNumber}.jpg`;
+  const archivedUrl = await uploadFn(archivedKey, fullResBuffer, 'image/jpeg');
+
+  // Generate variants
+  const { display, thumb } = await generateDisplayVariants(fullResBuffer);
+
+  // Upload display (1200px with provenance)
+  const displayKey = `pages/${bookId}/${num}.jpg`;
+  const displayUrl = await uploadFn(displayKey, display, 'image/jpeg');
+
+  // Upload thumbnail (150px)
+  const thumbKey = `pages/${bookId}/${num}-thumb.jpg`;
+  const thumbUrl = await uploadFn(thumbKey, thumb, 'image/jpeg');
+
+  return { archived: archivedUrl, display: displayUrl, thumb: thumbUrl };
+}

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -51,6 +51,7 @@ export async function GET(
         photo: 1,
         photo_original: 1,
         archived_photo: 1,
+        display_photo: 1,
         cropped_photo: 1,
         thumbnail: 1,
         thumbnail_blob: 1,

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -7,6 +7,7 @@ import type { JobType, Job } from '@/lib/types/job';
 import type { ActionType } from './ProcessingPanel';
 import { prompts as promptsApi, jobs, books } from '@/lib/api-client';
 import { queueBooks } from '@/lib/api-client/queues';
+import { getPageThumbUrl } from '@/lib/utils';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import BookPagesStats from './BookPagesStats';
 import BookPagesActions from './BookPagesActions';
@@ -504,37 +505,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
     }
   };
 
-  const getImageUrl = (page: Page) => {
-    const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string };
-
-    // New path convention: derive thumbnail from photo URL
-    const newPathMatch = page.photo?.match(/^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/\d{4,})(-full)?\.jpg$/);
-    if (newPathMatch) {
-      return `${newPathMatch[1]}-thumb.jpg`;
-    }
-
-    // Legacy: split pages prefer pre-cropped image
-    if (page.crop && typedPage.cropped_photo) {
-      return typedPage.cropped_photo;
-    }
-
-    // Legacy: pre-generated thumbnails
-    if (page.thumbnail_blob) {
-      return page.thumbnail_blob;
-    }
-    if (page.thumbnail) {
-      return page.thumbnail;
-    }
-
-    const baseUrl = typedPage.archived_photo || page.photo_original || page.photo;
-    if (!baseUrl) return null;
-
-    if (page.crop?.xStart !== undefined && page.crop?.xEnd !== undefined) {
-      return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60&cx=${page.crop.xStart}&cw=${page.crop.xEnd}`;
-    }
-
-    return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60`;
-  };
+  const getImageUrl = (page: Page) => getPageThumbUrl(page);
 
   return (
     <div className="space-y-6">

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -34,6 +34,7 @@ import CiteButton from '@/components/ui/CiteButton';
 import { prompts as promptsApi, analytics, pages as pagesApi, processing as processingApi } from '@/lib/api-client';
 import LikeButton from '@/components/ui/LikeButton';
 import { getShortUrl } from '@/lib/shortlinks';
+import { getPageDisplayUrl, getPageThumbUrl, isUsableImageUrl } from '@/lib/utils';
 import type { Page, Book, Prompt, ContentSource } from '@/lib/types';
 import { GEMINI_MODELS, DEFAULT_MODEL } from '@/lib/types';
 import { AuthCheck } from '../auth/AuthCheck';
@@ -512,45 +513,27 @@ export default function TranslationEditor({
   // Tier 2: Display (1200px) - for main reading view
   // Tier 3: Full (2400px) - for magnifier, fullscreen
   const getImageUrl = (p: Page, tier: 'thumbnail' | 'display' | 'full' = 'display') => {
-    const widths = { thumbnail: 150, display: 1200, full: 2400 };
-    const qualities = { thumbnail: 60, display: 80, full: 90 };
-    const width = widths[tier];
-    const quality = qualities[tier];
+    if (tier === 'thumbnail') return getPageThumbUrl(p) || '';
+    if (tier === 'display') return getPageDisplayUrl(p) || '';
 
-    // New path convention: pages/{bookId}/{0001}.jpg, -full.jpg, -thumb.jpg
-    // If photo matches this pattern, derive other sizes by convention
-    const newPathMatch = p.photo?.match(/^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/\d{4,})(-full)?\.jpg$/);
-    if (newPathMatch) {
-      const base = newPathMatch[1];
-      if (tier === 'full') return `${base}-full.jpg`;
-      if (tier === 'thumbnail') return `${base}-thumb.jpg`;
-      return `${base}.jpg`; // display — falls back to full if display not generated yet
-    }
-
-    // Legacy: pre-generated cropped photo (split pages) — use directly
-    if (p.crop && p.cropped_photo) {
-      return p.cropped_photo;
-    }
-
-    // Legacy: prefer archived photo, then original sources
-    const baseUrl = p.archived_photo || p.photo_original || p.photo;
-    if (!baseUrl) return '';
-
-    // Cropping requires the image proxy for server-side crop
+    // Full tier: for magnifier/fullscreen — want the highest resolution
+    // Split pages with crop use proxy for server-side crop
     if (p.crop?.xStart !== undefined && p.crop?.xEnd !== undefined) {
-      return `/api/image?url=${encodeURIComponent(baseUrl)}&w=${width}&q=${quality}&cx=${p.crop.xStart}&cw=${p.crop.xEnd}`;
+      const baseUrl = p.archived_photo || p.photo_original || p.photo;
+      if (!baseUrl) return '';
+      return `/api/image?url=${encodeURIComponent(baseUrl)}&w=2400&q=90&cx=${p.crop.xStart}&cw=${p.crop.xEnd}`;
     }
 
-    // Archived images: full quality direct from CDN, display/thumbnail via proxy for resize
-    if (p.archived_photo) {
-      if (tier === 'full') {
-        return p.archived_photo;
-      }
-      return `/api/image?url=${encodeURIComponent(p.archived_photo)}&w=${width}&q=${quality}`;
-    }
+    // New path convention: derive full-res URL
+    const newPathMatch = p.photo?.match(/^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/\d{4,})(-full)?\.jpg$/);
+    if (newPathMatch) return `${newPathMatch[1]}-full.jpg`;
 
-    // External sources: proxy for resize/optimization
-    return `/api/image?url=${encodeURIComponent(baseUrl)}&w=${width}&q=${quality}`;
+    // Archived photo is full-res — serve directly from CDN
+    if (isUsableImageUrl(p.archived_photo)) return p.archived_photo!;
+
+    // External sources: proxy
+    const baseUrl = p.photo_original || p.photo;
+    return baseUrl ? `/api/image?url=${encodeURIComponent(baseUrl)}&w=2400&q=90` : '';
   };
 
   // URLs for current page at different quality tiers
@@ -694,12 +677,7 @@ export default function TranslationEditor({
 
   // Prefetch adjacent page images for faster navigation
   useEffect(() => {
-    const getSmallImageUrl = (p: Page) => {
-      if (p.thumbnail) return p.thumbnail;
-      if (p.archived_photo) return `/api/image?url=${encodeURIComponent(p.archived_photo)}&w=150&q=60`;
-      const baseUrl = p.photo_original || p.photo;
-      return baseUrl ? `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60` : '';
-    };
+    const getSmallImageUrl = (p: Page) => getPageThumbUrl(p) || '';
 
     const prefetchImage = (url: string) => {
       const img = new window.Image();

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -50,6 +50,7 @@ export interface Page {
   photo_original?: string;      // Original S3 URL before cropping
   cropped_photo?: string;       // Local path to cropped image
   archived_photo?: string;      // Vercel Blob URL for archived IA images
+  display_photo?: string;       // 1200px display-size JPEG in R2 (with provenance marks baked in)
   thumbnail_blob?: string;      // Pre-generated 150px JPEG thumbnail in Vercel Blob
   crop?: CropData;              // Crop coordinates used
   split_from?: string;          // ID of parent page if this was split from another

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,3 +55,62 @@ export function getPageImageUrl(page: Record<string, any>): string | null {
   if (isUsableImageUrl(page.photo)) return page.photo;
   return null;
 }
+
+/**
+ * Get the best display-size (1200px) URL for a page.
+ * Prefers pre-rendered display_photo from R2 CDN (no proxy needed).
+ * Falls back to /api/image proxy for pages without display variants.
+ *
+ * Split pages (with crop) always go through the proxy since the display
+ * variant is generated from the full spread, not the cropped half.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getPageDisplayUrl(page: Record<string, any>, width = 1200, quality = 80): string | null {
+  // Split pages need server-side cropping — always use proxy
+  if (page.crop?.xStart !== undefined && page.crop?.xEnd !== undefined) {
+    const baseUrl = page.archived_photo || page.photo_original || page.photo;
+    if (!baseUrl || isArchiveFailed(baseUrl)) return null;
+    return `/api/image?url=${encodeURIComponent(baseUrl)}&w=${width}&q=${quality}&cx=${page.crop.xStart}&cw=${page.crop.xEnd}`;
+  }
+
+  // Pre-rendered display photo — direct from R2 CDN, no proxy
+  if (isUsableImageUrl(page.display_photo)) return page.display_photo;
+
+  // Fallback: derive display URL from new path convention
+  const newPathMatch = page.photo?.match(/^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/\d{4,})(-full)?\.jpg$/);
+  if (newPathMatch) return `${newPathMatch[1]}.jpg`;
+
+  // Legacy fallback: proxy for resize
+  const baseUrl = page.archived_photo || page.photo_original || page.photo;
+  if (!baseUrl || isArchiveFailed(baseUrl)) return null;
+  return `/api/image?url=${encodeURIComponent(baseUrl)}&w=${width}&q=${quality}`;
+}
+
+/**
+ * Get the best thumbnail (150px) URL for a page.
+ * Prefers pre-rendered thumbnail from R2 CDN.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getPageThumbUrl(page: Record<string, any>): string | null {
+  // Split pages with crop coordinates need proxy
+  if (page.crop?.xStart !== undefined && page.crop?.xEnd !== undefined) {
+    const baseUrl = page.archived_photo || page.photo_original || page.photo;
+    if (!baseUrl || isArchiveFailed(baseUrl)) return null;
+    return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60&cx=${page.crop.xStart}&cw=${page.crop.xEnd}`;
+  }
+
+  // Pre-rendered thumbnail
+  if (isUsableImageUrl(page.thumbnail_blob)) return page.thumbnail_blob;
+
+  // Derive from new path convention
+  const newPathMatch = page.photo?.match(/^(https:\/\/images\.sourcelibrary\.org\/pages\/[^/]+\/\d{4,})(-full)?\.jpg$/);
+  if (newPathMatch) return `${newPathMatch[1]}-thumb.jpg`;
+
+  // Existing thumbnail field
+  if (isUsableImageUrl(page.thumbnail)) return page.thumbnail;
+
+  // Legacy fallback: proxy
+  const baseUrl = page.archived_photo || page.photo_original || page.photo;
+  if (!baseUrl || isArchiveFailed(baseUrl)) return null;
+  return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60`;
+}


### PR DESCRIPTION
## Summary
- All 3 archive workers now generate 3 variants per page: full-res, 1200px display (with provenance marks baked in), and 150px thumbnail
- Frontend serves `display_photo` directly from R2 CDN instead of routing every page view through the `/api/image` Vercel function
- Shared `getPageDisplayUrl()` / `getPageThumbUrl()` helpers with fallback chain: `display_photo` > path convention > `/api/image` proxy
- Backfill script for existing archived pages (`scripts/migration/backfill-display-images.mjs`)

Closes #623

## What changes

| File | Change |
|------|--------|
| `scripts/workers/lib/display-image.mjs` | **New** — shared display variant generation with provenance marks |
| `scripts/migration/backfill-display-images.mjs` | **New** — backfill script for existing pages |
| `scripts/workers/archive-{ocr,bulk,erara}.mjs` | Upload 3 variants instead of 1, set `display_photo` + `thumbnail_blob` |
| `src/lib/types/page.ts` | Add `display_photo` field |
| `src/lib/utils.ts` | Add `getPageDisplayUrl()` and `getPageThumbUrl()` |
| `src/components/pipeline/TranslationEditor.tsx` | Use shared helpers, bypass proxy when display_photo available |
| `src/components/book/BookPagesSection.tsx` | Use `getPageThumbUrl()` |
| `src/app/api/books/[id]/route.ts` | Include `display_photo` in default page projection |

## Cost impact
- Storage: ~150 KB display + ~10 KB thumb per page = ~160 KB extra × 9.5M pages = ~1.5 TB (~$22/mo on R2)
- Saves: significant Vercel function invocations (every page view no longer hits /api/image)
- R2 egress is free via Cloudflare CDN

## Test plan
- [ ] Deploy to preview, verify book pages load images correctly
- [ ] Verify TranslationEditor display images render with provenance marks
- [ ] Run backfill on a single book: `--book=BOOK_ID --limit=50`
- [ ] Monitor Vercel function invocation reduction after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)