### PR TITLE
Health probe: test browse query latency; archive workers sync counters

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -270,6 +270,18 @@ async function processBook(book, db) {
     stats.booksProcessed++;
     console.log(`    ${archived} archived, ${failed} failed`);
 
+    // Sync pages_archived counter on this book (#497)
+    if (archived > 0) {
+      const archivedCount = await db.collection('pages').countDocuments(
+        { book_id: book.id, archived_photo: { $exists: true, $nin: [null, ''] } },
+        { maxTimeMS: 10000 }
+      );
+      await db.collection('books').updateOne(
+        { id: book.id },
+        { $set: { pages_archived: archivedCount, updated_at: new Date() } }
+      );
+    }
+
   } catch (err) {
     console.log(`  [ERROR] ${book.title?.slice(0, 50)}: ${err.message?.slice(0, 100)}`);
     stats.booksFailed++;

--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -251,6 +251,18 @@ async function processBook(book, db) {
     const rate = (archived / ((Date.now() - stats.startTime) / 1000)).toFixed(1);
     console.log(`    ${archived}/${workItems.length} archived, ${failed} failed (${rate} pages/sec overall)`);
 
+    // Sync pages_archived counter (#497)
+    if (archived > 0) {
+      const archivedCount = await db.collection('pages').countDocuments(
+        { book_id: book.id, archived_photo: { $exists: true, $nin: [null, ''] } },
+        { maxTimeMS: 10000 }
+      );
+      await db.collection('books').updateOne(
+        { id: book.id },
+        { $set: { pages_archived: archivedCount, updated_at: new Date() } }
+      );
+    }
+
     // If all pages archived, mark book as archive_complete
     const remainingUnarchived = await db.collection('pages').countDocuments({
       book_id: book.id,

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -202,6 +202,7 @@ async function main() {
   let totalBytes = 0;
   let processed = 0;
   const domainStats = {};
+  const touchedBookIds = new Set();
 
   // Strategy: find books with pages that need archiving, regardless of pipeline status.
   // Books move through pipeline stages even if archiving isn't complete.
@@ -283,6 +284,7 @@ async function main() {
         archived++;
         totalBytes += result.bytes;
         domainStats[domain].ok++;
+        touchedBookIds.add(page.book_id);
       } else {
         failed++;
         domainStats[domain].fail++;
@@ -307,6 +309,23 @@ async function main() {
   const mb = (totalBytes / (1024 * 1024)).toFixed(1);
   console.log(`[archive-ocr] Done in ${duration}s: ${archived} archived (${mb} MB), ${failed} failed`);
   console.log(`[archive-ocr] Per-domain: ${Object.entries(domainStats).map(([d, s]) => `${d}:${s.ok}ok/${s.fail}fail`).join(', ')}`);
+
+  // Sync pages_archived counter on touched books (#497)
+  if (touchedBookIds.size > 0) {
+    let synced = 0;
+    for (const bookId of touchedBookIds) {
+      const archivedCount = await db.collection('pages').countDocuments(
+        { book_id: bookId, archived_photo: { $exists: true, $nin: [null, ''] } },
+        { maxTimeMS: 10000 }
+      );
+      await db.collection('books').updateOne(
+        { id: bookId },
+        { $set: { pages_archived: archivedCount, updated_at: new Date() } }
+      );
+      synced++;
+    }
+    console.log(`[archive-ocr] Synced pages_archived on ${synced} books`);
+  }
 
   // Log to cron_runs for monitoring
   await db.collection('cron_runs').insertOne({

--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -46,6 +46,33 @@ export const GET = withAdminAuth(async () => {
     });
   }
 
+  // --- 1b. User-facing query latency ---
+  // Tests the actual query pattern users hit (browse page).
+  // ping can return 14ms while this takes 300s if cache is thrashed.
+  // See: GitHub issue #567
+  try {
+    const browseStart = Date.now();
+    await db.collection('books')
+      .find({ visible: true, pages_count: { $gt: 0 } })
+      .sort({ created_at: -1 })
+      .limit(10)
+      .maxTimeMS(10000)
+      .project({ id: 1, title: 1 })
+      .toArray();
+    const browseMs = Date.now() - browseStart;
+    checks.browse_query = {
+      status: browseMs > 5000 ? 'critical'
+            : browseMs > 2000 ? 'warning'
+            : 'ok',
+      latency_ms: browseMs,
+    };
+  } catch (error) {
+    checks.browse_query = {
+      status: 'critical',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
   // --- Run remaining checks in parallel ---
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
   const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- **Health probe** (`/api/admin/health`): adds `browse_query` check that runs the actual user-facing query pattern (`visible: true, pages_count > 0, sort by created_at`). Flags warning at >2s, critical at >5s. The old probe only tested `ping` which returned 14ms while real queries took 326s during the Atlas crisis.
- **Archive workers** (`archive-ocr`, `archive-bulk`, `archive-erara`): all three now sync `book.pages_archived` after archiving pages. Previously only the sync-worker (every 2h) reconciled these counters.

Addresses #567 (health probe, item 3) and #497 (worker counter sync).

## Test plan
- [ ] Hit `/api/admin/health` and verify `browse_query` check appears with latency
- [ ] After Hetzner deploy, verify archive-ocr/bulk/erara logs show "Synced pages_archived" lines
- [ ] `npx tsc --noEmit` passes (done locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)