### PR TITLE
Fix /libraries/[slug] 5s timeout — contributing_library to Supabase

### DIFF
--- a/scripts/workers/supabase-sync.mjs
+++ b/scripts/workers/supabase-sync.mjs
@@ -210,6 +210,7 @@ for (const config of COLLECTIONS) {
       last_translation_at: 1, updated_at: 1, created_at: 1,
       categories: 1, collections: 1, collection_relevance: 1,
       'image_source.provider': 1,
+      'image_source.contributing_library': 1,
     },
   }).batchSize(200);
 
@@ -235,6 +236,7 @@ for (const config of COLLECTIONS) {
       collections: Array.isArray(book.collections) ? book.collections : [],
       collection_relevance: book.collection_relevance || null,
       image_source_provider: book.image_source?.provider || null,
+      contributing_library: book.image_source?.contributing_library || null,
     });
     if (batch.length >= 200) {
       const { error } = await supabase.from('books_catalog').upsert(batch, { onConflict: 'id' });

--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -61,6 +61,7 @@ function transformBook(book) {
     collections: Array.isArray(book.collections) ? book.collections : [],
     collection_relevance: book.collection_relevance || null,
     image_source_provider: book.image_source?.provider || null,
+    contributing_library: book.image_source?.contributing_library || null,
   };
 }
 
@@ -102,6 +103,7 @@ const projection = {
   last_translation_at: 1, updated_at: 1, created_at: 1,
   categories: 1, collections: 1, collection_relevance: 1,
   'image_source.provider': 1,
+  'image_source.contributing_library': 1,
 };
 
 const cursor = db.collection('books')

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { BookOpen, ExternalLink, Images, Library } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
+import { supabase } from '@/lib/supabase';
 import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
 import { notFound } from 'next/navigation';
 import { getPartnerBySlug, getAllPartnerSlugs } from '@/lib/library-partners';
@@ -117,21 +118,26 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
     } catch { /* Gallery is optional */ }
   }
 
-  // Contributing libraries from MongoDB (needs image_source.contributing_library, not in catalog)
-  let contributingLibraries: { name: string; count: number }[] = [];
-  try {
-    const db = await getDb();
-    const contributorsAgg = await db.collection('books').aggregate([
-      { $match: { 'image_source.provider': providerKey, visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 }, 'image_source.contributing_library': { $exists: true, $ne: null } } },
-      { $group: { _id: '$image_source.contributing_library', count: { $sum: 1 } } },
-      { $sort: { count: -1 } },
-      { $limit: 20 },
-    ], { maxTimeMS: 5000 }).toArray();
-    contributingLibraries = contributorsAgg.map(c => ({
-      name: c._id as string,
-      count: c.count as number,
-    }));
-  } catch { /* contributing libraries are optional */ }
+  // Contributing libraries from Supabase (was 5s+ MongoDB aggregation)
+  const { data: contribData } = await supabase
+    .from('books_catalog')
+    .select('contributing_library')
+    .eq('visible', true)
+    .eq('image_source_provider', providerKey)
+    .gt('pages_count', 0)
+    .gt('pages_translated', 0)
+    .not('contributing_library', 'is', null);
+
+  const contribCounts = new Map<string, number>();
+  for (const row of (contribData || [])) {
+    if (row.contributing_library) {
+      contribCounts.set(row.contributing_library, (contribCounts.get(row.contributing_library) || 0) + 1);
+    }
+  }
+  const contributingLibraries = [...contribCounts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 20);
 
   return {
     books: booksResult.books as unknown as BookItem[],


### PR DESCRIPTION
The last MongoDB query in the libraries page — contributing_library aggregation — took 5-6s. Now queries from books_catalog in Supabase.

Libraries/internet-archive: 6.3s → <1s expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)