### PR TITLE
Tune translate-worker for scheduler connection budget

### DIFF
--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -62,7 +62,7 @@ const WORKERS = [
     name: 'translate-worker',
     cmd: 'node scripts/workers/translate-worker.mjs',
     lock: '/tmp/sl-translate.lock',
-    connections: 50,
+    connections: 15,
     tier: 2,
     interval: 120,      // every 2 min
     healthMin: 'healthy',

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -27,7 +27,7 @@ import { createHash } from 'crypto';
 import { nanoid } from 'nanoid';
 
 // ── Config ──
-const CONCURRENCY = 40;          // Max books translating simultaneously
+const CONCURRENCY = 8;           // Max books translating simultaneously (tuned for 40-connection budget)
 const PAGES_PER_RUN = 8000;      // Global page cap per run (prevent runaway costs)
 const MAX_CONSECUTIVE_ERRORS = 5; // Per-book error threshold before giving up
 const RATE_LIMIT_BACKOFF_MS = 15000;
@@ -100,7 +100,7 @@ const MIN_OCR_CHARS_FOR_BATCH = 200;
 // ── MongoDB ──
 const client = new MongoClient(process.env.MONGODB_URI, {
   serverSelectionTimeoutMS: 10000,
-  maxPoolSize: CONCURRENCY + 10,
+  maxPoolSize: 15,
 });
 
 // ── Sanitize translation tags (matches src/lib/sanitize-translation-tags.ts) ──


### PR DESCRIPTION
## Summary
- translate-worker had `CONCURRENCY=40` / `maxPoolSize=50` from before the unified scheduler (#647)
- The scheduler's 40-connection budget could never fit it (`50 > 40`), so **translation was permanently skipped**
- Reduces concurrency to 8 books, pool to 15 connections — fits within budget alongside other workers

## Changes
- `translate-worker.mjs`: CONCURRENCY 40→8, maxPoolSize 50→15
- `scheduler.mjs`: connection cost estimate 50→15

## Connection math
| Workers | Connections |
|---------|------------|
| 5 tier-1/3 workers × 5 | 25 |
| translate-worker | 15 |
| **Total** | **40** (= budget) |

## Test plan
- [ ] Deploy to Hetzner (`git pull`)
- [ ] Watch scheduler log: translate-worker should now be SPAWNED, not SKIPPED
- [ ] Confirm Atlas connections stay under 40
- [ ] Verify translation pages/hour recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)