### PR TITLE
Add data freshness labels and 1h-30d time windows to pipeline tab

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -84,11 +84,13 @@ export default function AnalyticsPage() {
                 className="px-3 py-1.5 rounded-lg text-sm"
                 style={{ border: '1px solid var(--border-medium)', background: 'var(--bg-white)' }}
               >
+                <option value={1}>Last hour</option>
                 <option value={6}>Last 6 hours</option>
                 <option value={24}>Last 24 hours</option>
                 <option value={72}>Last 3 days</option>
                 <option value={168}>Last 7 days</option>
                 <option value={336}>Last 14 days</option>
+                <option value={720}>Last 30 days</option>
               </select>
             )}
             {(activeTab === 'usage' || activeTab === 'search') && (

--- a/src/app/api/analytics/pipeline/route.ts
+++ b/src/app/api/analytics/pipeline/route.ts
@@ -24,7 +24,7 @@ const CACHE_TTL_MS = 60 * 1000;
 export const GET = withAuth(async (request, session) => {
   try {
     const { searchParams } = new URL(request.url);
-    const hours = Math.min(parseInt(searchParams.get('hours') || '24', 10), 336); // max 14 days
+    const hours = Math.min(parseInt(searchParams.get('hours') || '24', 10), 720); // max 30 days
 
     // Check cache
     const cacheKey = `pipeline-${hours}`;
@@ -200,6 +200,14 @@ export const GET = withAuth(async (request, session) => {
         nearComplete, // >90% translated
       },
       query: { hours },
+      _meta: {
+        snapshotComputedAt: snapshot?.computed_at || null,
+        snapshotCount: snapshots.length,
+        snapshotRange: snapshots.length > 0
+          ? { from: snapshots[0].timestamp, to: snapshots[snapshots.length - 1].timestamp }
+          : null,
+        cronRunsCount: cronRuns.length,
+      },
     };
 
     // Update cache

--- a/src/components/analytics/tabs/PipelineTab.tsx
+++ b/src/components/analytics/tabs/PipelineTab.tsx
@@ -25,6 +25,25 @@ function smartLabel(iso: string, hours: number): string {
   return `${months[d.getMonth()]} ${d.getDate()}`;
 }
 
+/** Relative time ago string */
+function timeAgo(iso: string): string {
+  const mins = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}
+
+/** Small muted source label */
+function SourceLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-xs ml-2 font-normal" style={{ color: 'var(--text-muted)', opacity: 0.7 }}>
+      {children}
+    </span>
+  );
+}
+
 interface PipelineTabProps {
   hours: number;
 }
@@ -104,6 +123,9 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           <div className="flex justify-between items-baseline mb-2">
             <div className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
               Translation Progress
+              {pipelineData._meta?.snapshotComputedAt && (
+                <SourceLabel>snapshot {timeAgo(pipelineData._meta.snapshotComputedAt)}</SourceLabel>
+              )}
             </div>
             <div className="text-sm" style={{ color: 'var(--text-muted)' }}>
               {ec!.translation.toLocaleString()} / {ec!.ocr.toLocaleString()} books with OCR
@@ -129,6 +151,12 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
       )}
 
       {/* Velocity Cards */}
+      {pipelineData._meta?.snapshotRange && (
+        <div className="text-xs" style={{ color: 'var(--text-muted)', opacity: 0.7 }}>
+          Velocity computed from {pipelineData._meta.snapshotCount} snapshots
+          ({timeAgo(pipelineData._meta.snapshotRange.from)} to {timeAgo(pipelineData._meta.snapshotRange.to)})
+        </div>
+      )}
       <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
         <div className="p-5 rounded-xl" style={{ background: 'linear-gradient(135deg, var(--bg-white), #f0fdf4)', border: '1px solid var(--border-light)' }}>
           <div className="text-sm font-medium uppercase mb-1" style={{ color: 'var(--text-muted)' }}>OCR Velocity</div>
@@ -204,6 +232,9 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
             <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
               <Layers className="w-5 h-5" style={{ color: 'var(--accent-sage)' }} />
               Pipeline Funnel
+              {pipelineData._meta?.snapshotComputedAt && (
+                <SourceLabel>snapshot {timeAgo(pipelineData._meta.snapshotComputedAt)}</SourceLabel>
+              )}
             </h2>
             <div className="space-y-1.5">
               {sorted.map(({ status, count }) => (
@@ -257,6 +288,9 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
             <h2 className="text-lg font-medium mb-1 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
               <Image className="w-5 h-5" style={{ color: 'var(--accent-violet)' }} />
               Enrichment Coverage
+              {pipelineData._meta?.snapshotComputedAt && (
+                <SourceLabel>snapshot {timeAgo(pipelineData._meta.snapshotComputedAt)}</SourceLabel>
+              )}
             </h2>
             <p className="text-xs mb-4" style={{ color: 'var(--text-muted)' }}>
               {total.toLocaleString()} books with pages &middot; {cov.galleryImages.toLocaleString()} gallery images
@@ -292,6 +326,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
         <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
           <h2 className="text-lg font-medium mb-4" style={{ color: 'var(--text-primary)' }}>
             OCR & Translation Progress Over Time
+            <SourceLabel>pipeline_snapshots</SourceLabel>
           </h2>
           <MultiLineChart
             series={[
@@ -328,6 +363,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
             <h2 className="text-lg font-medium mb-4" style={{ color: 'var(--text-primary)' }}>
               Pipeline Throughput (pages/hr)
+              <SourceLabel>pipeline_snapshots</SourceLabel>
             </h2>
             <MultiLineChart
               series={[
@@ -386,6 +422,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
             <Clock className="w-5 h-5" style={{ color: 'var(--accent-sage)' }} />
             Cron Health
+            <SourceLabel>cron_runs ({pipelineData._meta?.cronRunsCount || 0} entries)</SourceLabel>
           </h2>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -456,6 +493,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
             <XCircle className="w-5 h-5" style={{ color: '#ef4444' }} />
             Recent AI Errors (last 6h)
+            <SourceLabel>gemini_usage</SourceLabel>
           </h2>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -498,6 +536,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
             <AlertTriangle className="w-5 h-5" style={{ color: 'var(--accent-rust)' }} />
             Books Needing Attention ({pipelineData.needsAttention.length})
+            <SourceLabel>live query</SourceLabel>
           </h2>
           <div className="space-y-3">
             {pipelineData.needsAttention.map((book) => (

--- a/src/lib/api-client/types/analytics.ts
+++ b/src/lib/api-client/types/analytics.ts
@@ -260,6 +260,12 @@ export interface PipelineData {
     nearComplete: number;
   };
   query: { hours: number };
+  _meta?: {
+    snapshotComputedAt: string | null;
+    snapshotCount: number;
+    snapshotRange: { from: string; to: string } | null;
+    cronRunsCount: number;
+  };
 }
 
 // --- Search Analytics ---


### PR DESCRIPTION
## Summary
- Each pipeline section now shows its data source and freshness (e.g. "snapshot 2h ago", "cron_runs (47 entries)")
- Time window expanded: 1h, 6h, 24h, 3d, 7d, 14d, 30d (was 6h-14d)
- API max raised from 14d to 30d

## Test plan
- [ ] Pipeline tab: each section header shows a small grey source label
- [ ] Select "Last hour" — x-axis shows minute-level times
- [ ] Select "Last 30 days" — x-axis shows dates, chart renders
- [ ] Velocity section shows "N snapshots (Xh ago to Yh ago)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)