### PR TITLE
Add job heartbeat and pre-spawn syntax check

### DIFF
--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -218,6 +218,20 @@ async function probeDbHealth(db) {
 // ── Spawn a worker ──
 
 function spawnWorker(worker) {
+  // Syntax-check the worker script before spawning — catches broken .mjs files early
+  const scriptMatch = worker.cmd.match(/node\s+([\w./\-]+\.mjs)/);
+  if (scriptMatch) {
+    try {
+      execSync(`node --check ${scriptMatch[1]}`, {
+        cwd: process.env.HOME ? `${process.env.HOME}/sourcelibrary` : '/root/sourcelibrary',
+        timeout: 5000,
+      });
+    } catch (err) {
+      console.error(`[scheduler] SYNTAX ERROR in ${scriptMatch[1]} — skipping ${worker.name}`);
+      return null;
+    }
+  }
+
   const timestamp = new Date().toISOString();
   appendFileSync(worker.log, `\n--- Spawned by scheduler at ${timestamp} ---\n`);
 
@@ -364,7 +378,11 @@ async function main() {
       if (DRY_RUN) {
         console.log(`[scheduler]   ${worker.name}: WOULD SPAWN (dry-run)`);
       } else {
-        spawnWorker(worker);
+        const pid = spawnWorker(worker);
+        if (pid === null) {
+          skipped.push(`${worker.name}(syntax)`);
+          continue;
+        }
         lastRuns[worker.name] = now;
       }
       usedConnections += worker.connections;

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -393,7 +393,15 @@ async function processBook(db, book, job, globalCounter) {
       break;
     }
 
-    // Check if job was cancelled externally
+    // Heartbeat — keeps zombie reaper from killing live work (every 10 pages)
+    if (translated % 10 === 0 && translated > 0) {
+      await db.collection('jobs').updateOne(
+        { id: job.id },
+        { $set: { updated_at: new Date(), pages_processed: translated } },
+      );
+    }
+
+    // Check if job was cancelled externally (every 50 pages, includes a read)
     if (translated % 50 === 0 && translated > 0) {
       const freshJob = await db.collection('jobs').findOne({ id: job.id }, { projection: { status: 1 } });
       if (freshJob?.status === 'cancelled' || freshJob?.status === 'failed') {


### PR DESCRIPTION
## Summary
Two reliability improvements for the scheduler/worker system:

1. **Job heartbeat** — translate-worker updates `job.updated_at` + `pages_processed` every 10 pages. Prevents the zombie reaper (30min threshold) from killing legitimately long translations (200 pages at batch-5 can take 20+ min).

2. **Pre-spawn syntax check** — scheduler runs `node --check` on each .mjs worker before spawning. Would have caught the extra-brace bug from #647 that silently broke all translation.

## Test plan
- [ ] Verify heartbeat: watch `jobs` collection for `updated_at` changes during translation
- [ ] Verify syntax check: temporarily break a worker, confirm scheduler logs SYNTAX ERROR and skips it
- [ ] Confirm no performance regression from the `node --check` calls (~100ms each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)