### PR TITLE
Freshen stats on /beta and /founding-donors

### DIFF
--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -212,7 +212,7 @@ export default function BetaLandingPage() {
             >
               Source Library uses AI to translate thousands of rare historical texts
               in early science, philosophy, medicine, alchemy, and theology into modern English.
-              Over 4,000 books. 1.6 million pages. 120 books free and open.
+              Over 9,000 books. 3 million pages. Thousands of books free and open.
               Register for free to access the full collection.
             </p>
 
@@ -353,12 +353,13 @@ export default function BetaLandingPage() {
       <section className="py-16 md:py-20 bg-stone-900">
         <div className="px-6 md:px-12 max-w-7xl mx-auto">
           <div className="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
+            {/* Stats last verified 2026-03-31. 9,344 visible books, 1M+ translated pages. */}
             {[
-              { number: '4,400+', label: 'Rare books' },
-              { number: '1.6M', label: 'Pages scanned' },
-              { number: '280K+', label: 'Pages translated' },
-              { number: '90+', label: 'Languages' },
-              { number: '53K+', label: 'Illustrations' },
+              { number: '9,000+', label: 'Rare books' },
+              { number: '3M+', label: 'Pages scanned' },
+              { number: '1M+', label: 'Pages translated' },
+              { number: '100+', label: 'Languages' },
+              { number: '74K+', label: 'Illustrations' },
             ].map((stat) => (
               <div key={stat.label}>
                 <div
@@ -390,9 +391,9 @@ export default function BetaLandingPage() {
           <p
             className="text-lg text-white/50 mb-10 max-w-xl mx-auto font-body"
           >
-            Source Library opens February 22, 2026.
-            120 books are completely open, no account needed.
-            Register for free to unlock the full collection of over 4,000 texts.
+            Source Library is live and growing every day.
+            Thousands of books are completely open, no account needed.
+            Register for free to unlock the full collection of over 9,000 texts.
             No payment required, ever.
           </p>
 

--- a/src/app/founding-donors/page.tsx
+++ b/src/app/founding-donors/page.tsx
@@ -58,11 +58,12 @@ export default function FoundingDonorsPage() {
         <h3 className="font-serif text-2xl text-primary pt-12 mb-6">Where we are today</h3>
 
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-8">
+          {/* Stats last verified 2026-03-31 */}
           {[
-            { number: '10,000+', label: 'Books in collection' },
-            { number: '4,300+', label: 'Books fully translated' },
-            { number: '800K+', label: 'Pages translated' },
-            { number: '15+', label: 'Source languages' },
+            { number: '9,000+', label: 'Books in collection' },
+            { number: '2,600+', label: 'Books fully translated' },
+            { number: '1M+', label: 'Pages translated' },
+            { number: '100+', label: 'Source languages' },
             { number: '< 5,000', label: 'Perseus + Loeb + Sacred-texts combined' },
             { number: 'Free', label: 'Open access to all' },
           ].map((stat) => (


### PR DESCRIPTION
## Summary
- `/beta`: 4,400→9,000+ books, 1.6M→3M+ pages, 280K→1M+ translated, 90→100+ languages, 53K→74K+ illustrations. Remove stale "opens February 22" launch date.
- `/founding-donors`: 10,000→9,000+ books, 4,300→2,600+ translated, 800K→1M+ pages, 15→100+ languages.
- Added comments noting verification date so future staleness is easy to spot.

Stats verified 2026-03-31 via live DB query (9,344 visible books).

## Test plan
- [ ] Verify /beta renders with updated numbers
- [ ] Verify /founding-donors renders with updated numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)