### PR TITLE
Fix search UI: highlights, result limit, See all link

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') || '';
-    const limit = Math.min(parseInt(searchParams.get('limit') || '5'), 10);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '8'), 12);
     const galleryLimit = Math.min(parseInt(searchParams.get('gallery_limit') || '6'), 12);
 
     // Parse filters
@@ -134,7 +134,8 @@ async function searchBooks(
       pipeline.push({ $match: postMatch });
     }
 
-    pipeline.push({ $limit: limit });
+    // Fetch one extra to detect if there are more results
+    pipeline.push({ $limit: limit + 1 });
     pipeline.push({ $project: bookProjection });
 
     books = await db.collection('books').aggregate(pipeline, { maxTimeMS: 5000 }).toArray();
@@ -159,7 +160,7 @@ async function searchBooks(
     books = await db.collection('books')
       .find(regexFilter)
       .project(bookProjection)
-      .limit(limit)
+      .limit(limit + 1)
       .toArray();
   }
 
@@ -201,8 +202,11 @@ async function searchBooks(
     }
   }
 
+  const hasMore = books.length > limit;
+  const truncated = hasMore ? books.slice(0, limit) : books;
+
   return {
-    results: books.map((b: any): SearchResult => {
+    results: truncated.map((b: any): SearchResult => {
       const summaryText = b.reading_summary?.overview;
       return {
         id: b.id,
@@ -226,7 +230,8 @@ async function searchBooks(
         quality_score: b.quality_score,
       };
     }),
-    total: books.length,
+    total: truncated.length,
+    hasMore,
   };
 }
 
@@ -326,7 +331,7 @@ async function searchIndex(db: any, query: string, limit: number) {
     }
   }
 
-  return { results, total: results.length };
+  return { results, total: results.length, hasMore: results.length >= limit };
 }
 
 async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: number): Promise<{ results: GalleryResult[]; total: number }> {

--- a/src/components/search/UnifiedSearch.tsx
+++ b/src/components/search/UnifiedSearch.tsx
@@ -113,7 +113,7 @@ export default function UnifiedSearch() {
     setIsOpen(true);
 
     try {
-      const data = await searchApi.unified(searchQuery, { limit: 5 });
+      const data = await searchApi.unified(searchQuery, { limit: 8 });
       setCachedResult(cacheKey, data);
       setResults(data);
     } catch (error) {
@@ -349,9 +349,9 @@ export default function UnifiedSearch() {
                   <div className="p-3">
                     <div className="flex items-center justify-between mb-2 px-2">
                       <span className="text-xs font-semibold text-stone-400 uppercase tracking-wide">
-                        Books ({results.books.total})
+                        Books{results.books.hasMore ? '' : ` (${results.books.total})`}
                       </span>
-                      {results.books.total > 5 && (
+                      {results.books.hasMore && (
                         <Link
                           href={`/search?q=${encodeURIComponent(query)}`}
                           className="text-xs text-accent-rust hover:text-accent-rust flex items-center gap-0.5"
@@ -404,9 +404,9 @@ export default function UnifiedSearch() {
                   <div className="p-3">
                     <div className="flex items-center justify-between mb-2 px-2">
                       <span className="text-xs font-semibold text-stone-400 uppercase tracking-wide">
-                        Index ({results.index.total})
+                        Index{results.index.hasMore ? '' : ` (${results.index.total})`}
                       </span>
-                      {results.index.total > 5 && (
+                      {results.index.hasMore && (
                         <Link
                           href={`/search?q=${encodeURIComponent(query)}&mode=index`}
                           className="text-xs text-accent-rust hover:text-accent-rust flex items-center gap-0.5"

--- a/src/lib/api-client/types/search.ts
+++ b/src/lib/api-client/types/search.ts
@@ -97,10 +97,12 @@ export interface UnifiedSearchResponse {
   books: {
     results: SearchResult[];
     total: number;
+    hasMore?: boolean;
   };
   index: {
     results: IndexSearchResult[];
     total: number;
+    hasMore?: boolean;
   };
   gallery?: {
     results: UnifiedGalleryResult[];

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,8 +1,17 @@
-import { normalizeText } from './utils';
-
 export interface TextSegment {
   text: string;
   highlight: boolean;
+}
+
+/**
+ * Normalize text for matching: NFD decompose, strip diacritics, lowercase.
+ * Does NOT trim — preserving position alignment with the character mapping.
+ */
+function normalizeForMatch(text: string): string {
+  return text
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
 }
 
 /**
@@ -20,17 +29,17 @@ export function splitByMatches(text: string, query: string): TextSegment[] {
     return [{ text, highlight: false }];
   }
 
-  const normalizedText = normalizeText(text);
+  // Use non-trimming normalize to keep position alignment with the mapping
+  const normalizedText = normalizeForMatch(text);
 
   // Build a boolean mask of which character positions match
   const mask = new Array(text.length).fill(false);
 
   for (const word of words) {
-    const normalizedWord = normalizeText(word);
+    const normalizedWord = normalizeForMatch(word).trim();
     if (normalizedWord.length === 0) continue;
 
     // Map normalized positions back to original positions.
-    // normalizeText does NFD + strip diacritics + lowercase + trim.
     const nfd = text.normalize('NFD');
     const nfdToOriginal: number[] = [];
 


### PR DESCRIPTION
## Summary
- **Highlight mismatch fix**: `splitByMatches()` used `normalizeText()` which `.trim()`s the text, causing position offset between the normalized search string and the character-to-original mapping. Replaced with a local `normalizeForMatch()` that skips trim.
- **Result limit**: Increased typeahead from 5 to 8 results (API max from 10 to 12)
- **"See all" link**: Was checking `total > 5` but `total` was always the returned count (≤ limit), so it never appeared. API now fetches `limit + 1` to detect `hasMore`, and UI uses that flag.

## Test plan
- [ ] Search for short queries like "ab", "he" — verify highlights match only the query letters
- [ ] Search for common terms — verify 8 results show instead of 5
- [ ] Search for broad terms (e.g. "de") — verify "See all" link appears in the dropdown
- [ ] Search for diacritics (e.g. "durer" should highlight "Dürer")

🤖 Generated with [Claude Code](https://claude.com/claude-code)