### PR TITLE
Raise scheduler budget to 60, translate concurrency to 15

### DIFF
--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -29,9 +29,9 @@ if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERBOSE = process.argv.includes('--verbose') || process.argv.includes('-v');
 
-// Global Atlas connection budget. Atlas M10 saturates around 40 concurrent
-// pipeline connections. Leave headroom for Vercel SSR/ISR queries.
-const MAX_CONNECTIONS = 40;
+// Global Atlas connection budget. With capped pools (maxPoolSize 5-20 per worker),
+// actual peak is well under Atlas M10 limits. 60 leaves headroom for Vercel SSR/ISR.
+const MAX_CONNECTIONS = 60;
 
 // ── Worker Definitions ──
 // Each worker has:
@@ -62,7 +62,7 @@ const WORKERS = [
     name: 'translate-worker',
     cmd: 'node scripts/workers/translate-worker.mjs',
     lock: '/tmp/sl-translate.lock',
-    connections: 15,
+    connections: 20,
     tier: 2,
     interval: 120,      // every 2 min
     healthMin: 'healthy',

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -27,7 +27,7 @@ import { createHash } from 'crypto';
 import { nanoid } from 'nanoid';
 
 // ── Config ──
-const CONCURRENCY = 8;           // Max books translating simultaneously (tuned for 40-connection budget)
+const CONCURRENCY = 15;          // Max books translating simultaneously (tuned for 60-connection budget)
 const PAGES_PER_RUN = 8000;      // Global page cap per run (prevent runaway costs)
 const MAX_CONSECUTIVE_ERRORS = 5; // Per-book error threshold before giving up
 const RATE_LIMIT_BACKOFF_MS = 15000;
@@ -100,7 +100,7 @@ const MIN_OCR_CHARS_FOR_BATCH = 200;
 // ── MongoDB ──
 const client = new MongoClient(process.env.MONGODB_URI, {
   serverSelectionTimeoutMS: 10000,
-  maxPoolSize: 15,
+  maxPoolSize: 20,
 });
 
 // ── Sanitize translation tags (matches src/lib/sanitize-translation-tags.ts) ──


### PR DESCRIPTION
## Summary
Follow-up to #650. Budget of 40 was too tight — archive-bulk and display-backfill kept getting bumped.

- MAX_CONNECTIONS: 40 → 60 (all workers peak at 55, leaves headroom for Vercel)
- translate-worker: CONCURRENCY 8→15, maxPoolSize 15→20
- All 8 workers can now run simultaneously

## Connection math
| Worker | Connections |
|--------|------------|
| pipeline-orchestrator | 5 |
| translate-worker | 20 |
| batch-collector | 5 |
| archive-ocr | 5 |
| archive-bulk | 5 |
| resize-worker | 5 |
| display-backfill | 5 |
| sync-worker | 5 |
| **Total** | **55 / 60** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)