### PR TITLE
Add BPH split review pages for visual QA

### DIFF
--- a/public/split-review-1.html
+++ b/public/split-review-1.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 1/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html" class="active">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c897f46c6f3cc53c85c983" data-idx="0">
+        <div class="book-header">
+          <span class="book-num">#1</span>
+          <h3>General assembly Manchester 13th November 1937 SRIA</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897f46c6f3cc53c85c983" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897f46c6f3cc53c85c983', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897f46c6f3cc53c85c983', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897f46c6f3cc53c85c983', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897f46c6f3cc53c85c983', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897f46c6f3cc53c85c983', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f46c6f3cc53c85c983%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f46c6f3cc53c85c983%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f46c6f3cc53c85c983%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f46c6f3cc53c85c983%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f46c6f3cc53c85c983%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63762881bf48c13c424d6" data-idx="1">
+        <div class="book-header">
+          <span class="book-num">#2</span>
+          <h3>Verzeichnis der Bücher zo gesamlet Johann Christian Gottfried Jahn</h3>
+          <span class="page-count">423 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63762881bf48c13c424d6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63762881bf48c13c424d6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63762881bf48c13c424d6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63762881bf48c13c424d6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63762881bf48c13c424d6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63762881bf48c13c424d6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63762881bf48c13c424d6%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63762881bf48c13c424d6%2F0169-full.jpg&w=600" alt="Page 169" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.169 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63762881bf48c13c424d6%2F0254-full.jpg&w=600" alt="Page 254" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.254 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63762881bf48c13c424d6%2F0338-full.jpg&w=600" alt="Page 338" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.338 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63762881bf48c13c424d6%2F0381-full.jpg&w=600" alt="Page 381" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.381 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8555f6c6f3cc53c853ace" data-idx="2">
+        <div class="book-header">
+          <span class="book-num">#3</span>
+          <h3>Memoria Fabriciana</h3>
+          <span class="page-count">40 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8555f6c6f3cc53c853ace" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8555f6c6f3cc53c853ace', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8555f6c6f3cc53c853ace', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8555f6c6f3cc53c853ace', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8555f6c6f3cc53c853ace', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8555f6c6f3cc53c853ace', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8555f6c6f3cc53c853ace%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8555f6c6f3cc53c853ace%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8555f6c6f3cc53c853ace%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8555f6c6f3cc53c853ace%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8555f6c6f3cc53c853ace%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82a976c6f3cc53c84c8c2" data-idx="3">
+        <div class="book-header">
+          <span class="book-num">#4</span>
+          <h3>Nodige bedenkingen op de niewe beweegingen, onlangs verwekt door den circulairen brief en andere middelen, tegen den auteur van 't boek de betoverde weereld</h3>
+          <span class="page-count">38 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82a976c6f3cc53c84c8c2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82a976c6f3cc53c84c8c2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82a976c6f3cc53c84c8c2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82a976c6f3cc53c84c8c2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82a976c6f3cc53c84c8c2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82a976c6f3cc53c84c8c2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a976c6f3cc53c84c8c2%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a976c6f3cc53c84c8c2%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a976c6f3cc53c84c8c2%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a976c6f3cc53c84c8c2%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a976c6f3cc53c84c8c2%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c849576c6f3cc53c851e42" data-idx="4">
+        <div class="book-header">
+          <span class="book-num">#5</span>
+          <h3>Die Abwege oder Irrungen und Versuchungen gutwilliger und frommer Menschen</h3>
+          <span class="page-count">329 pp</span>
+          <a href="https://sourcelibrary.org/book/69c849576c6f3cc53c851e42" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c849576c6f3cc53c851e42', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c849576c6f3cc53c851e42', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c849576c6f3cc53c851e42', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c849576c6f3cc53c851e42', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c849576c6f3cc53c851e42', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849576c6f3cc53c851e42%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849576c6f3cc53c851e42%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849576c6f3cc53c851e42%2F0197-full.jpg&w=600" alt="Page 197" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.197 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849576c6f3cc53c851e42%2F0263-full.jpg&w=600" alt="Page 263" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.263 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849576c6f3cc53c851e42%2F0296-full.jpg&w=600" alt="Page 296" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.296 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c786706a0f3d112faf992b" data-idx="5">
+        <div class="book-header">
+          <span class="book-num">#6</span>
+          <h3>Histoire de la condannation des Templiers, celle du schisme des Papes tenans le Siege en Avignon &amp; quelques Procès criminels</h3>
+          <span class="page-count">174 pp</span>
+          <a href="https://sourcelibrary.org/book/69c786706a0f3d112faf992b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c786706a0f3d112faf992b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c786706a0f3d112faf992b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c786706a0f3d112faf992b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c786706a0f3d112faf992b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c786706a0f3d112faf992b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c786706a0f3d112faf992b%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c786706a0f3d112faf992b%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c786706a0f3d112faf992b%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c786706a0f3d112faf992b%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c786706a0f3d112faf992b%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8714b6c6f3cc53c857537" data-idx="6">
+        <div class="book-header">
+          <span class="book-num">#7</span>
+          <h3>The controversy of the spirit</h3>
+          <span class="page-count">32 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8714b6c6f3cc53c857537" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8714b6c6f3cc53c857537', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8714b6c6f3cc53c857537', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8714b6c6f3cc53c857537', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8714b6c6f3cc53c857537', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8714b6c6f3cc53c857537', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8714b6c6f3cc53c857537%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8714b6c6f3cc53c857537%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8714b6c6f3cc53c857537%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8714b6c6f3cc53c857537%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8714b6c6f3cc53c857537%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ff35da9771c7163155fa" data-idx="7">
+        <div class="book-header">
+          <span class="book-num">#8</span>
+          <h3>Zeeusche nachtegael, ende des selfs dryderley gesang</h3>
+          <span class="page-count">117 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ff35da9771c7163155fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ff35da9771c7163155fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ff35da9771c7163155fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ff35da9771c7163155fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ff35da9771c7163155fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ff35da9771c7163155fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fa%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fa%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fa%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fa%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fa%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c805246c6f3cc53c845088" data-idx="8">
+        <div class="book-header">
+          <span class="book-num">#9</span>
+          <h3>Conjectura cabbalistica</h3>
+          <span class="page-count">150 pp</span>
+          <a href="https://sourcelibrary.org/book/69c805246c6f3cc53c845088" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c805246c6f3cc53c845088', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c805246c6f3cc53c845088', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c805246c6f3cc53c845088', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c805246c6f3cc53c845088', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c805246c6f3cc53c845088', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805246c6f3cc53c845088%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805246c6f3cc53c845088%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805246c6f3cc53c845088%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805246c6f3cc53c845088%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805246c6f3cc53c845088%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c738e16a0f3d112faf780c" data-idx="9">
+        <div class="book-header">
+          <span class="book-num">#10</span>
+          <h3>De vera solutione auri</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/69c738e16a0f3d112faf780c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c738e16a0f3d112faf780c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c738e16a0f3d112faf780c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c738e16a0f3d112faf780c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c738e16a0f3d112faf780c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c738e16a0f3d112faf780c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738e16a0f3d112faf780c%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738e16a0f3d112faf780c%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738e16a0f3d112faf780c%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738e16a0f3d112faf780c%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738e16a0f3d112faf780c%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c74af76a0f3d112faf828c" data-idx="10">
+        <div class="book-header">
+          <span class="book-num">#11</span>
+          <h3>Chronica, oder Beschreibung, der fürnembsten, gedenckwürdigen Thaten und Geschichten</h3>
+          <span class="page-count">226 pp</span>
+          <a href="https://sourcelibrary.org/book/69c74af76a0f3d112faf828c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c74af76a0f3d112faf828c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c74af76a0f3d112faf828c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c74af76a0f3d112faf828c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c74af76a0f3d112faf828c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c74af76a0f3d112faf828c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74af76a0f3d112faf828c%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74af76a0f3d112faf828c%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74af76a0f3d112faf828c%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74af76a0f3d112faf828c%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74af76a0f3d112faf828c%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88d006c6f3cc53c85adc9" data-idx="11">
+        <div class="book-header">
+          <span class="book-num">#12</span>
+          <h3>Het tweede boeck des auteurs, handelende van de drie principien</h3>
+          <span class="page-count">302 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88d006c6f3cc53c85adc9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88d006c6f3cc53c85adc9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88d006c6f3cc53c85adc9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88d006c6f3cc53c85adc9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88d006c6f3cc53c85adc9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88d006c6f3cc53c85adc9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d006c6f3cc53c85adc9%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d006c6f3cc53c85adc9%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d006c6f3cc53c85adc9%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d006c6f3cc53c85adc9%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d006c6f3cc53c85adc9%2F0272-full.jpg&w=600" alt="Page 272" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.272 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c774ad6a0f3d112faf9347" data-idx="12">
+        <div class="book-header">
+          <span class="book-num">#13</span>
+          <h3>Bibliotheca Fratrum Polonorum quos Unitarios vocant instructa operibus omnibus Fausti Socini, Johannis Crellii, Jonae Schlitingii &amp; Johannis Ludovici Wolzogenii</h3>
+          <span class="page-count">442 pp</span>
+          <a href="https://sourcelibrary.org/book/69c774ad6a0f3d112faf9347" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c774ad6a0f3d112faf9347', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c774ad6a0f3d112faf9347', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c774ad6a0f3d112faf9347', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c774ad6a0f3d112faf9347', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c774ad6a0f3d112faf9347', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774ad6a0f3d112faf9347%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774ad6a0f3d112faf9347%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774ad6a0f3d112faf9347%2F0265-full.jpg&w=600" alt="Page 265" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.265 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774ad6a0f3d112faf9347%2F0354-full.jpg&w=600" alt="Page 354" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.354 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774ad6a0f3d112faf9347%2F0398-full.jpg&w=600" alt="Page 398" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.398 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81c0f6c6f3cc53c849b2d" data-idx="13">
+        <div class="book-header">
+          <span class="book-num">#14</span>
+          <h3>Geistreiches Tractätlein von denen Reisen der Kinder Israel</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81c0f6c6f3cc53c849b2d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81c0f6c6f3cc53c849b2d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81c0f6c6f3cc53c849b2d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81c0f6c6f3cc53c849b2d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81c0f6c6f3cc53c849b2d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81c0f6c6f3cc53c849b2d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c0f6c6f3cc53c849b2d%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c0f6c6f3cc53c849b2d%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c0f6c6f3cc53c849b2d%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c0f6c6f3cc53c849b2d%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c0f6c6f3cc53c849b2d%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e34cc41628b775aa82" data-idx="14">
+        <div class="book-header">
+          <span class="book-num">#15</span>
+          <h3>Urim &amp; Thumim Moysis welches Aaron in Amts-Schildlein getragen Feuer-bleibendes Wasser</h3>
+          <span class="page-count">52 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e34cc41628b775aa82" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e34cc41628b775aa82', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e34cc41628b775aa82', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e34cc41628b775aa82', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e34cc41628b775aa82', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e34cc41628b775aa82', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa82%2F69c58291d4f81fc7c18b4c62.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa82%2F69c584f5d8ae1f7765f07c80.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa82%2F69c5860d93958885ee0afff1.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa82%2F69c587c0672e3e0db6081fd8.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa82%2F69c588553d7c7ef7c26006b2.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c644d6b463eebe7caaca07" data-idx="15">
+        <div class="book-header">
+          <span class="book-num">#16</span>
+          <h3>Vitulus aureus quem mundus adorat et orat oder: Ein sehr curiöses Tractätlein</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/69c644d6b463eebe7caaca07" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c644d6b463eebe7caaca07', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c644d6b463eebe7caaca07', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c644d6b463eebe7caaca07', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c644d6b463eebe7caaca07', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c644d6b463eebe7caaca07', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c644d6b463eebe7caaca07%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c644d6b463eebe7caaca07%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c644d6b463eebe7caaca07%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c644d6b463eebe7caaca07%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c644d6b463eebe7caaca07%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c831db6c6f3cc53c84ddef" data-idx="16">
+        <div class="book-header">
+          <span class="book-num">#17</span>
+          <h3>Triumph Wagen antimonii</h3>
+          <span class="page-count">353 pp</span>
+          <a href="https://sourcelibrary.org/book/69c831db6c6f3cc53c84ddef" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c831db6c6f3cc53c84ddef', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c831db6c6f3cc53c84ddef', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c831db6c6f3cc53c84ddef', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c831db6c6f3cc53c84ddef', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c831db6c6f3cc53c84ddef', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c831db6c6f3cc53c84ddef%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c831db6c6f3cc53c84ddef%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c831db6c6f3cc53c84ddef%2F0212-full.jpg&w=600" alt="Page 212" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.212 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c831db6c6f3cc53c84ddef%2F0282-full.jpg&w=600" alt="Page 282" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.282 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c831db6c6f3cc53c84ddef%2F0318-full.jpg&w=600" alt="Page 318" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.318 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee611b" data-idx="17">
+        <div class="book-header">
+          <span class="book-num">#18</span>
+          <h3>Magia adamica oder das Alterthum der Magie</h3>
+          <span class="page-count">90 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee611b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee611b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee611b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee611b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee611b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee611b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611b%2F69c53ca3bcdae20de4626975.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611b%2F69c53fc05e81357407368a60.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611b%2F69c5417dc2610db3800017b5.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611b%2F69c5431851b7ae8f6a718b6f.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611b%2F69c5443ac2610db3800017fd.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80eff6c6f3cc53c847150" data-idx="18">
+        <div class="book-header">
+          <span class="book-num">#19</span>
+          <h3>Aanwysing der heilsame politike gronden en maximen van de Republike van Holland en West-Vriesland</h3>
+          <span class="page-count">294 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80eff6c6f3cc53c847150" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80eff6c6f3cc53c847150', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80eff6c6f3cc53c847150', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80eff6c6f3cc53c847150', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80eff6c6f3cc53c847150', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80eff6c6f3cc53c847150', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80eff6c6f3cc53c847150%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80eff6c6f3cc53c847150%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80eff6c6f3cc53c847150%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80eff6c6f3cc53c847150%2F0235-full.jpg&w=600" alt="Page 235" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.235 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80eff6c6f3cc53c847150%2F0265-full.jpg&w=600" alt="Page 265" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.265 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a40992b884e4f81739da" data-idx="19">
+        <div class="book-header">
+          <span class="book-num">#20</span>
+          <h3>An antidote against atheism</h3>
+          <span class="page-count">221 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a40992b884e4f81739da" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a40992b884e4f81739da', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a40992b884e4f81739da', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a40992b884e4f81739da', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a40992b884e4f81739da', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a40992b884e4f81739da', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a40992b884e4f81739da%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a40992b884e4f81739da%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a40992b884e4f81739da%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a40992b884e4f81739da%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a40992b884e4f81739da%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7bb1725ec2ba5ccd7fa03" data-idx="20">
+        <div class="book-header">
+          <span class="book-num">#21</span>
+          <h3>Versuch einer neuen Aussicht über die mosaische Geschichte vom Falle der ersten Menschen</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7bb1725ec2ba5ccd7fa03" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7bb1725ec2ba5ccd7fa03', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7bb1725ec2ba5ccd7fa03', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7bb1725ec2ba5ccd7fa03', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7bb1725ec2ba5ccd7fa03', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7bb1725ec2ba5ccd7fa03', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1725ec2ba5ccd7fa03%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1725ec2ba5ccd7fa03%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1725ec2ba5ccd7fa03%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1725ec2ba5ccd7fa03%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1725ec2ba5ccd7fa03%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c806fd6c6f3cc53c845712" data-idx="21">
+        <div class="book-header">
+          <span class="book-num">#22</span>
+          <h3>De la vérité de la religion chrestienne</h3>
+          <span class="page-count">342 pp</span>
+          <a href="https://sourcelibrary.org/book/69c806fd6c6f3cc53c845712" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c806fd6c6f3cc53c845712', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c806fd6c6f3cc53c845712', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c806fd6c6f3cc53c845712', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c806fd6c6f3cc53c845712', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c806fd6c6f3cc53c845712', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806fd6c6f3cc53c845712%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806fd6c6f3cc53c845712%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806fd6c6f3cc53c845712%2F0205-full.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806fd6c6f3cc53c845712%2F0274-full.jpg&w=600" alt="Page 274" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.274 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806fd6c6f3cc53c845712%2F0308-full.jpg&w=600" alt="Page 308" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.308 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c868636c6f3cc53c8566cb" data-idx="22">
+        <div class="book-header">
+          <span class="book-num">#23</span>
+          <h3>Anleitung zur primitiven gabalistischen Wissenschaft</h3>
+          <span class="page-count">129 pp</span>
+          <a href="https://sourcelibrary.org/book/69c868636c6f3cc53c8566cb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c868636c6f3cc53c8566cb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c868636c6f3cc53c8566cb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c868636c6f3cc53c8566cb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c868636c6f3cc53c8566cb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c868636c6f3cc53c8566cb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c868636c6f3cc53c8566cb%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868636c6f3cc53c8566cb%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868636c6f3cc53c8566cb%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868636c6f3cc53c8566cb%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868636c6f3cc53c8566cb%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f4a26c6f3cc53c841975" data-idx="23">
+        <div class="book-header">
+          <span class="book-num">#24</span>
+          <h3>Medicina experimentalis Digbaeana, das ist: ausserlesene und bewärte Artzney-Mittel</h3>
+          <span class="page-count">140 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f4a26c6f3cc53c841975" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f4a26c6f3cc53c841975', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f4a26c6f3cc53c841975', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f4a26c6f3cc53c841975', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f4a26c6f3cc53c841975', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f4a26c6f3cc53c841975', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4a26c6f3cc53c841975%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4a26c6f3cc53c841975%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4a26c6f3cc53c841975%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4a26c6f3cc53c841975%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4a26c6f3cc53c841975%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c827256c6f3cc53c84bf47" data-idx="24">
+        <div class="book-header">
+          <span class="book-num">#25</span>
+          <h3>Von der natürlichen Philosophia und Verwandlung der Metallen in Gold und Silber</h3>
+          <span class="page-count">75 pp</span>
+          <a href="https://sourcelibrary.org/book/69c827256c6f3cc53c84bf47" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c827256c6f3cc53c84bf47', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c827256c6f3cc53c84bf47', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c827256c6f3cc53c84bf47', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c827256c6f3cc53c84bf47', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c827256c6f3cc53c84bf47', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827256c6f3cc53c84bf47%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827256c6f3cc53c84bf47%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827256c6f3cc53c84bf47%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827256c6f3cc53c84bf47%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827256c6f3cc53c84bf47%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f3fcda9771c716314e94" data-idx="25">
+        <div class="book-header">
+          <span class="book-num">#26</span>
+          <h3>Die Wolke über dem Heiligthum</h3>
+          <span class="page-count">54 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f3fcda9771c716314e94" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f3fcda9771c716314e94', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f3fcda9771c716314e94', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f3fcda9771c716314e94', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f3fcda9771c716314e94', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f3fcda9771c716314e94', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3fcda9771c716314e94%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3fcda9771c716314e94%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3fcda9771c716314e94%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3fcda9771c716314e94%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3fcda9771c716314e94%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88ae96c6f3cc53c85a7c3" data-idx="26">
+        <div class="book-header">
+          <span class="book-num">#27</span>
+          <h3>Symbola aureae mensae duodecim nationum</h3>
+          <span class="page-count">349 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88ae96c6f3cc53c85a7c3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88ae96c6f3cc53c85a7c3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88ae96c6f3cc53c85a7c3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88ae96c6f3cc53c85a7c3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88ae96c6f3cc53c85a7c3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88ae96c6f3cc53c85a7c3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ae96c6f3cc53c85a7c3%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ae96c6f3cc53c85a7c3%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ae96c6f3cc53c85a7c3%2F0209-full.jpg&w=600" alt="Page 209" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.209 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ae96c6f3cc53c85a7c3%2F0279-full.jpg&w=600" alt="Page 279" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.279 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ae96c6f3cc53c85a7c3%2F0314-full.jpg&w=600" alt="Page 314" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.314 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c832006c6f3cc53c84de5f" data-idx="27">
+        <div class="book-header">
+          <span class="book-num">#28</span>
+          <h3>Thesaurus, et armamentarium medico-chymicum</h3>
+          <span class="page-count">305 pp</span>
+          <a href="https://sourcelibrary.org/book/69c832006c6f3cc53c84de5f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c832006c6f3cc53c84de5f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c832006c6f3cc53c84de5f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c832006c6f3cc53c84de5f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c832006c6f3cc53c84de5f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c832006c6f3cc53c84de5f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832006c6f3cc53c84de5f%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832006c6f3cc53c84de5f%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832006c6f3cc53c84de5f%2F0183-full.jpg&w=600" alt="Page 183" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.183 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832006c6f3cc53c84de5f%2F0244-full.jpg&w=600" alt="Page 244" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.244 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832006c6f3cc53c84de5f%2F0275-full.jpg&w=600" alt="Page 275" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.275 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ef74fb10016c3f389fdb" data-idx="28">
+        <div class="book-header">
+          <span class="book-num">#29</span>
+          <h3>Vertrauliche Send-Schreiben, vom inneren ewigen Leben, wobey ein auserlesen Brief Jacob Böhmens, vom wahren Christen</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ef74fb10016c3f389fdb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ef74fb10016c3f389fdb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ef74fb10016c3f389fdb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ef74fb10016c3f389fdb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ef74fb10016c3f389fdb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ef74fb10016c3f389fdb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ef74fb10016c3f389fdb%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ef74fb10016c3f389fdb%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ef74fb10016c3f389fdb%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ef74fb10016c3f389fdb%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ef74fb10016c3f389fdb%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ba3925ec2ba5ccd7f930" data-idx="29">
+        <div class="book-header">
+          <span class="book-num">#30</span>
+          <h3>A free and impartial censure of the Platonick philosophy</h3>
+          <span class="page-count">70 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ba3925ec2ba5ccd7f930" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ba3925ec2ba5ccd7f930', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ba3925ec2ba5ccd7f930', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ba3925ec2ba5ccd7f930', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ba3925ec2ba5ccd7f930', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ba3925ec2ba5ccd7f930', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ba3925ec2ba5ccd7f930%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ba3925ec2ba5ccd7f930%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ba3925ec2ba5ccd7f930%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ba3925ec2ba5ccd7f930%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ba3925ec2ba5ccd7f930%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c815536c6f3cc53c84857d" data-idx="30">
+        <div class="book-header">
+          <span class="book-num">#31</span>
+          <h3>Histoire curieuse de la vie, de la conduite, &amp; des vrais sentiments du Sr. Jean de Labadie</h3>
+          <span class="page-count">196 pp</span>
+          <a href="https://sourcelibrary.org/book/69c815536c6f3cc53c84857d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c815536c6f3cc53c84857d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c815536c6f3cc53c84857d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c815536c6f3cc53c84857d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c815536c6f3cc53c84857d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c815536c6f3cc53c84857d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815536c6f3cc53c84857d%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815536c6f3cc53c84857d%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815536c6f3cc53c84857d%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815536c6f3cc53c84857d%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815536c6f3cc53c84857d%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c887ba6c6f3cc53c85a142" data-idx="31">
+        <div class="book-header">
+          <span class="book-num">#32</span>
+          <h3>The Rosicrucians. Their rites and mysteries</h3>
+          <span class="page-count">199 pp</span>
+          <a href="https://sourcelibrary.org/book/69c887ba6c6f3cc53c85a142" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c887ba6c6f3cc53c85a142', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c887ba6c6f3cc53c85a142', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c887ba6c6f3cc53c85a142', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c887ba6c6f3cc53c85a142', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c887ba6c6f3cc53c85a142', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887ba6c6f3cc53c85a142%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887ba6c6f3cc53c85a142%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887ba6c6f3cc53c85a142%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887ba6c6f3cc53c85a142%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887ba6c6f3cc53c85a142%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c884f06c6f3cc53c859a94" data-idx="32">
+        <div class="book-header">
+          <span class="book-num">#33</span>
+          <h3>De potestate ac sapiencia dei</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c884f06c6f3cc53c859a94" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c884f06c6f3cc53c859a94', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c884f06c6f3cc53c859a94', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c884f06c6f3cc53c859a94', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c884f06c6f3cc53c859a94', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c884f06c6f3cc53c859a94', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884f06c6f3cc53c859a94%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884f06c6f3cc53c859a94%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884f06c6f3cc53c859a94%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884f06c6f3cc53c859a94%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884f06c6f3cc53c859a94%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f9746c6f3cc53c8426c1" data-idx="33">
+        <div class="book-header">
+          <span class="book-num">#34</span>
+          <h3>Chymisches Laboratorium oder unter-erdische Naturkündigung</h3>
+          <span class="page-count">387 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f9746c6f3cc53c8426c1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f9746c6f3cc53c8426c1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f9746c6f3cc53c8426c1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f9746c6f3cc53c8426c1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f9746c6f3cc53c8426c1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f9746c6f3cc53c8426c1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9746c6f3cc53c8426c1%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9746c6f3cc53c8426c1%2F0155-full.jpg&w=600" alt="Page 155" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.155 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9746c6f3cc53c8426c1%2F0232-full.jpg&w=600" alt="Page 232" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.232 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9746c6f3cc53c8426c1%2F0310-full.jpg&w=600" alt="Page 310" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.310 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9746c6f3cc53c8426c1%2F0348-full.jpg&w=600" alt="Page 348" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.348 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81bf26c6f3cc53c849ad9" data-idx="34">
+        <div class="book-header">
+          <span class="book-num">#35</span>
+          <h3>Justifications de la doctrine de Madame de la Mothe-Guion</h3>
+          <span class="page-count">233 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81bf26c6f3cc53c849ad9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81bf26c6f3cc53c849ad9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81bf26c6f3cc53c849ad9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81bf26c6f3cc53c849ad9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81bf26c6f3cc53c849ad9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81bf26c6f3cc53c849ad9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81bf26c6f3cc53c849ad9%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81bf26c6f3cc53c849ad9%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81bf26c6f3cc53c849ad9%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81bf26c6f3cc53c849ad9%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81bf26c6f3cc53c849ad9%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418ae2b0edf3eaa2dd9aa" data-idx="35">
+        <div class="book-header">
+          <span class="book-num">#36</span>
+          <h3>Collection of Hebrew Texts on Cabalistic Matters (PH468)</h3>
+          <span class="page-count">142 pp</span>
+          <a href="https://sourcelibrary.org/book/hebrew-kabbalistic-collection-17th-18th-century-ms-various" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418ae2b0edf3eaa2dd9aa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418ae2b0edf3eaa2dd9aa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418ae2b0edf3eaa2dd9aa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418ae2b0edf3eaa2dd9aa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418ae2b0edf3eaa2dd9aa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ae2b0edf3eaa2dd9aa%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ae2b0edf3eaa2dd9aa%2F57.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ae2b0edf3eaa2dd9aa%2F85.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ae2b0edf3eaa2dd9aa%2F114.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ae2b0edf3eaa2dd9aa%2F128.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c804a16c6f3cc53c844f0d" data-idx="36">
+        <div class="book-header">
+          <span class="book-num">#37</span>
+          <h3>Traicté du feu et du sel</h3>
+          <span class="page-count">141 pp</span>
+          <a href="https://sourcelibrary.org/book/69c804a16c6f3cc53c844f0d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c804a16c6f3cc53c844f0d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c804a16c6f3cc53c844f0d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c804a16c6f3cc53c844f0d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c804a16c6f3cc53c844f0d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c804a16c6f3cc53c844f0d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804a16c6f3cc53c844f0d%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804a16c6f3cc53c844f0d%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804a16c6f3cc53c844f0d%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804a16c6f3cc53c844f0d%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804a16c6f3cc53c844f0d%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86fb56c6f3cc53c85713b" data-idx="37">
+        <div class="book-header">
+          <span class="book-num">#38</span>
+          <h3>Chrysopoeiae</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86fb56c6f3cc53c85713b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86fb56c6f3cc53c85713b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86fb56c6f3cc53c85713b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86fb56c6f3cc53c85713b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86fb56c6f3cc53c85713b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86fb56c6f3cc53c85713b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fb56c6f3cc53c85713b%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fb56c6f3cc53c85713b%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fb56c6f3cc53c85713b%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fb56c6f3cc53c85713b%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fb56c6f3cc53c85713b%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418de2b0edf3eaa2de13f" data-idx="38">
+        <div class="book-header">
+          <span class="book-num">#39</span>
+          <h3>Ars Magna — Ramon Llull (PH154)</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/ramon-llull-ars-magna-1686-ms-copy-llull" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418de2b0edf3eaa2de13f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418de2b0edf3eaa2de13f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418de2b0edf3eaa2de13f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418de2b0edf3eaa2de13f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418de2b0edf3eaa2de13f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418de2b0edf3eaa2de13f%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418de2b0edf3eaa2de13f%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418de2b0edf3eaa2de13f%2F35.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418de2b0edf3eaa2de13f%2F47.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418de2b0edf3eaa2de13f%2F53.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808346c6f3cc53c845c3d" data-idx="39">
+        <div class="book-header">
+          <span class="book-num">#40</span>
+          <h3>Der Geheimen Natur eröffnete Pforten und deroselben würckende Eigenschafften in Gut und Böse</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808346c6f3cc53c845c3d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808346c6f3cc53c845c3d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808346c6f3cc53c845c3d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808346c6f3cc53c845c3d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808346c6f3cc53c845c3d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808346c6f3cc53c845c3d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808346c6f3cc53c845c3d%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808346c6f3cc53c845c3d%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808346c6f3cc53c845c3d%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808346c6f3cc53c845c3d%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808346c6f3cc53c845c3d%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8581f6c6f3cc53c8541d9" data-idx="40">
+        <div class="book-header">
+          <span class="book-num">#41</span>
+          <h3>Analysis, das ist, Aufflösung der Wortrechnung Johannis Krafften</h3>
+          <span class="page-count">17 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8581f6c6f3cc53c8541d9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8581f6c6f3cc53c8541d9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8581f6c6f3cc53c8541d9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8581f6c6f3cc53c8541d9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8581f6c6f3cc53c8541d9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8581f6c6f3cc53c8541d9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8581f6c6f3cc53c8541d9%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8581f6c6f3cc53c8541d9%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8581f6c6f3cc53c8541d9%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8581f6c6f3cc53c8541d9%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8581f6c6f3cc53c8541d9%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85e206c6f3cc53c855103" data-idx="41">
+        <div class="book-header">
+          <span class="book-num">#42</span>
+          <h3>Apologie der Illuminaten</h3>
+          <span class="page-count">191 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85e206c6f3cc53c855103" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85e206c6f3cc53c855103', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85e206c6f3cc53c855103', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85e206c6f3cc53c855103', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85e206c6f3cc53c855103', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85e206c6f3cc53c855103', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e206c6f3cc53c855103%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e206c6f3cc53c855103%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e206c6f3cc53c855103%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e206c6f3cc53c855103%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e206c6f3cc53c855103%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8836b6c6f3cc53c859783" data-idx="42">
+        <div class="book-header">
+          <span class="book-num">#43</span>
+          <h3>La philosophie céleste</h3>
+          <span class="page-count">82 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8836b6c6f3cc53c859783" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8836b6c6f3cc53c859783', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8836b6c6f3cc53c859783', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8836b6c6f3cc53c859783', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8836b6c6f3cc53c859783', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8836b6c6f3cc53c859783', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8836b6c6f3cc53c859783%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8836b6c6f3cc53c859783%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8836b6c6f3cc53c859783%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8836b6c6f3cc53c859783%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8836b6c6f3cc53c859783%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="c1eb9995-02e3-45b3-afa1-c0a52fd5b646" data-idx="43">
+        <div class="book-header">
+          <span class="book-num">#44</span>
+          <h3>Geometrie practique</h3>
+          <span class="page-count">73 pp</span>
+          <a href="https://sourcelibrary.org/book/practical-geometry-bovelles" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('c1eb9995-02e3-45b3-afa1-c0a52fd5b646', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('c1eb9995-02e3-45b3-afa1-c0a52fd5b646', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('c1eb9995-02e3-45b3-afa1-c0a52fd5b646', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('c1eb9995-02e3-45b3-afa1-c0a52fd5b646', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('c1eb9995-02e3-45b3-afa1-c0a52fd5b646', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fc1eb9995-02e3-45b3-afa1-c0a52fd5b646%2F11.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fc1eb9995-02e3-45b3-afa1-c0a52fd5b646%2F33.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fc1eb9995-02e3-45b3-afa1-c0a52fd5b646%2F48.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fc1eb9995-02e3-45b3-afa1-c0a52fd5b646%2F62.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fc1eb9995-02e3-45b3-afa1-c0a52fd5b646%2F70.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f8226c6f3cc53c84228e" data-idx="44">
+        <div class="book-header">
+          <span class="book-num">#45</span>
+          <h3>Aurea Catena Homeri. Das ist: eine Beschreibung von dem Ursprung der Natur</h3>
+          <span class="page-count">267 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f8226c6f3cc53c84228e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f8226c6f3cc53c84228e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f8226c6f3cc53c84228e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f8226c6f3cc53c84228e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f8226c6f3cc53c84228e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f8226c6f3cc53c84228e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8226c6f3cc53c84228e%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8226c6f3cc53c84228e%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8226c6f3cc53c84228e%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8226c6f3cc53c84228e%2F0214-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8226c6f3cc53c84228e%2F0240-full.jpg&w=600" alt="Page 240" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.240 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a3f26c6f3cc53c85e777" data-idx="45">
+        <div class="book-header">
+          <span class="book-num">#46</span>
+          <h3>Discursus politici singulares, de informatione et coactione suditorum, ubi agitur</h3>
+          <span class="page-count">107 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a3f26c6f3cc53c85e777" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a3f26c6f3cc53c85e777', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a3f26c6f3cc53c85e777', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a3f26c6f3cc53c85e777', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a3f26c6f3cc53c85e777', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a3f26c6f3cc53c85e777', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3f26c6f3cc53c85e777%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3f26c6f3cc53c85e777%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3f26c6f3cc53c85e777%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3f26c6f3cc53c85e777%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3f26c6f3cc53c85e777%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909a2e7cf28baa1b4caec93" data-idx="46">
+        <div class="book-header">
+          <span class="book-num">#47</span>
+          <h3>De hermetica Aegyptiorum vetere et Paracelsicorum nova medicina</h3>
+          <span class="page-count">433 pp</span>
+          <a href="https://sourcelibrary.org/book/on-the-ancient-hermetic-medicine-of-the-egyptians-and-the-conring" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909a2e7cf28baa1b4caec93', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909a2e7cf28baa1b4caec93', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909a2e7cf28baa1b4caec93', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909a2e7cf28baa1b4caec93', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909a2e7cf28baa1b4caec93', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a2e7cf28baa1b4caec93%2F43.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a2e7cf28baa1b4caec93%2F173.jpg&w=600" alt="Page 173" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.173 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a2e7cf28baa1b4caec93%2F260.jpg&w=600" alt="Page 260" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.260 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a2e7cf28baa1b4caec93%2F346.jpg&w=600" alt="Page 346" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.346 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a2e7cf28baa1b4caec93%2F390.jpg&w=600" alt="Page 390" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.390 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c819d56c6f3cc53c849537" data-idx="47">
+        <div class="book-header">
+          <span class="book-num">#48</span>
+          <h3>Sopra l' amore o vero convito di Platone</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c819d56c6f3cc53c849537" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c819d56c6f3cc53c849537', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c819d56c6f3cc53c849537', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c819d56c6f3cc53c849537', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c819d56c6f3cc53c849537', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c819d56c6f3cc53c849537', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819d56c6f3cc53c849537%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819d56c6f3cc53c849537%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819d56c6f3cc53c849537%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819d56c6f3cc53c849537%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819d56c6f3cc53c849537%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fd3c6c6f3cc53c843331" data-idx="48">
+        <div class="book-header">
+          <span class="book-num">#49</span>
+          <h3>Anzeige eines bevorstehenden ausserordentlichen Erdfalls und erklärende Theorie desselben. Nebst einem Anhang betittelt an die Memphitischen Weisen</h3>
+          <span class="page-count">207 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fd3c6c6f3cc53c843331" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fd3c6c6f3cc53c843331', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fd3c6c6f3cc53c843331', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fd3c6c6f3cc53c843331', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fd3c6c6f3cc53c843331', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fd3c6c6f3cc53c843331', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd3c6c6f3cc53c843331%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd3c6c6f3cc53c843331%2F0083-full.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd3c6c6f3cc53c843331%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd3c6c6f3cc53c843331%2F0166-full.jpg&w=600" alt="Page 166" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.166 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd3c6c6f3cc53c843331%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87efc6c6f3cc53c858e17" data-idx="49">
+        <div class="book-header">
+          <span class="book-num">#50</span>
+          <h3>Mundus alter et idem</h3>
+          <span class="page-count">139 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87efc6c6f3cc53c858e17" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87efc6c6f3cc53c858e17', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87efc6c6f3cc53c858e17', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87efc6c6f3cc53c858e17', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87efc6c6f3cc53c858e17', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87efc6c6f3cc53c858e17', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87efc6c6f3cc53c858e17%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87efc6c6f3cc53c858e17%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87efc6c6f3cc53c858e17%2F0083-full.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87efc6c6f3cc53c858e17%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87efc6c6f3cc53c858e17%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2406c6f3cc53c85e3ac" data-idx="50">
+        <div class="book-header">
+          <span class="book-num">#51</span>
+          <h3>An essay on the Ancient Mysteries</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2406c6f3cc53c85e3ac" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2406c6f3cc53c85e3ac', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2406c6f3cc53c85e3ac', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2406c6f3cc53c85e3ac', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2406c6f3cc53c85e3ac', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2406c6f3cc53c85e3ac', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2406c6f3cc53c85e3ac%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2406c6f3cc53c85e3ac%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2406c6f3cc53c85e3ac%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2406c6f3cc53c85e3ac%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2406c6f3cc53c85e3ac%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c815be6c6f3cc53c848788" data-idx="51">
+        <div class="book-header">
+          <span class="book-num">#52</span>
+          <h3>W. à Brakel geregtveerdigt, in zyne betraffinge [!] aangaande de Leere en lydinge der Labadisten</h3>
+          <span class="page-count">58 pp</span>
+          <a href="https://sourcelibrary.org/book/69c815be6c6f3cc53c848788" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c815be6c6f3cc53c848788', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c815be6c6f3cc53c848788', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c815be6c6f3cc53c848788', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c815be6c6f3cc53c848788', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c815be6c6f3cc53c848788', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815be6c6f3cc53c848788%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815be6c6f3cc53c848788%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815be6c6f3cc53c848788%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815be6c6f3cc53c848788%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815be6c6f3cc53c848788%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89fe06c6f3cc53c85de54" data-idx="52">
+        <div class="book-header">
+          <span class="book-num">#53</span>
+          <h3>De physiologia christiana, et theologia gentili liber V. VI. VII. VIII. &amp; IX</h3>
+          <span class="page-count">331 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89fe06c6f3cc53c85de54" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89fe06c6f3cc53c85de54', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89fe06c6f3cc53c85de54', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89fe06c6f3cc53c85de54', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89fe06c6f3cc53c85de54', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89fe06c6f3cc53c85de54', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89fe06c6f3cc53c85de54%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89fe06c6f3cc53c85de54%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89fe06c6f3cc53c85de54%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89fe06c6f3cc53c85de54%2F0265-full.jpg&w=600" alt="Page 265" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.265 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89fe06c6f3cc53c85de54%2F0298-full.jpg&w=600" alt="Page 298" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.298 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e41a75791c06b6824e" data-idx="53">
+        <div class="book-header">
+          <span class="book-num">#54</span>
+          <h3>Verborgenheit des unsterblichen liquoris alcahest</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e41a75791c06b6824e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e41a75791c06b6824e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e41a75791c06b6824e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e41a75791c06b6824e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e41a75791c06b6824e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e41a75791c06b6824e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e41a75791c06b6824e%2F69c581e8b6680a025c4f968b.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e41a75791c06b6824e%2F69c5824bbf5fce5fd623638f.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e41a75791c06b6824e%2F69c582ee6c2069782a6e8b8a.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e41a75791c06b6824e%2F69c583344b88e3439a24e484.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e41a75791c06b6824e%2F69c5835e73dff3f63dbf6311.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898356c6f3cc53c85ca56" data-idx="54">
+        <div class="book-header">
+          <span class="book-num">#55</span>
+          <h3>An essay on the fundamental principles of operative occultism prepared by Manly P. Hall to accompany three oil paintings by Mihran K. Serailian</h3>
+          <span class="page-count">12 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898356c6f3cc53c85ca56" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898356c6f3cc53c85ca56', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898356c6f3cc53c85ca56', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898356c6f3cc53c85ca56', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898356c6f3cc53c85ca56', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898356c6f3cc53c85ca56', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898356c6f3cc53c85ca56%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898356c6f3cc53c85ca56%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898356c6f3cc53c85ca56%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898356c6f3cc53c85ca56%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898356c6f3cc53c85ca56%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c867756c6f3cc53c856582" data-idx="55">
+        <div class="book-header">
+          <span class="book-num">#56</span>
+          <h3>Amtliches Lehrgedicht der philosophischen Fakultät der Haupt- und Staats-Universität Muri</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c867756c6f3cc53c856582" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c867756c6f3cc53c856582', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c867756c6f3cc53c856582', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c867756c6f3cc53c856582', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c867756c6f3cc53c856582', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c867756c6f3cc53c856582', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c867756c6f3cc53c856582%2F2.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c867756c6f3cc53c856582%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c867756c6f3cc53c856582%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c867756c6f3cc53c856582%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867756c6f3cc53c856582%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8691a6c6f3cc53c8567f9" data-idx="56">
+        <div class="book-header">
+          <span class="book-num">#57</span>
+          <h3>The answer of the Lord</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8691a6c6f3cc53c8567f9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8691a6c6f3cc53c8567f9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8691a6c6f3cc53c8567f9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8691a6c6f3cc53c8567f9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8691a6c6f3cc53c8567f9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8691a6c6f3cc53c8567f9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8691a6c6f3cc53c8567f9%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8691a6c6f3cc53c8567f9%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8691a6c6f3cc53c8567f9%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8691a6c6f3cc53c8567f9%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8691a6c6f3cc53c8567f9%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808636c6f3cc53c845d1a" data-idx="57">
+        <div class="book-header">
+          <span class="book-num">#58</span>
+          <h3>Die Metaphysic in Connexion mit der Chemie</h3>
+          <span class="page-count">333 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808636c6f3cc53c845d1a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808636c6f3cc53c845d1a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808636c6f3cc53c845d1a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808636c6f3cc53c845d1a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808636c6f3cc53c845d1a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808636c6f3cc53c845d1a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808636c6f3cc53c845d1a%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808636c6f3cc53c845d1a%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808636c6f3cc53c845d1a%2F0200-full.jpg&w=600" alt="Page 200" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.200 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808636c6f3cc53c845d1a%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808636c6f3cc53c845d1a%2F0300-full.jpg&w=600" alt="Page 300" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.300 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="fec0b295-0795-440f-a467-434e17ba2a8e" data-idx="58">
+        <div class="book-header">
+          <span class="book-num">#59</span>
+          <h3>Asis rimonim</h3>
+          <span class="page-count">79 pp</span>
+          <a href="https://sourcelibrary.org/book/essence-of-pomegranates-gallico" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('fec0b295-0795-440f-a467-434e17ba2a8e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('fec0b295-0795-440f-a467-434e17ba2a8e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('fec0b295-0795-440f-a467-434e17ba2a8e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('fec0b295-0795-440f-a467-434e17ba2a8e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('fec0b295-0795-440f-a467-434e17ba2a8e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Ffec0b295-0795-440f-a467-434e17ba2a8e%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Ffec0b295-0795-440f-a467-434e17ba2a8e%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Ffec0b295-0795-440f-a467-434e17ba2a8e%2F47.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Ffec0b295-0795-440f-a467-434e17ba2a8e%2F63.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Ffec0b295-0795-440f-a467-434e17ba2a8e%2F71.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896f06c6f3cc53c85c69a" data-idx="59">
+        <div class="book-header">
+          <span class="book-num">#60</span>
+          <h3>A handbook of cartomancy. Fortune-telling and occult divination</h3>
+          <span class="page-count">80 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896f06c6f3cc53c85c69a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896f06c6f3cc53c85c69a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896f06c6f3cc53c85c69a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896f06c6f3cc53c85c69a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896f06c6f3cc53c85c69a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896f06c6f3cc53c85c69a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896f06c6f3cc53c85c69a%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896f06c6f3cc53c85c69a%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896f06c6f3cc53c85c69a%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896f06c6f3cc53c85c69a%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896f06c6f3cc53c85c69a%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82c706c6f3cc53c84ce29" data-idx="60">
+        <div class="book-header">
+          <span class="book-num">#61</span>
+          <h3>Essay sur le bonheur</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82c706c6f3cc53c84ce29" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82c706c6f3cc53c84ce29', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82c706c6f3cc53c84ce29', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82c706c6f3cc53c84ce29', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82c706c6f3cc53c84ce29', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82c706c6f3cc53c84ce29', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c706c6f3cc53c84ce29%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c706c6f3cc53c84ce29%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c706c6f3cc53c84ce29%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c706c6f3cc53c84ce29%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c706c6f3cc53c84ce29%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4194bddff1f043992a157" data-idx="61">
+        <div class="book-header">
+          <span class="book-num">#62</span>
+          <h3>Paradoxa, Emblemata, Aenigmata — Dionysius Andreas Freher (PH357)</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/freher-paradoxes-emblems-enigmas-18th-century-ms-freher" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4194bddff1f043992a157', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4194bddff1f043992a157', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4194bddff1f043992a157', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4194bddff1f043992a157', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4194bddff1f043992a157', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194bddff1f043992a157%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194bddff1f043992a157%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194bddff1f043992a157%2F27.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194bddff1f043992a157%2F36.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194bddff1f043992a157%2F41.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c880d16c6f3cc53c85916b" data-idx="62">
+        <div class="book-header">
+          <span class="book-num">#63</span>
+          <h3>Notes and materials for an adequate biography of the celebrated divine and theosopher, William Law</h3>
+          <span class="page-count">403 pp</span>
+          <a href="https://sourcelibrary.org/book/69c880d16c6f3cc53c85916b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c880d16c6f3cc53c85916b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c880d16c6f3cc53c85916b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c880d16c6f3cc53c85916b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c880d16c6f3cc53c85916b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c880d16c6f3cc53c85916b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880d16c6f3cc53c85916b%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880d16c6f3cc53c85916b%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880d16c6f3cc53c85916b%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880d16c6f3cc53c85916b%2F0322-full.jpg&w=600" alt="Page 322" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.322 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880d16c6f3cc53c85916b%2F0363-full.jpg&w=600" alt="Page 363" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.363 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c856196c6f3cc53c853cb1" data-idx="63">
+        <div class="book-header">
+          <span class="book-num">#64</span>
+          <h3>David Joris wt Hollandt des eertz-ketters waerachtighe historie</h3>
+          <span class="page-count">32 pp</span>
+          <a href="https://sourcelibrary.org/book/69c856196c6f3cc53c853cb1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c856196c6f3cc53c853cb1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c856196c6f3cc53c853cb1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c856196c6f3cc53c853cb1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c856196c6f3cc53c853cb1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c856196c6f3cc53c853cb1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856196c6f3cc53c853cb1%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856196c6f3cc53c853cb1%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856196c6f3cc53c853cb1%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856196c6f3cc53c853cb1%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856196c6f3cc53c853cb1%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909b0a0cf28baa1b4caf0e9" data-idx="64">
+        <div class="book-header">
+          <span class="book-num">#65</span>
+          <h3>Seht da den Menschen! Aus dem Franzoesischen: Ecce homo</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/behold-the-man-saint-martin" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909b0a0cf28baa1b4caf0e9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909b0a0cf28baa1b4caf0e9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909b0a0cf28baa1b4caf0e9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909b0a0cf28baa1b4caf0e9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909b0a0cf28baa1b4caf0e9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b0a0cf28baa1b4caf0e9%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b0a0cf28baa1b4caf0e9%2F31.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b0a0cf28baa1b4caf0e9%2F46.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b0a0cf28baa1b4caf0e9%2F62.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b0a0cf28baa1b4caf0e9%2F69.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c736b46a0f3d112faf76b0" data-idx="65">
+        <div class="book-header">
+          <span class="book-num">#66</span>
+          <h3>Jesuitici templi stupenda</h3>
+          <span class="page-count">105 pp</span>
+          <a href="https://sourcelibrary.org/book/69c736b46a0f3d112faf76b0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c736b46a0f3d112faf76b0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c736b46a0f3d112faf76b0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c736b46a0f3d112faf76b0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c736b46a0f3d112faf76b0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c736b46a0f3d112faf76b0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c736b46a0f3d112faf76b0%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c736b46a0f3d112faf76b0%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c736b46a0f3d112faf76b0%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c736b46a0f3d112faf76b0%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c736b46a0f3d112faf76b0%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c75d6d6a0f3d112faf8afb" data-idx="66">
+        <div class="book-header">
+          <span class="book-num">#67</span>
+          <h3>System der stoischen Philosophie</h3>
+          <span class="page-count">257 pp</span>
+          <a href="https://sourcelibrary.org/book/69c75d6d6a0f3d112faf8afb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c75d6d6a0f3d112faf8afb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c75d6d6a0f3d112faf8afb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c75d6d6a0f3d112faf8afb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c75d6d6a0f3d112faf8afb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c75d6d6a0f3d112faf8afb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d6d6a0f3d112faf8afb%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d6d6a0f3d112faf8afb%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d6d6a0f3d112faf8afb%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d6d6a0f3d112faf8afb%2F0206-full.jpg&w=600" alt="Page 206" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.206 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d6d6a0f3d112faf8afb%2F0231-full.jpg&w=600" alt="Page 231" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.231 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898306c6f3cc53c85ca46" data-idx="67">
+        <div class="book-header">
+          <span class="book-num">#68</span>
+          <h3>Elfin music: an anthology of English fairy poetry</h3>
+          <span class="page-count">165 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898306c6f3cc53c85ca46" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898306c6f3cc53c85ca46', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898306c6f3cc53c85ca46', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898306c6f3cc53c85ca46', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898306c6f3cc53c85ca46', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898306c6f3cc53c85ca46', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898306c6f3cc53c85ca46%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898306c6f3cc53c85ca46%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898306c6f3cc53c85ca46%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898306c6f3cc53c85ca46%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898306c6f3cc53c85ca46%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="023f2b73-5a9f-4ada-92c2-258a408d89c2" data-idx="68">
+        <div class="book-header">
+          <span class="book-num">#69</span>
+          <h3>Historia: von dem Leben und Wandel der heyligen Barlaam dess Einsidels, unnd Josaphat dess König in Indien Sohn</h3>
+          <span class="page-count">170 pp</span>
+          <a href="https://sourcelibrary.org/book/history-of-the-holy-barlaam-the-hermit-and-josaphat-the-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('023f2b73-5a9f-4ada-92c2-258a408d89c2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('023f2b73-5a9f-4ada-92c2-258a408d89c2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('023f2b73-5a9f-4ada-92c2-258a408d89c2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('023f2b73-5a9f-4ada-92c2-258a408d89c2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('023f2b73-5a9f-4ada-92c2-258a408d89c2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F023f2b73-5a9f-4ada-92c2-258a408d89c2%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F023f2b73-5a9f-4ada-92c2-258a408d89c2%2F68.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F023f2b73-5a9f-4ada-92c2-258a408d89c2%2F102.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F023f2b73-5a9f-4ada-92c2-258a408d89c2%2F136.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F023f2b73-5a9f-4ada-92c2-258a408d89c2%2F153.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c836d36c6f3cc53c84ecd6" data-idx="69">
+        <div class="book-header">
+          <span class="book-num">#70</span>
+          <h3>Hertzens-Theologie</h3>
+          <span class="page-count">646 pp</span>
+          <a href="https://sourcelibrary.org/book/69c836d36c6f3cc53c84ecd6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c836d36c6f3cc53c84ecd6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c836d36c6f3cc53c84ecd6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c836d36c6f3cc53c84ecd6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c836d36c6f3cc53c84ecd6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c836d36c6f3cc53c84ecd6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836d36c6f3cc53c84ecd6%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836d36c6f3cc53c84ecd6%2F0258-full.jpg&w=600" alt="Page 258" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.258 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836d36c6f3cc53c84ecd6%2F0388-full.jpg&w=600" alt="Page 388" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.388 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836d36c6f3cc53c84ecd6%2F0517-full.jpg&w=600" alt="Page 517" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.517 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836d36c6f3cc53c84ecd6%2F0581-full.jpg&w=600" alt="Page 581" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.581 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8993a6c6f3cc53c85cd3f" data-idx="70">
+        <div class="book-header">
+          <span class="book-num">#71</span>
+          <h3>Tyro-chymicus instructus epistola hermetica</h3>
+          <span class="page-count">40 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8993a6c6f3cc53c85cd3f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8993a6c6f3cc53c85cd3f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8993a6c6f3cc53c85cd3f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8993a6c6f3cc53c85cd3f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8993a6c6f3cc53c85cd3f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8993a6c6f3cc53c85cd3f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8993a6c6f3cc53c85cd3f%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8993a6c6f3cc53c85cd3f%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8993a6c6f3cc53c85cd3f%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8993a6c6f3cc53c85cd3f%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8993a6c6f3cc53c85cd3f%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c823356c6f3cc53c84afa2" data-idx="71">
+        <div class="book-header">
+          <span class="book-num">#72</span>
+          <h3>Epistolae</h3>
+          <span class="page-count">324 pp</span>
+          <a href="https://sourcelibrary.org/book/69c823356c6f3cc53c84afa2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c823356c6f3cc53c84afa2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c823356c6f3cc53c84afa2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c823356c6f3cc53c84afa2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c823356c6f3cc53c84afa2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c823356c6f3cc53c84afa2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823356c6f3cc53c84afa2%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823356c6f3cc53c84afa2%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823356c6f3cc53c84afa2%2F0194-full.jpg&w=600" alt="Page 194" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.194 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823356c6f3cc53c84afa2%2F0259-full.jpg&w=600" alt="Page 259" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.259 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823356c6f3cc53c84afa2%2F0292-full.jpg&w=600" alt="Page 292" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.292 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fae66c6f3cc53c842bf2" data-idx="72">
+        <div class="book-header">
+          <span class="book-num">#73</span>
+          <h3>Le Nazaréen, ou le Christianisme des Juifs, des gentils et des Mahométans</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fae66c6f3cc53c842bf2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fae66c6f3cc53c842bf2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fae66c6f3cc53c842bf2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fae66c6f3cc53c842bf2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fae66c6f3cc53c842bf2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fae66c6f3cc53c842bf2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae66c6f3cc53c842bf2%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae66c6f3cc53c842bf2%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae66c6f3cc53c842bf2%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae66c6f3cc53c842bf2%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae66c6f3cc53c842bf2%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581f0a0ac0c96f42b4018" data-idx="73">
+        <div class="book-header">
+          <span class="book-num">#74</span>
+          <h3>Een verklaringh over het getal 666</h3>
+          <span class="page-count">165 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581f0a0ac0c96f42b4018" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581f0a0ac0c96f42b4018', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581f0a0ac0c96f42b4018', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581f0a0ac0c96f42b4018', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581f0a0ac0c96f42b4018', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581f0a0ac0c96f42b4018', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581f0a0ac0c96f42b4018%2F69c584c1b63efbff22a451f6.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581f0a0ac0c96f42b4018%2F69c58b26f03859559f78ed2f.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581f0a0ac0c96f42b4018%2F69c58ef817d77c2d3926ee8d.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581f0a0ac0c96f42b4018%2F69c5921f1fd7b9ec8f993970.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581f0a0ac0c96f42b4018%2F69c593fd4bc64f343cc62575.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8231f6c6f3cc53c84af44" data-idx="74">
+        <div class="book-header">
+          <span class="book-num">#75</span>
+          <h3>Collegium physico-chymicum experimentale, oder Laboratorium chymicum</h3>
+          <span class="page-count">402 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8231f6c6f3cc53c84af44" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8231f6c6f3cc53c84af44', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8231f6c6f3cc53c84af44', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8231f6c6f3cc53c84af44', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8231f6c6f3cc53c84af44', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8231f6c6f3cc53c84af44', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8231f6c6f3cc53c84af44%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8231f6c6f3cc53c84af44%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8231f6c6f3cc53c84af44%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8231f6c6f3cc53c84af44%2F0322-full.jpg&w=600" alt="Page 322" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.322 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8231f6c6f3cc53c84af44%2F0362-full.jpg&w=600" alt="Page 362" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.362 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86fdd6c6f3cc53c85718f" data-idx="75">
+        <div class="book-header">
+          <span class="book-num">#76</span>
+          <h3>Chymische Schrifften</h3>
+          <span class="page-count">135 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86fdd6c6f3cc53c85718f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86fdd6c6f3cc53c85718f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86fdd6c6f3cc53c85718f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86fdd6c6f3cc53c85718f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86fdd6c6f3cc53c85718f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86fdd6c6f3cc53c85718f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fdd6c6f3cc53c85718f%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fdd6c6f3cc53c85718f%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fdd6c6f3cc53c85718f%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fdd6c6f3cc53c85718f%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fdd6c6f3cc53c85718f%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c883ef6c6f3cc53c85987e" data-idx="76">
+        <div class="book-header">
+          <span class="book-num">#77</span>
+          <h3>The pictorial key to the tarot. Being fragments of a secret tradition under the veil of divination</h3>
+          <span class="page-count">183 pp</span>
+          <a href="https://sourcelibrary.org/book/69c883ef6c6f3cc53c85987e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c883ef6c6f3cc53c85987e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c883ef6c6f3cc53c85987e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c883ef6c6f3cc53c85987e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c883ef6c6f3cc53c85987e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c883ef6c6f3cc53c85987e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ef6c6f3cc53c85987e%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ef6c6f3cc53c85987e%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ef6c6f3cc53c85987e%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ef6c6f3cc53c85987e%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ef6c6f3cc53c85987e%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6350d3e8cae136d149872" data-idx="77">
+        <div class="book-header">
+          <span class="book-num">#78</span>
+          <h3>Versuch ueber die kirchlichen Alterthuemer der Gnostiker</h3>
+          <span class="page-count">131 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6350d3e8cae136d149872" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6350d3e8cae136d149872', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6350d3e8cae136d149872', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6350d3e8cae136d149872', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6350d3e8cae136d149872', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6350d3e8cae136d149872', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6350d3e8cae136d149872%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6350d3e8cae136d149872%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6350d3e8cae136d149872%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6350d3e8cae136d149872%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6350d3e8cae136d149872%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83bb46c6f3cc53c84f75c" data-idx="78">
+        <div class="book-header">
+          <span class="book-num">#79</span>
+          <h3>Kurzgefasstes Leben der Madame Jeane Marie Bouviere de la Mothe-Gujon</h3>
+          <span class="page-count">144 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83bb46c6f3cc53c84f75c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83bb46c6f3cc53c84f75c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83bb46c6f3cc53c84f75c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83bb46c6f3cc53c84f75c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83bb46c6f3cc53c84f75c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83bb46c6f3cc53c84f75c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83bb46c6f3cc53c84f75c%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83bb46c6f3cc53c84f75c%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83bb46c6f3cc53c84f75c%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83bb46c6f3cc53c84f75c%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83bb46c6f3cc53c84f75c%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63768881bf48c13c424d7" data-idx="79">
+        <div class="book-header">
+          <span class="book-num">#80</span>
+          <h3>Viatorium, hoc est, de montibus planetarum</h3>
+          <span class="page-count">118 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63768881bf48c13c424d7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63768881bf48c13c424d7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63768881bf48c13c424d7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63768881bf48c13c424d7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63768881bf48c13c424d7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63768881bf48c13c424d7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63768881bf48c13c424d7%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63768881bf48c13c424d7%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63768881bf48c13c424d7%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63768881bf48c13c424d7%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63768881bf48c13c424d7%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a3ef6c6f3cc53c85e76e" data-idx="80">
+        <div class="book-header">
+          <span class="book-num">#81</span>
+          <h3>Origine de la maçonnerie adonhiramite</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a3ef6c6f3cc53c85e76e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a3ef6c6f3cc53c85e76e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a3ef6c6f3cc53c85e76e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a3ef6c6f3cc53c85e76e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a3ef6c6f3cc53c85e76e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a3ef6c6f3cc53c85e76e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3ef6c6f3cc53c85e76e%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3ef6c6f3cc53c85e76e%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3ef6c6f3cc53c85e76e%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3ef6c6f3cc53c85e76e%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a3ef6c6f3cc53c85e76e%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c800466c6f3cc53c843ec1" data-idx="81">
+        <div class="book-header">
+          <span class="book-num">#82</span>
+          <h3>Dissertatio de sobria alterius sexus frequentatione per sacros &amp; religiosos homines</h3>
+          <span class="page-count">325 pp</span>
+          <a href="https://sourcelibrary.org/book/69c800466c6f3cc53c843ec1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c800466c6f3cc53c843ec1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c800466c6f3cc53c843ec1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c800466c6f3cc53c843ec1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c800466c6f3cc53c843ec1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c800466c6f3cc53c843ec1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800466c6f3cc53c843ec1%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800466c6f3cc53c843ec1%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800466c6f3cc53c843ec1%2F0195-full.jpg&w=600" alt="Page 195" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.195 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800466c6f3cc53c843ec1%2F0260-full.jpg&w=600" alt="Page 260" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.260 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800466c6f3cc53c843ec1%2F0293-full.jpg&w=600" alt="Page 293" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.293 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c856786c6f3cc53c853e5c" data-idx="82">
+        <div class="book-header">
+          <span class="book-num">#83</span>
+          <h3>Q.D.B.V. L. Apuleium aegyptiis mysteriis ter initiatum</h3>
+          <span class="page-count">17 pp</span>
+          <a href="https://sourcelibrary.org/book/69c856786c6f3cc53c853e5c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c856786c6f3cc53c853e5c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c856786c6f3cc53c853e5c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c856786c6f3cc53c853e5c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c856786c6f3cc53c853e5c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c856786c6f3cc53c853e5c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856786c6f3cc53c853e5c%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856786c6f3cc53c853e5c%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856786c6f3cc53c853e5c%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856786c6f3cc53c853e5c%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856786c6f3cc53c853e5c%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c74c046a0f3d112faf8321" data-idx="83">
+        <div class="book-header">
+          <span class="book-num">#84</span>
+          <h3>Le Comte de Gabalis, ou entretiens sur les sciences secrètes</h3>
+          <span class="page-count">82 pp</span>
+          <a href="https://sourcelibrary.org/book/69c74c046a0f3d112faf8321" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c74c046a0f3d112faf8321', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c74c046a0f3d112faf8321', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c74c046a0f3d112faf8321', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c74c046a0f3d112faf8321', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c74c046a0f3d112faf8321', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74c046a0f3d112faf8321%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74c046a0f3d112faf8321%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74c046a0f3d112faf8321%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74c046a0f3d112faf8321%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74c046a0f3d112faf8321%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7dfcbbae5db59ace1a18f" data-idx="84">
+        <div class="book-header">
+          <span class="book-num">#85</span>
+          <h3>[Hebrew] Ein Lied aller Lieder</h3>
+          <span class="page-count">237 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7dfcbbae5db59ace1a18f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7dfcbbae5db59ace1a18f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7dfcbbae5db59ace1a18f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7dfcbbae5db59ace1a18f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7dfcbbae5db59ace1a18f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7dfcbbae5db59ace1a18f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dfcbbae5db59ace1a18f%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dfcbbae5db59ace1a18f%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dfcbbae5db59ace1a18f%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dfcbbae5db59ace1a18f%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dfcbbae5db59ace1a18f%2F0213-full.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8791d6c6f3cc53c8583f6" data-idx="85">
+        <div class="book-header">
+          <span class="book-num">#86</span>
+          <h3>Hexastichon Sebastiani Brant n[!] memorabiles evangelistarum figuras</h3>
+          <span class="page-count">24 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8791d6c6f3cc53c8583f6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8791d6c6f3cc53c8583f6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8791d6c6f3cc53c8583f6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8791d6c6f3cc53c8583f6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8791d6c6f3cc53c8583f6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8791d6c6f3cc53c8583f6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8791d6c6f3cc53c8583f6%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8791d6c6f3cc53c8583f6%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8791d6c6f3cc53c8583f6%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8791d6c6f3cc53c8583f6%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8791d6c6f3cc53c8583f6%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7faaf6c6f3cc53c842b61" data-idx="86">
+        <div class="book-header">
+          <span class="book-num">#87</span>
+          <h3>Theologia naturalis. Sive entis increati et creati</h3>
+          <span class="page-count">570 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7faaf6c6f3cc53c842b61" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7faaf6c6f3cc53c842b61', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7faaf6c6f3cc53c842b61', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7faaf6c6f3cc53c842b61', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7faaf6c6f3cc53c842b61', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7faaf6c6f3cc53c842b61', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7faaf6c6f3cc53c842b61%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7faaf6c6f3cc53c842b61%2F0228-full.jpg&w=600" alt="Page 228" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.228 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7faaf6c6f3cc53c842b61%2F0342-full.jpg&w=600" alt="Page 342" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.342 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7faaf6c6f3cc53c842b61%2F0456-full.jpg&w=600" alt="Page 456" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.456 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7faaf6c6f3cc53c842b61%2F0513-full.jpg&w=600" alt="Page 513" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.513 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c836936c6f3cc53c84ec3d" data-idx="87">
+        <div class="book-header">
+          <span class="book-num">#88</span>
+          <h3>Drey geistreiche Lehr- und Trost Büchlein</h3>
+          <span class="page-count">163 pp</span>
+          <a href="https://sourcelibrary.org/book/69c836936c6f3cc53c84ec3d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c836936c6f3cc53c84ec3d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c836936c6f3cc53c84ec3d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c836936c6f3cc53c84ec3d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c836936c6f3cc53c84ec3d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c836936c6f3cc53c84ec3d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836936c6f3cc53c84ec3d%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836936c6f3cc53c84ec3d%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836936c6f3cc53c84ec3d%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836936c6f3cc53c84ec3d%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836936c6f3cc53c84ec3d%2F0147-full.jpg&w=600" alt="Page 147" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.147 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8460b6c6f3cc53c851695" data-idx="88">
+        <div class="book-header">
+          <span class="book-num">#89</span>
+          <h3>Christliche, schriffmässige, wolgegründete Rettunge der Vier Bücher vom wahren Christenthumb</h3>
+          <span class="page-count">595 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8460b6c6f3cc53c851695" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8460b6c6f3cc53c851695', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8460b6c6f3cc53c851695', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8460b6c6f3cc53c851695', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8460b6c6f3cc53c851695', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8460b6c6f3cc53c851695', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8460b6c6f3cc53c851695%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8460b6c6f3cc53c851695%2F0238-full.jpg&w=600" alt="Page 238" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.238 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8460b6c6f3cc53c851695%2F0357-full.jpg&w=600" alt="Page 357" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.357 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8460b6c6f3cc53c851695%2F0476-full.jpg&w=600" alt="Page 476" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.476 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8460b6c6f3cc53c851695%2F0536-full.jpg&w=600" alt="Page 536" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.536 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7657f6a0f3d112faf8f43" data-idx="89">
+        <div class="book-header">
+          <span class="book-num">#90</span>
+          <h3>Adversus Catharos et Valdenses libri quinque</h3>
+          <span class="page-count">322 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7657f6a0f3d112faf8f43" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7657f6a0f3d112faf8f43', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7657f6a0f3d112faf8f43', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7657f6a0f3d112faf8f43', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7657f6a0f3d112faf8f43', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7657f6a0f3d112faf8f43', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7657f6a0f3d112faf8f43%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7657f6a0f3d112faf8f43%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7657f6a0f3d112faf8f43%2F0193-full.jpg&w=600" alt="Page 193" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.193 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7657f6a0f3d112faf8f43%2F0258-full.jpg&w=600" alt="Page 258" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.258 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7657f6a0f3d112faf8f43%2F0290-full.jpg&w=600" alt="Page 290" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.290 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87d326c6f3cc53c858adb" data-idx="90">
+        <div class="book-header">
+          <span class="book-num">#91</span>
+          <h3>Letters and communications</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87d326c6f3cc53c858adb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87d326c6f3cc53c858adb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87d326c6f3cc53c858adb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87d326c6f3cc53c858adb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87d326c6f3cc53c858adb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87d326c6f3cc53c858adb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d326c6f3cc53c858adb%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d326c6f3cc53c858adb%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d326c6f3cc53c858adb%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d326c6f3cc53c858adb%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d326c6f3cc53c858adb%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8000c6c6f3cc53c843dc1" data-idx="91">
+        <div class="book-header">
+          <span class="book-num">#92</span>
+          <h3>An hermeticall banquet, drest by a spagyricall cook</h3>
+          <span class="page-count">106 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8000c6c6f3cc53c843dc1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8000c6c6f3cc53c843dc1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8000c6c6f3cc53c843dc1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8000c6c6f3cc53c843dc1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8000c6c6f3cc53c843dc1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8000c6c6f3cc53c843dc1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8000c6c6f3cc53c843dc1%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8000c6c6f3cc53c843dc1%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8000c6c6f3cc53c843dc1%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8000c6c6f3cc53c843dc1%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8000c6c6f3cc53c843dc1%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c887946c6f3cc53c85a0d6" data-idx="92">
+        <div class="book-header">
+          <span class="book-num">#93</span>
+          <h3>Cest le romant de la rose</h3>
+          <span class="page-count">194 pp</span>
+          <a href="https://sourcelibrary.org/book/69c887946c6f3cc53c85a0d6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c887946c6f3cc53c85a0d6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c887946c6f3cc53c85a0d6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c887946c6f3cc53c85a0d6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c887946c6f3cc53c85a0d6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c887946c6f3cc53c85a0d6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887946c6f3cc53c85a0d6%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887946c6f3cc53c85a0d6%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887946c6f3cc53c85a0d6%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887946c6f3cc53c85a0d6%2F0155-full.jpg&w=600" alt="Page 155" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.155 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887946c6f3cc53c85a0d6%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c648c4b2d26d717d1aaa42" data-idx="93">
+        <div class="book-header">
+          <span class="book-num">#94</span>
+          <h3>La vraie maçonnerie d'adoption</h3>
+          <span class="page-count">78 pp</span>
+          <a href="https://sourcelibrary.org/book/69c648c4b2d26d717d1aaa42" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c648c4b2d26d717d1aaa42', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c648c4b2d26d717d1aaa42', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c648c4b2d26d717d1aaa42', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c648c4b2d26d717d1aaa42', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c648c4b2d26d717d1aaa42', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c4b2d26d717d1aaa42%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c4b2d26d717d1aaa42%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c4b2d26d717d1aaa42%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c4b2d26d717d1aaa42%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c4b2d26d717d1aaa42%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808046c6f3cc53c845b2f" data-idx="94">
+        <div class="book-header">
+          <span class="book-num">#95</span>
+          <h3>Antwort an Theodorum Candidum, wegen des Cluvers fameuse Charteque, wider den Wegweiser zur einigen Warheit</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808046c6f3cc53c845b2f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808046c6f3cc53c845b2f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808046c6f3cc53c845b2f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808046c6f3cc53c845b2f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808046c6f3cc53c845b2f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808046c6f3cc53c845b2f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808046c6f3cc53c845b2f%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808046c6f3cc53c845b2f%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808046c6f3cc53c845b2f%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808046c6f3cc53c845b2f%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808046c6f3cc53c845b2f%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69099634cf28baa1b4cae779" data-idx="95">
+        <div class="book-header">
+          <span class="book-num">#96</span>
+          <h3>[Cyrillisch:] Sleutel tot de geheimen van de natuur</h3>
+          <span class="page-count">401 pp</span>
+          <a href="https://sourcelibrary.org/book/key-to-the-secrets-of-nature-eckartshausen" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69099634cf28baa1b4cae779', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69099634cf28baa1b4cae779', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69099634cf28baa1b4cae779', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69099634cf28baa1b4cae779', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69099634cf28baa1b4cae779', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099634cf28baa1b4cae779%2F40.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099634cf28baa1b4cae779%2F160.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099634cf28baa1b4cae779%2F241.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099634cf28baa1b4cae779%2F321.jpg&w=600" alt="Page 321" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.321 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099634cf28baa1b4cae779%2F361.jpg&w=600" alt="Page 361" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.361 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c833fa6c6f3cc53c84e3bf" data-idx="96">
+        <div class="book-header">
+          <span class="book-num">#97</span>
+          <h3>Der richtigste Weg durch Christum zu Gott</h3>
+          <span class="page-count">68 pp</span>
+          <a href="https://sourcelibrary.org/book/69c833fa6c6f3cc53c84e3bf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c833fa6c6f3cc53c84e3bf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c833fa6c6f3cc53c84e3bf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c833fa6c6f3cc53c84e3bf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c833fa6c6f3cc53c84e3bf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c833fa6c6f3cc53c84e3bf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833fa6c6f3cc53c84e3bf%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833fa6c6f3cc53c84e3bf%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833fa6c6f3cc53c84e3bf%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833fa6c6f3cc53c84e3bf%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833fa6c6f3cc53c84e3bf%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c809586c6f3cc53c8460c7" data-idx="97">
+        <div class="book-header">
+          <span class="book-num">#98</span>
+          <h3>Magia, ofte de wonderlijcke, seer lustighe, ende vermaeckelijcke wercken der naturen</h3>
+          <span class="page-count">205 pp</span>
+          <a href="https://sourcelibrary.org/book/69c809586c6f3cc53c8460c7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c809586c6f3cc53c8460c7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c809586c6f3cc53c8460c7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c809586c6f3cc53c8460c7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c809586c6f3cc53c8460c7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c809586c6f3cc53c8460c7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809586c6f3cc53c8460c7%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809586c6f3cc53c8460c7%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809586c6f3cc53c8460c7%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809586c6f3cc53c8460c7%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809586c6f3cc53c8460c7%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8957d6c6f3cc53c85c345" data-idx="98">
+        <div class="book-header">
+          <span class="book-num">#99</span>
+          <h3>De Nibelungen Ring. Een studie van de innerlijke beteekenis van Richard Wagners muziek-drana</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8957d6c6f3cc53c85c345" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8957d6c6f3cc53c85c345', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8957d6c6f3cc53c85c345', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8957d6c6f3cc53c85c345', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8957d6c6f3cc53c85c345', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8957d6c6f3cc53c85c345', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8957d6c6f3cc53c85c345%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8957d6c6f3cc53c85c345%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8957d6c6f3cc53c85c345%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8957d6c6f3cc53c85c345%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8957d6c6f3cc53c85c345%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6867c580aadfee9e955eca92" data-idx="99">
+        <div class="book-header">
+          <span class="book-num">#100</span>
+          <h3>Morgenröte im Aufgang, das ist: die Wurzel oder Mutter der Philosophiae, Astrolgiae und Theologiae</h3>
+          <span class="page-count">225 pp</span>
+          <a href="https://sourcelibrary.org/book/aurora-or-day-spring-the-root-of-philosophy-astrology-and-bohme" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867c580aadfee9e955eca92', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867c580aadfee9e955eca92', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867c580aadfee9e955eca92', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867c580aadfee9e955eca92', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867c580aadfee9e955eca92', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c580aadfee9e955eca92%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c580aadfee9e955eca92%2F90.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c580aadfee9e955eca92%2F135.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c580aadfee9e955eca92%2F180.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c580aadfee9e955eca92%2F203.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html" class="active">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-10.html
+++ b/public/split-review-10.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 10/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html" class="active">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c70a25da9771c716315eb4" data-idx="900">
+        <div class="book-header">
+          <span class="book-num">#901</span>
+          <h3>Geistreiche Predigten</h3>
+          <span class="page-count">498 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70a25da9771c716315eb4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70a25da9771c716315eb4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70a25da9771c716315eb4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70a25da9771c716315eb4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70a25da9771c716315eb4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70a25da9771c716315eb4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a25da9771c716315eb4%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a25da9771c716315eb4%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a25da9771c716315eb4%2F0299-full.jpg&w=600" alt="Page 299" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.299 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a25da9771c716315eb4%2F0398-full.jpg&w=600" alt="Page 398" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.398 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a25da9771c716315eb4%2F0448-full.jpg&w=600" alt="Page 448" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.448 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71c28da9771c716316924" data-idx="901">
+        <div class="book-header">
+          <span class="book-num">#902</span>
+          <h3>De divinis attributis, quae sephirot ab Hebraeis nuncupata</h3>
+          <span class="page-count">49 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71c28da9771c716316924" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71c28da9771c716316924', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71c28da9771c716316924', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71c28da9771c716316924', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71c28da9771c716316924', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71c28da9771c716316924', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71c28da9771c716316924%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71c28da9771c716316924%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71c28da9771c716316924%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71c28da9771c716316924%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71c28da9771c716316924%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c77c826a0f3d112faf96d1" data-idx="902">
+        <div class="book-header">
+          <span class="book-num">#903</span>
+          <h3>Explication de divers monumens singuliers, qui ont rapport à la religion des plus anciens peuples</h3>
+          <span class="page-count">314 pp</span>
+          <a href="https://sourcelibrary.org/book/69c77c826a0f3d112faf96d1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c77c826a0f3d112faf96d1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c77c826a0f3d112faf96d1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c77c826a0f3d112faf96d1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c77c826a0f3d112faf96d1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c77c826a0f3d112faf96d1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c826a0f3d112faf96d1%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c826a0f3d112faf96d1%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c826a0f3d112faf96d1%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c826a0f3d112faf96d1%2F0251-full.jpg&w=600" alt="Page 251" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.251 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c826a0f3d112faf96d1%2F0283-full.jpg&w=600" alt="Page 283" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.283 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8554d6c6f3cc53c853ab0" data-idx="903">
+        <div class="book-header">
+          <span class="book-num">#904</span>
+          <h3>Fasciculus considerationum brevissimarum De diversis materiis, quarum duas priores I. De Valentinianorum Aeonibus. II. De Angelorum Nominibus, Michael, Gabriel &amp;c.</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8554d6c6f3cc53c853ab0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8554d6c6f3cc53c853ab0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8554d6c6f3cc53c853ab0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8554d6c6f3cc53c853ab0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8554d6c6f3cc53c853ab0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8554d6c6f3cc53c853ab0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8554d6c6f3cc53c853ab0%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8554d6c6f3cc53c853ab0%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8554d6c6f3cc53c853ab0%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8554d6c6f3cc53c853ab0%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8554d6c6f3cc53c853ab0%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c883136c6f3cc53c8596bc" data-idx="904">
+        <div class="book-header">
+          <span class="book-num">#905</span>
+          <h3>A.P.S. Pansophisches Laboratorium. Mss. A. II. Kommenatre zum Mss. A.I. der Elementarklasse des Vorhofes</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c883136c6f3cc53c8596bc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c883136c6f3cc53c8596bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c883136c6f3cc53c8596bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c883136c6f3cc53c8596bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c883136c6f3cc53c8596bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c883136c6f3cc53c8596bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883136c6f3cc53c8596bc%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883136c6f3cc53c8596bc%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883136c6f3cc53c8596bc%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883136c6f3cc53c8596bc%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883136c6f3cc53c8596bc%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866e36c6f3cc53c85648f" data-idx="905">
+        <div class="book-header">
+          <span class="book-num">#906</span>
+          <h3>Allgemeines Hand- und Taschenbuch oder Universalphysik</h3>
+          <span class="page-count">111 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866e36c6f3cc53c85648f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866e36c6f3cc53c85648f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866e36c6f3cc53c85648f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866e36c6f3cc53c85648f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866e36c6f3cc53c85648f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866e36c6f3cc53c85648f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866e36c6f3cc53c85648f%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866e36c6f3cc53c85648f%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866e36c6f3cc53c85648f%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866e36c6f3cc53c85648f%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866e36c6f3cc53c85648f%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8971d6c6f3cc53c85c715" data-idx="906">
+        <div class="book-header">
+          <span class="book-num">#907</span>
+          <h3>The cloud upon the sanctuary by the councillor von Eckartshausen</h3>
+          <span class="page-count">76 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8971d6c6f3cc53c85c715" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8971d6c6f3cc53c85c715', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8971d6c6f3cc53c85c715', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8971d6c6f3cc53c85c715', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8971d6c6f3cc53c85c715', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8971d6c6f3cc53c85c715', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8971d6c6f3cc53c85c715%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8971d6c6f3cc53c85c715%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8971d6c6f3cc53c85c715%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8971d6c6f3cc53c85c715%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8971d6c6f3cc53c85c715%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f1caf08a1a5ab805bff8" data-idx="907">
+        <div class="book-header">
+          <span class="book-num">#908</span>
+          <h3>De natura et constitutione philosophiae Italicae seu Pythagoricae</h3>
+          <span class="page-count">117 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f1caf08a1a5ab805bff8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f1caf08a1a5ab805bff8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f1caf08a1a5ab805bff8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f1caf08a1a5ab805bff8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f1caf08a1a5ab805bff8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f1caf08a1a5ab805bff8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff8%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff8%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff8%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff8%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff8%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c872fa6c6f3cc53c8579c3" data-idx="908">
+        <div class="book-header">
+          <span class="book-num">#909</span>
+          <h3>Dissertatio de vita et scriptis Porphyrii</h3>
+          <span class="page-count">155 pp</span>
+          <a href="https://sourcelibrary.org/book/69c872fa6c6f3cc53c8579c3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c872fa6c6f3cc53c8579c3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c872fa6c6f3cc53c8579c3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c872fa6c6f3cc53c8579c3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c872fa6c6f3cc53c8579c3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c872fa6c6f3cc53c8579c3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c872fa6c6f3cc53c8579c3%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c872fa6c6f3cc53c8579c3%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c872fa6c6f3cc53c8579c3%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c872fa6c6f3cc53c8579c3%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c872fa6c6f3cc53c8579c3%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c885416c6f3cc53c859b44" data-idx="909">
+        <div class="book-header">
+          <span class="book-num">#910</span>
+          <h3>The principles of light and color: including among other things the harmonic laws of the universe, the etherio-atomic philosophy of force, chromo chemistry, chromo therapeutics, and the general philosophy of the fine forces, together with numerous discoveries and practical applications</h3>
+          <span class="page-count">296 pp</span>
+          <a href="https://sourcelibrary.org/book/69c885416c6f3cc53c859b44" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c885416c6f3cc53c859b44', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c885416c6f3cc53c859b44', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c885416c6f3cc53c859b44', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c885416c6f3cc53c859b44', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c885416c6f3cc53c859b44', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c885416c6f3cc53c859b44%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c885416c6f3cc53c859b44%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c885416c6f3cc53c859b44%2F0178-full.jpg&w=600" alt="Page 178" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.178 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c885416c6f3cc53c859b44%2F0237-full.jpg&w=600" alt="Page 237" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.237 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c885416c6f3cc53c859b44%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418d42b0edf3eaa2ddfeb" data-idx="910">
+        <div class="book-header">
+          <span class="book-num">#911</span>
+          <h3>Collection of Rosicrucian and Alchemical Texts (PH255)</h3>
+          <span class="page-count">160 pp</span>
+          <a href="https://sourcelibrary.org/book/rosicrucian-alchemical-collection-gualdi-brumhoffer-18th-c-brumhoffer" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418d42b0edf3eaa2ddfeb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418d42b0edf3eaa2ddfeb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418d42b0edf3eaa2ddfeb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418d42b0edf3eaa2ddfeb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418d42b0edf3eaa2ddfeb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d42b0edf3eaa2ddfeb%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940533840205131!PH255_0064.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940533840205131!PH255_0096.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940533840205131!PH255_0128.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940533840205131!PH255_0144.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2816c6f3cc53c85e442" data-idx="911">
+        <div class="book-header">
+          <span class="book-num">#912</span>
+          <h3>The star lore of the Bible</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2816c6f3cc53c85e442" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2816c6f3cc53c85e442', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2816c6f3cc53c85e442', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2816c6f3cc53c85e442', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2816c6f3cc53c85e442', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2816c6f3cc53c85e442', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2816c6f3cc53c85e442%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2816c6f3cc53c85e442%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2816c6f3cc53c85e442%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2816c6f3cc53c85e442%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2816c6f3cc53c85e442%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898286c6f3cc53c85ca2f" data-idx="912">
+        <div class="book-header">
+          <span class="book-num">#913</span>
+          <h3>The light of the world and the sun</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898286c6f3cc53c85ca2f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898286c6f3cc53c85ca2f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898286c6f3cc53c85ca2f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898286c6f3cc53c85ca2f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898286c6f3cc53c85ca2f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898286c6f3cc53c85ca2f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898286c6f3cc53c85ca2f%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898286c6f3cc53c85ca2f%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898286c6f3cc53c85ca2f%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898286c6f3cc53c85ca2f%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898286c6f3cc53c85ca2f%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f2b5da9771c716314dc0" data-idx="913">
+        <div class="book-header">
+          <span class="book-num">#914</span>
+          <h3>Wiedergefundene Hieroglyphen der heiligen Schrift</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f2b5da9771c716314dc0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f2b5da9771c716314dc0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f2b5da9771c716314dc0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f2b5da9771c716314dc0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f2b5da9771c716314dc0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f2b5da9771c716314dc0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f2b5da9771c716314dc0%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f2b5da9771c716314dc0%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f2b5da9771c716314dc0%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f2b5da9771c716314dc0%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f2b5da9771c716314dc0%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7978d6a0f3d112fafa0cf" data-idx="914">
+        <div class="book-header">
+          <span class="book-num">#915</span>
+          <h3>[Greek: Kata haireseon oudoekonta ... Panarion Contra octoginta haereses opus eximium, Panaria</h3>
+          <span class="page-count">281 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7978d6a0f3d112fafa0cf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7978d6a0f3d112fafa0cf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7978d6a0f3d112fafa0cf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7978d6a0f3d112fafa0cf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7978d6a0f3d112fafa0cf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7978d6a0f3d112fafa0cf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7978d6a0f3d112fafa0cf%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7978d6a0f3d112fafa0cf%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7978d6a0f3d112fafa0cf%2F0169-full.jpg&w=600" alt="Page 169" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.169 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7978d6a0f3d112fafa0cf%2F0225-full.jpg&w=600" alt="Page 225" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.225 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7978d6a0f3d112fafa0cf%2F0253-full.jpg&w=600" alt="Page 253" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.253 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80c766c6f3cc53c846a4b" data-idx="915">
+        <div class="book-header">
+          <span class="book-num">#916</span>
+          <h3>[Biblia] Liber psalmorum Davidis regis et prophetae</h3>
+          <span class="page-count">251 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80c766c6f3cc53c846a4b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80c766c6f3cc53c846a4b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80c766c6f3cc53c846a4b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80c766c6f3cc53c846a4b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80c766c6f3cc53c846a4b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80c766c6f3cc53c846a4b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c766c6f3cc53c846a4b%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c766c6f3cc53c846a4b%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c766c6f3cc53c846a4b%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c766c6f3cc53c846a4b%2F0201-full.jpg&w=600" alt="Page 201" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.201 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c766c6f3cc53c846a4b%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86ec66c6f3cc53c856f7d" data-idx="916">
+        <div class="book-header">
+          <span class="book-num">#917</span>
+          <h3>Celestis hierarchia. Ecclesiastica hierarchia. Divina nomina. Mystica theologia. Undecim epistolae. Undecim epistolae. Epistola una</h3>
+          <span class="page-count">124 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86ec66c6f3cc53c856f7d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86ec66c6f3cc53c856f7d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86ec66c6f3cc53c856f7d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86ec66c6f3cc53c856f7d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86ec66c6f3cc53c856f7d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86ec66c6f3cc53c856f7d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86ec66c6f3cc53c856f7d%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86ec66c6f3cc53c856f7d%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86ec66c6f3cc53c856f7d%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86ec66c6f3cc53c856f7d%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86ec66c6f3cc53c856f7d%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c812da6c6f3cc53c847ce3" data-idx="917">
+        <div class="book-header">
+          <span class="book-num">#918</span>
+          <h3>Een bloemhof van allerley lieflijkheyd sonder verdriet</h3>
+          <span class="page-count">353 pp</span>
+          <a href="https://sourcelibrary.org/book/69c812da6c6f3cc53c847ce3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c812da6c6f3cc53c847ce3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c812da6c6f3cc53c847ce3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c812da6c6f3cc53c847ce3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c812da6c6f3cc53c847ce3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c812da6c6f3cc53c847ce3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812da6c6f3cc53c847ce3%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812da6c6f3cc53c847ce3%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812da6c6f3cc53c847ce3%2F0212-full.jpg&w=600" alt="Page 212" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.212 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812da6c6f3cc53c847ce3%2F0282-full.jpg&w=600" alt="Page 282" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.282 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812da6c6f3cc53c847ce3%2F0318-full.jpg&w=600" alt="Page 318" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.318 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79da6732b9d1f2b38170c" data-idx="918">
+        <div class="book-header">
+          <span class="book-num">#919</span>
+          <h3>Haligraphia, Das ist, gründliche und eigendliche Beschreibung aller Saltz Mineralien</h3>
+          <span class="page-count">190 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79da6732b9d1f2b38170c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79da6732b9d1f2b38170c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79da6732b9d1f2b38170c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79da6732b9d1f2b38170c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79da6732b9d1f2b38170c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79da6732b9d1f2b38170c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170c%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170c%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170c%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170c%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170c%2F0171-full.jpg&w=600" alt="Page 171" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.171 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909aba7cf28baa1b4caef69" data-idx="919">
+        <div class="book-header">
+          <span class="book-num">#920</span>
+          <h3>Mirabilium divinorum humanorumque volumina quattuor</h3>
+          <span class="page-count">165 pp</span>
+          <a href="https://sourcelibrary.org/book/four-volumes-of-divine-and-human-marvels-champier" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909aba7cf28baa1b4caef69', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909aba7cf28baa1b4caef69', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909aba7cf28baa1b4caef69', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909aba7cf28baa1b4caef69', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909aba7cf28baa1b4caef69', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909aba7cf28baa1b4caef69%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909aba7cf28baa1b4caef69%2F66.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909aba7cf28baa1b4caef69%2F99.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909aba7cf28baa1b4caef69%2F132.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909aba7cf28baa1b4caef69%2F149.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82bb66c6f3cc53c84cbe7" data-idx="920">
+        <div class="book-header">
+          <span class="book-num">#921</span>
+          <h3>Critica sacra, de sacri codicis partitione, editionibus variis, linguis originalibus &amp; illibata puritate fontium</h3>
+          <span class="page-count">360 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82bb66c6f3cc53c84cbe7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82bb66c6f3cc53c84cbe7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82bb66c6f3cc53c84cbe7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82bb66c6f3cc53c84cbe7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82bb66c6f3cc53c84cbe7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82bb66c6f3cc53c84cbe7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82bb66c6f3cc53c84cbe7%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82bb66c6f3cc53c84cbe7%2F0144-full.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82bb66c6f3cc53c84cbe7%2F0216-full.jpg&w=600" alt="Page 216" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.216 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82bb66c6f3cc53c84cbe7%2F0288-full.jpg&w=600" alt="Page 288" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.288 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82bb66c6f3cc53c84cbe7%2F0324-full.jpg&w=600" alt="Page 324" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.324 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c891bf6c6f3cc53c85babd" data-idx="921">
+        <div class="book-header">
+          <span class="book-num">#922</span>
+          <h3>Eine sehr erbauliche Predigt</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c891bf6c6f3cc53c85babd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c891bf6c6f3cc53c85babd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c891bf6c6f3cc53c85babd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c891bf6c6f3cc53c85babd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c891bf6c6f3cc53c85babd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c891bf6c6f3cc53c85babd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891bf6c6f3cc53c85babd%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891bf6c6f3cc53c85babd%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891bf6c6f3cc53c85babd%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891bf6c6f3cc53c85babd%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891bf6c6f3cc53c85babd%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8001e6c6f3cc53c843e20" data-idx="922">
+        <div class="book-header">
+          <span class="book-num">#923</span>
+          <h3>Linguarum duodecim characteribus differentium alphabetum</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8001e6c6f3cc53c843e20" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8001e6c6f3cc53c843e20', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8001e6c6f3cc53c843e20', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8001e6c6f3cc53c843e20', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8001e6c6f3cc53c843e20', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8001e6c6f3cc53c843e20', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001e6c6f3cc53c843e20%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001e6c6f3cc53c843e20%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001e6c6f3cc53c843e20%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001e6c6f3cc53c843e20%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001e6c6f3cc53c843e20%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7cf0825ec2ba5ccd801a2" data-idx="923">
+        <div class="book-header">
+          <span class="book-num">#924</span>
+          <h3>Ocellus Lucanus en grec et en françois avec des dissertations sur les principales questions de la metaphysique, de la physique, &amp; de la morale des anciens</h3>
+          <span class="page-count">173 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7cf0825ec2ba5ccd801a2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7cf0825ec2ba5ccd801a2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7cf0825ec2ba5ccd801a2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7cf0825ec2ba5ccd801a2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7cf0825ec2ba5ccd801a2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7cf0825ec2ba5ccd801a2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cf0825ec2ba5ccd801a2%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cf0825ec2ba5ccd801a2%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cf0825ec2ba5ccd801a2%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cf0825ec2ba5ccd801a2%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cf0825ec2ba5ccd801a2%2F0156-full.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c834b86c6f3cc53c84e624" data-idx="924">
+        <div class="book-header">
+          <span class="book-num">#925</span>
+          <h3>Historia von der Lehre, Leben und Thaten deren beyden Apostel und jünger Christi Petri und Pauli</h3>
+          <span class="page-count">298 pp</span>
+          <a href="https://sourcelibrary.org/book/69c834b86c6f3cc53c84e624" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c834b86c6f3cc53c84e624', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c834b86c6f3cc53c84e624', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c834b86c6f3cc53c84e624', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c834b86c6f3cc53c84e624', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c834b86c6f3cc53c84e624', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834b86c6f3cc53c84e624%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834b86c6f3cc53c84e624%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834b86c6f3cc53c84e624%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834b86c6f3cc53c84e624%2F0238-full.jpg&w=600" alt="Page 238" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.238 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834b86c6f3cc53c84e624%2F0268-full.jpg&w=600" alt="Page 268" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.268 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c889fe6c6f3cc53c85a50f" data-idx="925">
+        <div class="book-header">
+          <span class="book-num">#926</span>
+          <h3>Au seuil du mystère</h3>
+          <span class="page-count">151 pp</span>
+          <a href="https://sourcelibrary.org/book/69c889fe6c6f3cc53c85a50f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c889fe6c6f3cc53c85a50f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c889fe6c6f3cc53c85a50f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c889fe6c6f3cc53c85a50f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c889fe6c6f3cc53c85a50f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c889fe6c6f3cc53c85a50f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889fe6c6f3cc53c85a50f%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889fe6c6f3cc53c85a50f%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889fe6c6f3cc53c85a50f%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889fe6c6f3cc53c85a50f%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889fe6c6f3cc53c85a50f%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41886f1200e2ab53cfd31" data-idx="926">
+        <div class="book-header">
+          <span class="book-num">#927</span>
+          <h3>Alchemical Texts: Hec ars est rara (PH173)</h3>
+          <span class="page-count">57 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-texts-16th-century-latin-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41886f1200e2ab53cfd31', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41886f1200e2ab53cfd31', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41886f1200e2ab53cfd31', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41886f1200e2ab53cfd31', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41886f1200e2ab53cfd31', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41886f1200e2ab53cfd31%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41886f1200e2ab53cfd31%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41886f1200e2ab53cfd31%2F34.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41886f1200e2ab53cfd31%2F46.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41886f1200e2ab53cfd31%2F51.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c887286c6f3cc53c859fc0" data-idx="927">
+        <div class="book-header">
+          <span class="book-num">#928</span>
+          <h3>Retrato del tabernaculo de Moseh</h3>
+          <span class="page-count">54 pp</span>
+          <a href="https://sourcelibrary.org/book/69c887286c6f3cc53c859fc0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c887286c6f3cc53c859fc0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c887286c6f3cc53c859fc0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c887286c6f3cc53c859fc0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c887286c6f3cc53c859fc0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c887286c6f3cc53c859fc0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887286c6f3cc53c859fc0%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887286c6f3cc53c859fc0%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887286c6f3cc53c859fc0%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887286c6f3cc53c859fc0%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887286c6f3cc53c859fc0%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898246c6f3cc53c85ca20" data-idx="928">
+        <div class="book-header">
+          <span class="book-num">#929</span>
+          <h3>The symbolism of the alphabet</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898246c6f3cc53c85ca20" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898246c6f3cc53c85ca20', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898246c6f3cc53c85ca20', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898246c6f3cc53c85ca20', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898246c6f3cc53c85ca20', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898246c6f3cc53c85ca20', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898246c6f3cc53c85ca20%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898246c6f3cc53c85ca20%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898246c6f3cc53c85ca20%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898246c6f3cc53c85ca20%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898246c6f3cc53c85ca20%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89a7f6c6f3cc53c85d1a6" data-idx="929">
+        <div class="book-header">
+          <span class="book-num">#930</span>
+          <h3>A new analysis of chronology</h3>
+          <span class="page-count">277 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89a7f6c6f3cc53c85d1a6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89a7f6c6f3cc53c85d1a6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89a7f6c6f3cc53c85d1a6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89a7f6c6f3cc53c85d1a6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89a7f6c6f3cc53c85d1a6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89a7f6c6f3cc53c85d1a6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a7f6c6f3cc53c85d1a6%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a7f6c6f3cc53c85d1a6%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a7f6c6f3cc53c85d1a6%2F0166-full.jpg&w=600" alt="Page 166" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.166 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a7f6c6f3cc53c85d1a6%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a7f6c6f3cc53c85d1a6%2F0249-full.jpg&w=600" alt="Page 249" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.249 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8029d6c6f3cc53c8447e5" data-idx="930">
+        <div class="book-header">
+          <span class="book-num">#931</span>
+          <h3>Le palais des curieux</h3>
+          <span class="page-count">307 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8029d6c6f3cc53c8447e5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8029d6c6f3cc53c8447e5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8029d6c6f3cc53c8447e5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8029d6c6f3cc53c8447e5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8029d6c6f3cc53c8447e5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8029d6c6f3cc53c8447e5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8029d6c6f3cc53c8447e5%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8029d6c6f3cc53c8447e5%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8029d6c6f3cc53c8447e5%2F0184-full.jpg&w=600" alt="Page 184" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.184 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8029d6c6f3cc53c8447e5%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8029d6c6f3cc53c8447e5%2F0276-full.jpg&w=600" alt="Page 276" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.276 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3551fbd40b95eaa36" data-idx="931">
+        <div class="book-header">
+          <span class="book-num">#932</span>
+          <h3>Uraltes chymisches Werk</h3>
+          <span class="page-count">172 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3551fbd40b95eaa36" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3551fbd40b95eaa36', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3551fbd40b95eaa36', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3551fbd40b95eaa36', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3551fbd40b95eaa36', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3551fbd40b95eaa36', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa36%2F69c584ef10190c78235917cb.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa36%2F69c58e9bffc1193fdce25ab3.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa36%2F69c593dd50c150df94a0b7d1.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa36%2F69c5985025d6ee818d9a90e8.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa36%2F69c59b6f0030949ab62bd6c4.jpg&w=600" alt="Page 155" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.155 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81da66c6f3cc53c84a036" data-idx="932">
+        <div class="book-header">
+          <span class="book-num">#933</span>
+          <h3>Essai sur le feu sacré et sur les Vestales</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81da66c6f3cc53c84a036" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81da66c6f3cc53c84a036', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81da66c6f3cc53c84a036', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81da66c6f3cc53c84a036', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81da66c6f3cc53c84a036', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81da66c6f3cc53c84a036', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81da66c6f3cc53c84a036%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81da66c6f3cc53c84a036%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81da66c6f3cc53c84a036%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81da66c6f3cc53c84a036%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81da66c6f3cc53c84a036%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c826b06c6f3cc53c84bd9b" data-idx="933">
+        <div class="book-header">
+          <span class="book-num">#934</span>
+          <h3>Magia divina oder gründ- und deutlicher Unterricht von denen fürnehmsten caballistischen Kunst-Stücken</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c826b06c6f3cc53c84bd9b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c826b06c6f3cc53c84bd9b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c826b06c6f3cc53c84bd9b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c826b06c6f3cc53c84bd9b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c826b06c6f3cc53c84bd9b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c826b06c6f3cc53c84bd9b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826b06c6f3cc53c84bd9b%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826b06c6f3cc53c84bd9b%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826b06c6f3cc53c84bd9b%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826b06c6f3cc53c84bd9b%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826b06c6f3cc53c84bd9b%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ebe4da9771c7163148a5" data-idx="934">
+        <div class="book-header">
+          <span class="book-num">#935</span>
+          <h3>Wasserstein der Weisen. Via veritatis</h3>
+          <span class="page-count">107 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ebe4da9771c7163148a5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ebe4da9771c7163148a5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ebe4da9771c7163148a5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ebe4da9771c7163148a5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ebe4da9771c7163148a5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ebe4da9771c7163148a5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ebe4da9771c7163148a5%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ebe4da9771c7163148a5%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ebe4da9771c7163148a5%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ebe4da9771c7163148a5%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ebe4da9771c7163148a5%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897fd6c6f3cc53c85c9a2" data-idx="935">
+        <div class="book-header">
+          <span class="book-num">#936</span>
+          <h3>The stanzas of Dzyan (From The Secret Doctrine)</h3>
+          <span class="page-count">40 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897fd6c6f3cc53c85c9a2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897fd6c6f3cc53c85c9a2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897fd6c6f3cc53c85c9a2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897fd6c6f3cc53c85c9a2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897fd6c6f3cc53c85c9a2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897fd6c6f3cc53c85c9a2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897fd6c6f3cc53c85c9a2%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897fd6c6f3cc53c85c9a2%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897fd6c6f3cc53c85c9a2%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897fd6c6f3cc53c85c9a2%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897fd6c6f3cc53c85c9a2%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8905a6c6f3cc53c85b618" data-idx="936">
+        <div class="book-header">
+          <span class="book-num">#937</span>
+          <h3>Was ist Theosophie? Die theosophische Gesellschaft und ihr Zweck nebst einer kurzgefassten Übersicht der Geschichte der Internationalen theosophischen Vereinigung und der Theosophischen Gesellschaft in Deutschland</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8905a6c6f3cc53c85b618" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8905a6c6f3cc53c85b618', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8905a6c6f3cc53c85b618', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8905a6c6f3cc53c85b618', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8905a6c6f3cc53c85b618', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8905a6c6f3cc53c85b618', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8905a6c6f3cc53c85b618%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8905a6c6f3cc53c85b618%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8905a6c6f3cc53c85b618%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8905a6c6f3cc53c85b618%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8905a6c6f3cc53c85b618%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c824346c6f3cc53c84b35c" data-idx="937">
+        <div class="book-header">
+          <span class="book-num">#938</span>
+          <h3>Mysteria physico-medica, ob augustissimos suos natales</h3>
+          <span class="page-count">114 pp</span>
+          <a href="https://sourcelibrary.org/book/69c824346c6f3cc53c84b35c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c824346c6f3cc53c84b35c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c824346c6f3cc53c84b35c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c824346c6f3cc53c84b35c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c824346c6f3cc53c84b35c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c824346c6f3cc53c84b35c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824346c6f3cc53c84b35c%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824346c6f3cc53c84b35c%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824346c6f3cc53c84b35c%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824346c6f3cc53c84b35c%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824346c6f3cc53c84b35c%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896426c6f3cc53c85c4ea" data-idx="938">
+        <div class="book-header">
+          <span class="book-num">#939</span>
+          <h3>The book of black magic and of pacts. Including the rites and mysteries of goëtic theurgy, sorcery, and infernal necromancy</h3>
+          <span class="page-count">174 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896426c6f3cc53c85c4ea" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896426c6f3cc53c85c4ea', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896426c6f3cc53c85c4ea', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896426c6f3cc53c85c4ea', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896426c6f3cc53c85c4ea', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896426c6f3cc53c85c4ea', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896426c6f3cc53c85c4ea%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896426c6f3cc53c85c4ea%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896426c6f3cc53c85c4ea%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896426c6f3cc53c85c4ea%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896426c6f3cc53c85c4ea%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c881136c6f3cc53c85920f" data-idx="939">
+        <div class="book-header">
+          <span class="book-num">#940</span>
+          <h3>The one primeval language traced experimentally through ancient inscriptions in alphabetic characters of lost powers from the four continents</h3>
+          <span class="page-count">140 pp</span>
+          <a href="https://sourcelibrary.org/book/69c881136c6f3cc53c85920f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c881136c6f3cc53c85920f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c881136c6f3cc53c85920f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c881136c6f3cc53c85920f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c881136c6f3cc53c85920f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c881136c6f3cc53c85920f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881136c6f3cc53c85920f%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881136c6f3cc53c85920f%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881136c6f3cc53c85920f%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881136c6f3cc53c85920f%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881136c6f3cc53c85920f%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b6c525ec2ba5ccd7f74d" data-idx="940">
+        <div class="book-header">
+          <span class="book-num">#941</span>
+          <h3>Sur l' univers</h3>
+          <span class="page-count">103 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b6c525ec2ba5ccd7f74d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b6c525ec2ba5ccd7f74d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b6c525ec2ba5ccd7f74d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b6c525ec2ba5ccd7f74d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b6c525ec2ba5ccd7f74d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b6c525ec2ba5ccd7f74d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c525ec2ba5ccd7f74d%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c525ec2ba5ccd7f74d%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c525ec2ba5ccd7f74d%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c525ec2ba5ccd7f74d%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c525ec2ba5ccd7f74d%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86d326c6f3cc53c856cd1" data-idx="941">
+        <div class="book-header">
+          <span class="book-num">#942</span>
+          <h3>Biblia cabalistica or the cabalistic bible</h3>
+          <span class="page-count">90 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86d326c6f3cc53c856cd1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86d326c6f3cc53c856cd1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86d326c6f3cc53c856cd1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86d326c6f3cc53c856cd1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86d326c6f3cc53c856cd1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86d326c6f3cc53c856cd1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d326c6f3cc53c856cd1%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d326c6f3cc53c856cd1%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d326c6f3cc53c856cd1%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d326c6f3cc53c856cd1%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d326c6f3cc53c856cd1%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c843436c6f3cc53c850f39" data-idx="942">
+        <div class="book-header">
+          <span class="book-num">#943</span>
+          <h3>Das platonisch-hermetische Christenthum</h3>
+          <span class="page-count">665 pp</span>
+          <a href="https://sourcelibrary.org/book/69c843436c6f3cc53c850f39" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c843436c6f3cc53c850f39', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c843436c6f3cc53c850f39', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c843436c6f3cc53c850f39', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c843436c6f3cc53c850f39', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c843436c6f3cc53c850f39', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843436c6f3cc53c850f39%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843436c6f3cc53c850f39%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843436c6f3cc53c850f39%2F0399-full.jpg&w=600" alt="Page 399" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.399 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843436c6f3cc53c850f39%2F0532-full.jpg&w=600" alt="Page 532" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.532 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843436c6f3cc53c850f39%2F0599-full.jpg&w=600" alt="Page 599" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.599 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418b02b0edf3eaa2dda3a" data-idx="943">
+        <div class="book-header">
+          <span class="book-num">#944</span>
+          <h3>Les véritables clavicules de Salomon (PH296)</h3>
+          <span class="page-count">81 pp</span>
+          <a href="https://sourcelibrary.org/book/true-keys-of-solomon-french-ms-18th-c-pseudo-solomon" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418b02b0edf3eaa2dda3a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418b02b0edf3eaa2dda3a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418b02b0edf3eaa2dda3a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418b02b0edf3eaa2dda3a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418b02b0edf3eaa2dda3a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b02b0edf3eaa2dda3a%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486339105131!PH296_0032.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486339105131!PH296_0049.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486339105131!PH296_0065.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486339105131!PH296_0073.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f47c6c6f3cc53c8418d4" data-idx="944">
+        <div class="book-header">
+          <span class="book-num">#945</span>
+          <h3>Uiber die Nothwendigkeit einer physiologischer Kenntnisse bei Beurtheilung der Verbrechen</h3>
+          <span class="page-count">158 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f47c6c6f3cc53c8418d4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f47c6c6f3cc53c8418d4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f47c6c6f3cc53c8418d4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f47c6c6f3cc53c8418d4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f47c6c6f3cc53c8418d4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f47c6c6f3cc53c8418d4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f47c6c6f3cc53c8418d4%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f47c6c6f3cc53c8418d4%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f47c6c6f3cc53c8418d4%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f47c6c6f3cc53c8418d4%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f47c6c6f3cc53c8418d4%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c860616c6f3cc53c8557a7" data-idx="945">
+        <div class="book-header">
+          <span class="book-num">#946</span>
+          <h3>Merckwürdiges Leben des ... Herrn Moritz Wilhelms</h3>
+          <span class="page-count">333 pp</span>
+          <a href="https://sourcelibrary.org/book/69c860616c6f3cc53c8557a7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c860616c6f3cc53c8557a7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c860616c6f3cc53c8557a7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c860616c6f3cc53c8557a7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c860616c6f3cc53c8557a7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c860616c6f3cc53c8557a7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860616c6f3cc53c8557a7%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860616c6f3cc53c8557a7%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860616c6f3cc53c8557a7%2F0200-full.jpg&w=600" alt="Page 200" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.200 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860616c6f3cc53c8557a7%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860616c6f3cc53c8557a7%2F0300-full.jpg&w=600" alt="Page 300" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.300 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8279f6c6f3cc53c84c0d0" data-idx="946">
+        <div class="book-header">
+          <span class="book-num">#947</span>
+          <h3>Ontdeckinghe vande monstreuse dwalingen des Libertijnschen vergodeden vrygheestes Hendric Nicolaessoon</h3>
+          <span class="page-count">152 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8279f6c6f3cc53c84c0d0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8279f6c6f3cc53c84c0d0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8279f6c6f3cc53c84c0d0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8279f6c6f3cc53c84c0d0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8279f6c6f3cc53c84c0d0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8279f6c6f3cc53c84c0d0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8279f6c6f3cc53c84c0d0%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8279f6c6f3cc53c84c0d0%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8279f6c6f3cc53c84c0d0%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8279f6c6f3cc53c84c0d0%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8279f6c6f3cc53c84c0d0%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c44f3e0787282ad593d7d" data-idx="947">
+        <div class="book-header">
+          <span class="book-num">#948</span>
+          <h3>Kirchen- oder Haus-Postill, über die Sonntags- und fürnehmste Fest-Evangelien durchs gantze Jahr</h3>
+          <span class="page-count">336 pp</span>
+          <a href="https://sourcelibrary.org/book/church-or-home-postil-on-the-gospels-for-sundays-and-weigel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c44f3e0787282ad593d7d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c44f3e0787282ad593d7d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c44f3e0787282ad593d7d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c44f3e0787282ad593d7d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c44f3e0787282ad593d7d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c44f3e0787282ad593d7d%2F34.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c44f3e0787282ad593d7d%2F134.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c44f3e0787282ad593d7d%2F202.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c44f3e0787282ad593d7d%2F269.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c44f3e0787282ad593d7d%2F302.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63cd593cbf3c0fd742521" data-idx="948">
+        <div class="book-header">
+          <span class="book-num">#949</span>
+          <h3>De metallorum ortu &amp; causis</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63cd593cbf3c0fd742521" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63cd593cbf3c0fd742521', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63cd593cbf3c0fd742521', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63cd593cbf3c0fd742521', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63cd593cbf3c0fd742521', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63cd593cbf3c0fd742521', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742521%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742521%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742521%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742521%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742521%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70a26da9771c716315eb5" data-idx="949">
+        <div class="book-header">
+          <span class="book-num">#950</span>
+          <h3>Histoire critique des mystères de l'antiquité</h3>
+          <span class="page-count">126 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70a26da9771c716315eb5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70a26da9771c716315eb5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70a26da9771c716315eb5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70a26da9771c716315eb5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70a26da9771c716315eb5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70a26da9771c716315eb5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a26da9771c716315eb5%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a26da9771c716315eb5%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a26da9771c716315eb5%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a26da9771c716315eb5%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a26da9771c716315eb5%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7dccc25ec2ba5ccd8088b" data-idx="950">
+        <div class="book-header">
+          <span class="book-num">#951</span>
+          <h3>Neuer Praedicanten-Spiegel</h3>
+          <span class="page-count">57 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7dccc25ec2ba5ccd8088b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7dccc25ec2ba5ccd8088b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7dccc25ec2ba5ccd8088b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7dccc25ec2ba5ccd8088b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7dccc25ec2ba5ccd8088b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7dccc25ec2ba5ccd8088b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dccc25ec2ba5ccd8088b%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dccc25ec2ba5ccd8088b%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dccc25ec2ba5ccd8088b%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dccc25ec2ba5ccd8088b%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dccc25ec2ba5ccd8088b%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909bd18cf28baa1b4caf5a5" data-idx="951">
+        <div class="book-header">
+          <span class="book-num">#952</span>
+          <h3>La sabiduria universal del Raymundo Lullio</h3>
+          <span class="page-count">27 pp</span>
+          <a href="https://sourcelibrary.org/book/the-universal-wisdom-of-raymundo-lullio-fullana" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909bd18cf28baa1b4caf5a5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909bd18cf28baa1b4caf5a5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909bd18cf28baa1b4caf5a5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909bd18cf28baa1b4caf5a5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909bd18cf28baa1b4caf5a5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bd18cf28baa1b4caf5a5%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bd18cf28baa1b4caf5a5%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bd18cf28baa1b4caf5a5%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bd18cf28baa1b4caf5a5%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bd18cf28baa1b4caf5a5%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c854596c6f3cc53c853821" data-idx="952">
+        <div class="book-header">
+          <span class="book-num">#953</span>
+          <h3>Abbildung des verborgenen Menschen des Hertzens</h3>
+          <span class="page-count">181 pp</span>
+          <a href="https://sourcelibrary.org/book/69c854596c6f3cc53c853821" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c854596c6f3cc53c853821', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c854596c6f3cc53c853821', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c854596c6f3cc53c853821', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c854596c6f3cc53c853821', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c854596c6f3cc53c853821', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854596c6f3cc53c853821%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854596c6f3cc53c853821%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854596c6f3cc53c853821%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854596c6f3cc53c853821%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854596c6f3cc53c853821%2F0163-full.jpg&w=600" alt="Page 163" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.163 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c883ce6c6f3cc53c859844" data-idx="953">
+        <div class="book-header">
+          <span class="book-num">#954</span>
+          <h3>The Phoenix. An illustrated review of occultism and philosophy</h3>
+          <span class="page-count">76 pp</span>
+          <a href="https://sourcelibrary.org/book/69c883ce6c6f3cc53c859844" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c883ce6c6f3cc53c859844', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c883ce6c6f3cc53c859844', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c883ce6c6f3cc53c859844', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c883ce6c6f3cc53c859844', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c883ce6c6f3cc53c859844', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ce6c6f3cc53c859844%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ce6c6f3cc53c859844%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ce6c6f3cc53c859844%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ce6c6f3cc53c859844%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c883ce6c6f3cc53c859844%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c707d4da9771c716315c94" data-idx="954">
+        <div class="book-header">
+          <span class="book-num">#955</span>
+          <h3>Preclarum summi in astrorum scientia</h3>
+          <span class="page-count">71 pp</span>
+          <a href="https://sourcelibrary.org/book/69c707d4da9771c716315c94" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c707d4da9771c716315c94', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c707d4da9771c716315c94', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c707d4da9771c716315c94', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c707d4da9771c716315c94', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c707d4da9771c716315c94', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c707d4da9771c716315c94%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c707d4da9771c716315c94%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c707d4da9771c716315c94%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c707d4da9771c716315c94%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c707d4da9771c716315c94%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8149b6c6f3cc53c84826c" data-idx="955">
+        <div class="book-header">
+          <span class="book-num">#956</span>
+          <h3>Le bon usage de l'Eucharistie</h3>
+          <span class="page-count">221 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8149b6c6f3cc53c84826c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8149b6c6f3cc53c84826c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8149b6c6f3cc53c84826c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8149b6c6f3cc53c84826c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8149b6c6f3cc53c84826c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8149b6c6f3cc53c84826c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8149b6c6f3cc53c84826c%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8149b6c6f3cc53c84826c%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8149b6c6f3cc53c84826c%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8149b6c6f3cc53c84826c%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8149b6c6f3cc53c84826c%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c764b46a0f3d112faf8ed7" data-idx="956">
+        <div class="book-header">
+          <span class="book-num">#957</span>
+          <h3>Dodecadis fatidicae Maleaci a tribu Levi</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c764b46a0f3d112faf8ed7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c764b46a0f3d112faf8ed7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c764b46a0f3d112faf8ed7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c764b46a0f3d112faf8ed7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c764b46a0f3d112faf8ed7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c764b46a0f3d112faf8ed7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed7%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed7%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed7%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed7%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed7%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c895676c6f3cc53c85c30d" data-idx="957">
+        <div class="book-header">
+          <span class="book-num">#958</span>
+          <h3>The kabbala: or, the true science of light. An introduction to the philosophy and theosophy of the ancient sages</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/69c895676c6f3cc53c85c30d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c895676c6f3cc53c85c30d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c895676c6f3cc53c85c30d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c895676c6f3cc53c85c30d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c895676c6f3cc53c85c30d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c895676c6f3cc53c85c30d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895676c6f3cc53c85c30d%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895676c6f3cc53c85c30d%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895676c6f3cc53c85c30d%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895676c6f3cc53c85c30d%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895676c6f3cc53c85c30d%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8148e6c6f3cc53c84823f" data-idx="958">
+        <div class="book-header">
+          <span class="book-num">#959</span>
+          <h3>Geestelijcke tyd-kortingen, van den christelyken dagh, of Gewichtige opmerckingen der geloovigen</h3>
+          <span class="page-count">95 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8148e6c6f3cc53c84823f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8148e6c6f3cc53c84823f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8148e6c6f3cc53c84823f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8148e6c6f3cc53c84823f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8148e6c6f3cc53c84823f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8148e6c6f3cc53c84823f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8148e6c6f3cc53c84823f%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8148e6c6f3cc53c84823f%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8148e6c6f3cc53c84823f%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8148e6c6f3cc53c84823f%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8148e6c6f3cc53c84823f%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88db16c6f3cc53c85af01" data-idx="959">
+        <div class="book-header">
+          <span class="book-num">#960</span>
+          <h3>Vergleichung der alten und newen Manicheer</h3>
+          <span class="page-count">49 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88db16c6f3cc53c85af01" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88db16c6f3cc53c85af01', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88db16c6f3cc53c85af01', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88db16c6f3cc53c85af01', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88db16c6f3cc53c85af01', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88db16c6f3cc53c85af01', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88db16c6f3cc53c85af01%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88db16c6f3cc53c85af01%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88db16c6f3cc53c85af01%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88db16c6f3cc53c85af01%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88db16c6f3cc53c85af01%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7cbf125ec2ba5ccd800a4" data-idx="960">
+        <div class="book-header">
+          <span class="book-num">#961</span>
+          <h3>Summa terminorum metaphysicorum</h3>
+          <span class="page-count">33 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7cbf125ec2ba5ccd800a4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7cbf125ec2ba5ccd800a4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7cbf125ec2ba5ccd800a4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7cbf125ec2ba5ccd800a4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7cbf125ec2ba5ccd800a4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7cbf125ec2ba5ccd800a4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cbf125ec2ba5ccd800a4%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cbf125ec2ba5ccd800a4%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cbf125ec2ba5ccd800a4%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cbf125ec2ba5ccd800a4%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cbf125ec2ba5ccd800a4%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8716b6c6f3cc53c857589" data-idx="961">
+        <div class="book-header">
+          <span class="book-num">#962</span>
+          <h3>Cosmographey: das ist Beschreibung aller Laender</h3>
+          <span class="page-count">807 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8716b6c6f3cc53c857589" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8716b6c6f3cc53c857589', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8716b6c6f3cc53c857589', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8716b6c6f3cc53c857589', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8716b6c6f3cc53c857589', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8716b6c6f3cc53c857589', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8716b6c6f3cc53c857589%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8716b6c6f3cc53c857589%2F0323-full.jpg&w=600" alt="Page 323" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.323 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8716b6c6f3cc53c857589%2F0484-full.jpg&w=600" alt="Page 484" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.484 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8716b6c6f3cc53c857589%2F0646-full.jpg&w=600" alt="Page 646" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.646 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8716b6c6f3cc53c857589%2F0726-full.jpg&w=600" alt="Page 726" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.726 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8306a6c6f3cc53c84da36" data-idx="962">
+        <div class="book-header">
+          <span class="book-num">#963</span>
+          <h3>Alchymia denudata revisa et aucta oder: das bisanhero nie recht geglaubte, durch die Erfahrung nunmehro aber würklich beglaubte, und aus allen Zweifel gesetzte [...] Wunder der Natur</h3>
+          <span class="page-count">311 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8306a6c6f3cc53c84da36" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8306a6c6f3cc53c84da36', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8306a6c6f3cc53c84da36', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8306a6c6f3cc53c84da36', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8306a6c6f3cc53c84da36', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8306a6c6f3cc53c84da36', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8306a6c6f3cc53c84da36%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8306a6c6f3cc53c84da36%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8306a6c6f3cc53c84da36%2F0187-full.jpg&w=600" alt="Page 187" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.187 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8306a6c6f3cc53c84da36%2F0249-full.jpg&w=600" alt="Page 249" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.249 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8306a6c6f3cc53c84da36%2F0280-full.jpg&w=600" alt="Page 280" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.280 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87ac06c6f3cc53c85874a" data-idx="963">
+        <div class="book-header">
+          <span class="book-num">#964</span>
+          <h3>History of the Societas Rosicruciana in Anglia</h3>
+          <span class="page-count">22 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87ac06c6f3cc53c85874a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87ac06c6f3cc53c85874a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87ac06c6f3cc53c85874a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87ac06c6f3cc53c85874a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87ac06c6f3cc53c85874a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87ac06c6f3cc53c85874a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ac06c6f3cc53c85874a%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ac06c6f3cc53c85874a%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ac06c6f3cc53c85874a%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ac06c6f3cc53c85874a%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ac06c6f3cc53c85874a%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c78d3a6a0f3d112faf99bc" data-idx="964">
+        <div class="book-header">
+          <span class="book-num">#965</span>
+          <h3>Saltz-Bund Gottes... in VIII Theilen</h3>
+          <span class="page-count">417 pp</span>
+          <a href="https://sourcelibrary.org/book/69c78d3a6a0f3d112faf99bc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c78d3a6a0f3d112faf99bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c78d3a6a0f3d112faf99bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c78d3a6a0f3d112faf99bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c78d3a6a0f3d112faf99bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c78d3a6a0f3d112faf99bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c78d3a6a0f3d112faf99bc%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c78d3a6a0f3d112faf99bc%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c78d3a6a0f3d112faf99bc%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c78d3a6a0f3d112faf99bc%2F0334-full.jpg&w=600" alt="Page 334" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.334 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c78d3a6a0f3d112faf99bc%2F0375-full.jpg&w=600" alt="Page 375" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.375 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a07f6c6f3cc53c85e005" data-idx="965">
+        <div class="book-header">
+          <span class="book-num">#966</span>
+          <h3>Les images ou tableaux de platte peinture de Philostrate Lemnien Sophiste Grec</h3>
+          <span class="page-count">599 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a07f6c6f3cc53c85e005" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a07f6c6f3cc53c85e005', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a07f6c6f3cc53c85e005', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a07f6c6f3cc53c85e005', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a07f6c6f3cc53c85e005', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a07f6c6f3cc53c85e005', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07f6c6f3cc53c85e005%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07f6c6f3cc53c85e005%2F0240-full.jpg&w=600" alt="Page 240" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.240 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07f6c6f3cc53c85e005%2F0359-full.jpg&w=600" alt="Page 359" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.359 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07f6c6f3cc53c85e005%2F0479-full.jpg&w=600" alt="Page 479" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.479 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07f6c6f3cc53c85e005%2F0539-full.jpg&w=600" alt="Page 539" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.539 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b2da25ec2ba5ccd7f49a" data-idx="966">
+        <div class="book-header">
+          <span class="book-num">#967</span>
+          <h3>[Hebrew: Sefer eshel Avraham]</h3>
+          <span class="page-count">194 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b2da25ec2ba5ccd7f49a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b2da25ec2ba5ccd7f49a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b2da25ec2ba5ccd7f49a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b2da25ec2ba5ccd7f49a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b2da25ec2ba5ccd7f49a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b2da25ec2ba5ccd7f49a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b2da25ec2ba5ccd7f49a%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b2da25ec2ba5ccd7f49a%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b2da25ec2ba5ccd7f49a%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b2da25ec2ba5ccd7f49a%2F0155-full.jpg&w=600" alt="Page 155" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.155 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b2da25ec2ba5ccd7f49a%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898156c6f3cc53c85c9f8" data-idx="967">
+        <div class="book-header">
+          <span class="book-num">#968</span>
+          <h3>Hellenism and Judaism</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898156c6f3cc53c85c9f8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898156c6f3cc53c85c9f8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898156c6f3cc53c85c9f8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898156c6f3cc53c85c9f8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898156c6f3cc53c85c9f8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898156c6f3cc53c85c9f8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898156c6f3cc53c85c9f8%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898156c6f3cc53c85c9f8%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898156c6f3cc53c85c9f8%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898156c6f3cc53c85c9f8%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898156c6f3cc53c85c9f8%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c802396c6f3cc53c844634" data-idx="968">
+        <div class="book-header">
+          <span class="book-num">#969</span>
+          <h3>De magistratibus Atheniensium liber</h3>
+          <span class="page-count">112 pp</span>
+          <a href="https://sourcelibrary.org/book/69c802396c6f3cc53c844634" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c802396c6f3cc53c844634', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c802396c6f3cc53c844634', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c802396c6f3cc53c844634', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c802396c6f3cc53c844634', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c802396c6f3cc53c844634', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802396c6f3cc53c844634%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802396c6f3cc53c844634%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802396c6f3cc53c844634%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802396c6f3cc53c844634%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802396c6f3cc53c844634%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c646465dec4c2fa41d36ac" data-idx="969">
+        <div class="book-header">
+          <span class="book-num">#970</span>
+          <h3>Vortrab der Leichbestattung des unseligen Pragischen Friedenschlusses</h3>
+          <span class="page-count">75 pp</span>
+          <a href="https://sourcelibrary.org/book/69c646465dec4c2fa41d36ac" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c646465dec4c2fa41d36ac', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c646465dec4c2fa41d36ac', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c646465dec4c2fa41d36ac', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c646465dec4c2fa41d36ac', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c646465dec4c2fa41d36ac', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c646465dec4c2fa41d36ac%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c646465dec4c2fa41d36ac%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c646465dec4c2fa41d36ac%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c646465dec4c2fa41d36ac%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c646465dec4c2fa41d36ac%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c852056c6f3cc53c85329c" data-idx="970">
+        <div class="book-header">
+          <span class="book-num">#971</span>
+          <h3>Neu-vermehrter Helden-Schatz</h3>
+          <span class="page-count">222 pp</span>
+          <a href="https://sourcelibrary.org/book/69c852056c6f3cc53c85329c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c852056c6f3cc53c85329c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c852056c6f3cc53c85329c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c852056c6f3cc53c85329c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c852056c6f3cc53c85329c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c852056c6f3cc53c85329c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852056c6f3cc53c85329c%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852056c6f3cc53c85329c%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852056c6f3cc53c85329c%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852056c6f3cc53c85329c%2F0178-full.jpg&w=600" alt="Page 178" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.178 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852056c6f3cc53c85329c%2F0200-full.jpg&w=600" alt="Page 200" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.200 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c77c816a0f3d112faf96d0" data-idx="971">
+        <div class="book-header">
+          <span class="book-num">#972</span>
+          <h3>Über Heilige Schrift, Judenthum, Recht der höchsten Gewalt in geistlichen Dingen, und Freyheit zu philosophiren</h3>
+          <span class="page-count">247 pp</span>
+          <a href="https://sourcelibrary.org/book/69c77c816a0f3d112faf96d0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c77c816a0f3d112faf96d0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c77c816a0f3d112faf96d0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c77c816a0f3d112faf96d0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c77c816a0f3d112faf96d0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c77c816a0f3d112faf96d0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c816a0f3d112faf96d0%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c816a0f3d112faf96d0%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c816a0f3d112faf96d0%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c816a0f3d112faf96d0%2F0198-full.jpg&w=600" alt="Page 198" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.198 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c816a0f3d112faf96d0%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84cb96c6f3cc53c8524fe" data-idx="972">
+        <div class="book-header">
+          <span class="book-num">#973</span>
+          <h3>Teutsch-evangelisches Judenthum</h3>
+          <span class="page-count">171 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84cb96c6f3cc53c8524fe" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84cb96c6f3cc53c8524fe', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84cb96c6f3cc53c8524fe', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84cb96c6f3cc53c8524fe', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84cb96c6f3cc53c8524fe', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84cb96c6f3cc53c8524fe', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb96c6f3cc53c8524fe%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb96c6f3cc53c8524fe%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb96c6f3cc53c8524fe%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb96c6f3cc53c8524fe%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb96c6f3cc53c8524fe%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c893bf6c6f3cc53c85bf65" data-idx="973">
+        <div class="book-header">
+          <span class="book-num">#974</span>
+          <h3>The answer of the Lord to the powers of darkness</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/69c893bf6c6f3cc53c85bf65" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c893bf6c6f3cc53c85bf65', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c893bf6c6f3cc53c85bf65', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c893bf6c6f3cc53c85bf65', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c893bf6c6f3cc53c85bf65', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c893bf6c6f3cc53c85bf65', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893bf6c6f3cc53c85bf65%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893bf6c6f3cc53c85bf65%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893bf6c6f3cc53c85bf65%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893bf6c6f3cc53c85bf65%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893bf6c6f3cc53c85bf65%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7dcca25ec2ba5ccd80881" data-idx="974">
+        <div class="book-header">
+          <span class="book-num">#975</span>
+          <h3>De triplici disciplina</h3>
+          <span class="page-count">291 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7dcca25ec2ba5ccd80881" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7dcca25ec2ba5ccd80881', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7dcca25ec2ba5ccd80881', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7dcca25ec2ba5ccd80881', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7dcca25ec2ba5ccd80881', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7dcca25ec2ba5ccd80881', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dcca25ec2ba5ccd80881%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dcca25ec2ba5ccd80881%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dcca25ec2ba5ccd80881%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dcca25ec2ba5ccd80881%2F0233-full.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dcca25ec2ba5ccd80881%2F0262-full.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8787d6c6f3cc53c85825a" data-idx="975">
+        <div class="book-header">
+          <span class="book-num">#976</span>
+          <h3>Geistliche Kurtzweil</h3>
+          <span class="page-count">90 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8787d6c6f3cc53c85825a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8787d6c6f3cc53c85825a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8787d6c6f3cc53c85825a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8787d6c6f3cc53c85825a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8787d6c6f3cc53c85825a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8787d6c6f3cc53c85825a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8787d6c6f3cc53c85825a%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8787d6c6f3cc53c85825a%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8787d6c6f3cc53c85825a%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8787d6c6f3cc53c85825a%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8787d6c6f3cc53c85825a%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c894b76c6f3cc53c85c180" data-idx="976">
+        <div class="book-header">
+          <span class="book-num">#977</span>
+          <h3>Metropolitan college transactions 1962</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c894b76c6f3cc53c85c180" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c894b76c6f3cc53c85c180', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c894b76c6f3cc53c85c180', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c894b76c6f3cc53c85c180', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c894b76c6f3cc53c85c180', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c894b76c6f3cc53c85c180', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894b76c6f3cc53c85c180%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894b76c6f3cc53c85c180%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894b76c6f3cc53c85c180%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894b76c6f3cc53c85c180%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894b76c6f3cc53c85c180%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82ecd6c6f3cc53c84d6f7" data-idx="977">
+        <div class="book-header">
+          <span class="book-num">#978</span>
+          <h3>An appeal to all that doubt or disbelieve the truths of the Gospel</h3>
+          <span class="page-count">177 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82ecd6c6f3cc53c84d6f7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82ecd6c6f3cc53c84d6f7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82ecd6c6f3cc53c84d6f7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82ecd6c6f3cc53c84d6f7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82ecd6c6f3cc53c84d6f7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82ecd6c6f3cc53c84d6f7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ecd6c6f3cc53c84d6f7%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ecd6c6f3cc53c84d6f7%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ecd6c6f3cc53c84d6f7%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ecd6c6f3cc53c84d6f7%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ecd6c6f3cc53c84d6f7%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8801f6c6f3cc53c859009" data-idx="978">
+        <div class="book-header">
+          <span class="book-num">#979</span>
+          <h3>Mystischer Glockenschlag. Drei mystische Traktätlein für alle Suchenden eines neuen Lebens in einer neuen Zeit!</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8801f6c6f3cc53c859009" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8801f6c6f3cc53c859009', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8801f6c6f3cc53c859009', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8801f6c6f3cc53c859009', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8801f6c6f3cc53c859009', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8801f6c6f3cc53c859009', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8801f6c6f3cc53c859009%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8801f6c6f3cc53c859009%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8801f6c6f3cc53c859009%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8801f6c6f3cc53c859009%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8801f6c6f3cc53c859009%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ffa56c6f3cc53c843c5e" data-idx="979">
+        <div class="book-header">
+          <span class="book-num">#980</span>
+          <h3>Hymns to the Supreme Being: an imitation of the eastern songs</h3>
+          <span class="page-count">95 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ffa56c6f3cc53c843c5e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ffa56c6f3cc53c843c5e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ffa56c6f3cc53c843c5e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ffa56c6f3cc53c843c5e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ffa56c6f3cc53c843c5e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ffa56c6f3cc53c843c5e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffa56c6f3cc53c843c5e%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffa56c6f3cc53c843c5e%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffa56c6f3cc53c843c5e%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffa56c6f3cc53c843c5e%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffa56c6f3cc53c843c5e%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80d8a6c6f3cc53c846d5d" data-idx="980">
+        <div class="book-header">
+          <span class="book-num">#981</span>
+          <h3>Acta B. Raymundi Lulli Majoricensis</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80d8a6c6f3cc53c846d5d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80d8a6c6f3cc53c846d5d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80d8a6c6f3cc53c846d5d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80d8a6c6f3cc53c846d5d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80d8a6c6f3cc53c846d5d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80d8a6c6f3cc53c846d5d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80d8a6c6f3cc53c846d5d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80d8a6c6f3cc53c846d5d%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80d8a6c6f3cc53c846d5d%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80d8a6c6f3cc53c846d5d%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80d8a6c6f3cc53c846d5d%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909afeecf28baa1b4caf0b5" data-idx="981">
+        <div class="book-header">
+          <span class="book-num">#982</span>
+          <h3>The strange effects of faith. Fourth part</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/the-strange-effects-of-faith-fourth-part-southcott" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909afeecf28baa1b4caf0b5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909afeecf28baa1b4caf0b5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909afeecf28baa1b4caf0b5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909afeecf28baa1b4caf0b5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909afeecf28baa1b4caf0b5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909afeecf28baa1b4caf0b5%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909afeecf28baa1b4caf0b5%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909afeecf28baa1b4caf0b5%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909afeecf28baa1b4caf0b5%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909afeecf28baa1b4caf0b5%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83d976c6f3cc53c84fcc6" data-idx="982">
+        <div class="book-header">
+          <span class="book-num">#983</span>
+          <h3>De leere van Jfr. Antonette Bourignon verdedigd</h3>
+          <span class="page-count">273 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83d976c6f3cc53c84fcc6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83d976c6f3cc53c84fcc6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83d976c6f3cc53c84fcc6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83d976c6f3cc53c84fcc6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83d976c6f3cc53c84fcc6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83d976c6f3cc53c84fcc6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d976c6f3cc53c84fcc6%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d976c6f3cc53c84fcc6%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d976c6f3cc53c84fcc6%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d976c6f3cc53c84fcc6%2F0218-full.jpg&w=600" alt="Page 218" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.218 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d976c6f3cc53c84fcc6%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909caa0cf28baa1b4cafc87" data-idx="983">
+        <div class="book-header">
+          <span class="book-num">#984</span>
+          <h3>[Nosce te ipsum]</h3>
+          <span class="page-count">27 pp</span>
+          <a href="https://sourcelibrary.org/book/know-thyself-reger-von-ehrenhart" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909caa0cf28baa1b4cafc87', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909caa0cf28baa1b4cafc87', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909caa0cf28baa1b4cafc87', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909caa0cf28baa1b4cafc87', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909caa0cf28baa1b4cafc87', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909caa0cf28baa1b4cafc87%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909caa0cf28baa1b4cafc87%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909caa0cf28baa1b4cafc87%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909caa0cf28baa1b4cafc87%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909caa0cf28baa1b4cafc87%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c842a76c6f3cc53c850d2e" data-idx="984">
+        <div class="book-header">
+          <span class="book-num">#985</span>
+          <h3>Abhandlung über die allgemeine Zusammenkunft der Freymaurer, bei den Gesundbrunnen in Wilhelmsbad</h3>
+          <span class="page-count">143 pp</span>
+          <a href="https://sourcelibrary.org/book/69c842a76c6f3cc53c850d2e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c842a76c6f3cc53c850d2e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c842a76c6f3cc53c850d2e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c842a76c6f3cc53c850d2e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c842a76c6f3cc53c850d2e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c842a76c6f3cc53c850d2e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842a76c6f3cc53c850d2e%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842a76c6f3cc53c850d2e%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842a76c6f3cc53c850d2e%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842a76c6f3cc53c850d2e%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842a76c6f3cc53c850d2e%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909d208cf28baa1b4cb003b" data-idx="985">
+        <div class="book-header">
+          <span class="book-num">#986</span>
+          <h3>Philaletha illustratus</h3>
+          <span class="page-count">99 pp</span>
+          <a href="https://sourcelibrary.org/book/the-lover-of-truth-illustrated-faust" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909d208cf28baa1b4cb003b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909d208cf28baa1b4cb003b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909d208cf28baa1b4cb003b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909d208cf28baa1b4cb003b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909d208cf28baa1b4cb003b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d208cf28baa1b4cb003b%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d208cf28baa1b4cb003b%2F40.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d208cf28baa1b4cb003b%2F59.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d208cf28baa1b4cb003b%2F79.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d208cf28baa1b4cb003b%2F89.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79da6732b9d1f2b38170b" data-idx="986">
+        <div class="book-header">
+          <span class="book-num">#987</span>
+          <h3>De perenni philosophia</h3>
+          <span class="page-count">386 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79da6732b9d1f2b38170b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79da6732b9d1f2b38170b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79da6732b9d1f2b38170b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79da6732b9d1f2b38170b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79da6732b9d1f2b38170b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79da6732b9d1f2b38170b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170b%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170b%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170b%2F0232-full.jpg&w=600" alt="Page 232" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.232 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170b%2F0309-full.jpg&w=600" alt="Page 309" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.309 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79da6732b9d1f2b38170b%2F0347-full.jpg&w=600" alt="Page 347" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.347 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c841f56c6f3cc53c850b5c" data-idx="987">
+        <div class="book-header">
+          <span class="book-num">#988</span>
+          <h3>Versuch über die Freymaurerey</h3>
+          <span class="page-count">159 pp</span>
+          <a href="https://sourcelibrary.org/book/69c841f56c6f3cc53c850b5c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c841f56c6f3cc53c850b5c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c841f56c6f3cc53c850b5c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c841f56c6f3cc53c850b5c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c841f56c6f3cc53c850b5c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c841f56c6f3cc53c850b5c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841f56c6f3cc53c850b5c%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841f56c6f3cc53c850b5c%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841f56c6f3cc53c850b5c%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841f56c6f3cc53c850b5c%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841f56c6f3cc53c850b5c%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee610b" data-idx="988">
+        <div class="book-header">
+          <span class="book-num">#989</span>
+          <h3>Philaletha illustratus</h3>
+          <span class="page-count">106 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee610b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee610b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee610b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee610b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee610b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee610b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee610b%2F69c5597c4117bb520183356f.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee610b%2F69c55e05d5ad149700658ad3.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee610b%2F69c560e7abbc9e679eff8344.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee610b%2F69c5637e9d070b7e0e1ead46.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee610b%2F69c5649e958bbce0a405ba8a.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c819256c6f3cc53c8492d0" data-idx="989">
+        <div class="book-header">
+          <span class="book-num">#990</span>
+          <h3>In quatuor Evangelia enarationes luculentissimae</h3>
+          <span class="page-count">511 pp</span>
+          <a href="https://sourcelibrary.org/book/69c819256c6f3cc53c8492d0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c819256c6f3cc53c8492d0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c819256c6f3cc53c8492d0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c819256c6f3cc53c8492d0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c819256c6f3cc53c8492d0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c819256c6f3cc53c8492d0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819256c6f3cc53c8492d0%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819256c6f3cc53c8492d0%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819256c6f3cc53c8492d0%2F0307-full.jpg&w=600" alt="Page 307" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.307 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819256c6f3cc53c8492d0%2F0409-full.jpg&w=600" alt="Page 409" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.409 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819256c6f3cc53c8492d0%2F0460-full.jpg&w=600" alt="Page 460" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.460 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898166c6f3cc53c85c9f9" data-idx="990">
+        <div class="book-header">
+          <span class="book-num">#991</span>
+          <h3>Cabul, or Christian symbolism in freemasonry</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898166c6f3cc53c85c9f9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898166c6f3cc53c85c9f9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898166c6f3cc53c85c9f9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898166c6f3cc53c85c9f9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898166c6f3cc53c85c9f9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898166c6f3cc53c85c9f9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898166c6f3cc53c85c9f9%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898166c6f3cc53c85c9f9%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898166c6f3cc53c85c9f9%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898166c6f3cc53c85c9f9%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898166c6f3cc53c85c9f9%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88a986c6f3cc53c85a6e1" data-idx="991">
+        <div class="book-header">
+          <span class="book-num">#992</span>
+          <h3>Speculum constantiae: das ist: Eine nohtwendige vermahnung an die jenige, so ihre Namen bereits bey der Fraternitet dess Rosencreutzes angegeben</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88a986c6f3cc53c85a6e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88a986c6f3cc53c85a6e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88a986c6f3cc53c85a6e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88a986c6f3cc53c85a6e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88a986c6f3cc53c85a6e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88a986c6f3cc53c85a6e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a986c6f3cc53c85a6e1%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a986c6f3cc53c85a6e1%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a986c6f3cc53c85a6e1%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a986c6f3cc53c85a6e1%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a986c6f3cc53c85a6e1%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89cc96c6f3cc53c85d668" data-idx="992">
+        <div class="book-header">
+          <span class="book-num">#993</span>
+          <h3>Historiam Jacobi Boehmii</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89cc96c6f3cc53c85d668" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89cc96c6f3cc53c85d668', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89cc96c6f3cc53c85d668', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89cc96c6f3cc53c85d668', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89cc96c6f3cc53c85d668', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89cc96c6f3cc53c85d668', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc96c6f3cc53c85d668%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc96c6f3cc53c85d668%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc96c6f3cc53c85d668%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc96c6f3cc53c85d668%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc96c6f3cc53c85d668%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8565b6c6f3cc53c853dea" data-idx="993">
+        <div class="book-header">
+          <span class="book-num">#994</span>
+          <h3>Abbildung des verborgenen Menschen des Hertzens</h3>
+          <span class="page-count">185 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8565b6c6f3cc53c853dea" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8565b6c6f3cc53c853dea', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8565b6c6f3cc53c853dea', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8565b6c6f3cc53c853dea', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8565b6c6f3cc53c853dea', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8565b6c6f3cc53c853dea', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8565b6c6f3cc53c853dea%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8565b6c6f3cc53c853dea%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8565b6c6f3cc53c853dea%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8565b6c6f3cc53c853dea%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8565b6c6f3cc53c853dea%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866746c6f3cc53c856409" data-idx="994">
+        <div class="book-header">
+          <span class="book-num">#995</span>
+          <h3>Die Alchemie. Das ist die Lehre von den grossen Geheim-Mitteln der Alchemisten und den Speculationen, welche man an sie knüpfte</h3>
+          <span class="page-count">151 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866746c6f3cc53c856409" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866746c6f3cc53c856409', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866746c6f3cc53c856409', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866746c6f3cc53c856409', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866746c6f3cc53c856409', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866746c6f3cc53c856409', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866746c6f3cc53c856409%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866746c6f3cc53c856409%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866746c6f3cc53c856409%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866746c6f3cc53c856409%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866746c6f3cc53c856409%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419072b0edf3eaa2de8db" data-idx="995">
+        <div class="book-header">
+          <span class="book-num">#996</span>
+          <h3>La Stéganographie — Johannes Trithemius (PH277)</h3>
+          <span class="page-count">149 pp</span>
+          <a href="https://sourcelibrary.org/book/trithemius-steganography-post-1787-french-translation-ms-trithemius" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419072b0edf3eaa2de8db', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419072b0edf3eaa2de8db', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419072b0edf3eaa2de8db', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419072b0edf3eaa2de8db', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419072b0edf3eaa2de8db', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419072b0edf3eaa2de8db%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486428805131!PH277_0060.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486428805131!PH277_0089.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486428805131!PH277_0119.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486428805131!PH277_0134.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81c766c6f3cc53c849c90" data-idx="996">
+        <div class="book-header">
+          <span class="book-num">#997</span>
+          <h3>Geloove, hoope, en liefde der Christenen, vertoond in den tweeden brief van den heiligen apostel Simeon Petrus</h3>
+          <span class="page-count">363 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81c766c6f3cc53c849c90" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81c766c6f3cc53c849c90', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81c766c6f3cc53c849c90', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81c766c6f3cc53c849c90', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81c766c6f3cc53c849c90', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81c766c6f3cc53c849c90', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c766c6f3cc53c849c90%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c766c6f3cc53c849c90%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c766c6f3cc53c849c90%2F0218-full.jpg&w=600" alt="Page 218" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.218 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c766c6f3cc53c849c90%2F0290-full.jpg&w=600" alt="Page 290" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.290 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c766c6f3cc53c849c90%2F0327-full.jpg&w=600" alt="Page 327" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.327 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c815d86c6f3cc53c848803" data-idx="997">
+        <div class="book-header">
+          <span class="book-num">#998</span>
+          <h3>Abregé du veritable christianisme &amp; teorique  &amp; pratique ou Recueïl de maximes chretienes</h3>
+          <span class="page-count">303 pp</span>
+          <a href="https://sourcelibrary.org/book/69c815d86c6f3cc53c848803" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c815d86c6f3cc53c848803', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c815d86c6f3cc53c848803', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c815d86c6f3cc53c848803', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c815d86c6f3cc53c848803', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c815d86c6f3cc53c848803', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815d86c6f3cc53c848803%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815d86c6f3cc53c848803%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815d86c6f3cc53c848803%2F0182-full.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815d86c6f3cc53c848803%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815d86c6f3cc53c848803%2F0273-full.jpg&w=600" alt="Page 273" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.273 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81ce16c6f3cc53c849e00" data-idx="998">
+        <div class="book-header">
+          <span class="book-num">#999</span>
+          <h3>Prima, media, et ultima. Ofte de eerste, middelste en laetste dingen</h3>
+          <span class="page-count">425 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81ce16c6f3cc53c849e00" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81ce16c6f3cc53c849e00', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81ce16c6f3cc53c849e00', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81ce16c6f3cc53c849e00', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81ce16c6f3cc53c849e00', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81ce16c6f3cc53c849e00', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81ce16c6f3cc53c849e00%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81ce16c6f3cc53c849e00%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81ce16c6f3cc53c849e00%2F0255-full.jpg&w=600" alt="Page 255" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.255 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81ce16c6f3cc53c849e00%2F0340-full.jpg&w=600" alt="Page 340" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.340 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81ce16c6f3cc53c849e00%2F0383-full.jpg&w=600" alt="Page 383" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.383 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41952ddff1f043992a1d4" data-idx="999">
+        <div class="book-header">
+          <span class="book-num">#1000</span>
+          <h3>Four Leaves from an Islamic Alchemical Text (PH412)</h3>
+          <span class="page-count">8 pp</span>
+          <a href="https://sourcelibrary.org/book/islamic-alchemical-fragment-arabic-ms-18th-c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41952ddff1f043992a1d4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41952ddff1f043992a1d4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41952ddff1f043992a1d4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41952ddff1f043992a1d4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41952ddff1f043992a1d4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41952ddff1f043992a1d4%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41952ddff1f043992a1d4%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41952ddff1f043992a1d4%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41952ddff1f043992a1d4%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41952ddff1f043992a1d4%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html" class="active">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-11.html
+++ b/public/split-review-11.html
@@ -1,0 +1,5377 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 11/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 89</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html" class="active">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c89c676c6f3cc53c85d59e" data-idx="1000">
+        <div class="book-header">
+          <span class="book-num">#1001</span>
+          <h3>E.S.T. Instructions</h3>
+          <span class="page-count">44 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89c676c6f3cc53c85d59e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89c676c6f3cc53c85d59e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89c676c6f3cc53c85d59e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89c676c6f3cc53c85d59e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89c676c6f3cc53c85d59e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89c676c6f3cc53c85d59e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c676c6f3cc53c85d59e%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c676c6f3cc53c85d59e%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c676c6f3cc53c85d59e%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c676c6f3cc53c85d59e%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c676c6f3cc53c85d59e%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909f42ecf28baa1b4cb0dc3" data-idx="1001">
+        <div class="book-header">
+          <span class="book-num">#1002</span>
+          <h3>Erzählungen zum Vergnügen und zur Seelenbildung</h3>
+          <span class="page-count">424 pp</span>
+          <a href="https://sourcelibrary.org/book/stories-for-pleasure-and-edification-eckartshausen" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909f42ecf28baa1b4cb0dc3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909f42ecf28baa1b4cb0dc3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909f42ecf28baa1b4cb0dc3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909f42ecf28baa1b4cb0dc3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909f42ecf28baa1b4cb0dc3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f42ecf28baa1b4cb0dc3%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f42ecf28baa1b4cb0dc3%2F170.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f42ecf28baa1b4cb0dc3%2F254.jpg&w=600" alt="Page 254" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.254 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f42ecf28baa1b4cb0dc3%2F339.jpg&w=600" alt="Page 339" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.339 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f42ecf28baa1b4cb0dc3%2F382.jpg&w=600" alt="Page 382" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.382 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c823c96c6f3cc53c84b1b6" data-idx="1002">
+        <div class="book-header">
+          <span class="book-num">#1003</span>
+          <h3>Chymische Schrifften</h3>
+          <span class="page-count">261 pp</span>
+          <a href="https://sourcelibrary.org/book/69c823c96c6f3cc53c84b1b6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c823c96c6f3cc53c84b1b6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c823c96c6f3cc53c84b1b6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c823c96c6f3cc53c84b1b6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c823c96c6f3cc53c84b1b6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c823c96c6f3cc53c84b1b6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823c96c6f3cc53c84b1b6%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823c96c6f3cc53c84b1b6%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823c96c6f3cc53c84b1b6%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823c96c6f3cc53c84b1b6%2F0209-full.jpg&w=600" alt="Page 209" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.209 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c823c96c6f3cc53c84b1b6%2F0235-full.jpg&w=600" alt="Page 235" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.235 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6125" data-idx="1003">
+        <div class="book-header">
+          <span class="book-num">#1004</span>
+          <h3>Opusculum de auditu kabbalistico sive ad omnes scientias introductorium</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6125" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6125', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6125', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6125', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6125', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6125', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6125%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6125%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6125%2F39.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6125%2F52.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6125%2F59.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c741f56a0f3d112faf7d44" data-idx="1004">
+        <div class="book-header">
+          <span class="book-num">#1005</span>
+          <h3>Neuer Versuch ueber die Weissagung vom Emmanuel</h3>
+          <span class="page-count">161 pp</span>
+          <a href="https://sourcelibrary.org/book/69c741f56a0f3d112faf7d44" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c741f56a0f3d112faf7d44', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c741f56a0f3d112faf7d44', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c741f56a0f3d112faf7d44', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c741f56a0f3d112faf7d44', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c741f56a0f3d112faf7d44', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741f56a0f3d112faf7d44%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741f56a0f3d112faf7d44%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741f56a0f3d112faf7d44%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741f56a0f3d112faf7d44%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741f56a0f3d112faf7d44%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f8936c6f3cc53c8423cd" data-idx="1005">
+        <div class="book-header">
+          <span class="book-num">#1006</span>
+          <h3>De rudimentis hebraicis</h3>
+          <span class="page-count">327 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f8936c6f3cc53c8423cd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f8936c6f3cc53c8423cd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f8936c6f3cc53c8423cd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f8936c6f3cc53c8423cd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f8936c6f3cc53c8423cd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f8936c6f3cc53c8423cd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8936c6f3cc53c8423cd%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8936c6f3cc53c8423cd%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8936c6f3cc53c8423cd%2F0196-full.jpg&w=600" alt="Page 196" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.196 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8936c6f3cc53c8423cd%2F0262-full.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8936c6f3cc53c8423cd%2F0294-full.jpg&w=600" alt="Page 294" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.294 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c819c16c6f3cc53c8494f1" data-idx="1006">
+        <div class="book-header">
+          <span class="book-num">#1007</span>
+          <h3>Weiteres Nachdencken uber einige Bedencken von der durch Doct. Petersen [...] aussgegebenen Prophezeygungen</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c819c16c6f3cc53c8494f1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c819c16c6f3cc53c8494f1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c819c16c6f3cc53c8494f1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c819c16c6f3cc53c8494f1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c819c16c6f3cc53c8494f1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c819c16c6f3cc53c8494f1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819c16c6f3cc53c8494f1%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819c16c6f3cc53c8494f1%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819c16c6f3cc53c8494f1%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819c16c6f3cc53c8494f1%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819c16c6f3cc53c8494f1%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418f02b0edf3eaa2de597" data-idx="1007">
+        <div class="book-header">
+          <span class="book-num">#1008</span>
+          <h3>Livre des figures hieroglyphiques — Nicolas Flamel (PH400)</h3>
+          <span class="page-count">134 pp</span>
+          <a href="https://sourcelibrary.org/book/flamel-book-of-hieroglyphic-figures-abraham-le-juif-flamel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418f02b0edf3eaa2de597', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418f02b0edf3eaa2de597', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418f02b0edf3eaa2de597', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418f02b0edf3eaa2de597', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418f02b0edf3eaa2de597', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f02b0edf3eaa2de597%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f02b0edf3eaa2de597%2F54.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f02b0edf3eaa2de597%2F80.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f02b0edf3eaa2de597%2F107.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f02b0edf3eaa2de597%2F121.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ef7dda9771c716314ba2" data-idx="1008">
+        <div class="book-header">
+          <span class="book-num">#1009</span>
+          <h3>Der Weisheit Morgenröthe, Das ist: Von den dreyen Principiis, oder Ursprung und Anfang aller Dinge im Geheimniss der Weisheit</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ef7dda9771c716314ba2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ef7dda9771c716314ba2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ef7dda9771c716314ba2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ef7dda9771c716314ba2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ef7dda9771c716314ba2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ef7dda9771c716314ba2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ef7dda9771c716314ba2%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ef7dda9771c716314ba2%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ef7dda9771c716314ba2%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ef7dda9771c716314ba2%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ef7dda9771c716314ba2%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82ddc6c6f3cc53c84d497" data-idx="1009">
+        <div class="book-header">
+          <span class="book-num">#1010</span>
+          <h3>[Hebrew: Mishpat HaMelech] Jus regium Hebraeorum e tenebris rabbinicis</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82ddc6c6f3cc53c84d497" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82ddc6c6f3cc53c84d497', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82ddc6c6f3cc53c84d497', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82ddc6c6f3cc53c84d497', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82ddc6c6f3cc53c84d497', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82ddc6c6f3cc53c84d497', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddc6c6f3cc53c84d497%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddc6c6f3cc53c84d497%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddc6c6f3cc53c84d497%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddc6c6f3cc53c84d497%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddc6c6f3cc53c84d497%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80fab6c6f3cc53c8472ed" data-idx="1010">
+        <div class="book-header">
+          <span class="book-num">#1011</span>
+          <h3>Piissimae tam de tempore quam de sanctis Homiliae</h3>
+          <span class="page-count">561 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80fab6c6f3cc53c8472ed" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80fab6c6f3cc53c8472ed', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80fab6c6f3cc53c8472ed', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80fab6c6f3cc53c8472ed', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80fab6c6f3cc53c8472ed', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80fab6c6f3cc53c8472ed', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80fab6c6f3cc53c8472ed%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80fab6c6f3cc53c8472ed%2F0224-full.jpg&w=600" alt="Page 224" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.224 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80fab6c6f3cc53c8472ed%2F0337-full.jpg&w=600" alt="Page 337" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.337 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80fab6c6f3cc53c8472ed%2F0449-full.jpg&w=600" alt="Page 449" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.449 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80fab6c6f3cc53c8472ed%2F0505-full.jpg&w=600" alt="Page 505" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.505 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897f96c6f3cc53c85c991" data-idx="1011">
+        <div class="book-header">
+          <span class="book-num">#1012</span>
+          <h3>Record of the joint convocation of the High Council and Metropolitan College, being the Jubilee Festival, held on July 11th, 1919</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897f96c6f3cc53c85c991" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897f96c6f3cc53c85c991', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897f96c6f3cc53c85c991', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897f96c6f3cc53c85c991', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897f96c6f3cc53c85c991', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897f96c6f3cc53c85c991', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f96c6f3cc53c85c991%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f96c6f3cc53c85c991%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f96c6f3cc53c85c991%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f96c6f3cc53c85c991%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897f96c6f3cc53c85c991%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c824f26c6f3cc53c84b6eb" data-idx="1012">
+        <div class="book-header">
+          <span class="book-num">#1013</span>
+          <h3>De nativitate mediatoris ultima</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/69c824f26c6f3cc53c84b6eb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c824f26c6f3cc53c84b6eb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c824f26c6f3cc53c84b6eb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c824f26c6f3cc53c84b6eb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c824f26c6f3cc53c84b6eb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c824f26c6f3cc53c84b6eb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824f26c6f3cc53c84b6eb%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824f26c6f3cc53c84b6eb%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824f26c6f3cc53c84b6eb%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824f26c6f3cc53c84b6eb%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824f26c6f3cc53c84b6eb%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85de26c6f3cc53c855057" data-idx="1013">
+        <div class="book-header">
+          <span class="book-num">#1014</span>
+          <h3>Aufklärung über wichtige Gegenstände in der Freymaurerey</h3>
+          <span class="page-count">131 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85de26c6f3cc53c855057" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85de26c6f3cc53c855057', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85de26c6f3cc53c855057', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85de26c6f3cc53c855057', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85de26c6f3cc53c855057', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85de26c6f3cc53c855057', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85de26c6f3cc53c855057%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85de26c6f3cc53c855057%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85de26c6f3cc53c855057%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85de26c6f3cc53c855057%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85de26c6f3cc53c855057%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c842b96c6f3cc53c850d69" data-idx="1014">
+        <div class="book-header">
+          <span class="book-num">#1015</span>
+          <h3>[Arabic] Alphabetum arabicum cum isagoge scribendi legendique Arabicè</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c842b96c6f3cc53c850d69" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c842b96c6f3cc53c850d69', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c842b96c6f3cc53c850d69', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c842b96c6f3cc53c850d69', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c842b96c6f3cc53c850d69', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c842b96c6f3cc53c850d69', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b96c6f3cc53c850d69%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b96c6f3cc53c850d69%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b96c6f3cc53c850d69%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b96c6f3cc53c850d69%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b96c6f3cc53c850d69%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4190a2b0edf3eaa2de972" data-idx="1015">
+        <div class="book-header">
+          <span class="book-num">#1016</span>
+          <h3>Amphitheatrum Sapientiae Aeternae — Heinrich Khunrath (PH355)</h3>
+          <span class="page-count">162 pp</span>
+          <a href="https://sourcelibrary.org/book/khunrath-amphitheatre-of-eternal-wisdom-1702-ms-khunrath" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4190a2b0edf3eaa2de972', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4190a2b0edf3eaa2de972', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4190a2b0edf3eaa2de972', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4190a2b0edf3eaa2de972', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4190a2b0edf3eaa2de972', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4190a2b0edf3eaa2de972%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581422505131!ph355_bph_mog_55_066.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581422505131!ph355_bph_mog_55_098.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581422505131!ph355_bph_mog_55_131.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581422505131!ph355_bph_mog_55_147.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c826e56c6f3cc53c84be63" data-idx="1016">
+        <div class="book-header">
+          <span class="book-num">#1017</span>
+          <h3>Essays on several important subjects in philosophy and religion</h3>
+          <span class="page-count">180 pp</span>
+          <a href="https://sourcelibrary.org/book/69c826e56c6f3cc53c84be63" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c826e56c6f3cc53c84be63', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c826e56c6f3cc53c84be63', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c826e56c6f3cc53c84be63', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c826e56c6f3cc53c84be63', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c826e56c6f3cc53c84be63', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826e56c6f3cc53c84be63%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826e56c6f3cc53c84be63%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826e56c6f3cc53c84be63%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826e56c6f3cc53c84be63%2F0144-full.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826e56c6f3cc53c84be63%2F0162-full.jpg&w=600" alt="Page 162" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.162 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c899336c6f3cc53c85cd2a" data-idx="1017">
+        <div class="book-header">
+          <span class="book-num">#1018</span>
+          <h3>Gospel</h3>
+          <span class="page-count">44 pp</span>
+          <a href="https://sourcelibrary.org/book/69c899336c6f3cc53c85cd2a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c899336c6f3cc53c85cd2a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c899336c6f3cc53c85cd2a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c899336c6f3cc53c85cd2a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c899336c6f3cc53c85cd2a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c899336c6f3cc53c85cd2a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899336c6f3cc53c85cd2a%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899336c6f3cc53c85cd2a%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899336c6f3cc53c85cd2a%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899336c6f3cc53c85cd2a%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899336c6f3cc53c85cd2a%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6867a4fefc518f6dbf334f36" data-idx="1018">
+        <div class="book-header">
+          <span class="book-num">#1019</span>
+          <h3>Astrologia aphoristica Ptolemaei, Hermetis, Ludovici de Rigiis, Almansoris, Hieronymi Cardani, et autoris innominati</h3>
+          <span class="page-count">233 pp</span>
+          <a href="https://sourcelibrary.org/book/aphoristic-astrology-of-ptolemy-hermes-and-others-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867a4fefc518f6dbf334f36', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867a4fefc518f6dbf334f36', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867a4fefc518f6dbf334f36', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867a4fefc518f6dbf334f36', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867a4fefc518f6dbf334f36', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a4fefc518f6dbf334f36%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a4fefc518f6dbf334f36%2F93.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a4fefc518f6dbf334f36%2F140.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a4fefc518f6dbf334f36%2F186.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a4fefc518f6dbf334f36%2F210.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8997b6c6f3cc53c85ce28" data-idx="1019">
+        <div class="book-header">
+          <span class="book-num">#1020</span>
+          <h3>Hier beghint een seer devoet boecxken ghenoempt Sinte Franciscus Soutere</h3>
+          <span class="page-count">105 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8997b6c6f3cc53c85ce28" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8997b6c6f3cc53c85ce28', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8997b6c6f3cc53c85ce28', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8997b6c6f3cc53c85ce28', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8997b6c6f3cc53c85ce28', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8997b6c6f3cc53c85ce28', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8997b6c6f3cc53c85ce28%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8997b6c6f3cc53c85ce28%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8997b6c6f3cc53c85ce28%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8997b6c6f3cc53c85ce28%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8997b6c6f3cc53c85ce28%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84f336c6f3cc53c852a32" data-idx="1020">
+        <div class="book-header">
+          <span class="book-num">#1021</span>
+          <h3>Reden zum Wohl der Menschheit über verschiedene Gegenstände</h3>
+          <span class="page-count">133 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84f336c6f3cc53c852a32" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84f336c6f3cc53c852a32', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84f336c6f3cc53c852a32', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84f336c6f3cc53c852a32', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84f336c6f3cc53c852a32', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84f336c6f3cc53c852a32', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84f336c6f3cc53c852a32%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84f336c6f3cc53c852a32%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84f336c6f3cc53c852a32%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84f336c6f3cc53c852a32%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84f336c6f3cc53c852a32%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83cb46c6f3cc53c84fa60" data-idx="1021">
+        <div class="book-header">
+          <span class="book-num">#1022</span>
+          <h3>[Cyrillic:] Ctiri knigi o istinnum christijanstve [=Four books of true christianity]</h3>
+          <span class="page-count">735 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83cb46c6f3cc53c84fa60" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83cb46c6f3cc53c84fa60', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83cb46c6f3cc53c84fa60', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83cb46c6f3cc53c84fa60', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83cb46c6f3cc53c84fa60', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83cb46c6f3cc53c84fa60', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83cb46c6f3cc53c84fa60%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83cb46c6f3cc53c84fa60%2F0294-full.jpg&w=600" alt="Page 294" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.294 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83cb46c6f3cc53c84fa60%2F0441-full.jpg&w=600" alt="Page 441" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.441 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83cb46c6f3cc53c84fa60%2F0588-full.jpg&w=600" alt="Page 588" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.588 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83cb46c6f3cc53c84fa60%2F0662-full.jpg&w=600" alt="Page 662" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.662 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81e1d6c6f3cc53c84a166" data-idx="1022">
+        <div class="book-header">
+          <span class="book-num">#1023</span>
+          <h3>Geschichte der Chemie</h3>
+          <span class="page-count">399 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81e1d6c6f3cc53c84a166" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81e1d6c6f3cc53c84a166', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81e1d6c6f3cc53c84a166', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81e1d6c6f3cc53c84a166', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81e1d6c6f3cc53c84a166', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81e1d6c6f3cc53c84a166', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e1d6c6f3cc53c84a166%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e1d6c6f3cc53c84a166%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e1d6c6f3cc53c84a166%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e1d6c6f3cc53c84a166%2F0319-full.jpg&w=600" alt="Page 319" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.319 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e1d6c6f3cc53c84a166%2F0359-full.jpg&w=600" alt="Page 359" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.359 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909c96acf28baa1b4cafbf3" data-idx="1023">
+        <div class="book-header">
+          <span class="book-num">#1024</span>
+          <h3>Dichiaratione sopra il XIII cap. dell'Apocalisse</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/declaration-on-the-13th-chapter-of-the-apocalypse-doni" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909c96acf28baa1b4cafbf3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909c96acf28baa1b4cafbf3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909c96acf28baa1b4cafbf3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909c96acf28baa1b4cafbf3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909c96acf28baa1b4cafbf3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c96acf28baa1b4cafbf3%2F2.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c96acf28baa1b4cafbf3%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c96acf28baa1b4cafbf3%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c96acf28baa1b4cafbf3%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c96acf28baa1b4cafbf3%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c861f66c6f3cc53c855aba" data-idx="1024">
+        <div class="book-header">
+          <span class="book-num">#1025</span>
+          <h3>Table chronographique de l' estat du christianisme</h3>
+          <span class="page-count">239 pp</span>
+          <a href="https://sourcelibrary.org/book/69c861f66c6f3cc53c855aba" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c861f66c6f3cc53c855aba', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c861f66c6f3cc53c855aba', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c861f66c6f3cc53c855aba', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c861f66c6f3cc53c855aba', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c861f66c6f3cc53c855aba', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c861f66c6f3cc53c855aba%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c861f66c6f3cc53c855aba%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c861f66c6f3cc53c855aba%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c861f66c6f3cc53c855aba%2F0191-full.jpg&w=600" alt="Page 191" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.191 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c861f66c6f3cc53c855aba%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88c3f6c6f3cc53c85ab96" data-idx="1025">
+        <div class="book-header">
+          <span class="book-num">#1026</span>
+          <h3>Theoretic arithmetic, in three books; containing the substance of all that has been written on this subject by Theo of Smyrna, Nicomachus, Iamblichus, and Boetius</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88c3f6c6f3cc53c85ab96" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88c3f6c6f3cc53c85ab96', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88c3f6c6f3cc53c85ab96', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88c3f6c6f3cc53c85ab96', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88c3f6c6f3cc53c85ab96', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88c3f6c6f3cc53c85ab96', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c3f6c6f3cc53c85ab96%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c3f6c6f3cc53c85ab96%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c3f6c6f3cc53c85ab96%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c3f6c6f3cc53c85ab96%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c3f6c6f3cc53c85ab96%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c811476c6f3cc53c847807" data-idx="1026">
+        <div class="book-header">
+          <span class="book-num">#1027</span>
+          <h3>Spinalba, ou les révélations de la Rose-Croix</h3>
+          <span class="page-count">226 pp</span>
+          <a href="https://sourcelibrary.org/book/69c811476c6f3cc53c847807" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c811476c6f3cc53c847807', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c811476c6f3cc53c847807', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c811476c6f3cc53c847807', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c811476c6f3cc53c847807', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c811476c6f3cc53c847807', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811476c6f3cc53c847807%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811476c6f3cc53c847807%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811476c6f3cc53c847807%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811476c6f3cc53c847807%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811476c6f3cc53c847807%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c891596c6f3cc53c85b967" data-idx="1027">
+        <div class="book-header">
+          <span class="book-num">#1028</span>
+          <h3>De Zoroastre bactriano, Hermete Trismegisto, Sanchoniatone phoenicio, eorumque scriptis. Spicilegium</h3>
+          <span class="page-count">169 pp</span>
+          <a href="https://sourcelibrary.org/book/69c891596c6f3cc53c85b967" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c891596c6f3cc53c85b967', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c891596c6f3cc53c85b967', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c891596c6f3cc53c85b967', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c891596c6f3cc53c85b967', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c891596c6f3cc53c85b967', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891596c6f3cc53c85b967%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891596c6f3cc53c85b967%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891596c6f3cc53c85b967%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891596c6f3cc53c85b967%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891596c6f3cc53c85b967%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8552d6c6f3cc53c853a69" data-idx="1028">
+        <div class="book-header">
+          <span class="book-num">#1029</span>
+          <h3>[Hebrew: Mafteach ha-Zohar]</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8552d6c6f3cc53c853a69" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8552d6c6f3cc53c853a69', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8552d6c6f3cc53c853a69', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8552d6c6f3cc53c853a69', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8552d6c6f3cc53c853a69', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8552d6c6f3cc53c853a69', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8552d6c6f3cc53c853a69%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8552d6c6f3cc53c853a69%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8552d6c6f3cc53c853a69%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8552d6c6f3cc53c853a69%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8552d6c6f3cc53c853a69%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c867a26c6f3cc53c8565d3" data-idx="1029">
+        <div class="book-header">
+          <span class="book-num">#1030</span>
+          <h3>Anacalypsis, an attempt to draw aside the veil of the Saitic Isis; or, an inquiry into the origin of languages, nations, and religions</h3>
+          <span class="page-count">464 pp</span>
+          <a href="https://sourcelibrary.org/book/69c867a26c6f3cc53c8565d3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c867a26c6f3cc53c8565d3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c867a26c6f3cc53c8565d3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c867a26c6f3cc53c8565d3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c867a26c6f3cc53c8565d3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c867a26c6f3cc53c8565d3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a26c6f3cc53c8565d3%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a26c6f3cc53c8565d3%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a26c6f3cc53c8565d3%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a26c6f3cc53c8565d3%2F0371-full.jpg&w=600" alt="Page 371" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.371 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a26c6f3cc53c8565d3%2F0418-full.jpg&w=600" alt="Page 418" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.418 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83e9d6c6f3cc53c8501d0" data-idx="1030">
+        <div class="book-header">
+          <span class="book-num">#1031</span>
+          <h3>Vom christenlichen Streyt</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83e9d6c6f3cc53c8501d0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83e9d6c6f3cc53c8501d0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83e9d6c6f3cc53c8501d0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83e9d6c6f3cc53c8501d0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83e9d6c6f3cc53c8501d0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83e9d6c6f3cc53c8501d0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e9d6c6f3cc53c8501d0%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e9d6c6f3cc53c8501d0%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e9d6c6f3cc53c8501d0%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e9d6c6f3cc53c8501d0%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e9d6c6f3cc53c8501d0%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418bc2b0edf3eaa2ddc19" data-idx="1031">
+        <div class="book-header">
+          <span class="book-num">#1032</span>
+          <h3>Ars cabalistica &amp; Clavicula Salomonis (PH224)</h3>
+          <span class="page-count">58 pp</span>
+          <a href="https://sourcelibrary.org/book/kabbalistic-art-key-of-solomon-two-esoteric-texts-18th-c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418bc2b0edf3eaa2ddc19', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418bc2b0edf3eaa2ddc19', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418bc2b0edf3eaa2ddc19', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418bc2b0edf3eaa2ddc19', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418bc2b0edf3eaa2ddc19', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418bc2b0edf3eaa2ddc19%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418bc2b0edf3eaa2ddc19%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940465239805131!PH224_0035.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940465239805131!PH224_0046.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940465239805131!PH224_0052.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c892a96c6f3cc53c85bcda" data-idx="1032">
+        <div class="book-header">
+          <span class="book-num">#1033</span>
+          <h3>A dispute between the woman and the powers of darkness</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/69c892a96c6f3cc53c85bcda" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c892a96c6f3cc53c85bcda', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c892a96c6f3cc53c85bcda', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c892a96c6f3cc53c85bcda', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c892a96c6f3cc53c85bcda', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c892a96c6f3cc53c85bcda', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892a96c6f3cc53c85bcda%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892a96c6f3cc53c85bcda%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892a96c6f3cc53c85bcda%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892a96c6f3cc53c85bcda%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892a96c6f3cc53c85bcda%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83b886c6f3cc53c84f6bc" data-idx="1033">
+        <div class="book-header">
+          <span class="book-num">#1034</span>
+          <h3>Biblisches Psalter-Schaz-Kästlein</h3>
+          <span class="page-count">238 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83b886c6f3cc53c84f6bc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83b886c6f3cc53c84f6bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83b886c6f3cc53c84f6bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83b886c6f3cc53c84f6bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83b886c6f3cc53c84f6bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83b886c6f3cc53c84f6bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b886c6f3cc53c84f6bc%2F0031-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b886c6f3cc53c84f6bc%2F0073-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b886c6f3cc53c84f6bc%2F0097-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b886c6f3cc53c84f6bc%2F0121-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b886c6f3cc53c84f6bc%2F0165-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c871856c6f3cc53c8575cb" data-idx="1034">
+        <div class="book-header">
+          <span class="book-num">#1035</span>
+          <h3>Het derde boeck des auteurs, zynde hooge ende diepe gronden van 't drievoudigh leven des menschen</h3>
+          <span class="page-count">220 pp</span>
+          <a href="https://sourcelibrary.org/book/69c871856c6f3cc53c8575cb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c871856c6f3cc53c8575cb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c871856c6f3cc53c8575cb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c871856c6f3cc53c8575cb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c871856c6f3cc53c8575cb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c871856c6f3cc53c8575cb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871856c6f3cc53c8575cb%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871856c6f3cc53c8575cb%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871856c6f3cc53c8575cb%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871856c6f3cc53c8575cb%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871856c6f3cc53c8575cb%2F0198-full.jpg&w=600" alt="Page 198" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.198 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f709da9771c71631511a" data-idx="1035">
+        <div class="book-header">
+          <span class="book-num">#1036</span>
+          <h3>The works</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f709da9771c71631511a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f709da9771c71631511a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f709da9771c71631511a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f709da9771c71631511a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f709da9771c71631511a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f709da9771c71631511a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f709da9771c71631511a%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f709da9771c71631511a%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f709da9771c71631511a%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f709da9771c71631511a%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f709da9771c71631511a%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855526c6f3cc53c853ab7" data-idx="1036">
+        <div class="book-header">
+          <span class="book-num">#1037</span>
+          <h3>Dess evangelischen Kirchen-Convents in Strassburg abgenöthigter historischer Bericht, von der jüngst daselbst entstandenen Pietistischen Brüderschaft, und Philadelphischen Gesellschaft</h3>
+          <span class="page-count">155 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855526c6f3cc53c853ab7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855526c6f3cc53c853ab7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855526c6f3cc53c853ab7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855526c6f3cc53c853ab7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855526c6f3cc53c853ab7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855526c6f3cc53c853ab7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855526c6f3cc53c853ab7%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855526c6f3cc53c853ab7%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855526c6f3cc53c853ab7%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855526c6f3cc53c853ab7%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855526c6f3cc53c853ab7%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83b7a6c6f3cc53c84f699" data-idx="1037">
+        <div class="book-header">
+          <span class="book-num">#1038</span>
+          <h3>Posthuma</h3>
+          <span class="page-count">527 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83b7a6c6f3cc53c84f699" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83b7a6c6f3cc53c84f699', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83b7a6c6f3cc53c84f699', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83b7a6c6f3cc53c84f699', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83b7a6c6f3cc53c84f699', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83b7a6c6f3cc53c84f699', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b7a6c6f3cc53c84f699%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b7a6c6f3cc53c84f699%2F0211-full.jpg&w=600" alt="Page 211" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.211 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b7a6c6f3cc53c84f699%2F0316-full.jpg&w=600" alt="Page 316" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.316 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b7a6c6f3cc53c84f699%2F0422-full.jpg&w=600" alt="Page 422" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.422 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b7a6c6f3cc53c84f699%2F0474-full.jpg&w=600" alt="Page 474" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.474 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418e32b0edf3eaa2de1be" data-idx="1038">
+        <div class="book-header">
+          <span class="book-num">#1039</span>
+          <h3>Arbor Philosophiae Desideratae — Ramon Llull (PH332)</h3>
+          <span class="page-count">228 pp</span>
+          <a href="https://sourcelibrary.org/book/llull-tree-of-desired-philosophy-ca-1600-latin-ms-llull" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418e32b0edf3eaa2de1be', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418e32b0edf3eaa2de1be', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418e32b0edf3eaa2de1be', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418e32b0edf3eaa2de1be', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418e32b0edf3eaa2de1be', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e32b0edf3eaa2de1be%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940550473405131!PH332_0091.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940550473405131!PH332_0137.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940550473405131!PH332_0182.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940550473405131!PH332_0205.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8259f6c6f3cc53c84b9a9" data-idx="1039">
+        <div class="book-header">
+          <span class="book-num">#1040</span>
+          <h3>Ein edler und nützlicher hermetischer, oder chymischer Discurs</h3>
+          <span class="page-count">49 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8259f6c6f3cc53c84b9a9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8259f6c6f3cc53c84b9a9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8259f6c6f3cc53c84b9a9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8259f6c6f3cc53c84b9a9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8259f6c6f3cc53c84b9a9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8259f6c6f3cc53c84b9a9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8259f6c6f3cc53c84b9a9%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8259f6c6f3cc53c84b9a9%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8259f6c6f3cc53c84b9a9%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8259f6c6f3cc53c84b9a9%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8259f6c6f3cc53c84b9a9%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7bffe25ec2ba5ccd7fcba" data-idx="1040">
+        <div class="book-header">
+          <span class="book-num">#1041</span>
+          <h3>Vorbothe, der am philosophischen Himmel hervor brechenden Morgen-Röthe</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7bffe25ec2ba5ccd7fcba" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7bffe25ec2ba5ccd7fcba', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7bffe25ec2ba5ccd7fcba', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7bffe25ec2ba5ccd7fcba', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7bffe25ec2ba5ccd7fcba', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7bffe25ec2ba5ccd7fcba', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffe25ec2ba5ccd7fcba%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffe25ec2ba5ccd7fcba%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffe25ec2ba5ccd7fcba%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffe25ec2ba5ccd7fcba%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffe25ec2ba5ccd7fcba%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fa186c6f3cc53c842946" data-idx="1041">
+        <div class="book-header">
+          <span class="book-num">#1042</span>
+          <h3>Epistolarum obscurorum virorum ad Dom. M. Ortuinum Gratium</h3>
+          <span class="page-count">210 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fa186c6f3cc53c842946" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fa186c6f3cc53c842946', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fa186c6f3cc53c842946', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fa186c6f3cc53c842946', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fa186c6f3cc53c842946', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fa186c6f3cc53c842946', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa186c6f3cc53c842946%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa186c6f3cc53c842946%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa186c6f3cc53c842946%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa186c6f3cc53c842946%2F0168-full.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa186c6f3cc53c842946%2F0189-full.jpg&w=600" alt="Page 189" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.189 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41948ddff1f043992a105" data-idx="1042">
+        <div class="book-header">
+          <span class="book-num">#1043</span>
+          <h3>Das geheime Werck der hermetischen Philosophie — d'Espagnet (PH479)</h3>
+          <span class="page-count">80 pp</span>
+          <a href="https://sourcelibrary.org/book/d-espagnet-secret-work-of-hermetic-philosophy-post-1685-d-espagnet" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41948ddff1f043992a105', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41948ddff1f043992a105', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41948ddff1f043992a105', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41948ddff1f043992a105', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41948ddff1f043992a105', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41948ddff1f043992a105%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41948ddff1f043992a105%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41948ddff1f043992a105%2F48.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41948ddff1f043992a105%2F64.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41948ddff1f043992a105%2F72.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c858356c6f3cc53c854211" data-idx="1043">
+        <div class="book-header">
+          <span class="book-num">#1044</span>
+          <h3>Oratio inauguralis, de Bohemorum et Moravorum ecclesia</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/69c858356c6f3cc53c854211" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c858356c6f3cc53c854211', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c858356c6f3cc53c854211', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c858356c6f3cc53c854211', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c858356c6f3cc53c854211', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c858356c6f3cc53c854211', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858356c6f3cc53c854211%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858356c6f3cc53c854211%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858356c6f3cc53c854211%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858356c6f3cc53c854211%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858356c6f3cc53c854211%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c734846a0f3d112faf755c" data-idx="1044">
+        <div class="book-header">
+          <span class="book-num">#1045</span>
+          <h3>[Hebrew: Sefer me'il Shemu'el]</h3>
+          <span class="page-count">165 pp</span>
+          <a href="https://sourcelibrary.org/book/69c734846a0f3d112faf755c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c734846a0f3d112faf755c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c734846a0f3d112faf755c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c734846a0f3d112faf755c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c734846a0f3d112faf755c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c734846a0f3d112faf755c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734846a0f3d112faf755c%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734846a0f3d112faf755c%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734846a0f3d112faf755c%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734846a0f3d112faf755c%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734846a0f3d112faf755c%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fb986c6f3cc53c842dcc" data-idx="1045">
+        <div class="book-header">
+          <span class="book-num">#1046</span>
+          <h3>De' ragguagli di Parnaso</h3>
+          <span class="page-count">401 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fb986c6f3cc53c842dcc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fb986c6f3cc53c842dcc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fb986c6f3cc53c842dcc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fb986c6f3cc53c842dcc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fb986c6f3cc53c842dcc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fb986c6f3cc53c842dcc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fb986c6f3cc53c842dcc%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fb986c6f3cc53c842dcc%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fb986c6f3cc53c842dcc%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fb986c6f3cc53c842dcc%2F0321-full.jpg&w=600" alt="Page 321" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.321 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fb986c6f3cc53c842dcc%2F0361-full.jpg&w=600" alt="Page 361" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.361 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c643c0b463eebe7caac967" data-idx="1046">
+        <div class="book-header">
+          <span class="book-num">#1047</span>
+          <h3>Vitulus aureus quem mundus adorat et orat: oder ein sehr curieuses Tractätlein</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c643c0b463eebe7caac967" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c643c0b463eebe7caac967', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c643c0b463eebe7caac967', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c643c0b463eebe7caac967', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c643c0b463eebe7caac967', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c643c0b463eebe7caac967', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c643c0b463eebe7caac967%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c643c0b463eebe7caac967%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c643c0b463eebe7caac967%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c643c0b463eebe7caac967%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c643c0b463eebe7caac967%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="dbdc472a-b39f-4005-abb4-654428f7bf61" data-idx="1047">
+        <div class="book-header">
+          <span class="book-num">#1048</span>
+          <h3>Curiosa physica</h3>
+          <span class="page-count">90 pp</span>
+          <a href="https://sourcelibrary.org/book/curious-physics-hellwig" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('dbdc472a-b39f-4005-abb4-654428f7bf61', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('dbdc472a-b39f-4005-abb4-654428f7bf61', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('dbdc472a-b39f-4005-abb4-654428f7bf61', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('dbdc472a-b39f-4005-abb4-654428f7bf61', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('dbdc472a-b39f-4005-abb4-654428f7bf61', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fdbdc472a-b39f-4005-abb4-654428f7bf61%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fdbdc472a-b39f-4005-abb4-654428f7bf61%2F36.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fdbdc472a-b39f-4005-abb4-654428f7bf61%2F54.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fdbdc472a-b39f-4005-abb4-654428f7bf61%2F72.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fdbdc472a-b39f-4005-abb4-654428f7bf61%2F81.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8014b6c6f3cc53c844292" data-idx="1048">
+        <div class="book-header">
+          <span class="book-num">#1049</span>
+          <h3>La sabiduria universal del Raymundo Lullio</h3>
+          <span class="page-count">27 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8014b6c6f3cc53c844292" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8014b6c6f3cc53c844292', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8014b6c6f3cc53c844292', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8014b6c6f3cc53c844292', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8014b6c6f3cc53c844292', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8014b6c6f3cc53c844292', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8014b6c6f3cc53c844292%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8014b6c6f3cc53c844292%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8014b6c6f3cc53c844292%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8014b6c6f3cc53c844292%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8014b6c6f3cc53c844292%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41945ddff1f043992a0e5" data-idx="1049">
+        <div class="book-header">
+          <span class="book-num">#1050</span>
+          <h3>Raphael — Abraham von Franckenberg (PH317)</h3>
+          <span class="page-count">30 pp</span>
+          <a href="https://sourcelibrary.org/book/franckenberg-raphael-holy-light-of-medicine-18th-century-ms-franckenberg" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41945ddff1f043992a0e5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41945ddff1f043992a0e5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41945ddff1f043992a0e5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41945ddff1f043992a0e5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41945ddff1f043992a0e5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41945ddff1f043992a0e5%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41945ddff1f043992a0e5%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41945ddff1f043992a0e5%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41945ddff1f043992a0e5%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41945ddff1f043992a0e5%2F27.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82d6c6c6f3cc53c84d26f" data-idx="1050">
+        <div class="book-header">
+          <span class="book-num">#1051</span>
+          <h3>Nosce te ipsum et cognosce Christum. Erkäntnis unser selbst in Adam</h3>
+          <span class="page-count">137 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82d6c6c6f3cc53c84d26f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82d6c6c6f3cc53c84d26f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82d6c6c6f3cc53c84d26f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82d6c6c6f3cc53c84d26f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82d6c6c6f3cc53c84d26f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82d6c6c6f3cc53c84d26f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d6c6c6f3cc53c84d26f%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d6c6c6f3cc53c84d26f%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d6c6c6f3cc53c84d26f%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d6c6c6f3cc53c84d26f%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d6c6c6f3cc53c84d26f%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c863316c6f3cc53c855ca6" data-idx="1051">
+        <div class="book-header">
+          <span class="book-num">#1052</span>
+          <h3>Die uralte Weisheit. Eine kurzgefasste Darstellung der Lehren der Theosophie</h3>
+          <span class="page-count">225 pp</span>
+          <a href="https://sourcelibrary.org/book/69c863316c6f3cc53c855ca6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c863316c6f3cc53c855ca6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c863316c6f3cc53c855ca6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c863316c6f3cc53c855ca6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c863316c6f3cc53c855ca6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c863316c6f3cc53c855ca6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c863316c6f3cc53c855ca6%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c863316c6f3cc53c855ca6%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c863316c6f3cc53c855ca6%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c863316c6f3cc53c855ca6%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c863316c6f3cc53c855ca6%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a19e6c6f3cc53c85e248" data-idx="1052">
+        <div class="book-header">
+          <span class="book-num">#1053</span>
+          <h3>Sechs Bücher vom wahren Christenthum. Paradies-Gärtlein</h3>
+          <span class="page-count">739 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a19e6c6f3cc53c85e248" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a19e6c6f3cc53c85e248', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a19e6c6f3cc53c85e248', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a19e6c6f3cc53c85e248', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a19e6c6f3cc53c85e248', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a19e6c6f3cc53c85e248', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a19e6c6f3cc53c85e248%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a19e6c6f3cc53c85e248%2F0296-full.jpg&w=600" alt="Page 296" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.296 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a19e6c6f3cc53c85e248%2F0443-full.jpg&w=600" alt="Page 443" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.443 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a19e6c6f3cc53c85e248%2F0591-full.jpg&w=600" alt="Page 591" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.591 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a19e6c6f3cc53c85e248%2F0665-full.jpg&w=600" alt="Page 665" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.665 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c719b6da9771c716316736" data-idx="1053">
+        <div class="book-header">
+          <span class="book-num">#1054</span>
+          <h3>The trial of Joanna Southcott</h3>
+          <span class="page-count">57 pp</span>
+          <a href="https://sourcelibrary.org/book/69c719b6da9771c716316736" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c719b6da9771c716316736', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c719b6da9771c716316736', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c719b6da9771c716316736', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c719b6da9771c716316736', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c719b6da9771c716316736', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c719b6da9771c716316736%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c719b6da9771c716316736%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c719b6da9771c716316736%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c719b6da9771c716316736%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c719b6da9771c716316736%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866616c6f3cc53c8563e4" data-idx="1054">
+        <div class="book-header">
+          <span class="book-num">#1055</span>
+          <h3>The alchemical papers of Arthur Edward Waite</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866616c6f3cc53c8563e4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866616c6f3cc53c8563e4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866616c6f3cc53c8563e4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866616c6f3cc53c8563e4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866616c6f3cc53c8563e4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866616c6f3cc53c8563e4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866616c6f3cc53c8563e4%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866616c6f3cc53c8563e4%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866616c6f3cc53c8563e4%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866616c6f3cc53c8563e4%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866616c6f3cc53c8563e4%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ad3625ec2ba5ccd7f19a" data-idx="1055">
+        <div class="book-header">
+          <span class="book-num">#1056</span>
+          <h3>Libro de magistrati degli Atheniesi</h3>
+          <span class="page-count">49 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ad3625ec2ba5ccd7f19a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ad3625ec2ba5ccd7f19a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ad3625ec2ba5ccd7f19a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ad3625ec2ba5ccd7f19a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ad3625ec2ba5ccd7f19a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ad3625ec2ba5ccd7f19a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19a%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19a%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19a%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19a%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19a%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c884876c6f3cc53c8599a5" data-idx="1056">
+        <div class="book-header">
+          <span class="book-num">#1057</span>
+          <h3>Le pilote de l'onde vive</h3>
+          <span class="page-count">124 pp</span>
+          <a href="https://sourcelibrary.org/book/69c884876c6f3cc53c8599a5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c884876c6f3cc53c8599a5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c884876c6f3cc53c8599a5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c884876c6f3cc53c8599a5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c884876c6f3cc53c8599a5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c884876c6f3cc53c8599a5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884876c6f3cc53c8599a5%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884876c6f3cc53c8599a5%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884876c6f3cc53c8599a5%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884876c6f3cc53c8599a5%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884876c6f3cc53c8599a5%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70fd0da9771c71631624d" data-idx="1057">
+        <div class="book-header">
+          <span class="book-num">#1058</span>
+          <h3>De verbo Dei scripto, et non scripto</h3>
+          <span class="page-count">449 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70fd0da9771c71631624d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70fd0da9771c71631624d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70fd0da9771c71631624d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70fd0da9771c71631624d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70fd0da9771c71631624d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70fd0da9771c71631624d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70fd0da9771c71631624d%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70fd0da9771c71631624d%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70fd0da9771c71631624d%2F0269-full.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70fd0da9771c71631624d%2F0359-full.jpg&w=600" alt="Page 359" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.359 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70fd0da9771c71631624d%2F0404-full.jpg&w=600" alt="Page 404" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.404 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e216295ea01b70c8d7d2" data-idx="1058">
+        <div class="book-header">
+          <span class="book-num">#1059</span>
+          <h3>[Hebrew: Seder olam raba ve seder olam suta]</h3>
+          <span class="page-count">87 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e216295ea01b70c8d7d2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e216295ea01b70c8d7d2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e216295ea01b70c8d7d2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e216295ea01b70c8d7d2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e216295ea01b70c8d7d2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e216295ea01b70c8d7d2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e216295ea01b70c8d7d2%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e216295ea01b70c8d7d2%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e216295ea01b70c8d7d2%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e216295ea01b70c8d7d2%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e216295ea01b70c8d7d2%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c813ac6c6f3cc53c847fd0" data-idx="1059">
+        <div class="book-header">
+          <span class="book-num">#1060</span>
+          <h3>The life of Lucilio (alias Julius Caesar) Vanini</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/69c813ac6c6f3cc53c847fd0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c813ac6c6f3cc53c847fd0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c813ac6c6f3cc53c847fd0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c813ac6c6f3cc53c847fd0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c813ac6c6f3cc53c847fd0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c813ac6c6f3cc53c847fd0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ac6c6f3cc53c847fd0%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ac6c6f3cc53c847fd0%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ac6c6f3cc53c847fd0%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ac6c6f3cc53c847fd0%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ac6c6f3cc53c847fd0%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c854206c6f3cc53c8537a4" data-idx="1060">
+        <div class="book-header">
+          <span class="book-num">#1061</span>
+          <h3>Nosce te ipsum, vel anatomicum vivum. Oder: Kurtz gefastes doch richtig gestelltes anatomisches Werck</h3>
+          <span class="page-count">36 pp</span>
+          <a href="https://sourcelibrary.org/book/69c854206c6f3cc53c8537a4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c854206c6f3cc53c8537a4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c854206c6f3cc53c8537a4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c854206c6f3cc53c8537a4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c854206c6f3cc53c8537a4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c854206c6f3cc53c8537a4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854206c6f3cc53c8537a4%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854206c6f3cc53c8537a4%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854206c6f3cc53c8537a4%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854206c6f3cc53c8537a4%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c854206c6f3cc53c8537a4%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418882b0edf3eaa2dd354" data-idx="1061">
+        <div class="book-header">
+          <span class="book-num">#1062</span>
+          <h3>Collection of Alchemical Illustrations (PH397)</h3>
+          <span class="page-count">49 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-illustrations-18th-century-german-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418882b0edf3eaa2dd354', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418882b0edf3eaa2dd354', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418882b0edf3eaa2dd354', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418882b0edf3eaa2dd354', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418882b0edf3eaa2dd354', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418882b0edf3eaa2dd354%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418882b0edf3eaa2dd354%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418882b0edf3eaa2dd354%2F29.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418882b0edf3eaa2dd354%2F39.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418882b0edf3eaa2dd354%2F44.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c874646c6f3cc53c857c74" data-idx="1062">
+        <div class="book-header">
+          <span class="book-num">#1063</span>
+          <h3>The elements of the true arithmetic of infinities</h3>
+          <span class="page-count">35 pp</span>
+          <a href="https://sourcelibrary.org/book/69c874646c6f3cc53c857c74" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c874646c6f3cc53c857c74', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c874646c6f3cc53c857c74', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c874646c6f3cc53c857c74', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c874646c6f3cc53c857c74', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c874646c6f3cc53c857c74', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874646c6f3cc53c857c74%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874646c6f3cc53c857c74%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874646c6f3cc53c857c74%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874646c6f3cc53c857c74%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874646c6f3cc53c857c74%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c814536c6f3cc53c848191" data-idx="1063">
+        <div class="book-header">
+          <span class="book-num">#1064</span>
+          <h3>[Theologia deutsch] Ein Deutsch Teologia</h3>
+          <span class="page-count">51 pp</span>
+          <a href="https://sourcelibrary.org/book/69c814536c6f3cc53c848191" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c814536c6f3cc53c848191', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c814536c6f3cc53c848191', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c814536c6f3cc53c848191', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c814536c6f3cc53c848191', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c814536c6f3cc53c848191', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814536c6f3cc53c848191%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814536c6f3cc53c848191%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814536c6f3cc53c848191%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814536c6f3cc53c848191%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814536c6f3cc53c848191%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82e676c6f3cc53c84d61e" data-idx="1064">
+        <div class="book-header">
+          <span class="book-num">#1065</span>
+          <h3>Thesaurus et armamentarium medico-chymicum</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82e676c6f3cc53c84d61e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82e676c6f3cc53c84d61e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82e676c6f3cc53c84d61e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82e676c6f3cc53c84d61e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82e676c6f3cc53c84d61e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82e676c6f3cc53c84d61e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e676c6f3cc53c84d61e%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e676c6f3cc53c84d61e%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e676c6f3cc53c84d61e%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e676c6f3cc53c84d61e%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e676c6f3cc53c84d61e%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8103c6c6f3cc53c8474c3" data-idx="1065">
+        <div class="book-header">
+          <span class="book-num">#1066</span>
+          <h3>Die Grewel der Verwüstung menschlichen Geschlechtes</h3>
+          <span class="page-count">708 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8103c6c6f3cc53c8474c3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8103c6c6f3cc53c8474c3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8103c6c6f3cc53c8474c3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8103c6c6f3cc53c8474c3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8103c6c6f3cc53c8474c3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8103c6c6f3cc53c8474c3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8103c6c6f3cc53c8474c3%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8103c6c6f3cc53c8474c3%2F0283-full.jpg&w=600" alt="Page 283" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.283 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8103c6c6f3cc53c8474c3%2F0425-full.jpg&w=600" alt="Page 425" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.425 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8103c6c6f3cc53c8474c3%2F0566-full.jpg&w=600" alt="Page 566" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.566 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8103c6c6f3cc53c8474c3%2F0637-full.jpg&w=600" alt="Page 637" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.637 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88a0d6c6f3cc53c85a52d" data-idx="1066">
+        <div class="book-header">
+          <span class="book-num">#1067</span>
+          <h3>Silentium post clamores, das ist, Apologi und Verantwortung</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88a0d6c6f3cc53c85a52d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88a0d6c6f3cc53c85a52d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88a0d6c6f3cc53c85a52d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88a0d6c6f3cc53c85a52d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88a0d6c6f3cc53c85a52d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88a0d6c6f3cc53c85a52d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a0d6c6f3cc53c85a52d%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a0d6c6f3cc53c85a52d%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a0d6c6f3cc53c85a52d%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a0d6c6f3cc53c85a52d%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a0d6c6f3cc53c85a52d%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e10c295ea01b70c8d66c" data-idx="1067">
+        <div class="book-header">
+          <span class="book-num">#1068</span>
+          <h3>Sententiae</h3>
+          <span class="page-count">402 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e10c295ea01b70c8d66c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e10c295ea01b70c8d66c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e10c295ea01b70c8d66c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e10c295ea01b70c8d66c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e10c295ea01b70c8d66c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e10c295ea01b70c8d66c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66c%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66c%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66c%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66c%2F0322-full.jpg&w=600" alt="Page 322" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.322 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66c%2F0362-full.jpg&w=600" alt="Page 362" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.362 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c833d26c6f3cc53c84e345" data-idx="1068">
+        <div class="book-header">
+          <span class="book-num">#1069</span>
+          <h3>Daemonomania pistoriana. Magica et cabalistica morborum curandorum ratio</h3>
+          <span class="page-count">103 pp</span>
+          <a href="https://sourcelibrary.org/book/69c833d26c6f3cc53c84e345" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c833d26c6f3cc53c84e345', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c833d26c6f3cc53c84e345', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c833d26c6f3cc53c84e345', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c833d26c6f3cc53c84e345', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c833d26c6f3cc53c84e345', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833d26c6f3cc53c84e345%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833d26c6f3cc53c84e345%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833d26c6f3cc53c84e345%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833d26c6f3cc53c84e345%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833d26c6f3cc53c84e345%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c731f56a0f3d112faf73d7" data-idx="1069">
+        <div class="book-header">
+          <span class="book-num">#1070</span>
+          <h3>[Hebrew:] Ma'yenei ha-yesh'ua</h3>
+          <span class="page-count">147 pp</span>
+          <a href="https://sourcelibrary.org/book/69c731f56a0f3d112faf73d7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c731f56a0f3d112faf73d7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c731f56a0f3d112faf73d7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c731f56a0f3d112faf73d7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c731f56a0f3d112faf73d7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c731f56a0f3d112faf73d7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731f56a0f3d112faf73d7%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731f56a0f3d112faf73d7%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731f56a0f3d112faf73d7%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731f56a0f3d112faf73d7%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731f56a0f3d112faf73d7%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419242b0edf3eaa2dedbf" data-idx="1070">
+        <div class="book-header">
+          <span class="book-num">#1071</span>
+          <h3>Processo del cavalier Francesco Giuseppe Borri (PH280)</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/trial-of-francesco-borri-alchemist-s-inquisition-post-1659-borri" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419242b0edf3eaa2dedbf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419242b0edf3eaa2dedbf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419242b0edf3eaa2dedbf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419242b0edf3eaa2dedbf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419242b0edf3eaa2dedbf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419242b0edf3eaa2dedbf%2F2.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419242b0edf3eaa2dedbf%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419242b0edf3eaa2dedbf%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419242b0edf3eaa2dedbf%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419242b0edf3eaa2dedbf%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c862ac6c6f3cc53c855bc2" data-idx="1071">
+        <div class="book-header">
+          <span class="book-num">#1072</span>
+          <h3>Theodicaea, oder, Versuch und Abhandlung, wie die Güte und Gerechtigkeit Gottes ...zu verteidigen</h3>
+          <span class="page-count">570 pp</span>
+          <a href="https://sourcelibrary.org/book/69c862ac6c6f3cc53c855bc2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c862ac6c6f3cc53c855bc2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c862ac6c6f3cc53c855bc2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c862ac6c6f3cc53c855bc2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c862ac6c6f3cc53c855bc2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c862ac6c6f3cc53c855bc2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c862ac6c6f3cc53c855bc2%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c862ac6c6f3cc53c855bc2%2F0228-full.jpg&w=600" alt="Page 228" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.228 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c862ac6c6f3cc53c855bc2%2F0342-full.jpg&w=600" alt="Page 342" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.342 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c862ac6c6f3cc53c855bc2%2F0456-full.jpg&w=600" alt="Page 456" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.456 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c862ac6c6f3cc53c855bc2%2F0513-full.jpg&w=600" alt="Page 513" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.513 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4186cf1200e2ab53cf8bf" data-idx="1072">
+        <div class="book-header">
+          <span class="book-num">#1073</span>
+          <h3>De Secretis Antimonii (PH418 A)</h3>
+          <span class="page-count">70 pp</span>
+          <a href="https://sourcelibrary.org/book/secrets-of-antimony-alexander-von-suchten-1598-suchten" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4186cf1200e2ab53cf8bf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4186cf1200e2ab53cf8bf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4186cf1200e2ab53cf8bf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4186cf1200e2ab53cf8bf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4186cf1200e2ab53cf8bf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186cf1200e2ab53cf8bf%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186cf1200e2ab53cf8bf%2F28.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186cf1200e2ab53cf8bf%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186cf1200e2ab53cf8bf%2F56.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186cf1200e2ab53cf8bf%2F63.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8907a6c6f3cc53c85b67f" data-idx="1073">
+        <div class="book-header">
+          <span class="book-num">#1074</span>
+          <h3>Weg der Wiedergeburt</h3>
+          <span class="page-count">231 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8907a6c6f3cc53c85b67f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8907a6c6f3cc53c85b67f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8907a6c6f3cc53c85b67f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8907a6c6f3cc53c85b67f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8907a6c6f3cc53c85b67f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8907a6c6f3cc53c85b67f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8907a6c6f3cc53c85b67f%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8907a6c6f3cc53c85b67f%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8907a6c6f3cc53c85b67f%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8907a6c6f3cc53c85b67f%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8907a6c6f3cc53c85b67f%2F0208-full.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7605a6a0f3d112faf8c1a" data-idx="1074">
+        <div class="book-header">
+          <span class="book-num">#1075</span>
+          <h3>Report from the Committee to whom the petition of the deputies of the United Moravian Churches ... was referred: together with some extracts of the most material vouchers and papers, contained in the appendix to the said report</h3>
+          <span class="page-count">111 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7605a6a0f3d112faf8c1a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7605a6a0f3d112faf8c1a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7605a6a0f3d112faf8c1a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7605a6a0f3d112faf8c1a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7605a6a0f3d112faf8c1a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7605a6a0f3d112faf8c1a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7605a6a0f3d112faf8c1a%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7605a6a0f3d112faf8c1a%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7605a6a0f3d112faf8c1a%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7605a6a0f3d112faf8c1a%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7605a6a0f3d112faf8c1a%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808006c6f3cc53c845b18" data-idx="1075">
+        <div class="book-header">
+          <span class="book-num">#1076</span>
+          <h3>Specimen de gemmarum origine et virtutibus</h3>
+          <span class="page-count">115 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808006c6f3cc53c845b18" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808006c6f3cc53c845b18', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808006c6f3cc53c845b18', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808006c6f3cc53c845b18', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808006c6f3cc53c845b18', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808006c6f3cc53c845b18', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808006c6f3cc53c845b18%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808006c6f3cc53c845b18%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808006c6f3cc53c845b18%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808006c6f3cc53c845b18%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808006c6f3cc53c845b18%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909e609cf28baa1b4cb0705" data-idx="1076">
+        <div class="book-header">
+          <span class="book-num">#1077</span>
+          <h3>Die Macht der Kinder in der letzten Zeit</h3>
+          <span class="page-count">164 pp</span>
+          <a href="https://sourcelibrary.org/book/the-power-of-children-in-recent-times-petersen" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909e609cf28baa1b4cb0705', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909e609cf28baa1b4cb0705', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909e609cf28baa1b4cb0705', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909e609cf28baa1b4cb0705', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909e609cf28baa1b4cb0705', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909e609cf28baa1b4cb0705%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909e609cf28baa1b4cb0705%2F66.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909e609cf28baa1b4cb0705%2F98.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909e609cf28baa1b4cb0705%2F131.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909e609cf28baa1b4cb0705%2F148.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fbc26c6f3cc53c842e50" data-idx="1077">
+        <div class="book-header">
+          <span class="book-num">#1078</span>
+          <h3>Theological and practical divinity</h3>
+          <span class="page-count">209 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fbc26c6f3cc53c842e50" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fbc26c6f3cc53c842e50', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fbc26c6f3cc53c842e50', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fbc26c6f3cc53c842e50', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fbc26c6f3cc53c842e50', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fbc26c6f3cc53c842e50', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fbc26c6f3cc53c842e50%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fbc26c6f3cc53c842e50%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fbc26c6f3cc53c842e50%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fbc26c6f3cc53c842e50%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fbc26c6f3cc53c842e50%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7d4dc25ec2ba5ccd8050a" data-idx="1078">
+        <div class="book-header">
+          <span class="book-num">#1079</span>
+          <h3>Physiologia Medica</h3>
+          <span class="page-count">491 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7d4dc25ec2ba5ccd8050a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7d4dc25ec2ba5ccd8050a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7d4dc25ec2ba5ccd8050a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7d4dc25ec2ba5ccd8050a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7d4dc25ec2ba5ccd8050a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7d4dc25ec2ba5ccd8050a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd8050a%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd8050a%2F0196-full.jpg&w=600" alt="Page 196" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.196 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd8050a%2F0295-full.jpg&w=600" alt="Page 295" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.295 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd8050a%2F0393-full.jpg&w=600" alt="Page 393" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.393 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd8050a%2F0442-full.jpg&w=600" alt="Page 442" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.442 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88cfc6c6f3cc53c85adc2" data-idx="1079">
+        <div class="book-header">
+          <span class="book-num">#1080</span>
+          <h3>Trinité-Principe. Compendium</h3>
+          <span class="page-count">99 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88cfc6c6f3cc53c85adc2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88cfc6c6f3cc53c85adc2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88cfc6c6f3cc53c85adc2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88cfc6c6f3cc53c85adc2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88cfc6c6f3cc53c85adc2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88cfc6c6f3cc53c85adc2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cfc6c6f3cc53c85adc2%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cfc6c6f3cc53c85adc2%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cfc6c6f3cc53c85adc2%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cfc6c6f3cc53c85adc2%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cfc6c6f3cc53c85adc2%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fa3f6c6f3cc53c8429ec" data-idx="1080">
+        <div class="book-header">
+          <span class="book-num">#1081</span>
+          <h3>Harmonia Reuchlini et Lutheri A. MDXVII</h3>
+          <span class="page-count">84 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fa3f6c6f3cc53c8429ec" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fa3f6c6f3cc53c8429ec', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fa3f6c6f3cc53c8429ec', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fa3f6c6f3cc53c8429ec', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fa3f6c6f3cc53c8429ec', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fa3f6c6f3cc53c8429ec', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa3f6c6f3cc53c8429ec%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa3f6c6f3cc53c8429ec%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa3f6c6f3cc53c8429ec%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa3f6c6f3cc53c8429ec%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa3f6c6f3cc53c8429ec%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c879206c6f3cc53c8583fa" data-idx="1081">
+        <div class="book-header">
+          <span class="book-num">#1082</span>
+          <h3>Hirten-Brief an die wahren und ächten Freymäurer alten Systems</h3>
+          <span class="page-count">133 pp</span>
+          <a href="https://sourcelibrary.org/book/69c879206c6f3cc53c8583fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c879206c6f3cc53c8583fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c879206c6f3cc53c8583fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c879206c6f3cc53c8583fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c879206c6f3cc53c8583fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c879206c6f3cc53c8583fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879206c6f3cc53c8583fa%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879206c6f3cc53c8583fa%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879206c6f3cc53c8583fa%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879206c6f3cc53c8583fa%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879206c6f3cc53c8583fa%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71f52da9771c716316b0c" data-idx="1082">
+        <div class="book-header">
+          <span class="book-num">#1083</span>
+          <h3>Brüderliche Vermahnungen an einige Brüder Freymäurer</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71f52da9771c716316b0c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71f52da9771c716316b0c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71f52da9771c716316b0c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71f52da9771c716316b0c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71f52da9771c716316b0c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71f52da9771c716316b0c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f52da9771c716316b0c%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f52da9771c716316b0c%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f52da9771c716316b0c%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f52da9771c716316b0c%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f52da9771c716316b0c%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c886bb6c6f3cc53c859e88" data-idx="1083">
+        <div class="book-header">
+          <span class="book-num">#1084</span>
+          <h3>The real history of the Rosicrucians founded on their own manifestoes, and on facts and documents collected from the writings of initiated brethren</h3>
+          <span class="page-count">252 pp</span>
+          <a href="https://sourcelibrary.org/book/69c886bb6c6f3cc53c859e88" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c886bb6c6f3cc53c859e88', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c886bb6c6f3cc53c859e88', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c886bb6c6f3cc53c859e88', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c886bb6c6f3cc53c859e88', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c886bb6c6f3cc53c859e88', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886bb6c6f3cc53c859e88%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886bb6c6f3cc53c859e88%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886bb6c6f3cc53c859e88%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886bb6c6f3cc53c859e88%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886bb6c6f3cc53c859e88%2F0227-full.jpg&w=600" alt="Page 227" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.227 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82eb86c6f3cc53c84d6c9" data-idx="1084">
+        <div class="book-header">
+          <span class="book-num">#1085</span>
+          <h3>Rettung dess guten ehrlichen Namens. Herrn Johann Faulhabers bestelten Rechenmeisters und mathematici etc. in Ulm</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82eb86c6f3cc53c84d6c9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82eb86c6f3cc53c84d6c9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82eb86c6f3cc53c84d6c9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82eb86c6f3cc53c84d6c9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82eb86c6f3cc53c84d6c9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82eb86c6f3cc53c84d6c9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82eb86c6f3cc53c84d6c9%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82eb86c6f3cc53c84d6c9%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82eb86c6f3cc53c84d6c9%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82eb86c6f3cc53c84d6c9%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82eb86c6f3cc53c84d6c9%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82ebd6c6f3cc53c84d6cd" data-idx="1085">
+        <div class="book-header">
+          <span class="book-num">#1086</span>
+          <h3>Les principes de la nature, ou de la generation des choses</h3>
+          <span class="page-count">191 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82ebd6c6f3cc53c84d6cd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82ebd6c6f3cc53c84d6cd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82ebd6c6f3cc53c84d6cd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82ebd6c6f3cc53c84d6cd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82ebd6c6f3cc53c84d6cd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82ebd6c6f3cc53c84d6cd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ebd6c6f3cc53c84d6cd%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ebd6c6f3cc53c84d6cd%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ebd6c6f3cc53c84d6cd%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ebd6c6f3cc53c84d6cd%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ebd6c6f3cc53c84d6cd%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69099983cf28baa1b4cae913" data-idx="1086">
+        <div class="book-header">
+          <span class="book-num">#1087</span>
+          <h3>Von der liebe Gottes ein wunder hübsch underrichtung</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/a-wonderfully-beautiful-instruction-on-the-love-of-god-staupitz" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69099983cf28baa1b4cae913', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69099983cf28baa1b4cae913', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69099983cf28baa1b4cae913', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69099983cf28baa1b4cae913', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69099983cf28baa1b4cae913', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099983cf28baa1b4cae913%2F2.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099983cf28baa1b4cae913%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099983cf28baa1b4cae913%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099983cf28baa1b4cae913%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099983cf28baa1b4cae913%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c824716c6f3cc53c84b46e" data-idx="1087">
+        <div class="book-header">
+          <span class="book-num">#1088</span>
+          <h3>Die alleen-spraecke der zielen met Godt</h3>
+          <span class="page-count">149 pp</span>
+          <a href="https://sourcelibrary.org/book/69c824716c6f3cc53c84b46e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c824716c6f3cc53c84b46e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c824716c6f3cc53c84b46e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c824716c6f3cc53c84b46e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c824716c6f3cc53c84b46e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c824716c6f3cc53c84b46e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824716c6f3cc53c84b46e%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824716c6f3cc53c84b46e%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824716c6f3cc53c84b46e%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824716c6f3cc53c84b46e%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824716c6f3cc53c84b46e%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4192e2b0edf3eaa2def0d" data-idx="1088">
+        <div class="book-header">
+          <span class="book-num">#1089</span>
+          <h3>Artephij — Geheimes Buch des Steins der Weisen (PH240)</h3>
+          <span class="page-count">87 pp</span>
+          <a href="https://sourcelibrary.org/book/artephius-secret-book-of-the-philosopher-s-stone-18th-c-scheibenhof" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4192e2b0edf3eaa2def0d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4192e2b0edf3eaa2def0d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4192e2b0edf3eaa2def0d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4192e2b0edf3eaa2def0d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4192e2b0edf3eaa2def0d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4192e2b0edf3eaa2def0d%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485735505131!PH240_0035.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485735505131!PH240_0052.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485735505131!PH240_0070.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485735505131!PH240_0078.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html" class="active">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-2.html
+++ b/public/split-review-2.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 2/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html" class="active">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c89bf46c6f3cc53c85d4a4" data-idx="100">
+        <div class="book-header">
+          <span class="book-num">#101</span>
+          <h3>The serpent myth</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89bf46c6f3cc53c85d4a4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89bf46c6f3cc53c85d4a4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89bf46c6f3cc53c85d4a4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89bf46c6f3cc53c85d4a4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89bf46c6f3cc53c85d4a4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89bf46c6f3cc53c85d4a4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89bf46c6f3cc53c85d4a4%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89bf46c6f3cc53c85d4a4%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89bf46c6f3cc53c85d4a4%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89bf46c6f3cc53c85d4a4%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89bf46c6f3cc53c85d4a4%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c801686c6f3cc53c844303" data-idx="101">
+        <div class="book-header">
+          <span class="book-num">#102</span>
+          <h3>Verhandelinge van des menschen verlossinge</h3>
+          <span class="page-count">263 pp</span>
+          <a href="https://sourcelibrary.org/book/69c801686c6f3cc53c844303" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c801686c6f3cc53c844303', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c801686c6f3cc53c844303', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c801686c6f3cc53c844303', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c801686c6f3cc53c844303', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c801686c6f3cc53c844303', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801686c6f3cc53c844303%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801686c6f3cc53c844303%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801686c6f3cc53c844303%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801686c6f3cc53c844303%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801686c6f3cc53c844303%2F0237-full.jpg&w=600" alt="Page 237" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.237 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418cc2b0edf3eaa2ddea6" data-idx="102">
+        <div class="book-header">
+          <span class="book-num">#103</span>
+          <h3>Eine kurze Eröffnung der dreyen Principien (PH464)</h3>
+          <span class="page-count">120 pp</span>
+          <a href="https://sourcelibrary.org/book/opening-of-the-three-principles-graber-gichtel-1808-gichtel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418cc2b0edf3eaa2ddea6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418cc2b0edf3eaa2ddea6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418cc2b0edf3eaa2ddea6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418cc2b0edf3eaa2ddea6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418cc2b0edf3eaa2ddea6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418cc2b0edf3eaa2ddea6%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940506839805131!PH464_048.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940506839805131!PH464_072.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940506839805131!PH464_096.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940506839805131!PH464_108.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6105" data-idx="103">
+        <div class="book-header">
+          <span class="book-num">#104</span>
+          <h3>Les plus secrets mystères des hauts grades de la maçonnerie dévoilés</h3>
+          <span class="page-count">82 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6105" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6105', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6105', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6105', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6105', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6105', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6105%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6105%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6105%2F49.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6105%2F66.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6105%2F74.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3551fbd40b95eaa32" data-idx="104">
+        <div class="book-header">
+          <span class="book-num">#105</span>
+          <h3>Versuch einer Geschichte des Tempelherrenordens</h3>
+          <span class="page-count">82 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3551fbd40b95eaa32" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3551fbd40b95eaa32', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3551fbd40b95eaa32', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3551fbd40b95eaa32', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3551fbd40b95eaa32', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3551fbd40b95eaa32', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa32%2F69c583022d4d1c12aa11cebe.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa32%2F69c58728d8ae1f7765f07cba.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa32%2F69c58a24aa0a0dceb519b2bf.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa32%2F69c58c2ff03859559f78ed49.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa32%2F69c58d95ffc1193fdce25a8b.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8982b6c6f3cc53c85ca37" data-idx="105">
+        <div class="book-header">
+          <span class="book-num">#106</span>
+          <h3>The Journal of the Alchemical Society</h3>
+          <span class="page-count">217 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8982b6c6f3cc53c85ca37" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8982b6c6f3cc53c85ca37', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8982b6c6f3cc53c85ca37', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8982b6c6f3cc53c85ca37', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8982b6c6f3cc53c85ca37', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8982b6c6f3cc53c85ca37', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982b6c6f3cc53c85ca37%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982b6c6f3cc53c85ca37%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982b6c6f3cc53c85ca37%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982b6c6f3cc53c85ca37%2F0174-full.jpg&w=600" alt="Page 174" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.174 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982b6c6f3cc53c85ca37%2F0195-full.jpg&w=600" alt="Page 195" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.195 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6123" data-idx="106">
+        <div class="book-header">
+          <span class="book-num">#107</span>
+          <h3>Pymander. Asclepius. De mysteriis Aegyptiorum. In Platonicum Alcibiadem, de anima &amp; daemone. De sacrificio</h3>
+          <span class="page-count">237 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6123" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6123', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6123', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6123', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6123', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6123', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6123%2F69c55b89bcd37402a1a4bf07.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6123%2F69c5646ef380bcbb4f585f66.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6123%2F69c569b8160f55f98931921b.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6123%2F69c56f4352540f4987dbab83.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6123%2F69c571c6159ed8681265e5ba.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87bd56c6f3cc53c858922" data-idx="107">
+        <div class="book-header">
+          <span class="book-num">#108</span>
+          <h3>De laudibus sancte crucis</h3>
+          <span class="page-count">91 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87bd56c6f3cc53c858922" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87bd56c6f3cc53c858922', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87bd56c6f3cc53c858922', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87bd56c6f3cc53c858922', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87bd56c6f3cc53c858922', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87bd56c6f3cc53c858922', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bd56c6f3cc53c858922%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bd56c6f3cc53c858922%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bd56c6f3cc53c858922%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bd56c6f3cc53c858922%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bd56c6f3cc53c858922%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f4326c6f3cc53c841793" data-idx="108">
+        <div class="book-header">
+          <span class="book-num">#109</span>
+          <h3>Scenen aus dem Geisterreiche</h3>
+          <span class="page-count">175 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f4326c6f3cc53c841793" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f4326c6f3cc53c841793', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f4326c6f3cc53c841793', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f4326c6f3cc53c841793', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f4326c6f3cc53c841793', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f4326c6f3cc53c841793', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4326c6f3cc53c841793%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4326c6f3cc53c841793%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4326c6f3cc53c841793%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4326c6f3cc53c841793%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4326c6f3cc53c841793%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85cb76c6f3cc53c854d3f" data-idx="109">
+        <div class="book-header">
+          <span class="book-num">#110</span>
+          <h3>The Divine Being and its attributes</h3>
+          <span class="page-count">132 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85cb76c6f3cc53c854d3f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85cb76c6f3cc53c854d3f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85cb76c6f3cc53c854d3f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85cb76c6f3cc53c854d3f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85cb76c6f3cc53c854d3f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85cb76c6f3cc53c854d3f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cb76c6f3cc53c854d3f%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cb76c6f3cc53c854d3f%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cb76c6f3cc53c854d3f%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cb76c6f3cc53c854d3f%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cb76c6f3cc53c854d3f%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4195ef6141ca31143b773" data-idx="110">
+        <div class="book-header">
+          <span class="book-num">#111</span>
+          <h3>Catalogue of Alchemical MSS of Elias Ashmole, Bodleian (PH377)</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/catalog-of-ashmole-s-alchemical-manuscripts-bodleian-library-hamilton-jones" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4195ef6141ca31143b773', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4195ef6141ca31143b773', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4195ef6141ca31143b773', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4195ef6141ca31143b773', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4195ef6141ca31143b773', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195ef6141ca31143b773%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195ef6141ca31143b773%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940447228505131!PH377_0026.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940447228505131!PH377_0034.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940447228505131!PH377_0039.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87ae96c6f3cc53c858797" data-idx="111">
+        <div class="book-header">
+          <span class="book-num">#112</span>
+          <h3>Der Hüter</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87ae96c6f3cc53c858797" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87ae96c6f3cc53c858797', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87ae96c6f3cc53c858797', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87ae96c6f3cc53c858797', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87ae96c6f3cc53c858797', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87ae96c6f3cc53c858797', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ae96c6f3cc53c858797%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ae96c6f3cc53c858797%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ae96c6f3cc53c858797%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ae96c6f3cc53c858797%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ae96c6f3cc53c858797%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87e076c6f3cc53c858c5a" data-idx="112">
+        <div class="book-header">
+          <span class="book-num">#113</span>
+          <h3>Le livre intitule lart de bien vivre; et de bien mourir</h3>
+          <span class="page-count">183 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87e076c6f3cc53c858c5a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87e076c6f3cc53c858c5a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87e076c6f3cc53c858c5a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87e076c6f3cc53c858c5a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87e076c6f3cc53c858c5a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87e076c6f3cc53c858c5a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e076c6f3cc53c858c5a%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e076c6f3cc53c858c5a%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e076c6f3cc53c858c5a%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e076c6f3cc53c858c5a%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e076c6f3cc53c858c5a%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c838a66c6f3cc53c84f0d1" data-idx="113">
+        <div class="book-header">
+          <span class="book-num">#114</span>
+          <h3>Postilla oder geistreiche Erklärung der gewöhnlichen Sonn- und Fest-Tags-Evangelien</h3>
+          <span class="page-count">788 pp</span>
+          <a href="https://sourcelibrary.org/book/69c838a66c6f3cc53c84f0d1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c838a66c6f3cc53c84f0d1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c838a66c6f3cc53c84f0d1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c838a66c6f3cc53c84f0d1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c838a66c6f3cc53c84f0d1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c838a66c6f3cc53c84f0d1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838a66c6f3cc53c84f0d1%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838a66c6f3cc53c84f0d1%2F0315-full.jpg&w=600" alt="Page 315" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.315 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838a66c6f3cc53c84f0d1%2F0473-full.jpg&w=600" alt="Page 473" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.473 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838a66c6f3cc53c84f0d1%2F0630-full.jpg&w=600" alt="Page 630" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.630 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838a66c6f3cc53c84f0d1%2F0709-full.jpg&w=600" alt="Page 709" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.709 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c771e96a0f3d112faf91b8" data-idx="114">
+        <div class="book-header">
+          <span class="book-num">#115</span>
+          <h3>Curiositez inouyes, sur la sculpture talismanique des Persans. Horoscope des patriarches et lecture des estoilles</h3>
+          <span class="page-count">180 pp</span>
+          <a href="https://sourcelibrary.org/book/69c771e96a0f3d112faf91b8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c771e96a0f3d112faf91b8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c771e96a0f3d112faf91b8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c771e96a0f3d112faf91b8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c771e96a0f3d112faf91b8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c771e96a0f3d112faf91b8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771e96a0f3d112faf91b8%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771e96a0f3d112faf91b8%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771e96a0f3d112faf91b8%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771e96a0f3d112faf91b8%2F0144-full.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771e96a0f3d112faf91b8%2F0162-full.jpg&w=600" alt="Page 162" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.162 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8437d6c6f3cc53c851018" data-idx="115">
+        <div class="book-header">
+          <span class="book-num">#116</span>
+          <h3>Medulla animae, das ist, von Vollkommenheit aller Tugenden</h3>
+          <span class="page-count">293 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8437d6c6f3cc53c851018" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8437d6c6f3cc53c851018', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8437d6c6f3cc53c851018', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8437d6c6f3cc53c851018', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8437d6c6f3cc53c851018', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8437d6c6f3cc53c851018', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8437d6c6f3cc53c851018%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8437d6c6f3cc53c851018%2F0117-full.jpg&w=600" alt="Page 117" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.117 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8437d6c6f3cc53c851018%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8437d6c6f3cc53c851018%2F0234-full.jpg&w=600" alt="Page 234" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.234 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8437d6c6f3cc53c851018%2F0264-full.jpg&w=600" alt="Page 264" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.264 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c819dc6c6f3cc53c849548" data-idx="116">
+        <div class="book-header">
+          <span class="book-num">#117</span>
+          <h3>Levendige herts-theologie</h3>
+          <span class="page-count">100 pp</span>
+          <a href="https://sourcelibrary.org/book/69c819dc6c6f3cc53c849548" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c819dc6c6f3cc53c849548', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c819dc6c6f3cc53c849548', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c819dc6c6f3cc53c849548', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c819dc6c6f3cc53c849548', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c819dc6c6f3cc53c849548', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819dc6c6f3cc53c849548%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819dc6c6f3cc53c849548%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819dc6c6f3cc53c849548%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819dc6c6f3cc53c849548%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c819dc6c6f3cc53c849548%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909d4a7cf28baa1b4cb01a5" data-idx="117">
+        <div class="book-header">
+          <span class="book-num">#118</span>
+          <h3>Téléscope de Zoroastre, ou clef de la grande cabale divinatoire des mages</h3>
+          <span class="page-count">97 pp</span>
+          <a href="https://sourcelibrary.org/book/telescope-of-zoroaster-or-the-key-to-the-great-divinatory-nerciat" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909d4a7cf28baa1b4cb01a5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909d4a7cf28baa1b4cb01a5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909d4a7cf28baa1b4cb01a5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909d4a7cf28baa1b4cb01a5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909d4a7cf28baa1b4cb01a5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d4a7cf28baa1b4cb01a5%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d4a7cf28baa1b4cb01a5%2F39.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d4a7cf28baa1b4cb01a5%2F58.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d4a7cf28baa1b4cb01a5%2F78.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d4a7cf28baa1b4cb01a5%2F87.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c718aada9771c71631663b" data-idx="118">
+        <div class="book-header">
+          <span class="book-num">#119</span>
+          <h3>Evangelische Kirchen-Harmonie</h3>
+          <span class="page-count">507 pp</span>
+          <a href="https://sourcelibrary.org/book/69c718aada9771c71631663b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c718aada9771c71631663b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c718aada9771c71631663b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c718aada9771c71631663b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c718aada9771c71631663b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c718aada9771c71631663b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c718aada9771c71631663b%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c718aada9771c71631663b%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c718aada9771c71631663b%2F0304-full.jpg&w=600" alt="Page 304" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.304 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c718aada9771c71631663b%2F0406-full.jpg&w=600" alt="Page 406" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.406 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c718aada9771c71631663b%2F0456-full.jpg&w=600" alt="Page 456" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.456 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8278b6c6f3cc53c84c09a" data-idx="119">
+        <div class="book-header">
+          <span class="book-num">#120</span>
+          <h3>Samlungen [!] von Briefen und Aufsätzen über die Gassnerischen und Schröpferischen Geisterbeschwörungen</h3>
+          <span class="page-count">363 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8278b6c6f3cc53c84c09a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8278b6c6f3cc53c84c09a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8278b6c6f3cc53c84c09a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8278b6c6f3cc53c84c09a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8278b6c6f3cc53c84c09a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8278b6c6f3cc53c84c09a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8278b6c6f3cc53c84c09a%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8278b6c6f3cc53c84c09a%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8278b6c6f3cc53c84c09a%2F0218-full.jpg&w=600" alt="Page 218" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.218 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8278b6c6f3cc53c84c09a%2F0290-full.jpg&w=600" alt="Page 290" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.290 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8278b6c6f3cc53c84c09a%2F0327-full.jpg&w=600" alt="Page 327" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.327 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c634823e8cae136d1497fa" data-idx="120">
+        <div class="book-header">
+          <span class="book-num">#121</span>
+          <h3>Versuch über die Beschuldigungen welche dem Tempelherrenorden gemacht worden, und über dessen Geheimniss</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c634823e8cae136d1497fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c634823e8cae136d1497fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c634823e8cae136d1497fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c634823e8cae136d1497fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c634823e8cae136d1497fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c634823e8cae136d1497fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c634823e8cae136d1497fa%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c634823e8cae136d1497fa%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c634823e8cae136d1497fa%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c634823e8cae136d1497fa%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c634823e8cae136d1497fa%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41958cea21ec2e5d0e11a" data-idx="121">
+        <div class="book-header">
+          <span class="book-num">#122</span>
+          <h3>Introduction Hominis — Johann Ambrosius Siebmacher (PH404)</h3>
+          <span class="page-count">76 pp</span>
+          <a href="https://sourcelibrary.org/book/siebmacher-introduction-of-man-what-to-study-in-life-1607-siebmacher" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41958cea21ec2e5d0e11a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41958cea21ec2e5d0e11a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41958cea21ec2e5d0e11a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41958cea21ec2e5d0e11a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41958cea21ec2e5d0e11a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41958cea21ec2e5d0e11a%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41958cea21ec2e5d0e11a%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41958cea21ec2e5d0e11a%2F46.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41958cea21ec2e5d0e11a%2F61.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41958cea21ec2e5d0e11a%2F68.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b9e125ec2ba5ccd7f8b5" data-idx="122">
+        <div class="book-header">
+          <span class="book-num">#123</span>
+          <h3>Dissertation von der Universal-Tinctur</h3>
+          <span class="page-count">139 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b9e125ec2ba5ccd7f8b5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b9e125ec2ba5ccd7f8b5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b9e125ec2ba5ccd7f8b5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b9e125ec2ba5ccd7f8b5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b9e125ec2ba5ccd7f8b5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b9e125ec2ba5ccd7f8b5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b9e125ec2ba5ccd7f8b5%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b9e125ec2ba5ccd7f8b5%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b9e125ec2ba5ccd7f8b5%2F0083-full.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b9e125ec2ba5ccd7f8b5%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b9e125ec2ba5ccd7f8b5%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c72e586a0f3d112faf71e3" data-idx="123">
+        <div class="book-header">
+          <span class="book-num">#124</span>
+          <h3>[Greek: Peri Bion, Dogmaton kai apophthegmaton ton en philosophia eudokimesanton: biblia deka] De vitis, decretis &amp; responsis celebrium philosophorum libri decem</h3>
+          <span class="page-count">301 pp</span>
+          <a href="https://sourcelibrary.org/book/69c72e586a0f3d112faf71e3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c72e586a0f3d112faf71e3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c72e586a0f3d112faf71e3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c72e586a0f3d112faf71e3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c72e586a0f3d112faf71e3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c72e586a0f3d112faf71e3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72e586a0f3d112faf71e3%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72e586a0f3d112faf71e3%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72e586a0f3d112faf71e3%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72e586a0f3d112faf71e3%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72e586a0f3d112faf71e3%2F0271-full.jpg&w=600" alt="Page 271" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.271 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86df86c6f3cc53c856ded" data-idx="124">
+        <div class="book-header">
+          <span class="book-num">#125</span>
+          <h3>Cabala, speculum artis et naturae, in alchymia</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86df86c6f3cc53c856ded" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86df86c6f3cc53c856ded', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86df86c6f3cc53c856ded', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86df86c6f3cc53c856ded', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86df86c6f3cc53c856ded', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86df86c6f3cc53c856ded', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86df86c6f3cc53c856ded%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86df86c6f3cc53c856ded%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86df86c6f3cc53c856ded%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86df86c6f3cc53c856ded%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86df86c6f3cc53c856ded%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6fe30da9771c71631554a" data-idx="125">
+        <div class="book-header">
+          <span class="book-num">#126</span>
+          <h3>Ueber die Zauberkraefte der Natur</h3>
+          <span class="page-count">57 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6fe30da9771c71631554a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6fe30da9771c71631554a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6fe30da9771c71631554a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6fe30da9771c71631554a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6fe30da9771c71631554a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6fe30da9771c71631554a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fe30da9771c71631554a%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fe30da9771c71631554a%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fe30da9771c71631554a%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fe30da9771c71631554a%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fe30da9771c71631554a%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8701f6c6f3cc53c857213" data-idx="126">
+        <div class="book-header">
+          <span class="book-num">#127</span>
+          <h3>Chymisticum artificium naturae</h3>
+          <span class="page-count">317 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8701f6c6f3cc53c857213" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8701f6c6f3cc53c857213', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8701f6c6f3cc53c857213', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8701f6c6f3cc53c857213', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8701f6c6f3cc53c857213', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8701f6c6f3cc53c857213', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8701f6c6f3cc53c857213%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8701f6c6f3cc53c857213%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8701f6c6f3cc53c857213%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8701f6c6f3cc53c857213%2F0254-full.jpg&w=600" alt="Page 254" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.254 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8701f6c6f3cc53c857213%2F0285-full.jpg&w=600" alt="Page 285" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.285 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8059e6c6f3cc53c845291" data-idx="127">
+        <div class="book-header">
+          <span class="book-num">#128</span>
+          <h3>Abgenöthigtes jedoch Andern nicht wieder aufgenöthigtes Glaubens-Bekentniss</h3>
+          <span class="page-count">193 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8059e6c6f3cc53c845291" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8059e6c6f3cc53c845291', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8059e6c6f3cc53c845291', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8059e6c6f3cc53c845291', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8059e6c6f3cc53c845291', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8059e6c6f3cc53c845291', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845291%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845291%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845291%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845291%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845291%2F0174-full.jpg&w=600" alt="Page 174" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.174 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41874f1200e2ab53cf922" data-idx="128">
+        <div class="book-header">
+          <span class="book-num">#129</span>
+          <h3>Lehr-Sätze eines Philosophi von der Weisheit und Chymie (PH475 A)</h3>
+          <span class="page-count">42 pp</span>
+          <a href="https://sourcelibrary.org/book/teachings-of-a-philosopher-on-wisdom-and-chemistry-schwartzfuss" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41874f1200e2ab53cf922', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41874f1200e2ab53cf922', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41874f1200e2ab53cf922', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41874f1200e2ab53cf922', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41874f1200e2ab53cf922', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41874f1200e2ab53cf922%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41874f1200e2ab53cf922%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41874f1200e2ab53cf922%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41874f1200e2ab53cf922%2F34.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41874f1200e2ab53cf922%2F38.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85e7f6c6f3cc53c855203" data-idx="129">
+        <div class="book-header">
+          <span class="book-num">#130</span>
+          <h3>Enchiridion Leonis papae</h3>
+          <span class="page-count">95 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85e7f6c6f3cc53c855203" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85e7f6c6f3cc53c855203', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85e7f6c6f3cc53c855203', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85e7f6c6f3cc53c855203', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85e7f6c6f3cc53c855203', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85e7f6c6f3cc53c855203', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e7f6c6f3cc53c855203%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e7f6c6f3cc53c855203%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e7f6c6f3cc53c855203%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e7f6c6f3cc53c855203%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e7f6c6f3cc53c855203%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c795836a0f3d112fafa04e" data-idx="130">
+        <div class="book-header">
+          <span class="book-num">#131</span>
+          <h3>Lehr-Sätze von der Atheisterey und dem Aberglauben</h3>
+          <span class="page-count">429 pp</span>
+          <a href="https://sourcelibrary.org/book/69c795836a0f3d112fafa04e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c795836a0f3d112fafa04e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c795836a0f3d112fafa04e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c795836a0f3d112fafa04e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c795836a0f3d112fafa04e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c795836a0f3d112fafa04e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795836a0f3d112fafa04e%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795836a0f3d112fafa04e%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795836a0f3d112fafa04e%2F0257-full.jpg&w=600" alt="Page 257" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.257 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795836a0f3d112fafa04e%2F0343-full.jpg&w=600" alt="Page 343" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.343 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795836a0f3d112fafa04e%2F0386-full.jpg&w=600" alt="Page 386" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.386 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c887a66c6f3cc53c85a109" data-idx="131">
+        <div class="book-header">
+          <span class="book-num">#132</span>
+          <h3>Rosa florescens, contra F.G. Menapii calumnias. Das ist: kurtzer Bericht und Widerantwort</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/69c887a66c6f3cc53c85a109" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c887a66c6f3cc53c85a109', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c887a66c6f3cc53c85a109', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c887a66c6f3cc53c85a109', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c887a66c6f3cc53c85a109', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c887a66c6f3cc53c85a109', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887a66c6f3cc53c85a109%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887a66c6f3cc53c85a109%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887a66c6f3cc53c85a109%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887a66c6f3cc53c85a109%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887a66c6f3cc53c85a109%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419302b0edf3eaa2def66" data-idx="132">
+        <div class="book-header">
+          <span class="book-num">#133</span>
+          <h3>Explication des fourneaux et vaisseaux — Jaques Wecher (PH288)</h3>
+          <span class="page-count">78 pp</span>
+          <a href="https://sourcelibrary.org/book/chemical-furnaces-vessels-wecher-17th-century-french-ms-wecher" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419302b0edf3eaa2def66', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419302b0edf3eaa2def66', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419302b0edf3eaa2def66', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419302b0edf3eaa2def66', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419302b0edf3eaa2def66', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419302b0edf3eaa2def66%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524728405131!PH288_0031.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524728405131!PH288_0047.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524728405131!PH288_0062.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524728405131!PH288_0070.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8254d6c6f3cc53c84b865" data-idx="133">
+        <div class="book-header">
+          <span class="book-num">#134</span>
+          <h3>Apologia chrysopoeiae et argyropoeiae</h3>
+          <span class="page-count">120 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8254d6c6f3cc53c84b865" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8254d6c6f3cc53c84b865', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8254d6c6f3cc53c84b865', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8254d6c6f3cc53c84b865', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8254d6c6f3cc53c84b865', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8254d6c6f3cc53c84b865', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8254d6c6f3cc53c84b865%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8254d6c6f3cc53c84b865%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8254d6c6f3cc53c84b865%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8254d6c6f3cc53c84b865%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8254d6c6f3cc53c84b865%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6121" data-idx="134">
+        <div class="book-header">
+          <span class="book-num">#135</span>
+          <h3>Les plus secrets mystères des hauts grades de la maçonnerie dévoilés</h3>
+          <span class="page-count">92 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6121" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6121', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6121', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6121', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6121', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6121', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6121%2F69c55941b0edcc5524034d80.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6121%2F69c55d38d5ad149700658ab4.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6121%2F69c55fdee0767c71288fadb0.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6121%2F69c561f4468cc7c14e9843f6.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6121%2F69c562bf75f9912ac29195de.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419172b0edf3eaa2dec27" data-idx="135">
+        <div class="book-header">
+          <span class="book-num">#136</span>
+          <h3>La Toyson d'Or — Salomon Trismosin (PH167)</h3>
+          <span class="page-count">91 pp</span>
+          <a href="https://sourcelibrary.org/book/golden-fleece-trismosin-splendor-solis-author-18th-century-trismosin" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419172b0edf3eaa2dec27', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419172b0edf3eaa2dec27', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419172b0edf3eaa2dec27', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419172b0edf3eaa2dec27', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419172b0edf3eaa2dec27', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419172b0edf3eaa2dec27%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419172b0edf3eaa2dec27%2F36.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419172b0edf3eaa2dec27%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419172b0edf3eaa2dec27%2F73.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419172b0edf3eaa2dec27%2F82.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41899e9bfda40a8a6c767" data-idx="136">
+        <div class="book-header">
+          <span class="book-num">#137</span>
+          <h3>De Occulta Philosophia — Paracelsus (PH253)</h3>
+          <span class="page-count">80 pp</span>
+          <a href="https://sourcelibrary.org/book/paracelsus-on-occult-philosophy-16th-century-german-ms-paracelsus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41899e9bfda40a8a6c767', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41899e9bfda40a8a6c767', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41899e9bfda40a8a6c767', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41899e9bfda40a8a6c767', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41899e9bfda40a8a6c767', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41899e9bfda40a8a6c767%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41899e9bfda40a8a6c767%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41899e9bfda40a8a6c767%2F48.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41899e9bfda40a8a6c767%2F64.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41899e9bfda40a8a6c767%2F72.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c843386c6f3cc53c850f0f" data-idx="137">
+        <div class="book-header">
+          <span class="book-num">#138</span>
+          <h3>Dictionnaire de chymie</h3>
+          <span class="page-count">311 pp</span>
+          <a href="https://sourcelibrary.org/book/69c843386c6f3cc53c850f0f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c843386c6f3cc53c850f0f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c843386c6f3cc53c850f0f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c843386c6f3cc53c850f0f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c843386c6f3cc53c850f0f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c843386c6f3cc53c850f0f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843386c6f3cc53c850f0f%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843386c6f3cc53c850f0f%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843386c6f3cc53c850f0f%2F0187-full.jpg&w=600" alt="Page 187" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.187 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843386c6f3cc53c850f0f%2F0249-full.jpg&w=600" alt="Page 249" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.249 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843386c6f3cc53c850f0f%2F0280-full.jpg&w=600" alt="Page 280" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.280 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c895ab6c6f3cc53c85c3ae" data-idx="138">
+        <div class="book-header">
+          <span class="book-num">#139</span>
+          <h3>Salon des Champs-Élysées. Règle pour la geste esthétique</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c895ab6c6f3cc53c85c3ae" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c895ab6c6f3cc53c85c3ae', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c895ab6c6f3cc53c85c3ae', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c895ab6c6f3cc53c85c3ae', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c895ab6c6f3cc53c85c3ae', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c895ab6c6f3cc53c85c3ae', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895ab6c6f3cc53c85c3ae%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895ab6c6f3cc53c85c3ae%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895ab6c6f3cc53c85c3ae%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895ab6c6f3cc53c85c3ae%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895ab6c6f3cc53c85c3ae%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fe2e6c6f3cc53c8436b4" data-idx="139">
+        <div class="book-header">
+          <span class="book-num">#140</span>
+          <h3>Discours fait en une celebre assemblée [...] touchant le guerison des playes par la poudre de sympathie</h3>
+          <span class="page-count">105 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fe2e6c6f3cc53c8436b4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fe2e6c6f3cc53c8436b4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fe2e6c6f3cc53c8436b4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fe2e6c6f3cc53c8436b4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fe2e6c6f3cc53c8436b4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fe2e6c6f3cc53c8436b4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2e6c6f3cc53c8436b4%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2e6c6f3cc53c8436b4%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2e6c6f3cc53c8436b4%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2e6c6f3cc53c8436b4%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2e6c6f3cc53c8436b4%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c726be01e1be0c9ac74d2b" data-idx="140">
+        <div class="book-header">
+          <span class="book-num">#141</span>
+          <h3>[Greek: Gnomologia]</h3>
+          <span class="page-count">50 pp</span>
+          <a href="https://sourcelibrary.org/book/69c726be01e1be0c9ac74d2b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c726be01e1be0c9ac74d2b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c726be01e1be0c9ac74d2b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c726be01e1be0c9ac74d2b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c726be01e1be0c9ac74d2b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c726be01e1be0c9ac74d2b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c726be01e1be0c9ac74d2b%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c726be01e1be0c9ac74d2b%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c726be01e1be0c9ac74d2b%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c726be01e1be0c9ac74d2b%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c726be01e1be0c9ac74d2b%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855096c6f3cc53c853a0b" data-idx="141">
+        <div class="book-header">
+          <span class="book-num">#142</span>
+          <h3>Tractätlein, von Christ-schuldiger Erbauung des Nächsten durch gottselige Gespräche</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855096c6f3cc53c853a0b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855096c6f3cc53c853a0b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855096c6f3cc53c853a0b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855096c6f3cc53c853a0b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855096c6f3cc53c853a0b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855096c6f3cc53c853a0b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855096c6f3cc53c853a0b%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855096c6f3cc53c853a0b%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855096c6f3cc53c853a0b%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855096c6f3cc53c853a0b%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855096c6f3cc53c853a0b%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87e976c6f3cc53c858d72" data-idx="142">
+        <div class="book-header">
+          <span class="book-num">#143</span>
+          <h3>Manuductio hermetico-philosophica, oder richtige Handleitung zu der wahren philosophischen Medicin. Sol sine veste</h3>
+          <span class="page-count">163 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87e976c6f3cc53c858d72" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87e976c6f3cc53c858d72', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87e976c6f3cc53c858d72', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87e976c6f3cc53c858d72', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87e976c6f3cc53c858d72', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87e976c6f3cc53c858d72', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e976c6f3cc53c858d72%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e976c6f3cc53c858d72%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e976c6f3cc53c858d72%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e976c6f3cc53c858d72%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87e976c6f3cc53c858d72%2F0147-full.jpg&w=600" alt="Page 147" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.147 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c878bb6c6f3cc53c858317" data-idx="143">
+        <div class="book-header">
+          <span class="book-num">#144</span>
+          <h3>Haupt-Schlüssel der Paracelsischen Arcanen, oder das zehende Buch der Archidoxen</h3>
+          <span class="page-count">17 pp</span>
+          <a href="https://sourcelibrary.org/book/69c878bb6c6f3cc53c858317" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c878bb6c6f3cc53c858317', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c878bb6c6f3cc53c858317', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c878bb6c6f3cc53c858317', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c878bb6c6f3cc53c858317', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c878bb6c6f3cc53c858317', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878bb6c6f3cc53c858317%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878bb6c6f3cc53c858317%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878bb6c6f3cc53c858317%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878bb6c6f3cc53c858317%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878bb6c6f3cc53c858317%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41872f1200e2ab53cf907" data-idx="144">
+        <div class="book-header">
+          <span class="book-num">#145</span>
+          <h3>Brunnen der Weisheit (PH475 B)</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/fountain-of-wisdom-anonymus-von-schwartzfuss-1706-schwartzfuss" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41872f1200e2ab53cf907', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41872f1200e2ab53cf907', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41872f1200e2ab53cf907', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41872f1200e2ab53cf907', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41872f1200e2ab53cf907', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41872f1200e2ab53cf907%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41872f1200e2ab53cf907%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41872f1200e2ab53cf907%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41872f1200e2ab53cf907%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41872f1200e2ab53cf907%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b45e25ec2ba5ccd7f5be" data-idx="145">
+        <div class="book-header">
+          <span class="book-num">#146</span>
+          <h3>[Hebrew: Sefer shiv'im tikunei ha-zohar]</h3>
+          <span class="page-count">177 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b45e25ec2ba5ccd7f5be" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b45e25ec2ba5ccd7f5be', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b45e25ec2ba5ccd7f5be', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b45e25ec2ba5ccd7f5be', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b45e25ec2ba5ccd7f5be', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b45e25ec2ba5ccd7f5be', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b45e25ec2ba5ccd7f5be%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b45e25ec2ba5ccd7f5be%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b45e25ec2ba5ccd7f5be%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b45e25ec2ba5ccd7f5be%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b45e25ec2ba5ccd7f5be%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c886e46c6f3cc53c859ef8" data-idx="146">
+        <div class="book-header">
+          <span class="book-num">#147</span>
+          <h3>De religione christiana</h3>
+          <span class="page-count">73 pp</span>
+          <a href="https://sourcelibrary.org/book/69c886e46c6f3cc53c859ef8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c886e46c6f3cc53c859ef8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c886e46c6f3cc53c859ef8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c886e46c6f3cc53c859ef8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c886e46c6f3cc53c859ef8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c886e46c6f3cc53c859ef8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886e46c6f3cc53c859ef8%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886e46c6f3cc53c859ef8%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886e46c6f3cc53c859ef8%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886e46c6f3cc53c859ef8%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886e46c6f3cc53c859ef8%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7eea2fb10016c3f389f29" data-idx="147">
+        <div class="book-header">
+          <span class="book-num">#148</span>
+          <h3>Le cimetière d'Amboise</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7eea2fb10016c3f389f29" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7eea2fb10016c3f389f29', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7eea2fb10016c3f389f29', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7eea2fb10016c3f389f29', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7eea2fb10016c3f389f29', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7eea2fb10016c3f389f29', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eea2fb10016c3f389f29%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eea2fb10016c3f389f29%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eea2fb10016c3f389f29%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eea2fb10016c3f389f29%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eea2fb10016c3f389f29%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c754576a0f3d112faf8690" data-idx="148">
+        <div class="book-header">
+          <span class="book-num">#149</span>
+          <h3>The idea of the law charactered from Moses to King Charles</h3>
+          <span class="page-count">149 pp</span>
+          <a href="https://sourcelibrary.org/book/69c754576a0f3d112faf8690" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c754576a0f3d112faf8690', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c754576a0f3d112faf8690', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c754576a0f3d112faf8690', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c754576a0f3d112faf8690', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c754576a0f3d112faf8690', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c754576a0f3d112faf8690%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c754576a0f3d112faf8690%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c754576a0f3d112faf8690%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c754576a0f3d112faf8690%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c754576a0f3d112faf8690%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c64545b463eebe7caaca49" data-idx="149">
+        <div class="book-header">
+          <span class="book-num">#150</span>
+          <h3>Volkomene Nederlandsche concordantie</h3>
+          <span class="page-count">632 pp</span>
+          <a href="https://sourcelibrary.org/book/69c64545b463eebe7caaca49" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c64545b463eebe7caaca49', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c64545b463eebe7caaca49', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c64545b463eebe7caaca49', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c64545b463eebe7caaca49', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c64545b463eebe7caaca49', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64545b463eebe7caaca49%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64545b463eebe7caaca49%2F0253-full.jpg&w=600" alt="Page 253" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.253 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64545b463eebe7caaca49%2F0379-full.jpg&w=600" alt="Page 379" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.379 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64545b463eebe7caaca49%2F0506-full.jpg&w=600" alt="Page 506" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.506 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64545b463eebe7caaca49%2F0569-full.jpg&w=600" alt="Page 569" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.569 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c884fe6c6f3cc53c859ac3" data-idx="150">
+        <div class="book-header">
+          <span class="book-num">#151</span>
+          <h3>Predig</h3>
+          <span class="page-count">347 pp</span>
+          <a href="https://sourcelibrary.org/book/69c884fe6c6f3cc53c859ac3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c884fe6c6f3cc53c859ac3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c884fe6c6f3cc53c859ac3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c884fe6c6f3cc53c859ac3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c884fe6c6f3cc53c859ac3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c884fe6c6f3cc53c859ac3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884fe6c6f3cc53c859ac3%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884fe6c6f3cc53c859ac3%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884fe6c6f3cc53c859ac3%2F0208-full.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884fe6c6f3cc53c859ac3%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884fe6c6f3cc53c859ac3%2F0312-full.jpg&w=600" alt="Page 312" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.312 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41863f1200e2ab53cf76f" data-idx="151">
+        <div class="book-header">
+          <span class="book-num">#152</span>
+          <h3>Chemiae definitio, objectum, origo, usus, et divisio (PH164 bis)</h3>
+          <span class="page-count">131 pp</span>
+          <a href="https://sourcelibrary.org/book/definition-of-chemistry-18th-century-latin-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41863f1200e2ab53cf76f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41863f1200e2ab53cf76f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41863f1200e2ab53cf76f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41863f1200e2ab53cf76f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41863f1200e2ab53cf76f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41863f1200e2ab53cf76f%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513540305131!ph164_052.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513540305131!ph164_079.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513540305131!ph164_105.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513540305131!ph164_118.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f4ebda9771c716314f85" data-idx="152">
+        <div class="book-header">
+          <span class="book-num">#153</span>
+          <h3>D.O.M.A. Wolmeinendes Bedencken, von der Fama und Confession der Bruderschafft dess RosenCreutzes</h3>
+          <span class="page-count">161 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f4ebda9771c716314f85" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f4ebda9771c716314f85', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f4ebda9771c716314f85', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f4ebda9771c716314f85', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f4ebda9771c716314f85', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f4ebda9771c716314f85', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4ebda9771c716314f85%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4ebda9771c716314f85%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4ebda9771c716314f85%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4ebda9771c716314f85%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4ebda9771c716314f85%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909d1c8cf28baa1b4cb0023" data-idx="153">
+        <div class="book-header">
+          <span class="book-num">#154</span>
+          <h3>Der mitternächtige Post-Reuter</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/the-midnight-post-rider-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909d1c8cf28baa1b4cb0023', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909d1c8cf28baa1b4cb0023', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909d1c8cf28baa1b4cb0023', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909d1c8cf28baa1b4cb0023', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909d1c8cf28baa1b4cb0023', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d1c8cf28baa1b4cb0023%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d1c8cf28baa1b4cb0023%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d1c8cf28baa1b4cb0023%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d1c8cf28baa1b4cb0023%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d1c8cf28baa1b4cb0023%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c888a16c6f3cc53c85a348" data-idx="154">
+        <div class="book-header">
+          <span class="book-num">#155</span>
+          <h3>Saturn Gnosis. Offizielles Publikationsorgan der deutschen Gross-Loge Fraternitas Saturni Orient Berlin</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/69c888a16c6f3cc53c85a348" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c888a16c6f3cc53c85a348', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c888a16c6f3cc53c85a348', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c888a16c6f3cc53c85a348', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c888a16c6f3cc53c85a348', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c888a16c6f3cc53c85a348', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888a16c6f3cc53c85a348%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888a16c6f3cc53c85a348%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888a16c6f3cc53c85a348%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888a16c6f3cc53c85a348%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888a16c6f3cc53c85a348%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8831d6c6f3cc53c8596e0" data-idx="155">
+        <div class="book-header">
+          <span class="book-num">#156</span>
+          <h3>Parentale Brief-Extracten</h3>
+          <span class="page-count">86 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8831d6c6f3cc53c8596e0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8831d6c6f3cc53c8596e0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8831d6c6f3cc53c8596e0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8831d6c6f3cc53c8596e0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8831d6c6f3cc53c8596e0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8831d6c6f3cc53c8596e0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8831d6c6f3cc53c8596e0%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8831d6c6f3cc53c8596e0%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8831d6c6f3cc53c8596e0%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8831d6c6f3cc53c8596e0%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8831d6c6f3cc53c8596e0%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c834c26c6f3cc53c84e647" data-idx="156">
+        <div class="book-header">
+          <span class="book-num">#157</span>
+          <h3>Der Weg zu Christo</h3>
+          <span class="page-count">146 pp</span>
+          <a href="https://sourcelibrary.org/book/69c834c26c6f3cc53c84e647" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c834c26c6f3cc53c84e647', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c834c26c6f3cc53c84e647', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c834c26c6f3cc53c84e647', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c834c26c6f3cc53c84e647', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c834c26c6f3cc53c84e647', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834c26c6f3cc53c84e647%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834c26c6f3cc53c84e647%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834c26c6f3cc53c84e647%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834c26c6f3cc53c84e647%2F0117-full.jpg&w=600" alt="Page 117" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.117 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834c26c6f3cc53c84e647%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c738816a0f3d112faf7800" data-idx="157">
+        <div class="book-header">
+          <span class="book-num">#158</span>
+          <h3>Send-Schreiben von dem Vielfrass</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c738816a0f3d112faf7800" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c738816a0f3d112faf7800', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c738816a0f3d112faf7800', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c738816a0f3d112faf7800', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c738816a0f3d112faf7800', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c738816a0f3d112faf7800', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738816a0f3d112faf7800%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738816a0f3d112faf7800%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738816a0f3d112faf7800%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738816a0f3d112faf7800%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738816a0f3d112faf7800%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86de86c6f3cc53c856dd8" data-idx="158">
+        <div class="book-header">
+          <span class="book-num">#159</span>
+          <h3>Das Buch Bahir. Auch genannt Midrasch des Rabbi Nechunja ben Hakana</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86de86c6f3cc53c856dd8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86de86c6f3cc53c856dd8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86de86c6f3cc53c856dd8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86de86c6f3cc53c856dd8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86de86c6f3cc53c856dd8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86de86c6f3cc53c856dd8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86de86c6f3cc53c856dd8%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86de86c6f3cc53c856dd8%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86de86c6f3cc53c856dd8%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86de86c6f3cc53c856dd8%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86de86c6f3cc53c856dd8%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41933e9bfda40a8a6c818" data-idx="159">
+        <div class="book-header">
+          <span class="book-num">#160</span>
+          <h3>Elementa Chemiae — Barchusen (PH205)</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/barchusen-elements-of-chemistry-philosopher-s-stone-barchusen" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41933e9bfda40a8a6c818', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41933e9bfda40a8a6c818', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41933e9bfda40a8a6c818', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41933e9bfda40a8a6c818', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41933e9bfda40a8a6c818', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41933e9bfda40a8a6c818%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41933e9bfda40a8a6c818%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41933e9bfda40a8a6c818%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41933e9bfda40a8a6c818%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41933e9bfda40a8a6c818%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84e366c6f3cc53c852895" data-idx="160">
+        <div class="book-header">
+          <span class="book-num">#161</span>
+          <h3>Raphael artem medicam explanans</h3>
+          <span class="page-count">80 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84e366c6f3cc53c852895" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84e366c6f3cc53c852895', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84e366c6f3cc53c852895', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84e366c6f3cc53c852895', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84e366c6f3cc53c852895', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84e366c6f3cc53c852895', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e366c6f3cc53c852895%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e366c6f3cc53c852895%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e366c6f3cc53c852895%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e366c6f3cc53c852895%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e366c6f3cc53c852895%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909c41acf28baa1b4caf923" data-idx="161">
+        <div class="book-header">
+          <span class="book-num">#162</span>
+          <h3>Horus oder astrognostisches Endurtheil</h3>
+          <span class="page-count">329 pp</span>
+          <a href="https://sourcelibrary.org/book/horus-or-astrognostic-final-judgment-wuensch" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909c41acf28baa1b4caf923', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909c41acf28baa1b4caf923', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909c41acf28baa1b4caf923', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909c41acf28baa1b4caf923', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909c41acf28baa1b4caf923', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c41acf28baa1b4caf923%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c41acf28baa1b4caf923%2F132.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c41acf28baa1b4caf923%2F197.jpg&w=600" alt="Page 197" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.197 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c41acf28baa1b4caf923%2F263.jpg&w=600" alt="Page 263" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.263 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c41acf28baa1b4caf923%2F296.jpg&w=600" alt="Page 296" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.296 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7653b6a0f3d112faf8ef5" data-idx="162">
+        <div class="book-header">
+          <span class="book-num">#163</span>
+          <h3>Acta eruditarum recognitionum, in publicam lucem et censuram Societatis Universalis Recognoscentium</h3>
+          <span class="page-count">125 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7653b6a0f3d112faf8ef5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7653b6a0f3d112faf8ef5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7653b6a0f3d112faf8ef5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7653b6a0f3d112faf8ef5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7653b6a0f3d112faf8ef5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7653b6a0f3d112faf8ef5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7653b6a0f3d112faf8ef5%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7653b6a0f3d112faf8ef5%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7653b6a0f3d112faf8ef5%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7653b6a0f3d112faf8ef5%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7653b6a0f3d112faf8ef5%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82aff6c6f3cc53c84c9d6" data-idx="163">
+        <div class="book-header">
+          <span class="book-num">#164</span>
+          <h3>[Hebrew] Das ist: die göttliche Versöhnlichkeit und Menschwerdung dess Engels des Bundes</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82aff6c6f3cc53c84c9d6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82aff6c6f3cc53c84c9d6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82aff6c6f3cc53c84c9d6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82aff6c6f3cc53c84c9d6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82aff6c6f3cc53c84c9d6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82aff6c6f3cc53c84c9d6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82aff6c6f3cc53c84c9d6%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82aff6c6f3cc53c84c9d6%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82aff6c6f3cc53c84c9d6%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82aff6c6f3cc53c84c9d6%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82aff6c6f3cc53c84c9d6%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89c076c6f3cc53c85d4c9" data-idx="164">
+        <div class="book-header">
+          <span class="book-num">#165</span>
+          <h3>Freemasonry: its outward and visible signs</h3>
+          <span class="page-count">94 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89c076c6f3cc53c85d4c9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89c076c6f3cc53c85d4c9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89c076c6f3cc53c85d4c9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89c076c6f3cc53c85d4c9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89c076c6f3cc53c85d4c9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89c076c6f3cc53c85d4c9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c076c6f3cc53c85d4c9%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c076c6f3cc53c85d4c9%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c076c6f3cc53c85d4c9%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c076c6f3cc53c85d4c9%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89c076c6f3cc53c85d4c9%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6113" data-idx="165">
+        <div class="book-header">
+          <span class="book-num">#166</span>
+          <h3>Menippus sive dialogorum satyricorum centuria</h3>
+          <span class="page-count">137 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6113" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6113', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6113', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6113', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6113', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6113', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6113%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6113%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6113%2F82.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6113%2F110.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6113%2F123.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e32e2f948a050a505e" data-idx="166">
+        <div class="book-header">
+          <span class="book-num">#167</span>
+          <h3>Ueber den Ursprung und die vornehmsten Schicksale der Orden der Rosenkreuzer und Freymaurer</h3>
+          <span class="page-count">218 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e32e2f948a050a505e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e32e2f948a050a505e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e32e2f948a050a505e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e32e2f948a050a505e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e32e2f948a050a505e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e32e2f948a050a505e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505e%2F69c585a38beb317a159b0ccf.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505e%2F69c58ef1af891ea7aa527566.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505e%2F69c595b8dd529cca3a361054.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505e%2F69c59b92c4ce7c7099fc66dc.jpg&w=600" alt="Page 174" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.174 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505e%2F69c59e537db2841b119badf6.jpg&w=600" alt="Page 196" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.196 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b5d025ec2ba5ccd7f617" data-idx="167">
+        <div class="book-header">
+          <span class="book-num">#168</span>
+          <h3>Physica-mystica und physica sacra sacratissima</h3>
+          <span class="page-count">141 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b5d025ec2ba5ccd7f617" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b5d025ec2ba5ccd7f617', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b5d025ec2ba5ccd7f617', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b5d025ec2ba5ccd7f617', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b5d025ec2ba5ccd7f617', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b5d025ec2ba5ccd7f617', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b5d025ec2ba5ccd7f617%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b5d025ec2ba5ccd7f617%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b5d025ec2ba5ccd7f617%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b5d025ec2ba5ccd7f617%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b5d025ec2ba5ccd7f617%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4195acea21ec2e5d0e168" data-idx="168">
+        <div class="book-header">
+          <span class="book-num">#169</span>
+          <h3>Rosaire des Philosophes — Rosarium Philosophorum (PH333)</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/rosary-of-the-philosophers-alchemical-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4195acea21ec2e5d0e168', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4195acea21ec2e5d0e168', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4195acea21ec2e5d0e168', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4195acea21ec2e5d0e168', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4195acea21ec2e5d0e168', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195acea21ec2e5d0e168%2F2.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195acea21ec2e5d0e168%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195acea21ec2e5d0e168%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195acea21ec2e5d0e168%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4195acea21ec2e5d0e168%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e8a2fb10016c3f389ce9" data-idx="169">
+        <div class="book-header">
+          <span class="book-num">#170</span>
+          <h3>Himmlische Offenbarungen</h3>
+          <span class="page-count">575 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e8a2fb10016c3f389ce9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e8a2fb10016c3f389ce9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e8a2fb10016c3f389ce9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e8a2fb10016c3f389ce9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e8a2fb10016c3f389ce9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e8a2fb10016c3f389ce9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e8a2fb10016c3f389ce9%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e8a2fb10016c3f389ce9%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e8a2fb10016c3f389ce9%2F0345-full.jpg&w=600" alt="Page 345" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.345 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e8a2fb10016c3f389ce9%2F0460-full.jpg&w=600" alt="Page 460" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.460 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e8a2fb10016c3f389ce9%2F0518-full.jpg&w=600" alt="Page 518" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.518 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71882da9771c716316633" data-idx="170">
+        <div class="book-header">
+          <span class="book-num">#171</span>
+          <h3>Astrologia aphoristica Ptolemaei, Hermetis, Ludovici de Rigiis, Almansoris, Hieronymi Cardani, et autoris innominati</h3>
+          <span class="page-count">233 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71882da9771c716316633" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71882da9771c716316633', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71882da9771c716316633', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71882da9771c716316633', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71882da9771c716316633', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71882da9771c716316633', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71882da9771c716316633%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71882da9771c716316633%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71882da9771c716316633%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71882da9771c716316633%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71882da9771c716316633%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8994b6c6f3cc53c85cd8a" data-idx="171">
+        <div class="book-header">
+          <span class="book-num">#172</span>
+          <h3>Magia, oft de wonderlicke wercken der naturen</h3>
+          <span class="page-count">212 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8994b6c6f3cc53c85cd8a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8994b6c6f3cc53c85cd8a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8994b6c6f3cc53c85cd8a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8994b6c6f3cc53c85cd8a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8994b6c6f3cc53c85cd8a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8994b6c6f3cc53c85cd8a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8994b6c6f3cc53c85cd8a%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8994b6c6f3cc53c85cd8a%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8994b6c6f3cc53c85cd8a%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8994b6c6f3cc53c85cd8a%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8994b6c6f3cc53c85cd8a%2F0191-full.jpg&w=600" alt="Page 191" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.191 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79c3d6a0f3d112fafa256" data-idx="172">
+        <div class="book-header">
+          <span class="book-num">#173</span>
+          <h3>Antidotarium medico-chymicum reformatum</h3>
+          <span class="page-count">567 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79c3d6a0f3d112fafa256" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79c3d6a0f3d112fafa256', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79c3d6a0f3d112fafa256', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79c3d6a0f3d112fafa256', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79c3d6a0f3d112fafa256', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79c3d6a0f3d112fafa256', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79c3d6a0f3d112fafa256%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79c3d6a0f3d112fafa256%2F0227-full.jpg&w=600" alt="Page 227" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.227 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79c3d6a0f3d112fafa256%2F0340-full.jpg&w=600" alt="Page 340" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.340 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79c3d6a0f3d112fafa256%2F0454-full.jpg&w=600" alt="Page 454" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.454 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79c3d6a0f3d112fafa256%2F0510-full.jpg&w=600" alt="Page 510" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.510 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41881f1200e2ab53cfb8d" data-idx="173">
+        <div class="book-header">
+          <span class="book-num">#174</span>
+          <h3>Collection of Alchemical Texts (PH338)</h3>
+          <span class="page-count">299 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-compendium-rupescissa-aquinas-rhazes-mid-1500s-al-razi" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41881f1200e2ab53cfb8d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41881f1200e2ab53cfb8d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41881f1200e2ab53cfb8d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41881f1200e2ab53cfb8d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41881f1200e2ab53cfb8d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41881f1200e2ab53cfb8d%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41881f1200e2ab53cfb8d%2F120.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41881f1200e2ab53cfb8d%2F179.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560357605131!PH338_0239.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560357605131!PH338_0269.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866316c6f3cc53c856381" data-idx="174">
+        <div class="book-header">
+          <span class="book-num">#175</span>
+          <h3>Aesch mezareph or purifying fire. A chymico-kabalistic treatise collected from the Kabala denudata of Knorr von Rosenroth. Translated by a lover of Philalethes, 1714</h3>
+          <span class="page-count">48 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866316c6f3cc53c856381" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866316c6f3cc53c856381', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866316c6f3cc53c856381', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866316c6f3cc53c856381', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866316c6f3cc53c856381', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866316c6f3cc53c856381', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866316c6f3cc53c856381%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866316c6f3cc53c856381%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866316c6f3cc53c856381%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866316c6f3cc53c856381%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866316c6f3cc53c856381%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c804406c6f3cc53c844dd0" data-idx="175">
+        <div class="book-header">
+          <span class="book-num">#176</span>
+          <h3>Philosophia pia</h3>
+          <span class="page-count">130 pp</span>
+          <a href="https://sourcelibrary.org/book/69c804406c6f3cc53c844dd0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c804406c6f3cc53c844dd0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c804406c6f3cc53c844dd0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c804406c6f3cc53c844dd0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c804406c6f3cc53c844dd0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c804406c6f3cc53c844dd0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804406c6f3cc53c844dd0%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804406c6f3cc53c844dd0%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804406c6f3cc53c844dd0%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804406c6f3cc53c844dd0%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804406c6f3cc53c844dd0%2F0117-full.jpg&w=600" alt="Page 117" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.117 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63da4b463eebe7caac5ae" data-idx="176">
+        <div class="book-header">
+          <span class="book-num">#177</span>
+          <h3>Viridarium chymicum, das ist: Chymisches Lust-Gärtlein</h3>
+          <span class="page-count">128 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63da4b463eebe7caac5ae" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63da4b463eebe7caac5ae', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63da4b463eebe7caac5ae', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63da4b463eebe7caac5ae', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63da4b463eebe7caac5ae', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63da4b463eebe7caac5ae', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63da4b463eebe7caac5ae%2F0007-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63da4b463eebe7caac5ae%2F0026-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63da4b463eebe7caac5ae%2F0039-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63da4b463eebe7caac5ae%2F0051-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63da4b463eebe7caac5ae%2F0058-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63918881bf48c13c42647" data-idx="177">
+        <div class="book-header">
+          <span class="book-num">#178</span>
+          <h3>La vie de damoiselle Antoinette Bourignon</h3>
+          <span class="page-count">550 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63918881bf48c13c42647" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63918881bf48c13c42647', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63918881bf48c13c42647', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63918881bf48c13c42647', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63918881bf48c13c42647', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63918881bf48c13c42647', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42647%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42647%2F0220-full.jpg&w=600" alt="Page 220" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.220 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42647%2F0330-full.jpg&w=600" alt="Page 330" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.330 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42647%2F0440-full.jpg&w=600" alt="Page 440" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.440 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42647%2F0495-full.jpg&w=600" alt="Page 495" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.495 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79fed92b884e4f817374f" data-idx="178">
+        <div class="book-header">
+          <span class="book-num">#179</span>
+          <h3>[Hebrew: Sefer sha'arei orah]</h3>
+          <span class="page-count">102 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79fed92b884e4f817374f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79fed92b884e4f817374f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79fed92b884e4f817374f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79fed92b884e4f817374f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79fed92b884e4f817374f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79fed92b884e4f817374f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79fed92b884e4f817374f%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79fed92b884e4f817374f%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79fed92b884e4f817374f%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79fed92b884e4f817374f%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79fed92b884e4f817374f%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79f1492b884e4f817372f" data-idx="179">
+        <div class="book-header">
+          <span class="book-num">#180</span>
+          <h3>[Hebrew: Sefer ha-bahir]</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79f1492b884e4f817372f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79f1492b884e4f817372f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79f1492b884e4f817372f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79f1492b884e4f817372f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79f1492b884e4f817372f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79f1492b884e4f817372f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79f1492b884e4f817372f%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79f1492b884e4f817372f%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79f1492b884e4f817372f%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79f1492b884e4f817372f%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79f1492b884e4f817372f%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418f52b0edf3eaa2de625" data-idx="180">
+        <div class="book-header">
+          <span class="book-num">#181</span>
+          <h3>Livre des figures hieroglyphiques (PH406)</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/flamel-hieroglyphic-figures-18th-century-ms-flamel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418f52b0edf3eaa2de625', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418f52b0edf3eaa2de625', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418f52b0edf3eaa2de625', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418f52b0edf3eaa2de625', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418f52b0edf3eaa2de625', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f52b0edf3eaa2de625%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f52b0edf3eaa2de625%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f52b0edf3eaa2de625%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940506438305131!ph406_bph_mo_126_030.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940506438305131!ph406_bph_mo_126_033.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82cb86c6f3cc53c84cf6e" data-idx="181">
+        <div class="book-header">
+          <span class="book-num">#182</span>
+          <h3>Vanden weldaden</h3>
+          <span class="page-count">249 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82cb86c6f3cc53c84cf6e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82cb86c6f3cc53c84cf6e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82cb86c6f3cc53c84cf6e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82cb86c6f3cc53c84cf6e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82cb86c6f3cc53c84cf6e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82cb86c6f3cc53c84cf6e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb86c6f3cc53c84cf6e%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb86c6f3cc53c84cf6e%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb86c6f3cc53c84cf6e%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb86c6f3cc53c84cf6e%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb86c6f3cc53c84cf6e%2F0224-full.jpg&w=600" alt="Page 224" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.224 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41884f1200e2ab53cfcba" data-idx="182">
+        <div class="book-header">
+          <span class="book-num">#183</span>
+          <h3>Collection of Alchemical Texts (PH482)</h3>
+          <span class="page-count">117 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-collection-korndorffer-grossschedel-post-1627-aicha" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41884f1200e2ab53cfcba', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41884f1200e2ab53cfcba', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41884f1200e2ab53cfcba', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41884f1200e2ab53cfcba', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41884f1200e2ab53cfcba', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41884f1200e2ab53cfcba%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940510334305131!PH482_0047.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940510334305131!PH482_0070.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940510334305131!PH482_0094.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940510334305131!PH482_0105.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418eb2b0edf3eaa2de3d9" data-idx="183">
+        <div class="book-header">
+          <span class="book-num">#184</span>
+          <h3>Alchemical Works — George Ripley &amp; George Starkey (PH223)</h3>
+          <span class="page-count">151 pp</span>
+          <a href="https://sourcelibrary.org/book/ripley-starkey-alchemical-works-18th-century-french-ms-starkey" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418eb2b0edf3eaa2de3d9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418eb2b0edf3eaa2de3d9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418eb2b0edf3eaa2de3d9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418eb2b0edf3eaa2de3d9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418eb2b0edf3eaa2de3d9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418eb2b0edf3eaa2de3d9%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418eb2b0edf3eaa2de3d9%2F60.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418eb2b0edf3eaa2de3d9%2F91.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418eb2b0edf3eaa2de3d9%2F121.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418eb2b0edf3eaa2de3d9%2F136.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e4a0ac0c96f42b4016" data-idx="184">
+        <div class="book-header">
+          <span class="book-num">#185</span>
+          <h3>Veritatis proscenium</h3>
+          <span class="page-count">32 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e4a0ac0c96f42b4016" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e4a0ac0c96f42b4016', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e4a0ac0c96f42b4016', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e4a0ac0c96f42b4016', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e4a0ac0c96f42b4016', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e4a0ac0c96f42b4016', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4a0ac0c96f42b4016%2F69c5825c73dff3f63dbf62fb.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4a0ac0c96f42b4016%2F69c58571c3d77d7dfcb42b5d.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4a0ac0c96f42b4016%2F69c586f26c9503caf5f6cd6a.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4a0ac0c96f42b4016%2F69c5891f62ff3ddc150cdf61.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4a0ac0c96f42b4016%2F69c5898e1ea82a3c387eeefc.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80b306c6f3cc53c846684" data-idx="185">
+        <div class="book-header">
+          <span class="book-num">#186</span>
+          <h3>Phaedon oder über die Unsterblichkeit der Seele</h3>
+          <span class="page-count">159 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80b306c6f3cc53c846684" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80b306c6f3cc53c846684', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80b306c6f3cc53c846684', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80b306c6f3cc53c846684', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80b306c6f3cc53c846684', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80b306c6f3cc53c846684', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b306c6f3cc53c846684%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b306c6f3cc53c846684%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b306c6f3cc53c846684%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b306c6f3cc53c846684%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b306c6f3cc53c846684%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8006e6c6f3cc53c843f4c" data-idx="186">
+        <div class="book-header">
+          <span class="book-num">#187</span>
+          <h3>Ars magna, generalis et ultima</h3>
+          <span class="page-count">137 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8006e6c6f3cc53c843f4c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8006e6c6f3cc53c843f4c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8006e6c6f3cc53c843f4c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8006e6c6f3cc53c843f4c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8006e6c6f3cc53c843f4c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8006e6c6f3cc53c843f4c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8006e6c6f3cc53c843f4c%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8006e6c6f3cc53c843f4c%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8006e6c6f3cc53c843f4c%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8006e6c6f3cc53c843f4c%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8006e6c6f3cc53c843f4c%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4192b2b0edf3eaa2dee6d" data-idx="187">
+        <div class="book-header">
+          <span class="book-num">#188</span>
+          <h3>Aurea Catena Homeri — Anton Kirchweger (PH336)</h3>
+          <span class="page-count">158 pp</span>
+          <a href="https://sourcelibrary.org/book/golden-chain-of-homer-kirchweger-18th-century-ms-kirchweger" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4192b2b0edf3eaa2dee6d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4192b2b0edf3eaa2dee6d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4192b2b0edf3eaa2dee6d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4192b2b0edf3eaa2dee6d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4192b2b0edf3eaa2dee6d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4192b2b0edf3eaa2dee6d%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563680905131!PH336_063.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563680905131!PH336_095.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563680905131!PH336_126.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563680905131!PH336_142.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4191a2b0edf3eaa2dec84" data-idx="188">
+        <div class="book-header">
+          <span class="book-num">#189</span>
+          <h3>Discours sur la pierre des philosophes (PH249)</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/discourse-on-the-philosopher-s-stone-18th-century-french-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4191a2b0edf3eaa2dec84', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4191a2b0edf3eaa2dec84', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4191a2b0edf3eaa2dec84', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4191a2b0edf3eaa2dec84', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4191a2b0edf3eaa2dec84', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191a2b0edf3eaa2dec84%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191a2b0edf3eaa2dec84%2F35.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191a2b0edf3eaa2dec84%2F53.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191a2b0edf3eaa2dec84%2F70.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191a2b0edf3eaa2dec84%2F79.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85ab66c6f3cc53c854930" data-idx="189">
+        <div class="book-header">
+          <span class="book-num">#190</span>
+          <h3>Historie und Beschreibung der mystischen Theologie, oder geheimen Gottes Gelehrtheit, wie auch der alten und neuen Mysticorum</h3>
+          <span class="page-count">391 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85ab66c6f3cc53c854930" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85ab66c6f3cc53c854930', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85ab66c6f3cc53c854930', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85ab66c6f3cc53c854930', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85ab66c6f3cc53c854930', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85ab66c6f3cc53c854930', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85ab66c6f3cc53c854930%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85ab66c6f3cc53c854930%2F0156-full.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85ab66c6f3cc53c854930%2F0235-full.jpg&w=600" alt="Page 235" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.235 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85ab66c6f3cc53c854930%2F0313-full.jpg&w=600" alt="Page 313" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.313 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85ab66c6f3cc53c854930%2F0352-full.jpg&w=600" alt="Page 352" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.352 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c879b86c6f3cc53c858529" data-idx="190">
+        <div class="book-header">
+          <span class="book-num">#191</span>
+          <h3>Historica narratio de fratrum orthodoxonum ecclesiis in Bohemia, Moravia et Polonia</h3>
+          <span class="page-count">251 pp</span>
+          <a href="https://sourcelibrary.org/book/69c879b86c6f3cc53c858529" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c879b86c6f3cc53c858529', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c879b86c6f3cc53c858529', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c879b86c6f3cc53c858529', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c879b86c6f3cc53c858529', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c879b86c6f3cc53c858529', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879b86c6f3cc53c858529%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879b86c6f3cc53c858529%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879b86c6f3cc53c858529%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879b86c6f3cc53c858529%2F0201-full.jpg&w=600" alt="Page 201" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.201 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879b86c6f3cc53c858529%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86dde6c6f3cc53c856dc5" data-idx="191">
+        <div class="book-header">
+          <span class="book-num">#192</span>
+          <h3>[Cyrillisch:] Brieven aan een vriend en testament aan een zoon over de Orde van het Hl.K. (= Heilig Kruis)</h3>
+          <span class="page-count">120 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86dde6c6f3cc53c856dc5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86dde6c6f3cc53c856dc5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86dde6c6f3cc53c856dc5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86dde6c6f3cc53c856dc5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86dde6c6f3cc53c856dc5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86dde6c6f3cc53c856dc5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86dde6c6f3cc53c856dc5%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86dde6c6f3cc53c856dc5%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86dde6c6f3cc53c856dc5%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86dde6c6f3cc53c856dc5%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86dde6c6f3cc53c856dc5%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896cb6c6f3cc53c85c64a" data-idx="192">
+        <div class="book-header">
+          <span class="book-num">#193</span>
+          <h3>Some deeper aspects of masonic symbolism</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896cb6c6f3cc53c85c64a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896cb6c6f3cc53c85c64a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896cb6c6f3cc53c85c64a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896cb6c6f3cc53c85c64a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896cb6c6f3cc53c85c64a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896cb6c6f3cc53c85c64a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896cb6c6f3cc53c85c64a%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896cb6c6f3cc53c85c64a%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896cb6c6f3cc53c85c64a%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896cb6c6f3cc53c85c64a%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896cb6c6f3cc53c85c64a%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88a5d6c6f3cc53c85a611" data-idx="193">
+        <div class="book-header">
+          <span class="book-num">#194</span>
+          <h3>Sophia: das ist, die holdseelige ewige Jungfrau der goettlichen Weisheit</h3>
+          <span class="page-count">150 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88a5d6c6f3cc53c85a611" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88a5d6c6f3cc53c85a611', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88a5d6c6f3cc53c85a611', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88a5d6c6f3cc53c85a611', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88a5d6c6f3cc53c85a611', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88a5d6c6f3cc53c85a611', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a5d6c6f3cc53c85a611%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a5d6c6f3cc53c85a611%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a5d6c6f3cc53c85a611%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a5d6c6f3cc53c85a611%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a5d6c6f3cc53c85a611%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e57afb10016c3f389b7e" data-idx="194">
+        <div class="book-header">
+          <span class="book-num">#195</span>
+          <h3>Ausführlicher Bericht vom Gebrauch desz Instruments so titulirt physico astrologicum instrumentum</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e57afb10016c3f389b7e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e57afb10016c3f389b7e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e57afb10016c3f389b7e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e57afb10016c3f389b7e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e57afb10016c3f389b7e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e57afb10016c3f389b7e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e57afb10016c3f389b7e%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e57afb10016c3f389b7e%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e57afb10016c3f389b7e%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e57afb10016c3f389b7e%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e57afb10016c3f389b7e%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418c42b0edf3eaa2ddc55" data-idx="195">
+        <div class="book-header">
+          <span class="book-num">#196</span>
+          <h3>Seraphinisch Blumen-Gärtlein — Jakob Böhme (PH182)</h3>
+          <span class="page-count">160 pp</span>
+          <a href="https://sourcelibrary.org/book/bohme-seraphic-flower-garden-extracts-from-all-works-bohme" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418c42b0edf3eaa2ddc55', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418c42b0edf3eaa2ddc55', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418c42b0edf3eaa2ddc55', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418c42b0edf3eaa2ddc55', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418c42b0edf3eaa2ddc55', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418c42b0edf3eaa2ddc55%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418c42b0edf3eaa2ddc55%2F64.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418c42b0edf3eaa2ddc55%2F96.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418c42b0edf3eaa2ddc55%2F128.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418c42b0edf3eaa2ddc55%2F144.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c826cd6c6f3cc53c84be0c" data-idx="196">
+        <div class="book-header">
+          <span class="book-num">#197</span>
+          <h3>The vanity of dogmatizing: or confidence in opinions</h3>
+          <span class="page-count">149 pp</span>
+          <a href="https://sourcelibrary.org/book/69c826cd6c6f3cc53c84be0c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c826cd6c6f3cc53c84be0c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c826cd6c6f3cc53c84be0c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c826cd6c6f3cc53c84be0c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c826cd6c6f3cc53c84be0c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c826cd6c6f3cc53c84be0c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cd6c6f3cc53c84be0c%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cd6c6f3cc53c84be0c%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cd6c6f3cc53c84be0c%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cd6c6f3cc53c84be0c%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cd6c6f3cc53c84be0c%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6494e71add5d9cc49ab69" data-idx="197">
+        <div class="book-header">
+          <span class="book-num">#198</span>
+          <h3>Waarheit in het binnenste, of bevindelyke godtgeleertheit</h3>
+          <span class="page-count">369 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6494e71add5d9cc49ab69" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6494e71add5d9cc49ab69', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6494e71add5d9cc49ab69', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6494e71add5d9cc49ab69', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6494e71add5d9cc49ab69', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6494e71add5d9cc49ab69', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494e71add5d9cc49ab69%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494e71add5d9cc49ab69%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494e71add5d9cc49ab69%2F0221-full.jpg&w=600" alt="Page 221" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.221 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494e71add5d9cc49ab69%2F0295-full.jpg&w=600" alt="Page 295" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.295 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494e71add5d9cc49ab69%2F0332-full.jpg&w=600" alt="Page 332" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.332 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c847e76c6f3cc53c851af9" data-idx="198">
+        <div class="book-header">
+          <span class="book-num">#199</span>
+          <h3>Gottselige Betrachtungen über die Auferstehung Jesu Christi</h3>
+          <span class="page-count">237 pp</span>
+          <a href="https://sourcelibrary.org/book/69c847e76c6f3cc53c851af9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c847e76c6f3cc53c851af9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c847e76c6f3cc53c851af9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c847e76c6f3cc53c851af9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c847e76c6f3cc53c851af9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c847e76c6f3cc53c851af9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847e76c6f3cc53c851af9%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847e76c6f3cc53c851af9%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847e76c6f3cc53c851af9%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847e76c6f3cc53c851af9%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847e76c6f3cc53c851af9%2F0213-full.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8088e6c6f3cc53c845de2" data-idx="199">
+        <div class="book-header">
+          <span class="book-num">#200</span>
+          <h3>Opus aureum ... drey unterschiedliche Tractat von der Alchimey</h3>
+          <span class="page-count">125 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8088e6c6f3cc53c845de2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8088e6c6f3cc53c845de2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8088e6c6f3cc53c845de2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8088e6c6f3cc53c845de2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8088e6c6f3cc53c845de2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8088e6c6f3cc53c845de2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8088e6c6f3cc53c845de2%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8088e6c6f3cc53c845de2%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8088e6c6f3cc53c845de2%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8088e6c6f3cc53c845de2%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8088e6c6f3cc53c845de2%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html" class="active">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-3.html
+++ b/public/split-review-3.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 3/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html" class="active">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c81fb36c6f3cc53c84a634" data-idx="200">
+        <div class="book-header">
+          <span class="book-num">#201</span>
+          <h3>Informatorium oder kurzer Unterricht</h3>
+          <span class="page-count">60 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81fb36c6f3cc53c84a634" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81fb36c6f3cc53c84a634', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81fb36c6f3cc53c84a634', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81fb36c6f3cc53c84a634', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81fb36c6f3cc53c84a634', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81fb36c6f3cc53c84a634', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fb36c6f3cc53c84a634%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fb36c6f3cc53c84a634%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fb36c6f3cc53c84a634%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fb36c6f3cc53c84a634%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fb36c6f3cc53c84a634%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c822f86c6f3cc53c84aea4" data-idx="201">
+        <div class="book-header">
+          <span class="book-num">#202</span>
+          <h3>Von der hermetischenn Philosophia, das ist, von dem gebenedeiten Stain der Weisen  Dicta Alani</h3>
+          <span class="page-count">105 pp</span>
+          <a href="https://sourcelibrary.org/book/69c822f86c6f3cc53c84aea4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c822f86c6f3cc53c84aea4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c822f86c6f3cc53c84aea4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c822f86c6f3cc53c84aea4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c822f86c6f3cc53c84aea4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c822f86c6f3cc53c84aea4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822f86c6f3cc53c84aea4%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822f86c6f3cc53c84aea4%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822f86c6f3cc53c84aea4%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822f86c6f3cc53c84aea4%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822f86c6f3cc53c84aea4%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c820ca6c6f3cc53c84a904" data-idx="202">
+        <div class="book-header">
+          <span class="book-num">#203</span>
+          <h3>Die isländische Edda</h3>
+          <span class="page-count">278 pp</span>
+          <a href="https://sourcelibrary.org/book/69c820ca6c6f3cc53c84a904" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c820ca6c6f3cc53c84a904', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c820ca6c6f3cc53c84a904', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c820ca6c6f3cc53c84a904', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c820ca6c6f3cc53c84a904', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c820ca6c6f3cc53c84a904', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820ca6c6f3cc53c84a904%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820ca6c6f3cc53c84a904%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820ca6c6f3cc53c84a904%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820ca6c6f3cc53c84a904%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820ca6c6f3cc53c84a904%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c4d40e0787282ad59401f" data-idx="203">
+        <div class="book-header">
+          <span class="book-num">#204</span>
+          <h3>Medulla animae, das ist, von Vollkommenheit aller Tugenden</h3>
+          <span class="page-count">307 pp</span>
+          <a href="https://sourcelibrary.org/book/the-marrow-of-the-soul-that-is-of-the-perfection-of-all-tauler" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c4d40e0787282ad59401f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c4d40e0787282ad59401f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c4d40e0787282ad59401f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c4d40e0787282ad59401f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c4d40e0787282ad59401f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c4d40e0787282ad59401f%2F31.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c4d40e0787282ad59401f%2F123.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c4d40e0787282ad59401f%2F184.jpg&w=600" alt="Page 184" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.184 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c4d40e0787282ad59401f%2F246.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c4d40e0787282ad59401f%2F276.jpg&w=600" alt="Page 276" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.276 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4190f2b0edf3eaa2deb09" data-idx="204">
+        <div class="book-header">
+          <span class="book-num">#205</span>
+          <h3>Aula Lucis — Thomas Vaughan (PH114 A)</h3>
+          <span class="page-count">100 pp</span>
+          <a href="https://sourcelibrary.org/book/thomas-vaughan-hall-of-light-1690-german-translation-ms-lange" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4190f2b0edf3eaa2deb09', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4190f2b0edf3eaa2deb09', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4190f2b0edf3eaa2deb09', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4190f2b0edf3eaa2deb09', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4190f2b0edf3eaa2deb09', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4190f2b0edf3eaa2deb09%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940609801005131!ph480_0040.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940609801005131!ph480_0060.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940609801005131!ph480_0080.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940609801005131!ph480_0090.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c820706c6f3cc53c84a844" data-idx="205">
+        <div class="book-header">
+          <span class="book-num">#206</span>
+          <h3>An enquiry into the patriarchal and druidical religion, temples, etc</h3>
+          <span class="page-count">58 pp</span>
+          <a href="https://sourcelibrary.org/book/69c820706c6f3cc53c84a844" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c820706c6f3cc53c84a844', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c820706c6f3cc53c84a844', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c820706c6f3cc53c84a844', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c820706c6f3cc53c84a844', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c820706c6f3cc53c84a844', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820706c6f3cc53c84a844%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820706c6f3cc53c84a844%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820706c6f3cc53c84a844%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820706c6f3cc53c84a844%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820706c6f3cc53c84a844%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82e516c6f3cc53c84d5ef" data-idx="206">
+        <div class="book-header">
+          <span class="book-num">#207</span>
+          <h3>De honesta disciplina. De poetis latinis eiusdem poematorum</h3>
+          <span class="page-count">181 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82e516c6f3cc53c84d5ef" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82e516c6f3cc53c84d5ef', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82e516c6f3cc53c84d5ef', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82e516c6f3cc53c84d5ef', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82e516c6f3cc53c84d5ef', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82e516c6f3cc53c84d5ef', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e516c6f3cc53c84d5ef%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e516c6f3cc53c84d5ef%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e516c6f3cc53c84d5ef%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e516c6f3cc53c84d5ef%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e516c6f3cc53c84d5ef%2F0163-full.jpg&w=600" alt="Page 163" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.163 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418fd2b0edf3eaa2de77f" data-idx="207">
+        <div class="book-header">
+          <span class="book-num">#208</span>
+          <h3>Das Büchlein von dritten Elia — Ezechiel Meth (PH157)</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/book-of-the-third-elijah-meth-pre-1617-meth" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418fd2b0edf3eaa2de77f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418fd2b0edf3eaa2de77f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418fd2b0edf3eaa2de77f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418fd2b0edf3eaa2de77f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418fd2b0edf3eaa2de77f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418fd2b0edf3eaa2de77f%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418fd2b0edf3eaa2de77f%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418fd2b0edf3eaa2de77f%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418fd2b0edf3eaa2de77f%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418fd2b0edf3eaa2de77f%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c843166c6f3cc53c850e9c" data-idx="208">
+        <div class="book-header">
+          <span class="book-num">#209</span>
+          <h3>Versuch einer Erklärung des Ursprunges der Sprache</h3>
+          <span class="page-count">139 pp</span>
+          <a href="https://sourcelibrary.org/book/69c843166c6f3cc53c850e9c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c843166c6f3cc53c850e9c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c843166c6f3cc53c850e9c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c843166c6f3cc53c850e9c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c843166c6f3cc53c850e9c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c843166c6f3cc53c850e9c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843166c6f3cc53c850e9c%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843166c6f3cc53c850e9c%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843166c6f3cc53c850e9c%2F0083-full.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843166c6f3cc53c850e9c%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843166c6f3cc53c850e9c%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866086c6f3cc53c856325" data-idx="209">
+        <div class="book-header">
+          <span class="book-num">#210</span>
+          <h3>De l'admirable pouvoir et puissance de l'art et de nature</h3>
+          <span class="page-count">57 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866086c6f3cc53c856325" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866086c6f3cc53c856325', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866086c6f3cc53c856325', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866086c6f3cc53c856325', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866086c6f3cc53c856325', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866086c6f3cc53c856325', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866086c6f3cc53c856325%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866086c6f3cc53c856325%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866086c6f3cc53c856325%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866086c6f3cc53c856325%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866086c6f3cc53c856325%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87ba46c6f3cc53c8588c7" data-idx="210">
+        <div class="book-header">
+          <span class="book-num">#211</span>
+          <h3>Klage der causae moralis und conditionis sine qua non</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87ba46c6f3cc53c8588c7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87ba46c6f3cc53c8588c7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87ba46c6f3cc53c8588c7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87ba46c6f3cc53c8588c7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87ba46c6f3cc53c8588c7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87ba46c6f3cc53c8588c7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ba46c6f3cc53c8588c7%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ba46c6f3cc53c8588c7%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ba46c6f3cc53c8588c7%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ba46c6f3cc53c8588c7%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ba46c6f3cc53c8588c7%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fea96c6f3cc53c8438b4" data-idx="211">
+        <div class="book-header">
+          <span class="book-num">#212</span>
+          <h3>Philosophie des hautes sciences</h3>
+          <span class="page-count">105 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fea96c6f3cc53c8438b4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fea96c6f3cc53c8438b4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fea96c6f3cc53c8438b4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fea96c6f3cc53c8438b4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fea96c6f3cc53c8438b4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fea96c6f3cc53c8438b4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fea96c6f3cc53c8438b4%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fea96c6f3cc53c8438b4%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fea96c6f3cc53c8438b4%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fea96c6f3cc53c8438b4%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fea96c6f3cc53c8438b4%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c893346c6f3cc53c85be3b" data-idx="212">
+        <div class="book-header">
+          <span class="book-num">#213</span>
+          <h3>The works of Thomas Vaughan: Eugenius Philalethes</h3>
+          <span class="page-count">287 pp</span>
+          <a href="https://sourcelibrary.org/book/69c893346c6f3cc53c85be3b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c893346c6f3cc53c85be3b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c893346c6f3cc53c85be3b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c893346c6f3cc53c85be3b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c893346c6f3cc53c85be3b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c893346c6f3cc53c85be3b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893346c6f3cc53c85be3b%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893346c6f3cc53c85be3b%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893346c6f3cc53c85be3b%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893346c6f3cc53c85be3b%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893346c6f3cc53c85be3b%2F0258-full.jpg&w=600" alt="Page 258" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.258 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c802c56c6f3cc53c8448b0" data-idx="213">
+        <div class="book-header">
+          <span class="book-num">#214</span>
+          <h3>[Syriac] Syriacae linguae Jesu Christo ... prima elementa</h3>
+          <span class="page-count">35 pp</span>
+          <a href="https://sourcelibrary.org/book/69c802c56c6f3cc53c8448b0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c802c56c6f3cc53c8448b0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c802c56c6f3cc53c8448b0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c802c56c6f3cc53c8448b0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c802c56c6f3cc53c8448b0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c802c56c6f3cc53c8448b0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802c56c6f3cc53c8448b0%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802c56c6f3cc53c8448b0%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802c56c6f3cc53c8448b0%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802c56c6f3cc53c8448b0%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802c56c6f3cc53c8448b0%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6109" data-idx="214">
+        <div class="book-header">
+          <span class="book-num">#215</span>
+          <h3>Philosophie d'amour</h3>
+          <span class="page-count">369 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6109" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6109', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6109', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6109', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6109', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6109', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6109%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6109%2F148.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6109%2F69c574faa0aa0f85ebb995b8.jpg&w=600" alt="Page 221" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.221 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6109%2F69c57be6a0aa0f85ebb99696.jpg&w=600" alt="Page 295" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.295 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6109%2F69c57f4da0aa0f85ebb99705.jpg&w=600" alt="Page 332" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.332 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c807206c6f3cc53c84578e" data-idx="215">
+        <div class="book-header">
+          <span class="book-num">#216</span>
+          <h3>[Greek] In sactos Maccabaeos, et in eorum matrem, homilia</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c807206c6f3cc53c84578e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c807206c6f3cc53c84578e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c807206c6f3cc53c84578e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c807206c6f3cc53c84578e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c807206c6f3cc53c84578e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c807206c6f3cc53c84578e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807206c6f3cc53c84578e%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807206c6f3cc53c84578e%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807206c6f3cc53c84578e%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807206c6f3cc53c84578e%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807206c6f3cc53c84578e%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3551fbd40b95eaa3c" data-idx="216">
+        <div class="book-header">
+          <span class="book-num">#217</span>
+          <h3>Verklaring van de evangelische parabolen</h3>
+          <span class="page-count">415 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3551fbd40b95eaa3c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3551fbd40b95eaa3c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3551fbd40b95eaa3c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3551fbd40b95eaa3c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3551fbd40b95eaa3c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3551fbd40b95eaa3c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3c%2F69c58e6024a7e2ec92e77a14.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3c%2F69c5adf028edf48064a947eb.jpg&w=600" alt="Page 166" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.166 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3c%2F69c5bf43af50176ac1d1846a.jpg&w=600" alt="Page 249" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.249 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e3551fbd40b95eaa3c%2F0332-full.jpg&w=600" alt="Page 332" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.332 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e3551fbd40b95eaa3c%2F0374-full.jpg&w=600" alt="Page 374" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.374 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7257101e1be0c9ac74c20" data-idx="217">
+        <div class="book-header">
+          <span class="book-num">#218</span>
+          <h3>Abrégé de l'histoire des Vaudois</h3>
+          <span class="page-count">189 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7257101e1be0c9ac74c20" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7257101e1be0c9ac74c20', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7257101e1be0c9ac74c20', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7257101e1be0c9ac74c20', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7257101e1be0c9ac74c20', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7257101e1be0c9ac74c20', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7257101e1be0c9ac74c20%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7257101e1be0c9ac74c20%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7257101e1be0c9ac74c20%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7257101e1be0c9ac74c20%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7257101e1be0c9ac74c20%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a63a92b884e4f8173b58" data-idx="218">
+        <div class="book-header">
+          <span class="book-num">#219</span>
+          <h3>[Hebrew: lechem panim] Aus denen orientalischen Sprachen hergeholter Beweis der Wahrheit des christ-catholischen Schau-Brods</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a63a92b884e4f8173b58" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a63a92b884e4f8173b58', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a63a92b884e4f8173b58', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a63a92b884e4f8173b58', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a63a92b884e4f8173b58', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a63a92b884e4f8173b58', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a63a92b884e4f8173b58%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a63a92b884e4f8173b58%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a63a92b884e4f8173b58%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a63a92b884e4f8173b58%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a63a92b884e4f8173b58%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81f486c6f3cc53c84a4d3" data-idx="219">
+        <div class="book-header">
+          <span class="book-num">#220</span>
+          <h3>De Foenicum literis</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81f486c6f3cc53c84a4d3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81f486c6f3cc53c84a4d3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81f486c6f3cc53c84a4d3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81f486c6f3cc53c84a4d3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81f486c6f3cc53c84a4d3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81f486c6f3cc53c84a4d3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f486c6f3cc53c84a4d3%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f486c6f3cc53c84a4d3%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f486c6f3cc53c84a4d3%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f486c6f3cc53c84a4d3%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f486c6f3cc53c84a4d3%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63cbcb463eebe7caac520" data-idx="220">
+        <div class="book-header">
+          <span class="book-num">#221</span>
+          <h3>Vier ausserlesene teutsche chemische Büchlein</h3>
+          <span class="page-count">262 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63cbcb463eebe7caac520" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63cbcb463eebe7caac520', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63cbcb463eebe7caac520', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63cbcb463eebe7caac520', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63cbcb463eebe7caac520', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63cbcb463eebe7caac520', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cbcb463eebe7caac520%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cbcb463eebe7caac520%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cbcb463eebe7caac520%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cbcb463eebe7caac520%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cbcb463eebe7caac520%2F0236-full.jpg&w=600" alt="Page 236" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.236 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c774af6a0f3d112faf9362" data-idx="221">
+        <div class="book-header">
+          <span class="book-num">#222</span>
+          <h3>Veteris testamenti ad veritatem Hebraicam recognitio</h3>
+          <span class="page-count">396 pp</span>
+          <a href="https://sourcelibrary.org/book/69c774af6a0f3d112faf9362" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c774af6a0f3d112faf9362', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c774af6a0f3d112faf9362', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c774af6a0f3d112faf9362', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c774af6a0f3d112faf9362', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c774af6a0f3d112faf9362', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774af6a0f3d112faf9362%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774af6a0f3d112faf9362%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774af6a0f3d112faf9362%2F0238-full.jpg&w=600" alt="Page 238" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.238 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774af6a0f3d112faf9362%2F0317-full.jpg&w=600" alt="Page 317" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.317 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c774af6a0f3d112faf9362%2F0356-full.jpg&w=600" alt="Page 356" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.356 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e32e2f948a050a505c" data-idx="222">
+        <div class="book-header">
+          <span class="book-num">#223</span>
+          <h3>Veredarius hermetico-philosophicus laetum et inauditum nuncium ad ferens</h3>
+          <span class="page-count">141 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e32e2f948a050a505c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e32e2f948a050a505c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e32e2f948a050a505c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e32e2f948a050a505c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e32e2f948a050a505c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e32e2f948a050a505c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505c%2F69c58456430d0a586a40110f.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505c%2F69c58c0d5428bcf4a279614d.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505c%2F69c58f184fb32cf385cc8aae.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505c%2F69c592571fd7b9ec8f993975.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505c%2F69c593b7629d576478ff3276.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c850b66c6f3cc53c852e7c" data-idx="223">
+        <div class="book-header">
+          <span class="book-num">#224</span>
+          <h3>Der mitternächtige Post-Reuter</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c850b66c6f3cc53c852e7c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c850b66c6f3cc53c852e7c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c850b66c6f3cc53c852e7c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c850b66c6f3cc53c852e7c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c850b66c6f3cc53c852e7c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c850b66c6f3cc53c852e7c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850b66c6f3cc53c852e7c%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850b66c6f3cc53c852e7c%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850b66c6f3cc53c852e7c%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850b66c6f3cc53c852e7c%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850b66c6f3cc53c852e7c%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c856fe6c6f3cc53c853f5a" data-idx="224">
+        <div class="book-header">
+          <span class="book-num">#225</span>
+          <h3>Das grosse Geheimniss der Menschwerdung des ewigen Worts</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c856fe6c6f3cc53c853f5a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c856fe6c6f3cc53c853f5a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c856fe6c6f3cc53c853f5a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c856fe6c6f3cc53c853f5a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c856fe6c6f3cc53c853f5a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c856fe6c6f3cc53c853f5a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856fe6c6f3cc53c853f5a%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856fe6c6f3cc53c853f5a%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856fe6c6f3cc53c853f5a%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856fe6c6f3cc53c853f5a%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856fe6c6f3cc53c853f5a%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f5526c6f3cc53c841b9b" data-idx="225">
+        <div class="book-header">
+          <span class="book-num">#226</span>
+          <h3>Viginti academiarum et scholarum illustrium tam intra quam ex Rom. Imp. nec non variarum ecclesiarum antistitum: nobilium it idem et aliorum clarissimorum virorum epicidia</h3>
+          <span class="page-count">205 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f5526c6f3cc53c841b9b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f5526c6f3cc53c841b9b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f5526c6f3cc53c841b9b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f5526c6f3cc53c841b9b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f5526c6f3cc53c841b9b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f5526c6f3cc53c841b9b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5526c6f3cc53c841b9b%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5526c6f3cc53c841b9b%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5526c6f3cc53c841b9b%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5526c6f3cc53c841b9b%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5526c6f3cc53c841b9b%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6e994da9771c7163146db" data-idx="226">
+        <div class="book-header">
+          <span class="book-num">#227</span>
+          <h3>Wasserstein der Weisen. Via veritatis</h3>
+          <span class="page-count">116 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6e994da9771c7163146db" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6e994da9771c7163146db', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6e994da9771c7163146db', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6e994da9771c7163146db', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6e994da9771c7163146db', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6e994da9771c7163146db', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e994da9771c7163146db%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e994da9771c7163146db%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e994da9771c7163146db%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e994da9771c7163146db%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e994da9771c7163146db%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41853fd44b1cae4ca2153" data-idx="227">
+        <div class="book-header">
+          <span class="book-num">#228</span>
+          <h3>Book of Hours for the Diocese of Utrecht (BPH 131)</h3>
+          <span class="page-count">308 pp</span>
+          <a href="https://sourcelibrary.org/book/adair-book-of-hours-utrecht-diocese-ca-1490-hours" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41853fd44b1cae4ca2153', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41853fd44b1cae4ca2153', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41853fd44b1cae4ca2153', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41853fd44b1cae4ca2153', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41853fd44b1cae4ca2153', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581405105131!031_ph131_aa5823_013r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581405105131!123_ph131_aa5823_059r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581405105131!185_ph131_aa5823_090r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581405105131!246_ph131_aa5823_120v.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581405105131!277_ph131_aa5823_136r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 277" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.277 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee610f" data-idx="228">
+        <div class="book-header">
+          <span class="book-num">#229</span>
+          <h3>Monas hieroglyphica</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee610f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee610f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee610f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee610f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee610f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee610f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610f%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610f%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610f%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610f%2F49.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610f%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81eef6c6f3cc53c84a3a3" data-idx="229">
+        <div class="book-header">
+          <span class="book-num">#230</span>
+          <h3>De religione christiana</h3>
+          <span class="page-count">94 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81eef6c6f3cc53c84a3a3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81eef6c6f3cc53c84a3a3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81eef6c6f3cc53c84a3a3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81eef6c6f3cc53c84a3a3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81eef6c6f3cc53c84a3a3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81eef6c6f3cc53c84a3a3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81eef6c6f3cc53c84a3a3%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81eef6c6f3cc53c84a3a3%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81eef6c6f3cc53c84a3a3%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81eef6c6f3cc53c84a3a3%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81eef6c6f3cc53c84a3a3%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41856f1200e2ab53cf343" data-idx="230">
+        <div class="book-header">
+          <span class="book-num">#231</span>
+          <h3>Book of Hours (BPH 134)</h3>
+          <span class="page-count">374 pp</span>
+          <a href="https://sourcelibrary.org/book/book-of-hours-dutch-illuminated-ms-ca-1470" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41856f1200e2ab53cf343', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41856f1200e2ab53cf343', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41856f1200e2ab53cf343', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41856f1200e2ab53cf343', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41856f1200e2ab53cf343', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41856f1200e2ab53cf343%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41856f1200e2ab53cf343%2F150.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940579723805131!223_ph134_112r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 224" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.224 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940579723805131!298_ph134_149v.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 299" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.299 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940579723805131!336_ph134_168v.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 337" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.337 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c748436a0f3d112faf8108" data-idx="231">
+        <div class="book-header">
+          <span class="book-num">#232</span>
+          <h3>The vanity of arts and sciences</h3>
+          <span class="page-count">201 pp</span>
+          <a href="https://sourcelibrary.org/book/69c748436a0f3d112faf8108" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c748436a0f3d112faf8108', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c748436a0f3d112faf8108', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c748436a0f3d112faf8108', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c748436a0f3d112faf8108', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c748436a0f3d112faf8108', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748436a0f3d112faf8108%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748436a0f3d112faf8108%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748436a0f3d112faf8108%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748436a0f3d112faf8108%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748436a0f3d112faf8108%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6fd8ada9771c7163154e0" data-idx="232">
+        <div class="book-header">
+          <span class="book-num">#233</span>
+          <h3>Vom Zank und Streit der Gelehrten um Christi Testamenta</h3>
+          <span class="page-count">27 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6fd8ada9771c7163154e0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6fd8ada9771c7163154e0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6fd8ada9771c7163154e0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6fd8ada9771c7163154e0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6fd8ada9771c7163154e0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6fd8ada9771c7163154e0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e0%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e0%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e0%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e0%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e0%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82ac36c6f3cc53c84c937" data-idx="233">
+        <div class="book-header">
+          <span class="book-num">#234</span>
+          <h3>Ondersoek en antwoord [...] op 't request door de gedeputeerden der Noordhollandsche synode tot Edam</h3>
+          <span class="page-count">54 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82ac36c6f3cc53c84c937" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82ac36c6f3cc53c84c937', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82ac36c6f3cc53c84c937', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82ac36c6f3cc53c84c937', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82ac36c6f3cc53c84c937', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82ac36c6f3cc53c84c937', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ac36c6f3cc53c84c937%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ac36c6f3cc53c84c937%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ac36c6f3cc53c84c937%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ac36c6f3cc53c84c937%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ac36c6f3cc53c84c937%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7085cda9771c716315ce7" data-idx="234">
+        <div class="book-header">
+          <span class="book-num">#235</span>
+          <h3>Die christliche Pflicht der Gedult in Leiden</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7085cda9771c716315ce7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7085cda9771c716315ce7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7085cda9771c716315ce7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7085cda9771c716315ce7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7085cda9771c716315ce7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7085cda9771c716315ce7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7085cda9771c716315ce7%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7085cda9771c716315ce7%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7085cda9771c716315ce7%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7085cda9771c716315ce7%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7085cda9771c716315ce7%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c891cb6c6f3cc53c85bada" data-idx="235">
+        <div class="book-header">
+          <span class="book-num">#236</span>
+          <h3>The lives of the adepts in alchemystical philosophy</h3>
+          <span class="page-count">206 pp</span>
+          <a href="https://sourcelibrary.org/book/69c891cb6c6f3cc53c85bada" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c891cb6c6f3cc53c85bada', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c891cb6c6f3cc53c85bada', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c891cb6c6f3cc53c85bada', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c891cb6c6f3cc53c85bada', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c891cb6c6f3cc53c85bada', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891cb6c6f3cc53c85bada%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891cb6c6f3cc53c85bada%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891cb6c6f3cc53c85bada%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891cb6c6f3cc53c85bada%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891cb6c6f3cc53c85bada%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909c8ebcf28baa1b4cafbb7" data-idx="236">
+        <div class="book-header">
+          <span class="book-num">#237</span>
+          <h3>Brunnen der Weisheit und Erkänntniss der Natur</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/fountain-of-wisdom-and-knowledge-of-nature-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909c8ebcf28baa1b4cafbb7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909c8ebcf28baa1b4cafbb7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909c8ebcf28baa1b4cafbb7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909c8ebcf28baa1b4cafbb7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909c8ebcf28baa1b4cafbb7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c8ebcf28baa1b4cafbb7%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c8ebcf28baa1b4cafbb7%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c8ebcf28baa1b4cafbb7%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c8ebcf28baa1b4cafbb7%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c8ebcf28baa1b4cafbb7%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81d686c6f3cc53c849f70" data-idx="237">
+        <div class="book-header">
+          <span class="book-num">#238</span>
+          <h3>A treatise on the nature of influx: or, of the intercourse between soul and body</h3>
+          <span class="page-count">89 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81d686c6f3cc53c849f70" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81d686c6f3cc53c849f70', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81d686c6f3cc53c849f70', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81d686c6f3cc53c849f70', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81d686c6f3cc53c849f70', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81d686c6f3cc53c849f70', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d686c6f3cc53c849f70%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d686c6f3cc53c849f70%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d686c6f3cc53c849f70%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d686c6f3cc53c849f70%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d686c6f3cc53c849f70%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88f666c6f3cc53c85b371" data-idx="238">
+        <div class="book-header">
+          <span class="book-num">#239</span>
+          <h3>Voyages de Pythagore</h3>
+          <span class="page-count">252 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88f666c6f3cc53c85b371" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88f666c6f3cc53c85b371', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88f666c6f3cc53c85b371', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88f666c6f3cc53c85b371', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88f666c6f3cc53c85b371', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88f666c6f3cc53c85b371', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f666c6f3cc53c85b371%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f666c6f3cc53c85b371%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f666c6f3cc53c85b371%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f666c6f3cc53c85b371%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f666c6f3cc53c85b371%2F0227-full.jpg&w=600" alt="Page 227" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.227 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e34cc41628b775aa84" data-idx="239">
+        <div class="book-header">
+          <span class="book-num">#240</span>
+          <h3>Veranthwortung fuer Herr Caspar Schwenckfelden</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e34cc41628b775aa84" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e34cc41628b775aa84', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e34cc41628b775aa84', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e34cc41628b775aa84', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e34cc41628b775aa84', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e34cc41628b775aa84', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa84%2F69c58270de3d105c26438b88.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa84%2F69c585b1618833b44d403856.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa84%2F69c588741060334447880a40.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa84%2F69c589daefd5d259312255d4.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa84%2F69c58b845b57418d7396d5ca.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c753b26a0f3d112faf8620" data-idx="240">
+        <div class="book-header">
+          <span class="book-num">#241</span>
+          <h3>Opuscula theologici, historici et philosophici argumenti tomi prioris</h3>
+          <span class="page-count">589 pp</span>
+          <a href="https://sourcelibrary.org/book/69c753b26a0f3d112faf8620" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c753b26a0f3d112faf8620', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c753b26a0f3d112faf8620', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c753b26a0f3d112faf8620', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c753b26a0f3d112faf8620', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c753b26a0f3d112faf8620', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c753b26a0f3d112faf8620%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c753b26a0f3d112faf8620%2F0236-full.jpg&w=600" alt="Page 236" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.236 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c753b26a0f3d112faf8620%2F0353-full.jpg&w=600" alt="Page 353" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.353 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c753b26a0f3d112faf8620%2F0471-full.jpg&w=600" alt="Page 471" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.471 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c753b26a0f3d112faf8620%2F0530-full.jpg&w=600" alt="Page 530" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.530 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c759b16a0f3d112faf871d" data-idx="241">
+        <div class="book-header">
+          <span class="book-num">#242</span>
+          <h3>Dictionnaire historique des cultes religieux</h3>
+          <span class="page-count">401 pp</span>
+          <a href="https://sourcelibrary.org/book/69c759b16a0f3d112faf871d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c759b16a0f3d112faf871d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c759b16a0f3d112faf871d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c759b16a0f3d112faf871d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c759b16a0f3d112faf871d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c759b16a0f3d112faf871d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c759b16a0f3d112faf871d%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c759b16a0f3d112faf871d%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c759b16a0f3d112faf871d%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c759b16a0f3d112faf871d%2F0321-full.jpg&w=600" alt="Page 321" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.321 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c759b16a0f3d112faf871d%2F0361-full.jpg&w=600" alt="Page 361" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.361 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c838976c6f3cc53c84f0a6" data-idx="242">
+        <div class="book-header">
+          <span class="book-num">#243</span>
+          <h3>Gesammlete kleine Schrifften</h3>
+          <span class="page-count">511 pp</span>
+          <a href="https://sourcelibrary.org/book/69c838976c6f3cc53c84f0a6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c838976c6f3cc53c84f0a6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c838976c6f3cc53c84f0a6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c838976c6f3cc53c84f0a6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c838976c6f3cc53c84f0a6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c838976c6f3cc53c84f0a6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838976c6f3cc53c84f0a6%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838976c6f3cc53c84f0a6%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838976c6f3cc53c84f0a6%2F0307-full.jpg&w=600" alt="Page 307" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.307 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838976c6f3cc53c84f0a6%2F0409-full.jpg&w=600" alt="Page 409" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.409 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c838976c6f3cc53c84f0a6%2F0460-full.jpg&w=600" alt="Page 460" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.460 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88edb6c6f3cc53c85b1f2" data-idx="243">
+        <div class="book-header">
+          <span class="book-num">#244</span>
+          <h3>Vita di san Giosafat, convertito da Barlaam</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88edb6c6f3cc53c85b1f2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88edb6c6f3cc53c85b1f2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88edb6c6f3cc53c85b1f2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88edb6c6f3cc53c85b1f2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88edb6c6f3cc53c85b1f2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88edb6c6f3cc53c85b1f2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88edb6c6f3cc53c85b1f2%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88edb6c6f3cc53c85b1f2%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88edb6c6f3cc53c85b1f2%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88edb6c6f3cc53c85b1f2%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88edb6c6f3cc53c85b1f2%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7d03525ec2ba5ccd8031e" data-idx="244">
+        <div class="book-header">
+          <span class="book-num">#245</span>
+          <h3>Theologia mystica cum speculativa</h3>
+          <span class="page-count">267 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7d03525ec2ba5ccd8031e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7d03525ec2ba5ccd8031e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7d03525ec2ba5ccd8031e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7d03525ec2ba5ccd8031e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7d03525ec2ba5ccd8031e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7d03525ec2ba5ccd8031e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03525ec2ba5ccd8031e%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03525ec2ba5ccd8031e%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03525ec2ba5ccd8031e%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03525ec2ba5ccd8031e%2F0214-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03525ec2ba5ccd8031e%2F0240-full.jpg&w=600" alt="Page 240" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.240 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909a8c1cf28baa1b4caee49" data-idx="245">
+        <div class="book-header">
+          <span class="book-num">#246</span>
+          <h3>Echo der von Gott hocherleuchten Fraternitet dess löblichen Ordens R.C.</h3>
+          <span class="page-count">143 pp</span>
+          <a href="https://sourcelibrary.org/book/echo-of-the-fraternity-highly-enlightened-by-god-of-the-sperber" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909a8c1cf28baa1b4caee49', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909a8c1cf28baa1b4caee49', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909a8c1cf28baa1b4caee49', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909a8c1cf28baa1b4caee49', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909a8c1cf28baa1b4caee49', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a8c1cf28baa1b4caee49%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a8c1cf28baa1b4caee49%2F57.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a8c1cf28baa1b4caee49%2F86.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a8c1cf28baa1b4caee49%2F114.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909a8c1cf28baa1b4caee49%2F129.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f7fe6c6f3cc53c842218" data-idx="246">
+        <div class="book-header">
+          <span class="book-num">#247</span>
+          <h3>De auditu kabbalistico sive ad omnes scientias introductorium</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f7fe6c6f3cc53c842218" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f7fe6c6f3cc53c842218', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f7fe6c6f3cc53c842218', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f7fe6c6f3cc53c842218', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f7fe6c6f3cc53c842218', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f7fe6c6f3cc53c842218', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f7fe6c6f3cc53c842218%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f7fe6c6f3cc53c842218%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f7fe6c6f3cc53c842218%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f7fe6c6f3cc53c842218%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f7fe6c6f3cc53c842218%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4193d2b0edf3eaa2df1bc" data-idx="247">
+        <div class="book-header">
+          <span class="book-num">#248</span>
+          <h3>Pandora — Hieronymus Reusner (PH190)</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/reusner-pandora-the-noblest-gift-of-god-18th-century-ms-reusner" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4193d2b0edf3eaa2df1bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4193d2b0edf3eaa2df1bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4193d2b0edf3eaa2df1bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4193d2b0edf3eaa2df1bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4193d2b0edf3eaa2df1bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193d2b0edf3eaa2df1bc%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513040205131!ph190_067.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513040205131!ph190_100.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513040205131!ph190_134.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940513040205131!ph190_150.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87f2e6c6f3cc53c858e79" data-idx="248">
+        <div class="book-header">
+          <span class="book-num">#249</span>
+          <h3>A mystagogical quintology</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87f2e6c6f3cc53c858e79" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87f2e6c6f3cc53c858e79', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87f2e6c6f3cc53c858e79', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87f2e6c6f3cc53c858e79', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87f2e6c6f3cc53c858e79', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87f2e6c6f3cc53c858e79', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f2e6c6f3cc53c858e79%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f2e6c6f3cc53c858e79%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f2e6c6f3cc53c858e79%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f2e6c6f3cc53c858e79%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f2e6c6f3cc53c858e79%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83c816c6f3cc53c84f9c2" data-idx="249">
+        <div class="book-header">
+          <span class="book-num">#250</span>
+          <h3>Metaphysische Kezereien</h3>
+          <span class="page-count">228 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83c816c6f3cc53c84f9c2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83c816c6f3cc53c84f9c2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83c816c6f3cc53c84f9c2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83c816c6f3cc53c84f9c2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83c816c6f3cc53c84f9c2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83c816c6f3cc53c84f9c2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c816c6f3cc53c84f9c2%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c816c6f3cc53c84f9c2%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c816c6f3cc53c84f9c2%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c816c6f3cc53c84f9c2%2F0182-full.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c816c6f3cc53c84f9c2%2F0205-full.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898f06c6f3cc53c85cc6e" data-idx="250">
+        <div class="book-header">
+          <span class="book-num">#251</span>
+          <h3>Die heilige Lehre von der Wiederbringung aller Dinge aus dem Worte Gottes</h3>
+          <span class="page-count">33 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898f06c6f3cc53c85cc6e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898f06c6f3cc53c85cc6e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898f06c6f3cc53c85cc6e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898f06c6f3cc53c85cc6e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898f06c6f3cc53c85cc6e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898f06c6f3cc53c85cc6e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898f06c6f3cc53c85cc6e%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898f06c6f3cc53c85cc6e%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898f06c6f3cc53c85cc6e%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898f06c6f3cc53c85cc6e%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898f06c6f3cc53c85cc6e%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c871b86c6f3cc53c857667" data-idx="251">
+        <div class="book-header">
+          <span class="book-num">#252</span>
+          <h3>Discours sur les miracles de Jesus-Christ</h3>
+          <span class="page-count">261 pp</span>
+          <a href="https://sourcelibrary.org/book/69c871b86c6f3cc53c857667" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c871b86c6f3cc53c857667', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c871b86c6f3cc53c857667', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c871b86c6f3cc53c857667', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c871b86c6f3cc53c857667', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c871b86c6f3cc53c857667', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871b86c6f3cc53c857667%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871b86c6f3cc53c857667%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871b86c6f3cc53c857667%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871b86c6f3cc53c857667%2F0209-full.jpg&w=600" alt="Page 209" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.209 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871b86c6f3cc53c857667%2F0235-full.jpg&w=600" alt="Page 235" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.235 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7dd28bae5db59ace1a068" data-idx="252">
+        <div class="book-header">
+          <span class="book-num">#253</span>
+          <h3>Historie der Wiedergebohrnen</h3>
+          <span class="page-count">665 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7dd28bae5db59ace1a068" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7dd28bae5db59ace1a068', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7dd28bae5db59ace1a068', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7dd28bae5db59ace1a068', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7dd28bae5db59ace1a068', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7dd28bae5db59ace1a068', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a068%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a068%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a068%2F0399-full.jpg&w=600" alt="Page 399" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.399 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a068%2F0532-full.jpg&w=600" alt="Page 532" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.532 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a068%2F0599-full.jpg&w=600" alt="Page 599" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.599 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c874af6c6f3cc53c857cd4" data-idx="253">
+        <div class="book-header">
+          <span class="book-num">#254</span>
+          <h3>An encyclopedic outline of masonic, hermetic, cabbalistic and rosicrucian symbolical philosophy. Being an interpretation of the secret teachings concealed within the rituals, allegories and mysteries of all ages</h3>
+          <span class="page-count">187 pp</span>
+          <a href="https://sourcelibrary.org/book/69c874af6c6f3cc53c857cd4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c874af6c6f3cc53c857cd4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c874af6c6f3cc53c857cd4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c874af6c6f3cc53c857cd4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c874af6c6f3cc53c857cd4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c874af6c6f3cc53c857cd4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874af6c6f3cc53c857cd4%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874af6c6f3cc53c857cd4%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874af6c6f3cc53c857cd4%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874af6c6f3cc53c857cd4%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c874af6c6f3cc53c857cd4%2F0168-full.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70182da9771c71631576f" data-idx="254">
+        <div class="book-header">
+          <span class="book-num">#255</span>
+          <h3>Ueber den Zweck des Freymaurerordens</h3>
+          <span class="page-count">132 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70182da9771c71631576f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70182da9771c71631576f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70182da9771c71631576f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70182da9771c71631576f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70182da9771c71631576f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70182da9771c71631576f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70182da9771c71631576f%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70182da9771c71631576f%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70182da9771c71631576f%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70182da9771c71631576f%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70182da9771c71631576f%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f8b46c6f3cc53c842434" data-idx="255">
+        <div class="book-header">
+          <span class="book-num">#256</span>
+          <h3>Basilica chymica. De signaturis rerum</h3>
+          <span class="page-count">296 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f8b46c6f3cc53c842434" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f8b46c6f3cc53c842434', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f8b46c6f3cc53c842434', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f8b46c6f3cc53c842434', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f8b46c6f3cc53c842434', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f8b46c6f3cc53c842434', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8b46c6f3cc53c842434%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8b46c6f3cc53c842434%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8b46c6f3cc53c842434%2F0178-full.jpg&w=600" alt="Page 178" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.178 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8b46c6f3cc53c842434%2F0237-full.jpg&w=600" alt="Page 237" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.237 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f8b46c6f3cc53c842434%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c869926c6f3cc53c8568a7" data-idx="256">
+        <div class="book-header">
+          <span class="book-num">#257</span>
+          <h3>Apologia: das ist, Verandtwortung: fuer Herr Caspar Schwenckfelden</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c869926c6f3cc53c8568a7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c869926c6f3cc53c8568a7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c869926c6f3cc53c8568a7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c869926c6f3cc53c8568a7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c869926c6f3cc53c8568a7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c869926c6f3cc53c8568a7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c869926c6f3cc53c8568a7%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869926c6f3cc53c8568a7%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869926c6f3cc53c8568a7%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869926c6f3cc53c8568a7%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869926c6f3cc53c8568a7%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89a4b6c6f3cc53c85d0e8" data-idx="257">
+        <div class="book-header">
+          <span class="book-num">#258</span>
+          <h3>La contemplation spirituelle extraicte des livres de Sainct Denys</h3>
+          <span class="page-count">79 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89a4b6c6f3cc53c85d0e8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89a4b6c6f3cc53c85d0e8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89a4b6c6f3cc53c85d0e8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89a4b6c6f3cc53c85d0e8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89a4b6c6f3cc53c85d0e8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89a4b6c6f3cc53c85d0e8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a4b6c6f3cc53c85d0e8%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a4b6c6f3cc53c85d0e8%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a4b6c6f3cc53c85d0e8%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a4b6c6f3cc53c85d0e8%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a4b6c6f3cc53c85d0e8%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c748446a0f3d112faf8113" data-idx="258">
+        <div class="book-header">
+          <span class="book-num">#259</span>
+          <h3>De l'esprit des choses</h3>
+          <span class="page-count">174 pp</span>
+          <a href="https://sourcelibrary.org/book/69c748446a0f3d112faf8113" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c748446a0f3d112faf8113', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c748446a0f3d112faf8113', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c748446a0f3d112faf8113', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c748446a0f3d112faf8113', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c748446a0f3d112faf8113', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748446a0f3d112faf8113%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748446a0f3d112faf8113%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748446a0f3d112faf8113%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748446a0f3d112faf8113%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c748446a0f3d112faf8113%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c816de6c6f3cc53c848bf2" data-idx="259">
+        <div class="book-header">
+          <span class="book-num">#260</span>
+          <h3>Het leven van B. de Spinoza. Een kort betoog van de waarheit des christelyken godtsdiensts</h3>
+          <span class="page-count">347 pp</span>
+          <a href="https://sourcelibrary.org/book/69c816de6c6f3cc53c848bf2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c816de6c6f3cc53c848bf2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c816de6c6f3cc53c848bf2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c816de6c6f3cc53c848bf2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c816de6c6f3cc53c848bf2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c816de6c6f3cc53c848bf2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816de6c6f3cc53c848bf2%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816de6c6f3cc53c848bf2%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816de6c6f3cc53c848bf2%2F0208-full.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816de6c6f3cc53c848bf2%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816de6c6f3cc53c848bf2%2F0312-full.jpg&w=600" alt="Page 312" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.312 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419422b0edf3eaa2df2b9" data-idx="260">
+        <div class="book-header">
+          <span class="book-num">#261</span>
+          <h3>Gott ist die reinste Liebe — Karl von Eckartshausen (PH237)</h3>
+          <span class="page-count">83 pp</span>
+          <a href="https://sourcelibrary.org/book/eckartshausen-god-is-the-purest-love-1826-eckartshausen" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419422b0edf3eaa2df2b9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419422b0edf3eaa2df2b9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419422b0edf3eaa2df2b9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419422b0edf3eaa2df2b9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419422b0edf3eaa2df2b9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419422b0edf3eaa2df2b9%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419422b0edf3eaa2df2b9%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419422b0edf3eaa2df2b9%2F50.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419422b0edf3eaa2df2b9%2F66.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419422b0edf3eaa2df2b9%2F75.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71f28da9771c716316afb" data-idx="261">
+        <div class="book-header">
+          <span class="book-num">#262</span>
+          <h3>Hermetisches Journal</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71f28da9771c716316afb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71f28da9771c716316afb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71f28da9771c716316afb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71f28da9771c716316afb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71f28da9771c716316afb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71f28da9771c716316afb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f28da9771c716316afb%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f28da9771c716316afb%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f28da9771c716316afb%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f28da9771c716316afb%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71f28da9771c716316afb%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fe2b6c6f3cc53c8436af" data-idx="262">
+        <div class="book-header">
+          <span class="book-num">#263</span>
+          <h3>Les oeuvres</h3>
+          <span class="page-count">328 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fe2b6c6f3cc53c8436af" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fe2b6c6f3cc53c8436af', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fe2b6c6f3cc53c8436af', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fe2b6c6f3cc53c8436af', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fe2b6c6f3cc53c8436af', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fe2b6c6f3cc53c8436af', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2b6c6f3cc53c8436af%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2b6c6f3cc53c8436af%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2b6c6f3cc53c8436af%2F0197-full.jpg&w=600" alt="Page 197" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.197 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2b6c6f3cc53c8436af%2F0262-full.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe2b6c6f3cc53c8436af%2F0295-full.jpg&w=600" alt="Page 295" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.295 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c64199b463eebe7caac809" data-idx="263">
+        <div class="book-header">
+          <span class="book-num">#264</span>
+          <h3>[Greek: Bioi philosophon kai sophiston] De vitis philosophorum et sophistarum</h3>
+          <span class="page-count">125 pp</span>
+          <a href="https://sourcelibrary.org/book/69c64199b463eebe7caac809" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c64199b463eebe7caac809', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c64199b463eebe7caac809', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c64199b463eebe7caac809', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c64199b463eebe7caac809', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c64199b463eebe7caac809', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64199b463eebe7caac809%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64199b463eebe7caac809%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64199b463eebe7caac809%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64199b463eebe7caac809%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64199b463eebe7caac809%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83c206c6f3cc53c84f871" data-idx="264">
+        <div class="book-header">
+          <span class="book-num">#265</span>
+          <h3>Schlüssel zu dem Cabinet der geheimen Schatz-Cammer der Natur</h3>
+          <span class="page-count">149 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83c206c6f3cc53c84f871" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83c206c6f3cc53c84f871', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83c206c6f3cc53c84f871', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83c206c6f3cc53c84f871', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83c206c6f3cc53c84f871', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83c206c6f3cc53c84f871', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c206c6f3cc53c84f871%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c206c6f3cc53c84f871%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c206c6f3cc53c84f871%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c206c6f3cc53c84f871%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c206c6f3cc53c84f871%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82ae46c6f3cc53c84c991" data-idx="265">
+        <div class="book-header">
+          <span class="book-num">#266</span>
+          <h3>De betooverde weereld van Balthasar Bekker ondersogt en weederlegt</h3>
+          <span class="page-count">348 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82ae46c6f3cc53c84c991" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82ae46c6f3cc53c84c991', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82ae46c6f3cc53c84c991', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82ae46c6f3cc53c84c991', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82ae46c6f3cc53c84c991', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82ae46c6f3cc53c84c991', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ae46c6f3cc53c84c991%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ae46c6f3cc53c84c991%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ae46c6f3cc53c84c991%2F0209-full.jpg&w=600" alt="Page 209" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.209 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ae46c6f3cc53c84c991%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ae46c6f3cc53c84c991%2F0313-full.jpg&w=600" alt="Page 313" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.313 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="68fb0b2712055a03a58d3193" data-idx="266">
+        <div class="book-header">
+          <span class="book-num">#267</span>
+          <h3>Liber egregius de unitate ecclesia</h3>
+          <span class="page-count">127 pp</span>
+          <a href="https://sourcelibrary.org/book/the-excellent-book-on-the-unity-of-the-church-hus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('68fb0b2712055a03a58d3193', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('68fb0b2712055a03a58d3193', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('68fb0b2712055a03a58d3193', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('68fb0b2712055a03a58d3193', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('68fb0b2712055a03a58d3193', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0b2712055a03a58d3193%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0b2712055a03a58d3193%2F51.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0b2712055a03a58d3193%2F76.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0b2712055a03a58d3193%2F102.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0b2712055a03a58d3193%2F114.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898106c6f3cc53c85c9eb" data-idx="267">
+        <div class="book-header">
+          <span class="book-num">#268</span>
+          <h3>A brief account of the life and works of St. Thomas Aquinas</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898106c6f3cc53c85c9eb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898106c6f3cc53c85c9eb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898106c6f3cc53c85c9eb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898106c6f3cc53c85c9eb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898106c6f3cc53c85c9eb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898106c6f3cc53c85c9eb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898106c6f3cc53c85c9eb%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898106c6f3cc53c85c9eb%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898106c6f3cc53c85c9eb%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898106c6f3cc53c85c9eb%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898106c6f3cc53c85c9eb%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8188a6c6f3cc53c849100" data-idx="268">
+        <div class="book-header">
+          <span class="book-num">#269</span>
+          <h3>L'impieté des Deistes</h3>
+          <span class="page-count">307 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8188a6c6f3cc53c849100" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8188a6c6f3cc53c849100', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8188a6c6f3cc53c849100', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8188a6c6f3cc53c849100', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8188a6c6f3cc53c849100', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8188a6c6f3cc53c849100', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8188a6c6f3cc53c849100%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8188a6c6f3cc53c849100%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8188a6c6f3cc53c849100%2F0184-full.jpg&w=600" alt="Page 184" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.184 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8188a6c6f3cc53c849100%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8188a6c6f3cc53c849100%2F0276-full.jpg&w=600" alt="Page 276" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.276 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c873a46c6f3cc53c857b27" data-idx="269">
+        <div class="book-header">
+          <span class="book-num">#270</span>
+          <h3>The dream of Ravan, a mystery</h3>
+          <span class="page-count">131 pp</span>
+          <a href="https://sourcelibrary.org/book/69c873a46c6f3cc53c857b27" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c873a46c6f3cc53c857b27', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c873a46c6f3cc53c857b27', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c873a46c6f3cc53c857b27', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c873a46c6f3cc53c857b27', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c873a46c6f3cc53c857b27', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c873a46c6f3cc53c857b27%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c873a46c6f3cc53c857b27%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c873a46c6f3cc53c857b27%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c873a46c6f3cc53c857b27%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c873a46c6f3cc53c857b27%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4187ef1200e2ab53cfa5c" data-idx="270">
+        <div class="book-header">
+          <span class="book-num">#271</span>
+          <h3>Collection of Alchemical Works (PH346)</h3>
+          <span class="page-count">303 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-anthology-18th-century-french-ms-various" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4187ef1200e2ab53cfa5c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4187ef1200e2ab53cfa5c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4187ef1200e2ab53cfa5c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4187ef1200e2ab53cfa5c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4187ef1200e2ab53cfa5c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187ef1200e2ab53cfa5c%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187ef1200e2ab53cfa5c%2F121.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187ef1200e2ab53cfa5c%2F182.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565076705131!PH346_242.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565076705131!PH346_273.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 273" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.273 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82cc66c6f3cc53c84cfbb" data-idx="271">
+        <div class="book-header">
+          <span class="book-num">#272</span>
+          <h3>Ion sive originum Graeciae restauratarum</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82cc66c6f3cc53c84cfbb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82cc66c6f3cc53c84cfbb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82cc66c6f3cc53c84cfbb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82cc66c6f3cc53c84cfbb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82cc66c6f3cc53c84cfbb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82cc66c6f3cc53c84cfbb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cc66c6f3cc53c84cfbb%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cc66c6f3cc53c84cfbb%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cc66c6f3cc53c84cfbb%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cc66c6f3cc53c84cfbb%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cc66c6f3cc53c84cfbb%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fe736c6f3cc53c8437d3" data-idx="272">
+        <div class="book-header">
+          <span class="book-num">#273</span>
+          <h3>Bibliothèque des anciens philosophes, contenant Les oeuvres  de Platon</h3>
+          <span class="page-count">269 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fe736c6f3cc53c8437d3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fe736c6f3cc53c8437d3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fe736c6f3cc53c8437d3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fe736c6f3cc53c8437d3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fe736c6f3cc53c8437d3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fe736c6f3cc53c8437d3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe736c6f3cc53c8437d3%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe736c6f3cc53c8437d3%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe736c6f3cc53c8437d3%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe736c6f3cc53c8437d3%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fe736c6f3cc53c8437d3%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ff776c6f3cc53c843bba" data-idx="273">
+        <div class="book-header">
+          <span class="book-num">#274</span>
+          <h3>The Bhagvat-geeta, or dialogues of Kreeshna and Arjoonin eighteen lectures with notes</h3>
+          <span class="page-count">85 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ff776c6f3cc53c843bba" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ff776c6f3cc53c843bba', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ff776c6f3cc53c843bba', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ff776c6f3cc53c843bba', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ff776c6f3cc53c843bba', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ff776c6f3cc53c843bba', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff776c6f3cc53c843bba%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff776c6f3cc53c843bba%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff776c6f3cc53c843bba%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff776c6f3cc53c843bba%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff776c6f3cc53c843bba%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8409d6c6f3cc53c8507c5" data-idx="274">
+        <div class="book-header">
+          <span class="book-num">#275</span>
+          <h3>Grosse Absichten des Ordens der Illuminaten</h3>
+          <span class="page-count">121 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8409d6c6f3cc53c8507c5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8409d6c6f3cc53c8507c5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8409d6c6f3cc53c8507c5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8409d6c6f3cc53c8507c5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8409d6c6f3cc53c8507c5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8409d6c6f3cc53c8507c5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8409d6c6f3cc53c8507c5%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8409d6c6f3cc53c8507c5%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8409d6c6f3cc53c8507c5%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8409d6c6f3cc53c8507c5%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8409d6c6f3cc53c8507c5%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c891196c6f3cc53c85b8bd" data-idx="275">
+        <div class="book-header">
+          <span class="book-num">#276</span>
+          <h3>Will now come forward</h3>
+          <span class="page-count">57 pp</span>
+          <a href="https://sourcelibrary.org/book/69c891196c6f3cc53c85b8bd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c891196c6f3cc53c85b8bd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c891196c6f3cc53c85b8bd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c891196c6f3cc53c85b8bd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c891196c6f3cc53c85b8bd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c891196c6f3cc53c85b8bd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891196c6f3cc53c85b8bd%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891196c6f3cc53c85b8bd%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891196c6f3cc53c85b8bd%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891196c6f3cc53c85b8bd%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891196c6f3cc53c85b8bd%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fcdf6c6f3cc53c8431ed" data-idx="276">
+        <div class="book-header">
+          <span class="book-num">#277</span>
+          <h3>Opera nuoer in lucem prodeuntia Liber gratie spiritualis visionum et revelationum</h3>
+          <span class="page-count">142 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fcdf6c6f3cc53c8431ed" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fcdf6c6f3cc53c8431ed', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fcdf6c6f3cc53c8431ed', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fcdf6c6f3cc53c8431ed', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fcdf6c6f3cc53c8431ed', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fcdf6c6f3cc53c8431ed', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fcdf6c6f3cc53c8431ed%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fcdf6c6f3cc53c8431ed%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fcdf6c6f3cc53c8431ed%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fcdf6c6f3cc53c8431ed%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fcdf6c6f3cc53c8431ed%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c829f36c6f3cc53c84c6ec" data-idx="277">
+        <div class="book-header">
+          <span class="book-num">#278</span>
+          <h3>Kleinere philosophische Schriften</h3>
+          <span class="page-count">277 pp</span>
+          <a href="https://sourcelibrary.org/book/69c829f36c6f3cc53c84c6ec" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c829f36c6f3cc53c84c6ec', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c829f36c6f3cc53c84c6ec', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c829f36c6f3cc53c84c6ec', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c829f36c6f3cc53c84c6ec', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c829f36c6f3cc53c84c6ec', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829f36c6f3cc53c84c6ec%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829f36c6f3cc53c84c6ec%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829f36c6f3cc53c84c6ec%2F0166-full.jpg&w=600" alt="Page 166" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.166 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829f36c6f3cc53c84c6ec%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829f36c6f3cc53c84c6ec%2F0249-full.jpg&w=600" alt="Page 249" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.249 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c632563e8cae136d149653" data-idx="278">
+        <div class="book-header">
+          <span class="book-num">#279</span>
+          <h3>Versuch über die Religionsgeschichte der ältesten Völker, besonders der Egyptier</h3>
+          <span class="page-count">169 pp</span>
+          <a href="https://sourcelibrary.org/book/69c632563e8cae136d149653" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c632563e8cae136d149653', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c632563e8cae136d149653', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c632563e8cae136d149653', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c632563e8cae136d149653', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c632563e8cae136d149653', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c632563e8cae136d149653%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c632563e8cae136d149653%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c632563e8cae136d149653%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c632563e8cae136d149653%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c632563e8cae136d149653%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808396c6f3cc53c845c4f" data-idx="279">
+        <div class="book-header">
+          <span class="book-num">#280</span>
+          <h3>Commentaria in archidoxorum libros X. D. Doctoris Theophrasti Paracelsi. Compendium astronomiae magnae</h3>
+          <span class="page-count">305 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808396c6f3cc53c845c4f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808396c6f3cc53c845c4f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808396c6f3cc53c845c4f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808396c6f3cc53c845c4f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808396c6f3cc53c845c4f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808396c6f3cc53c845c4f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808396c6f3cc53c845c4f%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808396c6f3cc53c845c4f%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808396c6f3cc53c845c4f%2F0183-full.jpg&w=600" alt="Page 183" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.183 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808396c6f3cc53c845c4f%2F0244-full.jpg&w=600" alt="Page 244" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.244 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808396c6f3cc53c845c4f%2F0275-full.jpg&w=600" alt="Page 275" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.275 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909ec3ecf28baa1b4cb09c3" data-idx="280">
+        <div class="book-header">
+          <span class="book-num">#281</span>
+          <h3>In quatuor Evangelia enarrationes luculentissimae</h3>
+          <span class="page-count">511 pp</span>
+          <a href="https://sourcelibrary.org/book/most-lucid-expositions-on-the-four-gospels-ochrid" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909ec3ecf28baa1b4cb09c3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909ec3ecf28baa1b4cb09c3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909ec3ecf28baa1b4cb09c3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909ec3ecf28baa1b4cb09c3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909ec3ecf28baa1b4cb09c3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ec3ecf28baa1b4cb09c3%2F51.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ec3ecf28baa1b4cb09c3%2F204.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ec3ecf28baa1b4cb09c3%2F307.jpg&w=600" alt="Page 307" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.307 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ec3ecf28baa1b4cb09c3%2F409.jpg&w=600" alt="Page 409" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.409 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ec3ecf28baa1b4cb09c3%2F460.jpg&w=600" alt="Page 460" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.460 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c879476c6f3cc53c858445" data-idx="281">
+        <div class="book-header">
+          <span class="book-num">#282</span>
+          <h3>Historia passionis, mortis, sepulturae et resurrectionis Jesu Christi</h3>
+          <span class="page-count">89 pp</span>
+          <a href="https://sourcelibrary.org/book/69c879476c6f3cc53c858445" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c879476c6f3cc53c858445', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c879476c6f3cc53c858445', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c879476c6f3cc53c858445', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c879476c6f3cc53c858445', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c879476c6f3cc53c858445', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879476c6f3cc53c858445%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879476c6f3cc53c858445%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879476c6f3cc53c858445%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879476c6f3cc53c858445%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879476c6f3cc53c858445%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fc9f6c6f3cc53c843131" data-idx="282">
+        <div class="book-header">
+          <span class="book-num">#283</span>
+          <h3>Libro della spiritual gratia</h3>
+          <span class="page-count">127 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fc9f6c6f3cc53c843131" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fc9f6c6f3cc53c843131', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fc9f6c6f3cc53c843131', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fc9f6c6f3cc53c843131', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fc9f6c6f3cc53c843131', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fc9f6c6f3cc53c843131', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc9f6c6f3cc53c843131%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc9f6c6f3cc53c843131%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc9f6c6f3cc53c843131%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc9f6c6f3cc53c843131%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc9f6c6f3cc53c843131%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ec0fda9771c7163148cc" data-idx="283">
+        <div class="book-header">
+          <span class="book-num">#284</span>
+          <h3>Wasserstein der Weysen. Via veritatis</h3>
+          <span class="page-count">145 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ec0fda9771c7163148cc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ec0fda9771c7163148cc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ec0fda9771c7163148cc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ec0fda9771c7163148cc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ec0fda9771c7163148cc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ec0fda9771c7163148cc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ec0fda9771c7163148cc%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ec0fda9771c7163148cc%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ec0fda9771c7163148cc%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ec0fda9771c7163148cc%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ec0fda9771c7163148cc%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c877ac6c6f3cc53c85809b" data-idx="284">
+        <div class="book-header">
+          <span class="book-num">#285</span>
+          <h3>From the caves and jungles of Hindostan</h3>
+          <span class="page-count">173 pp</span>
+          <a href="https://sourcelibrary.org/book/69c877ac6c6f3cc53c85809b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c877ac6c6f3cc53c85809b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c877ac6c6f3cc53c85809b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c877ac6c6f3cc53c85809b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c877ac6c6f3cc53c85809b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c877ac6c6f3cc53c85809b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877ac6c6f3cc53c85809b%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877ac6c6f3cc53c85809b%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877ac6c6f3cc53c85809b%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877ac6c6f3cc53c85809b%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877ac6c6f3cc53c85809b%2F0156-full.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7d4dc25ec2ba5ccd80510" data-idx="285">
+        <div class="book-header">
+          <span class="book-num">#286</span>
+          <h3>Liber Sohar</h3>
+          <span class="page-count">398 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7d4dc25ec2ba5ccd80510" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7d4dc25ec2ba5ccd80510', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7d4dc25ec2ba5ccd80510', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7d4dc25ec2ba5ccd80510', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7d4dc25ec2ba5ccd80510', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7d4dc25ec2ba5ccd80510', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd80510%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd80510%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd80510%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd80510%2F0318-full.jpg&w=600" alt="Page 318" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.318 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d4dc25ec2ba5ccd80510%2F0358-full.jpg&w=600" alt="Page 358" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.358 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c74f7f6a0f3d112faf848b" data-idx="286">
+        <div class="book-header">
+          <span class="book-num">#287</span>
+          <h3>Operis politici: variis digressionibus philologicis &amp; iuridicis illustrati</h3>
+          <span class="page-count">205 pp</span>
+          <a href="https://sourcelibrary.org/book/69c74f7f6a0f3d112faf848b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c74f7f6a0f3d112faf848b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c74f7f6a0f3d112faf848b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c74f7f6a0f3d112faf848b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c74f7f6a0f3d112faf848b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c74f7f6a0f3d112faf848b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74f7f6a0f3d112faf848b%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74f7f6a0f3d112faf848b%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74f7f6a0f3d112faf848b%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74f7f6a0f3d112faf848b%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74f7f6a0f3d112faf848b%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="68fb0dc412055a03a58d3281" data-idx="287">
+        <div class="book-header">
+          <span class="book-num">#288</span>
+          <h3>Pymander, de potestate et sapientia Dei</h3>
+          <span class="page-count">237 pp</span>
+          <a href="https://sourcelibrary.org/book/pymander-asclepius-on-the-mysteries-of-the-egyptians-proclus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('68fb0dc412055a03a58d3281', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('68fb0dc412055a03a58d3281', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('68fb0dc412055a03a58d3281', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('68fb0dc412055a03a58d3281', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('68fb0dc412055a03a58d3281', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0dc412055a03a58d3281%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0dc412055a03a58d3281%2F95.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0dc412055a03a58d3281%2F142.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0dc412055a03a58d3281%2F190.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fb0dc412055a03a58d3281%2F213.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c846296c6f3cc53c8516d9" data-idx="288">
+        <div class="book-header">
+          <span class="book-num">#289</span>
+          <h3>Pimander. Asclepius. Crater Hermetis</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/69c846296c6f3cc53c8516d9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c846296c6f3cc53c8516d9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c846296c6f3cc53c8516d9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c846296c6f3cc53c8516d9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c846296c6f3cc53c8516d9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c846296c6f3cc53c8516d9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846296c6f3cc53c8516d9%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846296c6f3cc53c8516d9%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846296c6f3cc53c8516d9%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846296c6f3cc53c8516d9%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846296c6f3cc53c8516d9%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85cf76c6f3cc53c854dca" data-idx="289">
+        <div class="book-header">
+          <span class="book-num">#290</span>
+          <h3>Opuscules spirituels</h3>
+          <span class="page-count">308 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85cf76c6f3cc53c854dca" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85cf76c6f3cc53c854dca', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85cf76c6f3cc53c854dca', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85cf76c6f3cc53c854dca', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85cf76c6f3cc53c854dca', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85cf76c6f3cc53c854dca', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cf76c6f3cc53c854dca%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cf76c6f3cc53c854dca%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cf76c6f3cc53c854dca%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cf76c6f3cc53c854dca%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85cf76c6f3cc53c854dca%2F0277-full.jpg&w=600" alt="Page 277" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.277 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c850866c6f3cc53c852d8b" data-idx="290">
+        <div class="book-header">
+          <span class="book-num">#291</span>
+          <h3>Geistreiche Schrifften</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c850866c6f3cc53c852d8b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c850866c6f3cc53c852d8b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c850866c6f3cc53c852d8b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c850866c6f3cc53c852d8b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c850866c6f3cc53c852d8b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c850866c6f3cc53c852d8b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850866c6f3cc53c852d8b%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850866c6f3cc53c852d8b%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850866c6f3cc53c852d8b%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850866c6f3cc53c852d8b%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850866c6f3cc53c852d8b%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c833616c6f3cc53c84e250" data-idx="291">
+        <div class="book-header">
+          <span class="book-num">#292</span>
+          <h3>Logica et philosophia</h3>
+          <span class="page-count">71 pp</span>
+          <a href="https://sourcelibrary.org/book/69c833616c6f3cc53c84e250" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c833616c6f3cc53c84e250', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c833616c6f3cc53c84e250', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c833616c6f3cc53c84e250', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c833616c6f3cc53c84e250', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c833616c6f3cc53c84e250', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833616c6f3cc53c84e250%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833616c6f3cc53c84e250%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833616c6f3cc53c84e250%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833616c6f3cc53c84e250%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833616c6f3cc53c84e250%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85a876c6f3cc53c8548cd" data-idx="292">
+        <div class="book-header">
+          <span class="book-num">#293</span>
+          <h3>D. Ioannis Rusbrochii summi atque sanctiss. viri, quem insignis quidam theologus alterum Dionysium Areopagitam appelat, Opera omnia: nunc demùm post annos fermè ducentos è Brabantiae Germanico idiomate reditta Latinè per F. Laurentium Surium, Carthusiae Coloniensis alumnum.</h3>
+          <span class="page-count">295 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85a876c6f3cc53c8548cd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85a876c6f3cc53c8548cd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85a876c6f3cc53c8548cd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85a876c6f3cc53c8548cd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85a876c6f3cc53c8548cd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85a876c6f3cc53c8548cd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a876c6f3cc53c8548cd%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a876c6f3cc53c8548cd%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a876c6f3cc53c8548cd%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a876c6f3cc53c8548cd%2F0236-full.jpg&w=600" alt="Page 236" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.236 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a876c6f3cc53c8548cd%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e4ef9444b5fe7c4794" data-idx="293">
+        <div class="book-header">
+          <span class="book-num">#294</span>
+          <h3>Unparteiische Samlungen zur Historie der Rosenkreuzer</h3>
+          <span class="page-count">325 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e4ef9444b5fe7c4794" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e4ef9444b5fe7c4794', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e4ef9444b5fe7c4794', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e4ef9444b5fe7c4794', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e4ef9444b5fe7c4794', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e4ef9444b5fe7c4794', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4ef9444b5fe7c4794%2F69c5872635776c9b1a874646.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4ef9444b5fe7c4794%2F69c59518a89c55aa728c3bdc.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4ef9444b5fe7c4794%2F69c59dd9292a8d760cef6497.jpg&w=600" alt="Page 195" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.195 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4ef9444b5fe7c4794%2F69c5a6045e95dcfa7fa8f749.jpg&w=600" alt="Page 260" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.260 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e4ef9444b5fe7c4794%2F69c5aab5b53e8e69bef794b2.jpg&w=600" alt="Page 293" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.293 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88c2e6c6f3cc53c85ab59" data-idx="294">
+        <div class="book-header">
+          <span class="book-num">#295</span>
+          <h3>Theologia naturalis</h3>
+          <span class="page-count">168 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88c2e6c6f3cc53c85ab59" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88c2e6c6f3cc53c85ab59', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88c2e6c6f3cc53c85ab59', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88c2e6c6f3cc53c85ab59', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88c2e6c6f3cc53c85ab59', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88c2e6c6f3cc53c85ab59', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c2e6c6f3cc53c85ab59%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c2e6c6f3cc53c85ab59%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c2e6c6f3cc53c85ab59%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c2e6c6f3cc53c85ab59%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c2e6c6f3cc53c85ab59%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c851c56c6f3cc53c853201" data-idx="295">
+        <div class="book-header">
+          <span class="book-num">#296</span>
+          <h3>Kurze Historie der so genannten Inspirirten und Inspirations- Gemeinden, Auf Teutsch: der Propheten-Kinder und Propheten-Schule</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c851c56c6f3cc53c853201" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c851c56c6f3cc53c853201', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c851c56c6f3cc53c853201', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c851c56c6f3cc53c853201', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c851c56c6f3cc53c853201', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c851c56c6f3cc53c853201', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851c56c6f3cc53c853201%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851c56c6f3cc53c853201%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851c56c6f3cc53c853201%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851c56c6f3cc53c853201%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851c56c6f3cc53c853201%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c836fb6c6f3cc53c84ed48" data-idx="296">
+        <div class="book-header">
+          <span class="book-num">#297</span>
+          <h3>Versuch eines fruchtbaren Auszugs der Kirchengeschichte</h3>
+          <span class="page-count">357 pp</span>
+          <a href="https://sourcelibrary.org/book/69c836fb6c6f3cc53c84ed48" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c836fb6c6f3cc53c84ed48', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c836fb6c6f3cc53c84ed48', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c836fb6c6f3cc53c84ed48', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c836fb6c6f3cc53c84ed48', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c836fb6c6f3cc53c84ed48', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836fb6c6f3cc53c84ed48%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836fb6c6f3cc53c84ed48%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836fb6c6f3cc53c84ed48%2F0214-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836fb6c6f3cc53c84ed48%2F0286-full.jpg&w=600" alt="Page 286" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.286 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836fb6c6f3cc53c84ed48%2F0321-full.jpg&w=600" alt="Page 321" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.321 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82afa6c6f3cc53c84c9c8" data-idx="297">
+        <div class="book-header">
+          <span class="book-num">#298</span>
+          <h3>Beginselen der meetkonst</h3>
+          <span class="page-count">356 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82afa6c6f3cc53c84c9c8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82afa6c6f3cc53c84c9c8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82afa6c6f3cc53c84c9c8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82afa6c6f3cc53c84c9c8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82afa6c6f3cc53c84c9c8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82afa6c6f3cc53c84c9c8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82afa6c6f3cc53c84c9c8%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82afa6c6f3cc53c84c9c8%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82afa6c6f3cc53c84c9c8%2F0214-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82afa6c6f3cc53c84c9c8%2F0285-full.jpg&w=600" alt="Page 285" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.285 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82afa6c6f3cc53c84c9c8%2F0320-full.jpg&w=600" alt="Page 320" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.320 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f518da9771c716314fa1" data-idx="298">
+        <div class="book-header">
+          <span class="book-num">#299</span>
+          <h3>Twonder-boeck</h3>
+          <span class="page-count">413 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f518da9771c716314fa1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f518da9771c716314fa1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f518da9771c716314fa1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f518da9771c716314fa1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f518da9771c716314fa1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f518da9771c716314fa1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f518da9771c716314fa1%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f518da9771c716314fa1%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f518da9771c716314fa1%2F0248-full.jpg&w=600" alt="Page 248" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.248 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f518da9771c716314fa1%2F0330-full.jpg&w=600" alt="Page 330" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.330 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f518da9771c716314fa1%2F0372-full.jpg&w=600" alt="Page 372" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.372 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808226c6f3cc53c845bd5" data-idx="299">
+        <div class="book-header">
+          <span class="book-num">#300</span>
+          <h3>Der gülden Gesundbrunnen</h3>
+          <span class="page-count">33 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808226c6f3cc53c845bd5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808226c6f3cc53c845bd5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808226c6f3cc53c845bd5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808226c6f3cc53c845bd5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808226c6f3cc53c845bd5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808226c6f3cc53c845bd5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808226c6f3cc53c845bd5%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808226c6f3cc53c845bd5%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808226c6f3cc53c845bd5%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808226c6f3cc53c845bd5%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808226c6f3cc53c845bd5%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html" class="active">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-4.html
+++ b/public/split-review-4.html
@@ -1,0 +1,6008 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 4/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html" class="active">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c8a25f6c6f3cc53c85e3f2" data-idx="300">
+        <div class="book-header">
+          <span class="book-num">#301</span>
+          <h3>The religious and masonic symbolism of stones</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a25f6c6f3cc53c85e3f2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a25f6c6f3cc53c85e3f2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a25f6c6f3cc53c85e3f2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a25f6c6f3cc53c85e3f2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a25f6c6f3cc53c85e3f2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a25f6c6f3cc53c85e3f2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a25f6c6f3cc53c85e3f2%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a25f6c6f3cc53c85e3f2%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a25f6c6f3cc53c85e3f2%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a25f6c6f3cc53c85e3f2%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a25f6c6f3cc53c85e3f2%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855006c6f3cc53c8539fa" data-idx="301">
+        <div class="book-header">
+          <span class="book-num">#302</span>
+          <h3>Symphonesis Christianorum oder Tractat von den einzelen und Privat-Zusammenkunfften der Christen</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855006c6f3cc53c8539fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855006c6f3cc53c8539fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855006c6f3cc53c8539fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855006c6f3cc53c8539fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855006c6f3cc53c8539fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855006c6f3cc53c8539fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855006c6f3cc53c8539fa%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855006c6f3cc53c8539fa%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855006c6f3cc53c8539fa%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855006c6f3cc53c8539fa%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855006c6f3cc53c8539fa%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909ba43cf28baa1b4caf455" data-idx="302">
+        <div class="book-header">
+          <span class="book-num">#303</span>
+          <h3>Controversiae cum Judaeis prodromi libri II</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/two-books-of-the-introduction-to-the-controversies-with-the-wienner-von" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909ba43cf28baa1b4caf455', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909ba43cf28baa1b4caf455', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909ba43cf28baa1b4caf455', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909ba43cf28baa1b4caf455', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909ba43cf28baa1b4caf455', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ba43cf28baa1b4caf455%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ba43cf28baa1b4caf455%2F67.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ba43cf28baa1b4caf455%2F100.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ba43cf28baa1b4caf455%2F134.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909ba43cf28baa1b4caf455%2F150.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85a5d6c6f3cc53c854861" data-idx="303">
+        <div class="book-header">
+          <span class="book-num">#304</span>
+          <h3>I. Kurtze Erzehlung dessen was mit ... Herrn Hertzogs Moritz Wilhelms ... selbiger von der päbstischen Messe geredet II. Freude im Himmel über einen zur Evangelischen Gemeinde wiederkommenden Hertzog</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85a5d6c6f3cc53c854861" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85a5d6c6f3cc53c854861', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85a5d6c6f3cc53c854861', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85a5d6c6f3cc53c854861', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85a5d6c6f3cc53c854861', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85a5d6c6f3cc53c854861', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a5d6c6f3cc53c854861%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a5d6c6f3cc53c854861%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a5d6c6f3cc53c854861%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a5d6c6f3cc53c854861%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85a5d6c6f3cc53c854861%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7414f6a0f3d112faf7cf0" data-idx="304">
+        <div class="book-header">
+          <span class="book-num">#305</span>
+          <h3>Das Erste (-Sechst und letste) Hundert, allerhand sinnreicher und kurtzweiliger Antwort oder Reden</h3>
+          <span class="page-count">209 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7414f6a0f3d112faf7cf0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7414f6a0f3d112faf7cf0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7414f6a0f3d112faf7cf0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7414f6a0f3d112faf7cf0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7414f6a0f3d112faf7cf0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7414f6a0f3d112faf7cf0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7414f6a0f3d112faf7cf0%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7414f6a0f3d112faf7cf0%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7414f6a0f3d112faf7cf0%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7414f6a0f3d112faf7cf0%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7414f6a0f3d112faf7cf0%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82db06c6f3cc53c84d3cc" data-idx="305">
+        <div class="book-header">
+          <span class="book-num">#306</span>
+          <h3>In nomine Jesu! Biblia pauperum. Evangelium der Armen</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82db06c6f3cc53c84d3cc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82db06c6f3cc53c84d3cc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82db06c6f3cc53c84d3cc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82db06c6f3cc53c84d3cc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82db06c6f3cc53c84d3cc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82db06c6f3cc53c84d3cc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82db06c6f3cc53c84d3cc%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82db06c6f3cc53c84d3cc%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82db06c6f3cc53c84d3cc%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82db06c6f3cc53c84d3cc%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82db06c6f3cc53c84d3cc%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85d1a6c6f3cc53c854e28" data-idx="306">
+        <div class="book-header">
+          <span class="book-num">#307</span>
+          <h3>Unterricht von der Magia naturali</h3>
+          <span class="page-count">175 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85d1a6c6f3cc53c854e28" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85d1a6c6f3cc53c854e28', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85d1a6c6f3cc53c854e28', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85d1a6c6f3cc53c854e28', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85d1a6c6f3cc53c854e28', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85d1a6c6f3cc53c854e28', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d1a6c6f3cc53c854e28%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d1a6c6f3cc53c854e28%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d1a6c6f3cc53c854e28%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d1a6c6f3cc53c854e28%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d1a6c6f3cc53c854e28%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c853156c6f3cc53c853532" data-idx="307">
+        <div class="book-header">
+          <span class="book-num">#308</span>
+          <h3>Geistreiche Schrifften</h3>
+          <span class="page-count">187 pp</span>
+          <a href="https://sourcelibrary.org/book/69c853156c6f3cc53c853532" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c853156c6f3cc53c853532', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c853156c6f3cc53c853532', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c853156c6f3cc53c853532', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c853156c6f3cc53c853532', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c853156c6f3cc53c853532', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853156c6f3cc53c853532%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853156c6f3cc53c853532%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853156c6f3cc53c853532%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853156c6f3cc53c853532%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853156c6f3cc53c853532%2F0168-full.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85caf6c6f3cc53c854d2f" data-idx="308">
+        <div class="book-header">
+          <span class="book-num">#309</span>
+          <h3>Ueber das erste Wesensgesetz in der Schöpfung</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85caf6c6f3cc53c854d2f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85caf6c6f3cc53c854d2f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85caf6c6f3cc53c854d2f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85caf6c6f3cc53c854d2f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85caf6c6f3cc53c854d2f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85caf6c6f3cc53c854d2f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85caf6c6f3cc53c854d2f%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85caf6c6f3cc53c854d2f%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85caf6c6f3cc53c854d2f%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85caf6c6f3cc53c854d2f%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85caf6c6f3cc53c854d2f%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c805766c6f3cc53c8451e8" data-idx="309">
+        <div class="book-header">
+          <span class="book-num">#310</span>
+          <h3>Oeuvres spirituelles</h3>
+          <span class="page-count">340 pp</span>
+          <a href="https://sourcelibrary.org/book/69c805766c6f3cc53c8451e8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c805766c6f3cc53c8451e8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c805766c6f3cc53c8451e8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c805766c6f3cc53c8451e8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c805766c6f3cc53c8451e8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c805766c6f3cc53c8451e8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805766c6f3cc53c8451e8%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805766c6f3cc53c8451e8%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805766c6f3cc53c8451e8%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805766c6f3cc53c8451e8%2F0272-full.jpg&w=600" alt="Page 272" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.272 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805766c6f3cc53c8451e8%2F0306-full.jpg&w=600" alt="Page 306" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.306 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c62f1789e1344e8dd54250" data-idx="310">
+        <div class="book-header">
+          <span class="book-num">#311</span>
+          <h3>Versuch einer unpartheiischen und gründlichen Ketzergeschichte</h3>
+          <span class="page-count">235 pp</span>
+          <a href="https://sourcelibrary.org/book/69c62f1789e1344e8dd54250" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c62f1789e1344e8dd54250', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c62f1789e1344e8dd54250', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c62f1789e1344e8dd54250', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c62f1789e1344e8dd54250', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c62f1789e1344e8dd54250', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c62f1789e1344e8dd54250%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c62f1789e1344e8dd54250%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c62f1789e1344e8dd54250%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c62f1789e1344e8dd54250%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c62f1789e1344e8dd54250%2F0212-full.jpg&w=600" alt="Page 212" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.212 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81d036c6f3cc53c849e6b" data-idx="311">
+        <div class="book-header">
+          <span class="book-num">#312</span>
+          <h3>Jezus en de ziel</h3>
+          <span class="page-count">103 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81d036c6f3cc53c849e6b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81d036c6f3cc53c849e6b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81d036c6f3cc53c849e6b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81d036c6f3cc53c849e6b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81d036c6f3cc53c849e6b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81d036c6f3cc53c849e6b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d036c6f3cc53c849e6b%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d036c6f3cc53c849e6b%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d036c6f3cc53c849e6b%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d036c6f3cc53c849e6b%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81d036c6f3cc53c849e6b%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89edb6c6f3cc53c85db1d" data-idx="312">
+        <div class="book-header">
+          <span class="book-num">#313</span>
+          <h3>Thesaurus et armamentarium medico-chymicum</h3>
+          <span class="page-count">312 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89edb6c6f3cc53c85db1d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89edb6c6f3cc53c85db1d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89edb6c6f3cc53c85db1d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89edb6c6f3cc53c85db1d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89edb6c6f3cc53c85db1d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89edb6c6f3cc53c85db1d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89edb6c6f3cc53c85db1d%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89edb6c6f3cc53c85db1d%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89edb6c6f3cc53c85db1d%2F0187-full.jpg&w=600" alt="Page 187" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.187 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89edb6c6f3cc53c85db1d%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89edb6c6f3cc53c85db1d%2F0281-full.jpg&w=600" alt="Page 281" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.281 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c844a66c6f3cc53c85135b" data-idx="313">
+        <div class="book-header">
+          <span class="book-num">#314</span>
+          <h3>Aufschlüsse zur Magie</h3>
+          <span class="page-count">263 pp</span>
+          <a href="https://sourcelibrary.org/book/69c844a66c6f3cc53c85135b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c844a66c6f3cc53c85135b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c844a66c6f3cc53c85135b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c844a66c6f3cc53c85135b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c844a66c6f3cc53c85135b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c844a66c6f3cc53c85135b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844a66c6f3cc53c85135b%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844a66c6f3cc53c85135b%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844a66c6f3cc53c85135b%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844a66c6f3cc53c85135b%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844a66c6f3cc53c85135b%2F0237-full.jpg&w=600" alt="Page 237" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.237 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70c73da9771c716316023" data-idx="314">
+        <div class="book-header">
+          <span class="book-num">#315</span>
+          <h3>Drey christliche Predigten von Versuchungen</h3>
+          <span class="page-count">189 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70c73da9771c716316023" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70c73da9771c716316023', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70c73da9771c716316023', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70c73da9771c716316023', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70c73da9771c716316023', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70c73da9771c716316023', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70c73da9771c716316023%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70c73da9771c716316023%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70c73da9771c716316023%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70c73da9771c716316023%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70c73da9771c716316023%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fae36c6f3cc53c842bed" data-idx="315">
+        <div class="book-header">
+          <span class="book-num">#316</span>
+          <h3>Les ruines, ou méditation sur les révolutions des empires</h3>
+          <span class="page-count">224 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fae36c6f3cc53c842bed" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fae36c6f3cc53c842bed', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fae36c6f3cc53c842bed', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fae36c6f3cc53c842bed', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fae36c6f3cc53c842bed', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fae36c6f3cc53c842bed', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae36c6f3cc53c842bed%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae36c6f3cc53c842bed%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae36c6f3cc53c842bed%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae36c6f3cc53c842bed%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fae36c6f3cc53c842bed%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c864916c6f3cc53c856012" data-idx="316">
+        <div class="book-header">
+          <span class="book-num">#317</span>
+          <h3>Le nouvel homme</h3>
+          <span class="page-count">227 pp</span>
+          <a href="https://sourcelibrary.org/book/69c864916c6f3cc53c856012" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c864916c6f3cc53c856012', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c864916c6f3cc53c856012', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c864916c6f3cc53c856012', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c864916c6f3cc53c856012', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c864916c6f3cc53c856012', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864916c6f3cc53c856012%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864916c6f3cc53c856012%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864916c6f3cc53c856012%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864916c6f3cc53c856012%2F0182-full.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864916c6f3cc53c856012%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85e806c6f3cc53c855207" data-idx="317">
+        <div class="book-header">
+          <span class="book-num">#318</span>
+          <h3>Geistliche Himmels-Leiter des gläubigen Christen Volks ... Aus Joh. Arndts, und andren Schriften ... zusammen getragen</h3>
+          <span class="page-count">235 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85e806c6f3cc53c855207" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85e806c6f3cc53c855207', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85e806c6f3cc53c855207', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85e806c6f3cc53c855207', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85e806c6f3cc53c855207', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85e806c6f3cc53c855207', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e806c6f3cc53c855207%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e806c6f3cc53c855207%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e806c6f3cc53c855207%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e806c6f3cc53c855207%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e806c6f3cc53c855207%2F0212-full.jpg&w=600" alt="Page 212" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.212 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6117" data-idx="318">
+        <div class="book-header">
+          <span class="book-num">#319</span>
+          <h3>Novum lumen chymicum</h3>
+          <span class="page-count">105 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6117" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6117', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6117', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6117', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6117', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6117', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6117%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6117%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6117%2F63.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6117%2F84.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6117%2F95.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fdb76c6f3cc53c8434e3" data-idx="319">
+        <div class="book-header">
+          <span class="book-num">#320</span>
+          <h3>Lettre à M. Dacier, ... relative à l'alphabet des hiéroglyphes phonétiques</h3>
+          <span class="page-count">40 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fdb76c6f3cc53c8434e3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fdb76c6f3cc53c8434e3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fdb76c6f3cc53c8434e3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fdb76c6f3cc53c8434e3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fdb76c6f3cc53c8434e3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fdb76c6f3cc53c8434e3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdb76c6f3cc53c8434e3%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdb76c6f3cc53c8434e3%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdb76c6f3cc53c8434e3%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdb76c6f3cc53c8434e3%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdb76c6f3cc53c8434e3%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c826cb6c6f3cc53c84be07" data-idx="320">
+        <div class="book-header">
+          <span class="book-num">#321</span>
+          <h3>Politischer Probier-stein, auss Parnasso</h3>
+          <span class="page-count">87 pp</span>
+          <a href="https://sourcelibrary.org/book/69c826cb6c6f3cc53c84be07" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c826cb6c6f3cc53c84be07', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c826cb6c6f3cc53c84be07', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c826cb6c6f3cc53c84be07', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c826cb6c6f3cc53c84be07', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c826cb6c6f3cc53c84be07', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cb6c6f3cc53c84be07%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cb6c6f3cc53c84be07%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cb6c6f3cc53c84be07%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cb6c6f3cc53c84be07%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c826cb6c6f3cc53c84be07%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c880a06c6f3cc53c8590fa" data-idx="321">
+        <div class="book-header">
+          <span class="book-num">#322</span>
+          <h3>A new light on the Renaissance displayed in contemporary emblems</h3>
+          <span class="page-count">145 pp</span>
+          <a href="https://sourcelibrary.org/book/69c880a06c6f3cc53c8590fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c880a06c6f3cc53c8590fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c880a06c6f3cc53c8590fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c880a06c6f3cc53c8590fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c880a06c6f3cc53c8590fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c880a06c6f3cc53c8590fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880a06c6f3cc53c8590fa%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880a06c6f3cc53c8590fa%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880a06c6f3cc53c8590fa%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880a06c6f3cc53c8590fa%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880a06c6f3cc53c8590fa%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82dcc6c6f3cc53c84d44d" data-idx="322">
+        <div class="book-header">
+          <span class="book-num">#323</span>
+          <h3>De Elia Artista. Oder wass Elias Artista für einer sey, und wass er in der Welt reformiren, oder verbesseren werde, wann er kombt?</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82dcc6c6f3cc53c84d44d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82dcc6c6f3cc53c84d44d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82dcc6c6f3cc53c84d44d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82dcc6c6f3cc53c84d44d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82dcc6c6f3cc53c84d44d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82dcc6c6f3cc53c84d44d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82dcc6c6f3cc53c84d44d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82dcc6c6f3cc53c84d44d%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82dcc6c6f3cc53c84d44d%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82dcc6c6f3cc53c84d44d%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82dcc6c6f3cc53c84d44d%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909bda4cf28baa1b4caf5dd" data-idx="323">
+        <div class="book-header">
+          <span class="book-num">#324</span>
+          <h3>Geestelijcke tyd-kortingen, van den christelyken dagh, of Gewichtige opmerckingen der geloovigen</h3>
+          <span class="page-count">95 pp</span>
+          <a href="https://sourcelibrary.org/book/spiritual-pastimes-of-the-christian-day-or-weighty-labadie" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909bda4cf28baa1b4caf5dd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909bda4cf28baa1b4caf5dd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909bda4cf28baa1b4caf5dd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909bda4cf28baa1b4caf5dd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909bda4cf28baa1b4caf5dd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bda4cf28baa1b4caf5dd%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bda4cf28baa1b4caf5dd%2F38.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bda4cf28baa1b4caf5dd%2F57.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bda4cf28baa1b4caf5dd%2F76.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bda4cf28baa1b4caf5dd%2F86.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8158e6c6f3cc53c84869b" data-idx="324">
+        <div class="book-header">
+          <span class="book-num">#325</span>
+          <h3>Versameling van eenige gewichtige gront-regels der christelyke leere</h3>
+          <span class="page-count">237 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8158e6c6f3cc53c84869b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8158e6c6f3cc53c84869b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8158e6c6f3cc53c84869b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8158e6c6f3cc53c84869b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8158e6c6f3cc53c84869b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8158e6c6f3cc53c84869b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158e6c6f3cc53c84869b%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158e6c6f3cc53c84869b%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158e6c6f3cc53c84869b%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158e6c6f3cc53c84869b%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158e6c6f3cc53c84869b%2F0213-full.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c846d76c6f3cc53c85182b" data-idx="325">
+        <div class="book-header">
+          <span class="book-num">#326</span>
+          <h3>Güldnes Schatz-Kästlein der Kinder Gottes</h3>
+          <span class="page-count">754 pp</span>
+          <a href="https://sourcelibrary.org/book/69c846d76c6f3cc53c85182b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c846d76c6f3cc53c85182b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c846d76c6f3cc53c85182b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c846d76c6f3cc53c85182b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c846d76c6f3cc53c85182b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c846d76c6f3cc53c85182b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846d76c6f3cc53c85182b%2F0038-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846d76c6f3cc53c85182b%2F0151-full.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846d76c6f3cc53c85182b%2F0226-full.jpg&w=600" alt="Page 452" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.452 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846d76c6f3cc53c85182b%2F0302-full.jpg&w=600" alt="Page 603" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.603 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846d76c6f3cc53c85182b%2F0340-full.jpg&w=600" alt="Page 679" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.679 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c878b16c6f3cc53c8582fd" data-idx="326">
+        <div class="book-header">
+          <span class="book-num">#327</span>
+          <h3>[Greek] Gemma magica oder magisches Edelgestein</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/69c878b16c6f3cc53c8582fd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c878b16c6f3cc53c8582fd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c878b16c6f3cc53c8582fd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c878b16c6f3cc53c8582fd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c878b16c6f3cc53c8582fd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c878b16c6f3cc53c8582fd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878b16c6f3cc53c8582fd%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878b16c6f3cc53c8582fd%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878b16c6f3cc53c8582fd%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878b16c6f3cc53c8582fd%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878b16c6f3cc53c8582fd%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a28f6c6f3cc53c85e463" data-idx="327">
+        <div class="book-header">
+          <span class="book-num">#328</span>
+          <h3>The religion, philosophy and occult science of China</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a28f6c6f3cc53c85e463" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a28f6c6f3cc53c85e463', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a28f6c6f3cc53c85e463', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a28f6c6f3cc53c85e463', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a28f6c6f3cc53c85e463', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a28f6c6f3cc53c85e463', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a28f6c6f3cc53c85e463%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a28f6c6f3cc53c85e463%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a28f6c6f3cc53c85e463%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a28f6c6f3cc53c85e463%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a28f6c6f3cc53c85e463%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c816456c6f3cc53c8489e1" data-idx="328">
+        <div class="book-header">
+          <span class="book-num">#329</span>
+          <h3>Gheestelycke sermoonen</h3>
+          <span class="page-count">377 pp</span>
+          <a href="https://sourcelibrary.org/book/69c816456c6f3cc53c8489e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c816456c6f3cc53c8489e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c816456c6f3cc53c8489e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c816456c6f3cc53c8489e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c816456c6f3cc53c8489e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c816456c6f3cc53c8489e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816456c6f3cc53c8489e1%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816456c6f3cc53c8489e1%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816456c6f3cc53c8489e1%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816456c6f3cc53c8489e1%2F0302-full.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816456c6f3cc53c8489e1%2F0339-full.jpg&w=600" alt="Page 339" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.339 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80e8c6c6f3cc53c846ff7" data-idx="329">
+        <div class="book-header">
+          <span class="book-num">#330</span>
+          <h3>Leben des Freyherrn Gottfried Wilhelm von Leibnitz</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80e8c6c6f3cc53c846ff7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80e8c6c6f3cc53c846ff7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80e8c6c6f3cc53c846ff7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80e8c6c6f3cc53c846ff7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80e8c6c6f3cc53c846ff7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80e8c6c6f3cc53c846ff7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80e8c6c6f3cc53c846ff7%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80e8c6c6f3cc53c846ff7%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80e8c6c6f3cc53c846ff7%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80e8c6c6f3cc53c846ff7%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80e8c6c6f3cc53c846ff7%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c899bb6c6f3cc53c85cf48" data-idx="330">
+        <div class="book-header">
+          <span class="book-num">#331</span>
+          <h3>De anatomia Antichristi</h3>
+          <span class="page-count">123 pp</span>
+          <a href="https://sourcelibrary.org/book/69c899bb6c6f3cc53c85cf48" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c899bb6c6f3cc53c85cf48', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c899bb6c6f3cc53c85cf48', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c899bb6c6f3cc53c85cf48', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c899bb6c6f3cc53c85cf48', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c899bb6c6f3cc53c85cf48', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899bb6c6f3cc53c85cf48%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899bb6c6f3cc53c85cf48%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899bb6c6f3cc53c85cf48%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899bb6c6f3cc53c85cf48%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899bb6c6f3cc53c85cf48%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81a1c6c6f3cc53c849654" data-idx="331">
+        <div class="book-header">
+          <span class="book-num">#332</span>
+          <h3>Gronden van zekerheid, of de regte betoogwyse der wiskundigen</h3>
+          <span class="page-count">263 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81a1c6c6f3cc53c849654" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81a1c6c6f3cc53c849654', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81a1c6c6f3cc53c849654', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81a1c6c6f3cc53c849654', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81a1c6c6f3cc53c849654', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81a1c6c6f3cc53c849654', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a1c6c6f3cc53c849654%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a1c6c6f3cc53c849654%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a1c6c6f3cc53c849654%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a1c6c6f3cc53c849654%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a1c6c6f3cc53c849654%2F0237-full.jpg&w=600" alt="Page 237" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.237 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86b906c6f3cc53c856b54" data-idx="332">
+        <div class="book-header">
+          <span class="book-num">#333</span>
+          <h3>A new light of mysticism. Azoth; or, the star in the east. Embracing the first matter of the magnum opus, the evolution of Aphrodite-Urania, the supernatural generation of the son of the sun, and the alchemical transfiguration of humanity</h3>
+          <span class="page-count">133 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86b906c6f3cc53c856b54" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86b906c6f3cc53c856b54', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86b906c6f3cc53c856b54', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86b906c6f3cc53c856b54', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86b906c6f3cc53c856b54', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86b906c6f3cc53c856b54', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b906c6f3cc53c856b54%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b906c6f3cc53c856b54%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b906c6f3cc53c856b54%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b906c6f3cc53c856b54%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b906c6f3cc53c856b54%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ff35da9771c7163155fb" data-idx="333">
+        <div class="book-header">
+          <span class="book-num">#334</span>
+          <h3>Zonder kruys geen kroon</h3>
+          <span class="page-count">377 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ff35da9771c7163155fb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ff35da9771c7163155fb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ff35da9771c7163155fb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ff35da9771c7163155fb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ff35da9771c7163155fb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ff35da9771c7163155fb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fb%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fb%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fb%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fb%2F0302-full.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ff35da9771c7163155fb%2F0339-full.jpg&w=600" alt="Page 339" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.339 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82d436c6f3cc53c84d1bc" data-idx="334">
+        <div class="book-header">
+          <span class="book-num">#335</span>
+          <h3>Ueber Wahrheit und sittliche Vollkommenheit</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82d436c6f3cc53c84d1bc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82d436c6f3cc53c84d1bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82d436c6f3cc53c84d1bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82d436c6f3cc53c84d1bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82d436c6f3cc53c84d1bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82d436c6f3cc53c84d1bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d436c6f3cc53c84d1bc%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d436c6f3cc53c84d1bc%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d436c6f3cc53c84d1bc%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d436c6f3cc53c84d1bc%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d436c6f3cc53c84d1bc%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ff336c6f3cc53c843acf" data-idx="335">
+        <div class="book-header">
+          <span class="book-num">#336</span>
+          <h3>Eine kurze Eroeffnung und Anweisung der dreyen Principien</h3>
+          <span class="page-count">73 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ff336c6f3cc53c843acf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ff336c6f3cc53c843acf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ff336c6f3cc53c843acf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ff336c6f3cc53c843acf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ff336c6f3cc53c843acf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ff336c6f3cc53c843acf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff336c6f3cc53c843acf%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+<div class="page-slot"><div class="no-image">No image<br>p.29</div></div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff336c6f3cc53c843acf%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff336c6f3cc53c843acf%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff336c6f3cc53c843acf%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7c02625ec2ba5ccd7fcd4" data-idx="336">
+        <div class="book-header">
+          <span class="book-num">#337</span>
+          <h3>Bibliotheca Askeviana. Sive catalogus librorum rarissimorum Antonii Askew</h3>
+          <span class="page-count">84 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7c02625ec2ba5ccd7fcd4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7c02625ec2ba5ccd7fcd4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7c02625ec2ba5ccd7fcd4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7c02625ec2ba5ccd7fcd4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7c02625ec2ba5ccd7fcd4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7c02625ec2ba5ccd7fcd4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c02625ec2ba5ccd7fcd4%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c02625ec2ba5ccd7fcd4%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c02625ec2ba5ccd7fcd4%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c02625ec2ba5ccd7fcd4%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c02625ec2ba5ccd7fcd4%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89ce36c6f3cc53c85d6b5" data-idx="337">
+        <div class="book-header">
+          <span class="book-num">#338</span>
+          <h3>Prophecies. A warning to the whole world</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89ce36c6f3cc53c85d6b5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89ce36c6f3cc53c85d6b5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89ce36c6f3cc53c85d6b5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89ce36c6f3cc53c85d6b5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89ce36c6f3cc53c85d6b5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89ce36c6f3cc53c85d6b5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ce36c6f3cc53c85d6b5%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ce36c6f3cc53c85d6b5%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ce36c6f3cc53c85d6b5%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ce36c6f3cc53c85d6b5%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ce36c6f3cc53c85d6b5%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419212b0edf3eaa2ded76" data-idx="338">
+        <div class="book-header">
+          <span class="book-num">#339</span>
+          <h3>La generation et operation du Grand Oeuvre (PH462)</h3>
+          <span class="page-count">71 pp</span>
+          <a href="https://sourcelibrary.org/book/generation-operation-of-the-great-work-early-20th-c-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419212b0edf3eaa2ded76', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419212b0edf3eaa2ded76', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419212b0edf3eaa2ded76', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419212b0edf3eaa2ded76', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419212b0edf3eaa2ded76', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419212b0edf3eaa2ded76%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540071605131!PH462_028.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540071605131!PH462_043.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540071605131!PH462_057.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540071605131!PH462_064.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c73a466a0f3d112faf7972" data-idx="339">
+        <div class="book-header">
+          <span class="book-num">#340</span>
+          <h3>Versuch einer freiern theologischen Lehrart, zur Bestätigung und Erläuterung seines lateinischen Buchs</h3>
+          <span class="page-count">381 pp</span>
+          <a href="https://sourcelibrary.org/book/69c73a466a0f3d112faf7972" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c73a466a0f3d112faf7972', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c73a466a0f3d112faf7972', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c73a466a0f3d112faf7972', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c73a466a0f3d112faf7972', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c73a466a0f3d112faf7972', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a466a0f3d112faf7972%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a466a0f3d112faf7972%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a466a0f3d112faf7972%2F0229-full.jpg&w=600" alt="Page 229" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.229 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a466a0f3d112faf7972%2F0305-full.jpg&w=600" alt="Page 305" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.305 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a466a0f3d112faf7972%2F0343-full.jpg&w=600" alt="Page 343" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.343 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87f546c6f3cc53c858ebd" data-idx="340">
+        <div class="book-header">
+          <span class="book-num">#341</span>
+          <h3>[Cyrillisch:] Het mysterie van het kruis van Jezus Christus</h3>
+          <span class="page-count">197 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87f546c6f3cc53c858ebd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87f546c6f3cc53c858ebd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87f546c6f3cc53c858ebd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87f546c6f3cc53c858ebd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87f546c6f3cc53c858ebd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87f546c6f3cc53c858ebd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f546c6f3cc53c858ebd%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f546c6f3cc53c858ebd%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f546c6f3cc53c858ebd%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f546c6f3cc53c858ebd%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87f546c6f3cc53c858ebd%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ad8825ec2ba5ccd7f1fd" data-idx="341">
+        <div class="book-header">
+          <span class="book-num">#342</span>
+          <h3>Disputationes chymico-medicae</h3>
+          <span class="page-count">221 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ad8825ec2ba5ccd7f1fd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fd%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fd%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fd%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fd%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fd%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80b956c6f3cc53c8467f5" data-idx="342">
+        <div class="book-header">
+          <span class="book-num">#343</span>
+          <h3>Apologia verae doctrinae eorum qui vulgo appellantur Waldenses vel Picardi. Retinuerunt enim Ioaniis Hussitae doctrinam</h3>
+          <span class="page-count">124 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80b956c6f3cc53c8467f5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80b956c6f3cc53c8467f5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80b956c6f3cc53c8467f5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80b956c6f3cc53c8467f5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80b956c6f3cc53c8467f5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80b956c6f3cc53c8467f5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b956c6f3cc53c8467f5%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b956c6f3cc53c8467f5%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b956c6f3cc53c8467f5%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b956c6f3cc53c8467f5%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b956c6f3cc53c8467f5%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855f76c6f3cc53c853c31" data-idx="343">
+        <div class="book-header">
+          <span class="book-num">#344</span>
+          <h3>Des erreurs et de la verité</h3>
+          <span class="page-count">219 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855f76c6f3cc53c853c31" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855f76c6f3cc53c853c31', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855f76c6f3cc53c853c31', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855f76c6f3cc53c853c31', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855f76c6f3cc53c853c31', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855f76c6f3cc53c853c31', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855f76c6f3cc53c853c31%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855f76c6f3cc53c853c31%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855f76c6f3cc53c853c31%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855f76c6f3cc53c853c31%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855f76c6f3cc53c853c31%2F0197-full.jpg&w=600" alt="Page 197" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.197 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8078c6c6f3cc53c8458e1" data-idx="344">
+        <div class="book-header">
+          <span class="book-num">#345</span>
+          <h3>Coelum philosophorum, seu liber de secretis naturae. Directorium summae summarum medicinae</h3>
+          <span class="page-count">340 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8078c6c6f3cc53c8458e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8078c6c6f3cc53c8458e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8078c6c6f3cc53c8458e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8078c6c6f3cc53c8458e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8078c6c6f3cc53c8458e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8078c6c6f3cc53c8458e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8078c6c6f3cc53c8458e1%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8078c6c6f3cc53c8458e1%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8078c6c6f3cc53c8458e1%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8078c6c6f3cc53c8458e1%2F0272-full.jpg&w=600" alt="Page 272" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.272 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8078c6c6f3cc53c8458e1%2F0306-full.jpg&w=600" alt="Page 306" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.306 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6107" data-idx="345">
+        <div class="book-header">
+          <span class="book-num">#346</span>
+          <h3>Philosophia maturata, oder ein ausführlicher philosophischer Tractat</h3>
+          <span class="page-count">54 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6107" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6107', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6107', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6107', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6107', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6107', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6107%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6107%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6107%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6107%2F43.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6107%2F49.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c809a46c6f3cc53c8461e7" data-idx="346">
+        <div class="book-header">
+          <span class="book-num">#347</span>
+          <h3>Il Metamorfosi metallico et humano</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c809a46c6f3cc53c8461e7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c809a46c6f3cc53c8461e7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c809a46c6f3cc53c8461e7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c809a46c6f3cc53c8461e7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c809a46c6f3cc53c8461e7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c809a46c6f3cc53c8461e7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809a46c6f3cc53c8461e7%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809a46c6f3cc53c8461e7%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809a46c6f3cc53c8461e7%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809a46c6f3cc53c8461e7%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809a46c6f3cc53c8461e7%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7433a6a0f3d112faf7eb8" data-idx="347">
+        <div class="book-header">
+          <span class="book-num">#348</span>
+          <h3>[Biblia]. Quincuplex psalterium</h3>
+          <span class="page-count">312 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7433a6a0f3d112faf7eb8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7433a6a0f3d112faf7eb8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7433a6a0f3d112faf7eb8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7433a6a0f3d112faf7eb8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7433a6a0f3d112faf7eb8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7433a6a0f3d112faf7eb8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7433a6a0f3d112faf7eb8%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7433a6a0f3d112faf7eb8%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7433a6a0f3d112faf7eb8%2F0187-full.jpg&w=600" alt="Page 187" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.187 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7433a6a0f3d112faf7eb8%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7433a6a0f3d112faf7eb8%2F0281-full.jpg&w=600" alt="Page 281" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.281 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ed7ada9771c716314a12" data-idx="348">
+        <div class="book-header">
+          <span class="book-num">#349</span>
+          <h3>The way to Christ discovered and described</h3>
+          <span class="page-count">238 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ed7ada9771c716314a12" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ed7ada9771c716314a12', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ed7ada9771c716314a12', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ed7ada9771c716314a12', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ed7ada9771c716314a12', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ed7ada9771c716314a12', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed7ada9771c716314a12%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed7ada9771c716314a12%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed7ada9771c716314a12%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed7ada9771c716314a12%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed7ada9771c716314a12%2F0214-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c635a73e8cae136d1498f6" data-idx="349">
+        <div class="book-header">
+          <span class="book-num">#350</span>
+          <h3>Versuch über die Religion der alten Ägypter und Griechen</h3>
+          <span class="page-count">106 pp</span>
+          <a href="https://sourcelibrary.org/book/69c635a73e8cae136d1498f6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c635a73e8cae136d1498f6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c635a73e8cae136d1498f6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c635a73e8cae136d1498f6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c635a73e8cae136d1498f6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c635a73e8cae136d1498f6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c635a73e8cae136d1498f6%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c635a73e8cae136d1498f6%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c635a73e8cae136d1498f6%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c635a73e8cae136d1498f6%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c635a73e8cae136d1498f6%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c802f46c6f3cc53c844964" data-idx="350">
+        <div class="book-header">
+          <span class="book-num">#351</span>
+          <h3>[Syriac] Liber sacrosancti evangelii de Jesu Christo</h3>
+          <span class="page-count">353 pp</span>
+          <a href="https://sourcelibrary.org/book/69c802f46c6f3cc53c844964" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c802f46c6f3cc53c844964', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c802f46c6f3cc53c844964', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c802f46c6f3cc53c844964', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c802f46c6f3cc53c844964', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c802f46c6f3cc53c844964', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802f46c6f3cc53c844964%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802f46c6f3cc53c844964%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802f46c6f3cc53c844964%2F0212-full.jpg&w=600" alt="Page 212" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.212 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802f46c6f3cc53c844964%2F0282-full.jpg&w=600" alt="Page 282" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.282 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802f46c6f3cc53c844964%2F0318-full.jpg&w=600" alt="Page 318" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.318 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c882d86c6f3cc53c859611" data-idx="351">
+        <div class="book-header">
+          <span class="book-num">#352</span>
+          <h3>Pandora: das ist, die edlest Gab Gottes</h3>
+          <span class="page-count">173 pp</span>
+          <a href="https://sourcelibrary.org/book/69c882d86c6f3cc53c859611" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c882d86c6f3cc53c859611', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c882d86c6f3cc53c859611', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c882d86c6f3cc53c859611', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c882d86c6f3cc53c859611', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c882d86c6f3cc53c859611', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c882d86c6f3cc53c859611%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c882d86c6f3cc53c859611%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c882d86c6f3cc53c859611%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c882d86c6f3cc53c859611%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c882d86c6f3cc53c859611%2F0156-full.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f3ec6c6f3cc53c841672" data-idx="352">
+        <div class="book-header">
+          <span class="book-num">#353</span>
+          <h3>Regel des geistlichen Lebens. Schöne ausserlesene Brieff</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f3ec6c6f3cc53c841672" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f3ec6c6f3cc53c841672', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f3ec6c6f3cc53c841672', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f3ec6c6f3cc53c841672', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f3ec6c6f3cc53c841672', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f3ec6c6f3cc53c841672', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ec6c6f3cc53c841672%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ec6c6f3cc53c841672%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ec6c6f3cc53c841672%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ec6c6f3cc53c841672%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ec6c6f3cc53c841672%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a22c6c6f3cc53c85e37d" data-idx="353">
+        <div class="book-header">
+          <span class="book-num">#354</span>
+          <h3>An essay upon the constitution of man: spirit, soul, body</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a22c6c6f3cc53c85e37d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a22c6c6f3cc53c85e37d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a22c6c6f3cc53c85e37d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a22c6c6f3cc53c85e37d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a22c6c6f3cc53c85e37d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a22c6c6f3cc53c85e37d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a22c6c6f3cc53c85e37d%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a22c6c6f3cc53c85e37d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a22c6c6f3cc53c85e37d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a22c6c6f3cc53c85e37d%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a22c6c6f3cc53c85e37d%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6494471add5d9cc49ab67" data-idx="354">
+        <div class="book-header">
+          <span class="book-num">#355</span>
+          <h3>Den vruchtbaermakenden wynstock Christus</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6494471add5d9cc49ab67" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6494471add5d9cc49ab67', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6494471add5d9cc49ab67', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6494471add5d9cc49ab67', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6494471add5d9cc49ab67', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6494471add5d9cc49ab67', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab67%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab67%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab67%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab67%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab67%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c887606c6f3cc53c85a05c" data-idx="355">
+        <div class="book-header">
+          <span class="book-num">#356</span>
+          <h3>Rivers of life, or sources and streams of the faiths of man in all lands; showing the evolution of faiths from the rudest symbolisms to the latest spiritual developments</h3>
+          <span class="page-count">319 pp</span>
+          <a href="https://sourcelibrary.org/book/69c887606c6f3cc53c85a05c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c887606c6f3cc53c85a05c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c887606c6f3cc53c85a05c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c887606c6f3cc53c85a05c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c887606c6f3cc53c85a05c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c887606c6f3cc53c85a05c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887606c6f3cc53c85a05c%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887606c6f3cc53c85a05c%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887606c6f3cc53c85a05c%2F0191-full.jpg&w=600" alt="Page 191" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.191 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887606c6f3cc53c85a05c%2F0255-full.jpg&w=600" alt="Page 255" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.255 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c887606c6f3cc53c85a05c%2F0287-full.jpg&w=600" alt="Page 287" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.287 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c814c56c6f3cc53c848325" data-idx="356">
+        <div class="book-header">
+          <span class="book-num">#357</span>
+          <h3>Historisch verhaal nopende der Labadisten scheuringh</h3>
+          <span class="page-count">345 pp</span>
+          <a href="https://sourcelibrary.org/book/69c814c56c6f3cc53c848325" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c814c56c6f3cc53c848325', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c814c56c6f3cc53c848325', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c814c56c6f3cc53c848325', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c814c56c6f3cc53c848325', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c814c56c6f3cc53c848325', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814c56c6f3cc53c848325%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814c56c6f3cc53c848325%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814c56c6f3cc53c848325%2F0207-full.jpg&w=600" alt="Page 207" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.207 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814c56c6f3cc53c848325%2F0276-full.jpg&w=600" alt="Page 276" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.276 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c814c56c6f3cc53c848325%2F0311-full.jpg&w=600" alt="Page 311" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.311 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909b50ecf28baa1b4caf28b" data-idx="357">
+        <div class="book-header">
+          <span class="book-num">#358</span>
+          <h3>Metaphysische Kezereien</h3>
+          <span class="page-count">228 pp</span>
+          <a href="https://sourcelibrary.org/book/metaphysical-heresies-gleichen" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909b50ecf28baa1b4caf28b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909b50ecf28baa1b4caf28b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909b50ecf28baa1b4caf28b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909b50ecf28baa1b4caf28b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909b50ecf28baa1b4caf28b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b50ecf28baa1b4caf28b%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b50ecf28baa1b4caf28b%2F91.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b50ecf28baa1b4caf28b%2F137.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b50ecf28baa1b4caf28b%2F182.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b50ecf28baa1b4caf28b%2F205.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c820586c6f3cc53c84a804" data-idx="358">
+        <div class="book-header">
+          <span class="book-num">#359</span>
+          <h3>Brevis, de lithosophistica, erronea quorundam, de lapide philosophico nunc disceptantium doctrina, religioni Christianae incommoda, observatio</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c820586c6f3cc53c84a804" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c820586c6f3cc53c84a804', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c820586c6f3cc53c84a804', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c820586c6f3cc53c84a804', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c820586c6f3cc53c84a804', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c820586c6f3cc53c84a804', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820586c6f3cc53c84a804%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820586c6f3cc53c84a804%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820586c6f3cc53c84a804%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820586c6f3cc53c84a804%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c820586c6f3cc53c84a804%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c828c36c6f3cc53c84c49e" data-idx="359">
+        <div class="book-header">
+          <span class="book-num">#360</span>
+          <h3>Treatise concerning the search after truth</h3>
+          <span class="page-count">214 pp</span>
+          <a href="https://sourcelibrary.org/book/69c828c36c6f3cc53c84c49e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c828c36c6f3cc53c84c49e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c828c36c6f3cc53c84c49e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c828c36c6f3cc53c84c49e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c828c36c6f3cc53c84c49e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c828c36c6f3cc53c84c49e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828c36c6f3cc53c84c49e%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828c36c6f3cc53c84c49e%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828c36c6f3cc53c84c49e%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828c36c6f3cc53c84c49e%2F0171-full.jpg&w=600" alt="Page 171" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.171 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828c36c6f3cc53c84c49e%2F0193-full.jpg&w=600" alt="Page 193" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.193 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418ba2b0edf3eaa2ddbf4" data-idx="360">
+        <div class="book-header">
+          <span class="book-num">#361</span>
+          <h3>Sanctum Almodellum Salomonis (PH329)</h3>
+          <span class="page-count">35 pp</span>
+          <a href="https://sourcelibrary.org/book/holy-almodel-of-solomon-latin-ms-18th-c-pseudo-solomon" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418ba2b0edf3eaa2ddbf4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418ba2b0edf3eaa2ddbf4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418ba2b0edf3eaa2ddbf4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418ba2b0edf3eaa2ddbf4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418ba2b0edf3eaa2ddbf4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ba2b0edf3eaa2ddbf4%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ba2b0edf3eaa2ddbf4%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ba2b0edf3eaa2ddbf4%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ba2b0edf3eaa2ddbf4%2F28.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ba2b0edf3eaa2ddbf4%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83b296c6f3cc53c84f5ca" data-idx="361">
+        <div class="book-header">
+          <span class="book-num">#362</span>
+          <h3>Erklärung vom gemeinen Secten-Wesen, Kirchen- und Abendmahl-gehen</h3>
+          <span class="page-count">56 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83b296c6f3cc53c84f5ca" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83b296c6f3cc53c84f5ca', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83b296c6f3cc53c84f5ca', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83b296c6f3cc53c84f5ca', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83b296c6f3cc53c84f5ca', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83b296c6f3cc53c84f5ca', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b296c6f3cc53c84f5ca%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b296c6f3cc53c84f5ca%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b296c6f3cc53c84f5ca%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b296c6f3cc53c84f5ca%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83b296c6f3cc53c84f5ca%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c835a16c6f3cc53c84e993" data-idx="362">
+        <div class="book-header">
+          <span class="book-num">#363</span>
+          <h3>Die geistreiche Bücher oder Schrifften</h3>
+          <span class="page-count">383 pp</span>
+          <a href="https://sourcelibrary.org/book/69c835a16c6f3cc53c84e993" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c835a16c6f3cc53c84e993', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c835a16c6f3cc53c84e993', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c835a16c6f3cc53c84e993', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c835a16c6f3cc53c84e993', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c835a16c6f3cc53c84e993', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835a16c6f3cc53c84e993%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835a16c6f3cc53c84e993%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835a16c6f3cc53c84e993%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835a16c6f3cc53c84e993%2F0306-full.jpg&w=600" alt="Page 306" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.306 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835a16c6f3cc53c84e993%2F0345-full.jpg&w=600" alt="Page 345" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.345 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4189f2b0edf3eaa2dd733" data-idx="363">
+        <div class="book-header">
+          <span class="book-num">#364</span>
+          <h3>Pranostyka — Paracelsus Czech Prognostication (PH306)</h3>
+          <span class="page-count">32 pp</span>
+          <a href="https://sourcelibrary.org/book/paracelsus-czech-prognostication-for-ferdinand-i-post-1536-paracelsus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4189f2b0edf3eaa2dd733', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4189f2b0edf3eaa2dd733', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4189f2b0edf3eaa2dd733', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4189f2b0edf3eaa2dd733', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4189f2b0edf3eaa2dd733', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189f2b0edf3eaa2dd733%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189f2b0edf3eaa2dd733%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189f2b0edf3eaa2dd733%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189f2b0edf3eaa2dd733%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189f2b0edf3eaa2dd733%2F29.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8126d6c6f3cc53c847b9d" data-idx="364">
+        <div class="book-header">
+          <span class="book-num">#365</span>
+          <h3>De betoverde weereld ... in vier boeken</h3>
+          <span class="page-count">490 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8126d6c6f3cc53c847b9d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8126d6c6f3cc53c847b9d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8126d6c6f3cc53c847b9d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8126d6c6f3cc53c847b9d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8126d6c6f3cc53c847b9d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8126d6c6f3cc53c847b9d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8126d6c6f3cc53c847b9d%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8126d6c6f3cc53c847b9d%2F0196-full.jpg&w=600" alt="Page 196" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.196 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8126d6c6f3cc53c847b9d%2F0294-full.jpg&w=600" alt="Page 294" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.294 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8126d6c6f3cc53c847b9d%2F0392-full.jpg&w=600" alt="Page 392" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.392 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8126d6c6f3cc53c847b9d%2F0441-full.jpg&w=600" alt="Page 441" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.441 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88b9f6c6f3cc53c85a997" data-idx="365">
+        <div class="book-header">
+          <span class="book-num">#366</span>
+          <h3>Tafel der Wiedergeburt</h3>
+          <span class="page-count">255 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88b9f6c6f3cc53c85a997" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88b9f6c6f3cc53c85a997', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88b9f6c6f3cc53c85a997', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88b9f6c6f3cc53c85a997', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88b9f6c6f3cc53c85a997', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88b9f6c6f3cc53c85a997', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b9f6c6f3cc53c85a997%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b9f6c6f3cc53c85a997%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b9f6c6f3cc53c85a997%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b9f6c6f3cc53c85a997%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b9f6c6f3cc53c85a997%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c856c76c6f3cc53c853eed" data-idx="366">
+        <div class="book-header">
+          <span class="book-num">#367</span>
+          <h3>Die geistliche Bücher und Schrifften</h3>
+          <span class="page-count">597 pp</span>
+          <a href="https://sourcelibrary.org/book/69c856c76c6f3cc53c853eed" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c856c76c6f3cc53c853eed', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c856c76c6f3cc53c853eed', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c856c76c6f3cc53c853eed', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c856c76c6f3cc53c853eed', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c856c76c6f3cc53c853eed', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856c76c6f3cc53c853eed%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856c76c6f3cc53c853eed%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856c76c6f3cc53c853eed%2F0358-full.jpg&w=600" alt="Page 358" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.358 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856c76c6f3cc53c853eed%2F0478-full.jpg&w=600" alt="Page 478" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.478 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c856c76c6f3cc53c853eed%2F0537-full.jpg&w=600" alt="Page 537" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.537 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70646da9771c716315b80" data-idx="367">
+        <div class="book-header">
+          <span class="book-num">#368</span>
+          <h3>Die geheime Naturlehre der hermetischen Wissenschaft</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70646da9771c716315b80" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70646da9771c716315b80', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70646da9771c716315b80', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70646da9771c716315b80', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70646da9771c716315b80', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70646da9771c716315b80', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70646da9771c716315b80%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70646da9771c716315b80%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70646da9771c716315b80%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70646da9771c716315b80%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70646da9771c716315b80%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80c136c6f3cc53c84694b" data-idx="368">
+        <div class="book-header">
+          <span class="book-num">#369</span>
+          <h3>Von der Spanischen Monarchy</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80c136c6f3cc53c84694b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80c136c6f3cc53c84694b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80c136c6f3cc53c84694b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80c136c6f3cc53c84694b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80c136c6f3cc53c84694b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80c136c6f3cc53c84694b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c136c6f3cc53c84694b%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c136c6f3cc53c84694b%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c136c6f3cc53c84694b%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c136c6f3cc53c84694b%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80c136c6f3cc53c84694b%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c703c6da9771c716315966" data-idx="369">
+        <div class="book-header">
+          <span class="book-num">#370</span>
+          <h3>L'antiquité dévoilée par ses usages</h3>
+          <span class="page-count">216 pp</span>
+          <a href="https://sourcelibrary.org/book/69c703c6da9771c716315966" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c703c6da9771c716315966', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c703c6da9771c716315966', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c703c6da9771c716315966', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c703c6da9771c716315966', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c703c6da9771c716315966', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c6da9771c716315966%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c6da9771c716315966%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c6da9771c716315966%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c6da9771c716315966%2F0173-full.jpg&w=600" alt="Page 173" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.173 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c6da9771c716315966%2F0194-full.jpg&w=600" alt="Page 194" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.194 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c879e06c6f3cc53c858579" data-idx="370">
+        <div class="book-header">
+          <span class="book-num">#371</span>
+          <h3>The history of magick</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/69c879e06c6f3cc53c858579" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c879e06c6f3cc53c858579', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c879e06c6f3cc53c858579', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c879e06c6f3cc53c858579', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c879e06c6f3cc53c858579', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c879e06c6f3cc53c858579', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879e06c6f3cc53c858579%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879e06c6f3cc53c858579%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879e06c6f3cc53c858579%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879e06c6f3cc53c858579%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c879e06c6f3cc53c858579%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c893236c6f3cc53c85be16" data-idx="371">
+        <div class="book-header">
+          <span class="book-num">#372</span>
+          <h3>The strange effects of faith [part 1]</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/69c893236c6f3cc53c85be16" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c893236c6f3cc53c85be16', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c893236c6f3cc53c85be16', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c893236c6f3cc53c85be16', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c893236c6f3cc53c85be16', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c893236c6f3cc53c85be16', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893236c6f3cc53c85be16%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893236c6f3cc53c85be16%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893236c6f3cc53c85be16%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893236c6f3cc53c85be16%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c893236c6f3cc53c85be16%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a6db92b884e4f8173c5a" data-idx="372">
+        <div class="book-header">
+          <span class="book-num">#373</span>
+          <h3>Freymüthige Betrachtungen über das Christenthum</h3>
+          <span class="page-count">239 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a6db92b884e4f8173c5a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a6db92b884e4f8173c5a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a6db92b884e4f8173c5a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a6db92b884e4f8173c5a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a6db92b884e4f8173c5a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a6db92b884e4f8173c5a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6db92b884e4f8173c5a%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6db92b884e4f8173c5a%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6db92b884e4f8173c5a%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6db92b884e4f8173c5a%2F0191-full.jpg&w=600" alt="Page 191" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.191 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6db92b884e4f8173c5a%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4191c2b0edf3eaa2decde" data-idx="373">
+        <div class="book-header">
+          <span class="book-num">#374</span>
+          <h3>Le grand rosaire des philosophes avec le mercure trismegiste (PH214)</h3>
+          <span class="page-count">73 pp</span>
+          <a href="https://sourcelibrary.org/book/great-rosary-of-the-philosophers-with-hermes-trismegistus-faber" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4191c2b0edf3eaa2decde', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4191c2b0edf3eaa2decde', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4191c2b0edf3eaa2decde', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4191c2b0edf3eaa2decde', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4191c2b0edf3eaa2decde', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191c2b0edf3eaa2decde%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485630705131!PH214_0029.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485630705131!PH214_0044.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485630705131!PH214_0058.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485630705131!PH214_0066.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c802796c6f3cc53c844745" data-idx="374">
+        <div class="book-header">
+          <span class="book-num">#375</span>
+          <h3>[Hebrew: Terumot ha-nedabah] oder Freywillige Heb-Opffer von allerhand in die Theologie lauffenden Materien</h3>
+          <span class="page-count">489 pp</span>
+          <a href="https://sourcelibrary.org/book/69c802796c6f3cc53c844745" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c802796c6f3cc53c844745', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c802796c6f3cc53c844745', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c802796c6f3cc53c844745', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c802796c6f3cc53c844745', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c802796c6f3cc53c844745', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802796c6f3cc53c844745%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802796c6f3cc53c844745%2F0196-full.jpg&w=600" alt="Page 196" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.196 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802796c6f3cc53c844745%2F0293-full.jpg&w=600" alt="Page 293" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.293 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802796c6f3cc53c844745%2F0391-full.jpg&w=600" alt="Page 391" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.391 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802796c6f3cc53c844745%2F0440-full.jpg&w=600" alt="Page 440" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.440 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fd1f6c6f3cc53c8432be" data-idx="375">
+        <div class="book-header">
+          <span class="book-num">#376</span>
+          <h3>Psychosophia oder Seelen-Weissheit</h3>
+          <span class="page-count">224 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fd1f6c6f3cc53c8432be" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fd1f6c6f3cc53c8432be', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fd1f6c6f3cc53c8432be', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fd1f6c6f3cc53c8432be', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fd1f6c6f3cc53c8432be', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fd1f6c6f3cc53c8432be', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd1f6c6f3cc53c8432be%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd1f6c6f3cc53c8432be%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd1f6c6f3cc53c8432be%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd1f6c6f3cc53c8432be%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fd1f6c6f3cc53c8432be%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c878566c6f3cc53c8581ea" data-idx="376">
+        <div class="book-header">
+          <span class="book-num">#377</span>
+          <h3>Vom Geist und Wesen der Dinge</h3>
+          <span class="page-count">150 pp</span>
+          <a href="https://sourcelibrary.org/book/69c878566c6f3cc53c8581ea" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c878566c6f3cc53c8581ea', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c878566c6f3cc53c8581ea', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c878566c6f3cc53c8581ea', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c878566c6f3cc53c8581ea', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c878566c6f3cc53c8581ea', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581ea%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581ea%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581ea%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581ea%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581ea%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418ab2b0edf3eaa2dd947" data-idx="377">
+        <div class="book-header">
+          <span class="book-num">#378</span>
+          <h3>Ars artium sive Ars magna cabalistica (PH337)</h3>
+          <span class="page-count">97 pp</span>
+          <a href="https://sourcelibrary.org/book/great-kabbalistic-art-hartmann-schopper-1564-1569-schopper" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418ab2b0edf3eaa2dd947', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418ab2b0edf3eaa2dd947', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418ab2b0edf3eaa2dd947', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418ab2b0edf3eaa2dd947', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418ab2b0edf3eaa2dd947', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ab2b0edf3eaa2dd947%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ab2b0edf3eaa2dd947%2F39.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ab2b0edf3eaa2dd947%2F58.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ab2b0edf3eaa2dd947%2F78.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ab2b0edf3eaa2dd947%2F87.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c827306c6f3cc53c84bf6c" data-idx="378">
+        <div class="book-header">
+          <span class="book-num">#379</span>
+          <h3>Der Naturmensch oder Geschichte des Hai Ebn Joktan</h3>
+          <span class="page-count">128 pp</span>
+          <a href="https://sourcelibrary.org/book/69c827306c6f3cc53c84bf6c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c827306c6f3cc53c84bf6c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c827306c6f3cc53c84bf6c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c827306c6f3cc53c84bf6c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c827306c6f3cc53c84bf6c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c827306c6f3cc53c84bf6c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827306c6f3cc53c84bf6c%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827306c6f3cc53c84bf6c%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827306c6f3cc53c84bf6c%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827306c6f3cc53c84bf6c%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827306c6f3cc53c84bf6c%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85f546c6f3cc53c8554e1" data-idx="379">
+        <div class="book-header">
+          <span class="book-num">#380</span>
+          <h3>L'Idee parfaicte de la philosophie hermetique</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85f546c6f3cc53c8554e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85f546c6f3cc53c8554e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85f546c6f3cc53c8554e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85f546c6f3cc53c8554e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85f546c6f3cc53c8554e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85f546c6f3cc53c8554e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f546c6f3cc53c8554e1%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f546c6f3cc53c8554e1%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f546c6f3cc53c8554e1%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f546c6f3cc53c8554e1%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f546c6f3cc53c8554e1%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c850c66c6f3cc53c852ebc" data-idx="380">
+        <div class="book-header">
+          <span class="book-num">#381</span>
+          <h3>Höchstnothwendige und zur Seelen Seligkeit sehr nützliche Erklärung etlicher Haupt-Puncten</h3>
+          <span class="page-count">299 pp</span>
+          <a href="https://sourcelibrary.org/book/69c850c66c6f3cc53c852ebc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c850c66c6f3cc53c852ebc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c850c66c6f3cc53c852ebc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c850c66c6f3cc53c852ebc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c850c66c6f3cc53c852ebc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c850c66c6f3cc53c852ebc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c66c6f3cc53c852ebc%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c66c6f3cc53c852ebc%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c66c6f3cc53c852ebc%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c66c6f3cc53c852ebc%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c66c6f3cc53c852ebc%2F0269-full.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41950ddff1f043992a1c6" data-idx="381">
+        <div class="book-header">
+          <span class="book-num">#382</span>
+          <h3>Copy of a Letter — Carl Joseph von Campagne (PH455C)</h3>
+          <span class="page-count">12 pp</span>
+          <a href="https://sourcelibrary.org/book/campagne-alchemical-letter-late-18th-early-19th-c-campagne" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41950ddff1f043992a1c6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41950ddff1f043992a1c6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41950ddff1f043992a1c6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41950ddff1f043992a1c6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41950ddff1f043992a1c6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41950ddff1f043992a1c6%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41950ddff1f043992a1c6%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41950ddff1f043992a1c6%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41950ddff1f043992a1c6%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41950ddff1f043992a1c6%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88dd06c6f3cc53c85af61" data-idx="382">
+        <div class="book-header">
+          <span class="book-num">#383</span>
+          <h3>Verordnung, wie das nach öffentlicher Uberreichung der evangelischen Glaubens-Confession zu Augspurg ... zweyte Jubel-Fest ... gefeyret werden solle</h3>
+          <span class="page-count">72 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88dd06c6f3cc53c85af61" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88dd06c6f3cc53c85af61', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88dd06c6f3cc53c85af61', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88dd06c6f3cc53c85af61', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88dd06c6f3cc53c85af61', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88dd06c6f3cc53c85af61', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88dd06c6f3cc53c85af61%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88dd06c6f3cc53c85af61%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88dd06c6f3cc53c85af61%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88dd06c6f3cc53c85af61%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88dd06c6f3cc53c85af61%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418f82b0edf3eaa2de64c" data-idx="383">
+        <div class="book-header">
+          <span class="book-num">#384</span>
+          <h3>Collection of Alchemical Texts — Flamel, Bernard, Llull (PH228)</h3>
+          <span class="page-count">142 pp</span>
+          <a href="https://sourcelibrary.org/book/flamel-bernard-of-trevisan-llull-alchemical-collection-18th-llull" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418f82b0edf3eaa2de64c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418f82b0edf3eaa2de64c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418f82b0edf3eaa2de64c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418f82b0edf3eaa2de64c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418f82b0edf3eaa2de64c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418f82b0edf3eaa2de64c%2F14.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940530639505131!ph228_0057.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940530639505131!ph228_0085.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940530639505131!ph228_0114.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940530639505131!ph228_0128.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e2ec295ea01b70c8d8da" data-idx="384">
+        <div class="book-header">
+          <span class="book-num">#385</span>
+          <h3>Insignia itinerarii Italici, quibus continentur antiquitates sacrae</h3>
+          <span class="page-count">120 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e2ec295ea01b70c8d8da" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e2ec295ea01b70c8d8da', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e2ec295ea01b70c8d8da', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e2ec295ea01b70c8d8da', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e2ec295ea01b70c8d8da', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e2ec295ea01b70c8d8da', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ec295ea01b70c8d8da%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ec295ea01b70c8d8da%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ec295ea01b70c8d8da%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ec295ea01b70c8d8da%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ec295ea01b70c8d8da%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b6c425ec2ba5ccd7f73d" data-idx="385">
+        <div class="book-header">
+          <span class="book-num">#386</span>
+          <h3>Select works and some pieces</h3>
+          <span class="page-count">198 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b6c425ec2ba5ccd7f73d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b6c425ec2ba5ccd7f73d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b6c425ec2ba5ccd7f73d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b6c425ec2ba5ccd7f73d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b6c425ec2ba5ccd7f73d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b6c425ec2ba5ccd7f73d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c425ec2ba5ccd7f73d%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c425ec2ba5ccd7f73d%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c425ec2ba5ccd7f73d%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c425ec2ba5ccd7f73d%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b6c425ec2ba5ccd7f73d%2F0178-full.jpg&w=600" alt="Page 178" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.178 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c648c1b2d26d717d1aaa41" data-idx="386">
+        <div class="book-header">
+          <span class="book-num">#387</span>
+          <h3>Du vray et parfait amour</h3>
+          <span class="page-count">401 pp</span>
+          <a href="https://sourcelibrary.org/book/69c648c1b2d26d717d1aaa41" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c648c1b2d26d717d1aaa41', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c648c1b2d26d717d1aaa41', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c648c1b2d26d717d1aaa41', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c648c1b2d26d717d1aaa41', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c648c1b2d26d717d1aaa41', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa41%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa41%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa41%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa41%2F0321-full.jpg&w=600" alt="Page 321" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.321 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa41%2F0361-full.jpg&w=600" alt="Page 361" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.361 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88aa76c6f3cc53c85a70c" data-idx="387">
+        <div class="book-header">
+          <span class="book-num">#388</span>
+          <h3>Starke Erweise aus den eigenen Schriften des hochheiligen Ordens Gold- und Rosenkreutzer</h3>
+          <span class="page-count">89 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88aa76c6f3cc53c85a70c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88aa76c6f3cc53c85a70c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88aa76c6f3cc53c85a70c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88aa76c6f3cc53c85a70c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88aa76c6f3cc53c85a70c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88aa76c6f3cc53c85a70c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aa76c6f3cc53c85a70c%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aa76c6f3cc53c85a70c%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aa76c6f3cc53c85a70c%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aa76c6f3cc53c85a70c%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aa76c6f3cc53c85a70c%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c802196c6f3cc53c8445c2" data-idx="388">
+        <div class="book-header">
+          <span class="book-num">#389</span>
+          <h3>Exercitatio historico-theologica de Guilielmo Postello</h3>
+          <span class="page-count">31 pp</span>
+          <a href="https://sourcelibrary.org/book/69c802196c6f3cc53c8445c2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c802196c6f3cc53c8445c2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c802196c6f3cc53c8445c2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c802196c6f3cc53c8445c2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c802196c6f3cc53c8445c2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c802196c6f3cc53c8445c2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802196c6f3cc53c8445c2%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802196c6f3cc53c8445c2%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802196c6f3cc53c8445c2%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802196c6f3cc53c8445c2%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802196c6f3cc53c8445c2%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87b516c6f3cc53c858836" data-idx="389">
+        <div class="book-header">
+          <span class="book-num">#390</span>
+          <h3>Der Jungfrau Antoinette Bourignon innerliches und aeuserliches Leben, aus ihren eigenen, und des Herrn Peter Poirets, Zeugnissen</h3>
+          <span class="page-count">189 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87b516c6f3cc53c858836" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87b516c6f3cc53c858836', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87b516c6f3cc53c858836', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87b516c6f3cc53c858836', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87b516c6f3cc53c858836', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87b516c6f3cc53c858836', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b516c6f3cc53c858836%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b516c6f3cc53c858836%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b516c6f3cc53c858836%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b516c6f3cc53c858836%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b516c6f3cc53c858836%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c72032da9771c716316baf" data-idx="390">
+        <div class="book-header">
+          <span class="book-num">#391</span>
+          <h3>Canon chronicus Aegyptiacus, Ebraicus, Graecus, &amp; disquisitiones</h3>
+          <span class="page-count">379 pp</span>
+          <a href="https://sourcelibrary.org/book/69c72032da9771c716316baf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c72032da9771c716316baf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c72032da9771c716316baf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c72032da9771c716316baf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c72032da9771c716316baf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c72032da9771c716316baf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72032da9771c716316baf%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72032da9771c716316baf%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72032da9771c716316baf%2F0227-full.jpg&w=600" alt="Page 227" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.227 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72032da9771c716316baf%2F0303-full.jpg&w=600" alt="Page 303" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.303 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72032da9771c716316baf%2F0341-full.jpg&w=600" alt="Page 341" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.341 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82d666c6f3cc53c84d24d" data-idx="391">
+        <div class="book-header">
+          <span class="book-num">#392</span>
+          <h3>Christus triumphans [...] Das heimliche, für aller Welt und Vernunft verborgene Geheimnis</h3>
+          <span class="page-count">113 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82d666c6f3cc53c84d24d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82d666c6f3cc53c84d24d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82d666c6f3cc53c84d24d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82d666c6f3cc53c84d24d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82d666c6f3cc53c84d24d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82d666c6f3cc53c84d24d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d666c6f3cc53c84d24d%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d666c6f3cc53c84d24d%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d666c6f3cc53c84d24d%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d666c6f3cc53c84d24d%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d666c6f3cc53c84d24d%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e10c295ea01b70c8d66d" data-idx="392">
+        <div class="book-header">
+          <span class="book-num">#393</span>
+          <h3>De kleyne chirurgie ende 't gast-huys boeck</h3>
+          <span class="page-count">129 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e10c295ea01b70c8d66d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e10c295ea01b70c8d66d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e10c295ea01b70c8d66d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e10c295ea01b70c8d66d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e10c295ea01b70c8d66d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e10c295ea01b70c8d66d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66d%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66d%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66d%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66d%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e10c295ea01b70c8d66d%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c813ea6c6f3cc53c848074" data-idx="393">
+        <div class="book-header">
+          <span class="book-num">#394</span>
+          <h3>Das entdeckte Heiligthum der Schwärmer</h3>
+          <span class="page-count">385 pp</span>
+          <a href="https://sourcelibrary.org/book/69c813ea6c6f3cc53c848074" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c813ea6c6f3cc53c848074', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c813ea6c6f3cc53c848074', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c813ea6c6f3cc53c848074', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c813ea6c6f3cc53c848074', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c813ea6c6f3cc53c848074', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ea6c6f3cc53c848074%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ea6c6f3cc53c848074%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ea6c6f3cc53c848074%2F0231-full.jpg&w=600" alt="Page 231" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.231 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ea6c6f3cc53c848074%2F0308-full.jpg&w=600" alt="Page 308" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.308 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c813ea6c6f3cc53c848074%2F0347-full.jpg&w=600" alt="Page 347" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.347 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69099e2acf28baa1b4caeafb" data-idx="394">
+        <div class="book-header">
+          <span class="book-num">#395</span>
+          <h3>Colloquium Rhodostauroticum</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/echo-of-the-rosicrucian-colloquy-that-is-reverberation-hilarionus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69099e2acf28baa1b4caeafb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69099e2acf28baa1b4caeafb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69099e2acf28baa1b4caeafb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69099e2acf28baa1b4caeafb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69099e2acf28baa1b4caeafb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099e2acf28baa1b4caeafb%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099e2acf28baa1b4caeafb%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099e2acf28baa1b4caeafb%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099e2acf28baa1b4caeafb%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099e2acf28baa1b4caeafb%2F48.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71b11da9771c71631684d" data-idx="395">
+        <div class="book-header">
+          <span class="book-num">#396</span>
+          <h3>Hermippus redivivus: or the sage's triumph over the old age and the grave</h3>
+          <span class="page-count">70 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71b11da9771c71631684d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71b11da9771c71631684d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71b11da9771c71631684d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71b11da9771c71631684d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71b11da9771c71631684d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71b11da9771c71631684d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b11da9771c71631684d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b11da9771c71631684d%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b11da9771c71631684d%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b11da9771c71631684d%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b11da9771c71631684d%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c803a86c6f3cc53c844c10" data-idx="396">
+        <div class="book-header">
+          <span class="book-num">#397</span>
+          <h3>Controversiae cum Judaeis prodromi libri II</h3>
+          <span class="page-count">167 pp</span>
+          <a href="https://sourcelibrary.org/book/69c803a86c6f3cc53c844c10" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c803a86c6f3cc53c844c10', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c803a86c6f3cc53c844c10', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c803a86c6f3cc53c844c10', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c803a86c6f3cc53c844c10', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c803a86c6f3cc53c844c10', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803a86c6f3cc53c844c10%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803a86c6f3cc53c844c10%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803a86c6f3cc53c844c10%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803a86c6f3cc53c844c10%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803a86c6f3cc53c844c10%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a1c492b884e4f817382f" data-idx="397">
+        <div class="book-header">
+          <span class="book-num">#398</span>
+          <h3>[Hebrew: Sefer me'orot natan]</h3>
+          <span class="page-count">109 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a1c492b884e4f817382f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a1c492b884e4f817382f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a1c492b884e4f817382f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a1c492b884e4f817382f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a1c492b884e4f817382f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a1c492b884e4f817382f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a1c492b884e4f817382f%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a1c492b884e4f817382f%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a1c492b884e4f817382f%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a1c492b884e4f817382f%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a1c492b884e4f817382f%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c870986c6f3cc53c85735b" data-idx="398">
+        <div class="book-header">
+          <span class="book-num">#399</span>
+          <h3>Commentariorum in apocalypsim Johannis</h3>
+          <span class="page-count">129 pp</span>
+          <a href="https://sourcelibrary.org/book/69c870986c6f3cc53c85735b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c870986c6f3cc53c85735b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c870986c6f3cc53c85735b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c870986c6f3cc53c85735b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c870986c6f3cc53c85735b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c870986c6f3cc53c85735b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870986c6f3cc53c85735b%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870986c6f3cc53c85735b%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870986c6f3cc53c85735b%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870986c6f3cc53c85735b%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870986c6f3cc53c85735b%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89d196c6f3cc53c85d762" data-idx="399">
+        <div class="book-header">
+          <span class="book-num">#400</span>
+          <h3>Codex Nasaraeus, liber Adami appellatus, Syriace transcriptus</h3>
+          <span class="page-count">508 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89d196c6f3cc53c85d762" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89d196c6f3cc53c85d762', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89d196c6f3cc53c85d762', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89d196c6f3cc53c85d762', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89d196c6f3cc53c85d762', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89d196c6f3cc53c85d762', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d196c6f3cc53c85d762%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d196c6f3cc53c85d762%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d196c6f3cc53c85d762%2F0305-full.jpg&w=600" alt="Page 305" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.305 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d196c6f3cc53c85d762%2F0406-full.jpg&w=600" alt="Page 406" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.406 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d196c6f3cc53c85d762%2F0457-full.jpg&w=600" alt="Page 457" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.457 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html" class="active">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-5.html
+++ b/public/split-review-5.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 5/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html" class="active">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="6867ad0f009d20a23245abad" data-idx="400">
+        <div class="book-header">
+          <span class="book-num">#401</span>
+          <h3>Kurtze Instruction zu der Geomantia, Auff die neue Arth nach astrologischer Application solches getheilet in Theoriam &amp; Praxin</h3>
+          <span class="page-count">47 pp</span>
+          <a href="https://sourcelibrary.org/book/brief-instruction-in-geomancy-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867ad0f009d20a23245abad', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867ad0f009d20a23245abad', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867ad0f009d20a23245abad', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867ad0f009d20a23245abad', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867ad0f009d20a23245abad', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867ad0f009d20a23245abad%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867ad0f009d20a23245abad%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867ad0f009d20a23245abad%2F28.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867ad0f009d20a23245abad%2F38.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867ad0f009d20a23245abad%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c851276c6f3cc53c853000" data-idx="401">
+        <div class="book-header">
+          <span class="book-num">#402</span>
+          <h3>Wohl und Weh, so der Geist der wahren Inspiration in denen Schwäbischen Landen und Reichs-Stätten</h3>
+          <span class="page-count">133 pp</span>
+          <a href="https://sourcelibrary.org/book/69c851276c6f3cc53c853000" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c851276c6f3cc53c853000', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c851276c6f3cc53c853000', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c851276c6f3cc53c853000', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c851276c6f3cc53c853000', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c851276c6f3cc53c853000', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851276c6f3cc53c853000%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851276c6f3cc53c853000%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851276c6f3cc53c853000%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851276c6f3cc53c853000%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851276c6f3cc53c853000%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c825d16c6f3cc53c84ba69" data-idx="402">
+        <div class="book-header">
+          <span class="book-num">#403</span>
+          <h3>Dictionnaire de chymie</h3>
+          <span class="page-count">307 pp</span>
+          <a href="https://sourcelibrary.org/book/69c825d16c6f3cc53c84ba69" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c825d16c6f3cc53c84ba69', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c825d16c6f3cc53c84ba69', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c825d16c6f3cc53c84ba69', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c825d16c6f3cc53c84ba69', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c825d16c6f3cc53c84ba69', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825d16c6f3cc53c84ba69%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825d16c6f3cc53c84ba69%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825d16c6f3cc53c84ba69%2F0184-full.jpg&w=600" alt="Page 184" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.184 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825d16c6f3cc53c84ba69%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825d16c6f3cc53c84ba69%2F0276-full.jpg&w=600" alt="Page 276" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.276 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e44d2f9394d7db2f01" data-idx="403">
+        <div class="book-header">
+          <span class="book-num">#404</span>
+          <h3>Unpartheyische Kirchen- und Ketzer-Historie, vom Anfang des Neuen Testaments bisz auf das Jahr Christi 1688</h3>
+          <span class="page-count">635 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e44d2f9394d7db2f01" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e44d2f9394d7db2f01', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e44d2f9394d7db2f01', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e44d2f9394d7db2f01', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e44d2f9394d7db2f01', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e44d2f9394d7db2f01', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e44d2f9394d7db2f01%2F69c59234adcd5e510fc7a423.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e44d2f9394d7db2f01%2F69c5b86a13161ae6b88bf614.jpg&w=600" alt="Page 254" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.254 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e44d2f9394d7db2f01%2F0381-full.jpg&w=600" alt="Page 381" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.381 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e44d2f9394d7db2f01%2F0508-full.jpg&w=600" alt="Page 508" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.508 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e44d2f9394d7db2f01%2F0572-full.jpg&w=600" alt="Page 572" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.572 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81fe46c6f3cc53c84a6d8" data-idx="404">
+        <div class="book-header">
+          <span class="book-num">#405</span>
+          <h3>[Greek: Logike Latreia], dat is redelyke godtsdienst</h3>
+          <span class="page-count">583 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81fe46c6f3cc53c84a6d8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81fe46c6f3cc53c84a6d8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81fe46c6f3cc53c84a6d8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81fe46c6f3cc53c84a6d8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81fe46c6f3cc53c84a6d8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81fe46c6f3cc53c84a6d8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fe46c6f3cc53c84a6d8%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fe46c6f3cc53c84a6d8%2F0233-full.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fe46c6f3cc53c84a6d8%2F0350-full.jpg&w=600" alt="Page 350" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.350 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fe46c6f3cc53c84a6d8%2F0466-full.jpg&w=600" alt="Page 466" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.466 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81fe46c6f3cc53c84a6d8%2F0525-full.jpg&w=600" alt="Page 525" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.525 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c852796c6f3cc53c8533c7" data-idx="405">
+        <div class="book-header">
+          <span class="book-num">#406</span>
+          <h3>Historisch moralischer Vorrath von catechetischen Unterweisungen nach den sechs Hauptstücken des Catechismi Lutheri</h3>
+          <span class="page-count">537 pp</span>
+          <a href="https://sourcelibrary.org/book/69c852796c6f3cc53c8533c7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c852796c6f3cc53c8533c7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c852796c6f3cc53c8533c7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c852796c6f3cc53c8533c7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c852796c6f3cc53c8533c7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c852796c6f3cc53c8533c7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852796c6f3cc53c8533c7%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852796c6f3cc53c8533c7%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852796c6f3cc53c8533c7%2F0322-full.jpg&w=600" alt="Page 322" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.322 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852796c6f3cc53c8533c7%2F0430-full.jpg&w=600" alt="Page 430" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.430 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c852796c6f3cc53c8533c7%2F0483-full.jpg&w=600" alt="Page 483" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.483 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82b186c6f3cc53c84ca1d" data-idx="406">
+        <div class="book-header">
+          <span class="book-num">#407</span>
+          <h3>Das durch den Glantz der geoffenbahrten Wahrheit ausgeloschne Irr-Licht</h3>
+          <span class="page-count">196 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82b186c6f3cc53c84ca1d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82b186c6f3cc53c84ca1d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82b186c6f3cc53c84ca1d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82b186c6f3cc53c84ca1d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82b186c6f3cc53c84ca1d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82b186c6f3cc53c84ca1d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82b186c6f3cc53c84ca1d%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82b186c6f3cc53c84ca1d%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82b186c6f3cc53c84ca1d%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82b186c6f3cc53c84ca1d%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82b186c6f3cc53c84ca1d%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89a626c6f3cc53c85d135" data-idx="407">
+        <div class="book-header">
+          <span class="book-num">#408</span>
+          <h3>Le serpent de la Genèse. Première septaine (livre I). Le temple de Satan</h3>
+          <span class="page-count">301 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89a626c6f3cc53c85d135" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89a626c6f3cc53c85d135', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89a626c6f3cc53c85d135', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89a626c6f3cc53c85d135', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89a626c6f3cc53c85d135', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89a626c6f3cc53c85d135', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a626c6f3cc53c85d135%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a626c6f3cc53c85d135%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a626c6f3cc53c85d135%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a626c6f3cc53c85d135%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a626c6f3cc53c85d135%2F0271-full.jpg&w=600" alt="Page 271" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.271 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898da6c6f3cc53c85cc33" data-idx="408">
+        <div class="book-header">
+          <span class="book-num">#409</span>
+          <h3>Salon de la Rose + Croix. Règles et monitoires</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898da6c6f3cc53c85cc33" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898da6c6f3cc53c85cc33', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898da6c6f3cc53c85cc33', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898da6c6f3cc53c85cc33', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898da6c6f3cc53c85cc33', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898da6c6f3cc53c85cc33', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898da6c6f3cc53c85cc33%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898da6c6f3cc53c85cc33%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898da6c6f3cc53c85cc33%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898da6c6f3cc53c85cc33%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898da6c6f3cc53c85cc33%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c77c496a0f3d112faf964b" data-idx="409">
+        <div class="book-header">
+          <span class="book-num">#410</span>
+          <h3>Guldenes Kalb</h3>
+          <span class="page-count">38 pp</span>
+          <a href="https://sourcelibrary.org/book/69c77c496a0f3d112faf964b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c77c496a0f3d112faf964b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c77c496a0f3d112faf964b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c77c496a0f3d112faf964b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c77c496a0f3d112faf964b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c77c496a0f3d112faf964b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c496a0f3d112faf964b%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c496a0f3d112faf964b%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c496a0f3d112faf964b%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c496a0f3d112faf964b%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c77c496a0f3d112faf964b%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7c9cb25ec2ba5ccd7fd73" data-idx="410">
+        <div class="book-header">
+          <span class="book-num">#411</span>
+          <h3>Historia Templariorum</h3>
+          <span class="page-count">256 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7c9cb25ec2ba5ccd7fd73" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7c9cb25ec2ba5ccd7fd73', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7c9cb25ec2ba5ccd7fd73', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7c9cb25ec2ba5ccd7fd73', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7c9cb25ec2ba5ccd7fd73', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7c9cb25ec2ba5ccd7fd73', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c9cb25ec2ba5ccd7fd73%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c9cb25ec2ba5ccd7fd73%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c9cb25ec2ba5ccd7fd73%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c9cb25ec2ba5ccd7fd73%2F0205-full.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7c9cb25ec2ba5ccd7fd73%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c824c36c6f3cc53c84b603" data-idx="411">
+        <div class="book-header">
+          <span class="book-num">#412</span>
+          <h3>Ephemeriden der gesammten Freimaurerei in Deutschland</h3>
+          <span class="page-count">103 pp</span>
+          <a href="https://sourcelibrary.org/book/69c824c36c6f3cc53c84b603" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c824c36c6f3cc53c84b603', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c824c36c6f3cc53c84b603', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c824c36c6f3cc53c84b603', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c824c36c6f3cc53c84b603', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c824c36c6f3cc53c84b603', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824c36c6f3cc53c84b603%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824c36c6f3cc53c84b603%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824c36c6f3cc53c84b603%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824c36c6f3cc53c84b603%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824c36c6f3cc53c84b603%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c3a0ce0787282ad593939" data-idx="412">
+        <div class="book-header">
+          <span class="book-num">#413</span>
+          <h3>Magni philosophorum arcani revelator</h3>
+          <span class="page-count">259 pp</span>
+          <a href="https://sourcelibrary.org/book/revealer-of-the-great-secret-of-the-philosophers-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c3a0ce0787282ad593939', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c3a0ce0787282ad593939', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c3a0ce0787282ad593939', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c3a0ce0787282ad593939', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c3a0ce0787282ad593939', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3a0ce0787282ad593939%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3a0ce0787282ad593939%2F104.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3a0ce0787282ad593939%2F155.jpg&w=600" alt="Page 155" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.155 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3a0ce0787282ad593939%2F207.jpg&w=600" alt="Page 207" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.207 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3a0ce0787282ad593939%2F233.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82a796c6f3cc53c84c881" data-idx="413">
+        <div class="book-header">
+          <span class="book-num">#414</span>
+          <h3>Twee brieven [...] aan Everhardus vander Hooght</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82a796c6f3cc53c84c881" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82a796c6f3cc53c84c881', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82a796c6f3cc53c84c881', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82a796c6f3cc53c84c881', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82a796c6f3cc53c84c881', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82a796c6f3cc53c84c881', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a796c6f3cc53c84c881%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a796c6f3cc53c84c881%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a796c6f3cc53c84c881%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a796c6f3cc53c84c881%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82a796c6f3cc53c84c881%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c850c06c6f3cc53c852ea5" data-idx="414">
+        <div class="book-header">
+          <span class="book-num">#415</span>
+          <h3>Alerm-Posaun : welche der Postilion deß grossen Löwens vom Geschlecht Juda in einem Gesicht im Traum hat hören blasen</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c850c06c6f3cc53c852ea5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c850c06c6f3cc53c852ea5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c850c06c6f3cc53c852ea5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c850c06c6f3cc53c852ea5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c850c06c6f3cc53c852ea5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c850c06c6f3cc53c852ea5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c06c6f3cc53c852ea5%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c06c6f3cc53c852ea5%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c06c6f3cc53c852ea5%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c06c6f3cc53c852ea5%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c850c06c6f3cc53c852ea5%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8480a6c6f3cc53c851b53" data-idx="415">
+        <div class="book-header">
+          <span class="book-num">#416</span>
+          <h3>Gesammlete kleine Schrifften</h3>
+          <span class="page-count">244 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8480a6c6f3cc53c851b53" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8480a6c6f3cc53c851b53', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8480a6c6f3cc53c851b53', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8480a6c6f3cc53c851b53', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8480a6c6f3cc53c851b53', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8480a6c6f3cc53c851b53', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8480a6c6f3cc53c851b53%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8480a6c6f3cc53c851b53%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8480a6c6f3cc53c851b53%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8480a6c6f3cc53c851b53%2F0195-full.jpg&w=600" alt="Page 195" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.195 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8480a6c6f3cc53c851b53%2F0220-full.jpg&w=600" alt="Page 220" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.220 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69099eb5cf28baa1b4caeb37" data-idx="416">
+        <div class="book-header">
+          <span class="book-num">#417</span>
+          <h3>Hypnerotomachie ou discours du songe de Poliphile</h3>
+          <span class="page-count">338 pp</span>
+          <a href="https://sourcelibrary.org/book/the-strife-of-love-in-a-dream-or-the-discourse-of-the-dream-colonna" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69099eb5cf28baa1b4caeb37', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69099eb5cf28baa1b4caeb37', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69099eb5cf28baa1b4caeb37', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69099eb5cf28baa1b4caeb37', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69099eb5cf28baa1b4caeb37', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099eb5cf28baa1b4caeb37%2F34.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099eb5cf28baa1b4caeb37%2F135.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099eb5cf28baa1b4caeb37%2F203.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099eb5cf28baa1b4caeb37%2F270.jpg&w=600" alt="Page 270" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.270 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099eb5cf28baa1b4caeb37%2F304.jpg&w=600" alt="Page 304" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.304 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c836106c6f3cc53c84eaa5" data-idx="417">
+        <div class="book-header">
+          <span class="book-num">#418</span>
+          <h3>Kurtzgefasste Historie von den zehen Haupt-Verfolgungen der ersten Christen</h3>
+          <span class="page-count">171 pp</span>
+          <a href="https://sourcelibrary.org/book/69c836106c6f3cc53c84eaa5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c836106c6f3cc53c84eaa5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c836106c6f3cc53c84eaa5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c836106c6f3cc53c84eaa5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c836106c6f3cc53c84eaa5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c836106c6f3cc53c84eaa5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836106c6f3cc53c84eaa5%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836106c6f3cc53c84eaa5%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836106c6f3cc53c84eaa5%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836106c6f3cc53c84eaa5%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c836106c6f3cc53c84eaa5%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82cf56c6f3cc53c84d07c" data-idx="418">
+        <div class="book-header">
+          <span class="book-num">#419</span>
+          <h3>Le comte de Gabalis, ou entretiens sur les sciences secrètes</h3>
+          <span class="page-count">118 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82cf56c6f3cc53c84d07c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82cf56c6f3cc53c84d07c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82cf56c6f3cc53c84d07c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82cf56c6f3cc53c84d07c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82cf56c6f3cc53c84d07c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82cf56c6f3cc53c84d07c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cf56c6f3cc53c84d07c%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cf56c6f3cc53c84d07c%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cf56c6f3cc53c84d07c%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cf56c6f3cc53c84d07c%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cf56c6f3cc53c84d07c%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8341e6c6f3cc53c84e45f" data-idx="419">
+        <div class="book-header">
+          <span class="book-num">#420</span>
+          <h3>[Greek: Gnothi seauton]. Nosce teipsum. Erkenne dich selbst</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8341e6c6f3cc53c84e45f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8341e6c6f3cc53c84e45f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8341e6c6f3cc53c84e45f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8341e6c6f3cc53c84e45f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8341e6c6f3cc53c84e45f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8341e6c6f3cc53c84e45f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8341e6c6f3cc53c84e45f%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8341e6c6f3cc53c84e45f%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8341e6c6f3cc53c84e45f%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8341e6c6f3cc53c84e45f%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8341e6c6f3cc53c84e45f%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63f28b463eebe7caac6bd" data-idx="420">
+        <div class="book-header">
+          <span class="book-num">#421</span>
+          <h3>Vitae et mortis consideratio politica</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63f28b463eebe7caac6bd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63f28b463eebe7caac6bd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63f28b463eebe7caac6bd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63f28b463eebe7caac6bd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63f28b463eebe7caac6bd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63f28b463eebe7caac6bd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63f28b463eebe7caac6bd%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63f28b463eebe7caac6bd%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63f28b463eebe7caac6bd%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63f28b463eebe7caac6bd%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63f28b463eebe7caac6bd%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418e62b0edf3eaa2de2a4" data-idx="421">
+        <div class="book-header">
+          <span class="book-num">#422</span>
+          <h3>Recueil de manuscrits chymiques — Basilius Valentinus (PH184)</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/basil-valentine-chemical-manuscripts-collection-1760-valentinus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418e62b0edf3eaa2de2a4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418e62b0edf3eaa2de2a4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418e62b0edf3eaa2de2a4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418e62b0edf3eaa2de2a4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418e62b0edf3eaa2de2a4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e62b0edf3eaa2de2a4%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e62b0edf3eaa2de2a4%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e62b0edf3eaa2de2a4%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e62b0edf3eaa2de2a4%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e62b0edf3eaa2de2a4%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8992d6c6f3cc53c85cd14" data-idx="422">
+        <div class="book-header">
+          <span class="book-num">#423</span>
+          <h3>SRIA Initiation rituals</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8992d6c6f3cc53c85cd14" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8992d6c6f3cc53c85cd14', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8992d6c6f3cc53c85cd14', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8992d6c6f3cc53c85cd14', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8992d6c6f3cc53c85cd14', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8992d6c6f3cc53c85cd14', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8992d6c6f3cc53c85cd14%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8992d6c6f3cc53c85cd14%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8992d6c6f3cc53c85cd14%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8992d6c6f3cc53c85cd14%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8992d6c6f3cc53c85cd14%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418e02b0edf3eaa2de17c" data-idx="423">
+        <div class="book-header">
+          <span class="book-num">#424</span>
+          <h3>Collection of Works attributed to Ramon Llull (PH225)</h3>
+          <span class="page-count">64 pp</span>
+          <a href="https://sourcelibrary.org/book/pseudo-lull-alchemical-collection-16th-century-latin-ms-llull" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418e02b0edf3eaa2de17c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418e02b0edf3eaa2de17c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418e02b0edf3eaa2de17c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418e02b0edf3eaa2de17c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418e02b0edf3eaa2de17c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e02b0edf3eaa2de17c%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940459240105131!PH225_0026.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940459240105131!PH225_0038.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940459240105131!PH225_0051.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940459240105131!PH225_0058.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81a4a6c6f3cc53c8496d9" data-idx="424">
+        <div class="book-header">
+          <span class="book-num">#425</span>
+          <h3>Prima, media, et ultima. Ofte de eerste, middelste en laetste dingen</h3>
+          <span class="page-count">424 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81a4a6c6f3cc53c8496d9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81a4a6c6f3cc53c8496d9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81a4a6c6f3cc53c8496d9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81a4a6c6f3cc53c8496d9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81a4a6c6f3cc53c8496d9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81a4a6c6f3cc53c8496d9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a4a6c6f3cc53c8496d9%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a4a6c6f3cc53c8496d9%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a4a6c6f3cc53c8496d9%2F0254-full.jpg&w=600" alt="Page 254" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.254 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a4a6c6f3cc53c8496d9%2F0339-full.jpg&w=600" alt="Page 339" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.339 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81a4a6c6f3cc53c8496d9%2F0382-full.jpg&w=600" alt="Page 382" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.382 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c764b46a0f3d112faf8ed5" data-idx="425">
+        <div class="book-header">
+          <span class="book-num">#426</span>
+          <h3>Seht da den Menschen! Aus dem Franzoesischen: Ecce homo</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c764b46a0f3d112faf8ed5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c764b46a0f3d112faf8ed5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c764b46a0f3d112faf8ed5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c764b46a0f3d112faf8ed5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c764b46a0f3d112faf8ed5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c764b46a0f3d112faf8ed5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed5%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed5%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed5%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed5%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c764b46a0f3d112faf8ed5%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b18425ec2ba5ccd7f44e" data-idx="426">
+        <div class="book-header">
+          <span class="book-num">#427</span>
+          <h3>[Hebrew: Sefer pardes rimmonim]</h3>
+          <span class="page-count">175 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b18425ec2ba5ccd7f44e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b18425ec2ba5ccd7f44e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b18425ec2ba5ccd7f44e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b18425ec2ba5ccd7f44e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b18425ec2ba5ccd7f44e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b18425ec2ba5ccd7f44e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b18425ec2ba5ccd7f44e%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b18425ec2ba5ccd7f44e%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b18425ec2ba5ccd7f44e%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b18425ec2ba5ccd7f44e%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b18425ec2ba5ccd7f44e%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79e8492b884e4f81736f2" data-idx="427">
+        <div class="book-header">
+          <span class="book-num">#428</span>
+          <h3>De divinis attributis, quae sephirot ab Hebraeis nuncupantur</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79e8492b884e4f81736f2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79e8492b884e4f81736f2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79e8492b884e4f81736f2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79e8492b884e4f81736f2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79e8492b884e4f81736f2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79e8492b884e4f81736f2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f2%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f2%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f2%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f2%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f2%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4185ff1200e2ab53cf613" data-idx="428">
+        <div class="book-header">
+          <span class="book-num">#429</span>
+          <h3>Book of Hours for the Diocese of Utrecht (PH 2)</h3>
+          <span class="page-count">346 pp</span>
+          <a href="https://sourcelibrary.org/book/book-of-hours-master-of-james-146-1491-146" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4185ff1200e2ab53cf613', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4185ff1200e2ab53cf613', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4185ff1200e2ab53cf613', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4185ff1200e2ab53cf613', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4185ff1200e2ab53cf613', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4185ff1200e2ab53cf613%2F35.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4185ff1200e2ab53cf613%2F138.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581722705131!208_ph002_aa5799_p196.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581722705131!277_ph002_aa5799_p265.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 277" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.277 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581722705131!311_ph002_aa5799_p299.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 311" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.311 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909bf03cf28baa1b4caf69d" data-idx="429">
+        <div class="book-header">
+          <span class="book-num">#430</span>
+          <h3>Le cimetière d'Amboise</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/the-cemetery-of-amboise-saint-martin" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909bf03cf28baa1b4caf69d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909bf03cf28baa1b4caf69d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909bf03cf28baa1b4caf69d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909bf03cf28baa1b4caf69d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909bf03cf28baa1b4caf69d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf03cf28baa1b4caf69d%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf03cf28baa1b4caf69d%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf03cf28baa1b4caf69d%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf03cf28baa1b4caf69d%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf03cf28baa1b4caf69d%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2186c6f3cc53c85e34d" data-idx="430">
+        <div class="book-header">
+          <span class="book-num">#431</span>
+          <h3>The ruins of Zimbabwe and the Ophir of Solomon</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2186c6f3cc53c85e34d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2186c6f3cc53c85e34d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2186c6f3cc53c85e34d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2186c6f3cc53c85e34d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2186c6f3cc53c85e34d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2186c6f3cc53c85e34d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2186c6f3cc53c85e34d%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2186c6f3cc53c85e34d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2186c6f3cc53c85e34d%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2186c6f3cc53c85e34d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2186c6f3cc53c85e34d%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87da86c6f3cc53c858bb2" data-idx="431">
+        <div class="book-header">
+          <span class="book-num">#432</span>
+          <h3>The living oracle; or, the star of Bethlehem</h3>
+          <span class="page-count">50 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87da86c6f3cc53c858bb2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87da86c6f3cc53c858bb2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87da86c6f3cc53c858bb2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87da86c6f3cc53c858bb2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87da86c6f3cc53c858bb2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87da86c6f3cc53c858bb2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da86c6f3cc53c858bb2%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da86c6f3cc53c858bb2%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da86c6f3cc53c858bb2%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da86c6f3cc53c858bb2%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da86c6f3cc53c858bb2%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c834a66c6f3cc53c84e5ea" data-idx="432">
+        <div class="book-header">
+          <span class="book-num">#433</span>
+          <h3>Geheime und innige Betrachtungen über die Psalmen Davids</h3>
+          <span class="page-count">257 pp</span>
+          <a href="https://sourcelibrary.org/book/69c834a66c6f3cc53c84e5ea" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c834a66c6f3cc53c84e5ea', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c834a66c6f3cc53c84e5ea', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c834a66c6f3cc53c84e5ea', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c834a66c6f3cc53c84e5ea', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c834a66c6f3cc53c84e5ea', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834a66c6f3cc53c84e5ea%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834a66c6f3cc53c84e5ea%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834a66c6f3cc53c84e5ea%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834a66c6f3cc53c84e5ea%2F0206-full.jpg&w=600" alt="Page 206" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.206 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c834a66c6f3cc53c84e5ea%2F0231-full.jpg&w=600" alt="Page 231" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.231 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70692da9771c716315bcd" data-idx="433">
+        <div class="book-header">
+          <span class="book-num">#434</span>
+          <h3>Philosophia nova astronomiae nostrae particula insignis. Von dem Reich der Natur</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70692da9771c716315bcd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70692da9771c716315bcd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70692da9771c716315bcd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70692da9771c716315bcd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70692da9771c716315bcd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70692da9771c716315bcd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70692da9771c716315bcd%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70692da9771c716315bcd%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70692da9771c716315bcd%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70692da9771c716315bcd%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70692da9771c716315bcd%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86fc56c6f3cc53c85715c" data-idx="434">
+        <div class="book-header">
+          <span class="book-num">#435</span>
+          <h3>Chymische Hochzeit: Christiani Rosenkreutz</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86fc56c6f3cc53c85715c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86fc56c6f3cc53c85715c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86fc56c6f3cc53c85715c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86fc56c6f3cc53c85715c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86fc56c6f3cc53c85715c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86fc56c6f3cc53c85715c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fc56c6f3cc53c85715c%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fc56c6f3cc53c85715c%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fc56c6f3cc53c85715c%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fc56c6f3cc53c85715c%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86fc56c6f3cc53c85715c%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909d388cf28baa1b4cb0103" data-idx="435">
+        <div class="book-header">
+          <span class="book-num">#436</span>
+          <h3>Raphael artem medicam explanans</h3>
+          <span class="page-count">80 pp</span>
+          <a href="https://sourcelibrary.org/book/raphael-explaining-the-art-of-medicine-hafenreffer" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909d388cf28baa1b4cb0103', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909d388cf28baa1b4cb0103', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909d388cf28baa1b4cb0103', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909d388cf28baa1b4cb0103', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909d388cf28baa1b4cb0103', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d388cf28baa1b4cb0103%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d388cf28baa1b4cb0103%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d388cf28baa1b4cb0103%2F48.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d388cf28baa1b4cb0103%2F64.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d388cf28baa1b4cb0103%2F72.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909cd99cf28baa1b4cafdf1" data-idx="436">
+        <div class="book-header">
+          <span class="book-num">#437</span>
+          <h3>Vier Tractaetlein</h3>
+          <span class="page-count">147 pp</span>
+          <a href="https://sourcelibrary.org/book/four-little-treatises-pordage" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909cd99cf28baa1b4cafdf1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909cd99cf28baa1b4cafdf1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909cd99cf28baa1b4cafdf1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909cd99cf28baa1b4cafdf1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909cd99cf28baa1b4cafdf1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cd99cf28baa1b4cafdf1%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cd99cf28baa1b4cafdf1%2F59.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cd99cf28baa1b4cafdf1%2F88.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cd99cf28baa1b4cafdf1%2F118.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cd99cf28baa1b4cafdf1%2F132.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418b72b0edf3eaa2ddb8e" data-idx="437">
+        <div class="book-header">
+          <span class="book-num">#438</span>
+          <h3>The Clavis or Key to Unlock the Mysteries of Magic of Rabbi Salomon (PH304)</h3>
+          <span class="page-count">100 pp</span>
+          <a href="https://sourcelibrary.org/book/key-to-the-mysteries-of-magic-ebenezer-sibley-19th-c-sibley" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418b72b0edf3eaa2ddb8e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418b72b0edf3eaa2ddb8e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418b72b0edf3eaa2ddb8e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418b72b0edf3eaa2ddb8e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418b72b0edf3eaa2ddb8e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b72b0edf3eaa2ddb8e%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485524705131!ph304_0040.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485524705131!ph304_0060.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485524705131!ph304_0080.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485524705131!ph304_0090.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c892e26c6f3cc53c85bd6f" data-idx="438">
+        <div class="book-header">
+          <span class="book-num">#439</span>
+          <h3>Feuerzeug christenlicher Andacht</h3>
+          <span class="page-count">74 pp</span>
+          <a href="https://sourcelibrary.org/book/69c892e26c6f3cc53c85bd6f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c892e26c6f3cc53c85bd6f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c892e26c6f3cc53c85bd6f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c892e26c6f3cc53c85bd6f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c892e26c6f3cc53c85bd6f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c892e26c6f3cc53c85bd6f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892e26c6f3cc53c85bd6f%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892e26c6f3cc53c85bd6f%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892e26c6f3cc53c85bd6f%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892e26c6f3cc53c85bd6f%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892e26c6f3cc53c85bd6f%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89ffe6c6f3cc53c85deb7" data-idx="439">
+        <div class="book-header">
+          <span class="book-num">#440</span>
+          <h3>De idolatria liber</h3>
+          <span class="page-count">94 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89ffe6c6f3cc53c85deb7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89ffe6c6f3cc53c85deb7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89ffe6c6f3cc53c85deb7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89ffe6c6f3cc53c85deb7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89ffe6c6f3cc53c85deb7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89ffe6c6f3cc53c85deb7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ffe6c6f3cc53c85deb7%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ffe6c6f3cc53c85deb7%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ffe6c6f3cc53c85deb7%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ffe6c6f3cc53c85deb7%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ffe6c6f3cc53c85deb7%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f259f08a1a5ab805c04e" data-idx="440">
+        <div class="book-header">
+          <span class="book-num">#441</span>
+          <h3>[Greek Enchiridion]</h3>
+          <span class="page-count">70 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f259f08a1a5ab805c04e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f259f08a1a5ab805c04e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f259f08a1a5ab805c04e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f259f08a1a5ab805c04e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f259f08a1a5ab805c04e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f259f08a1a5ab805c04e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f259f08a1a5ab805c04e%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f259f08a1a5ab805c04e%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f259f08a1a5ab805c04e%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f259f08a1a5ab805c04e%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f259f08a1a5ab805c04e%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3354cca56a12bc607" data-idx="441">
+        <div class="book-header">
+          <span class="book-num">#442</span>
+          <h3>Versammlungs-Rede</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3354cca56a12bc607" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3354cca56a12bc607', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3354cca56a12bc607', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3354cca56a12bc607', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3354cca56a12bc607', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3354cca56a12bc607', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc607%2F69c581e7de3d105c26438b76.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc607%2F69c582f7e25d70f7252a87b8.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc607%2F69c583fe4dc3caea675560cb.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc607%2F69c584334dc3caea675560d1.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc607%2F69c584b63cb3e789005912d8.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909d654cf28baa1b4cb0269" data-idx="442">
+        <div class="book-header">
+          <span class="book-num">#443</span>
+          <h3>Opuscula theologici, historici et philosophici argumenti tomi prioris</h3>
+          <span class="page-count">589 pp</span>
+          <a href="https://sourcelibrary.org/book/the-first-volume-of-minor-works-on-theological-historical-zimmermann" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909d654cf28baa1b4cb0269', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909d654cf28baa1b4cb0269', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909d654cf28baa1b4cb0269', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909d654cf28baa1b4cb0269', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909d654cf28baa1b4cb0269', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d654cf28baa1b4cb0269%2F59.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d654cf28baa1b4cb0269%2F236.jpg&w=600" alt="Page 236" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.236 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d654cf28baa1b4cb0269%2F353.jpg&w=600" alt="Page 353" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.353 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d654cf28baa1b4cb0269%2F471.jpg&w=600" alt="Page 471" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.471 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909d654cf28baa1b4cb0269%2F530.jpg&w=600" alt="Page 530" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.530 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8597a6c6f3cc53c8545c9" data-idx="443">
+        <div class="book-header">
+          <span class="book-num">#444</span>
+          <h3>Theatrum sympateticum, ofte wonder toneel der natuirs verborgentheden</h3>
+          <span class="page-count">279 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8597a6c6f3cc53c8545c9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8597a6c6f3cc53c8545c9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8597a6c6f3cc53c8545c9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8597a6c6f3cc53c8545c9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8597a6c6f3cc53c8545c9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8597a6c6f3cc53c8545c9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8597a6c6f3cc53c8545c9%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8597a6c6f3cc53c8545c9%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8597a6c6f3cc53c8545c9%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8597a6c6f3cc53c8545c9%2F0223-full.jpg&w=600" alt="Page 223" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.223 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8597a6c6f3cc53c8545c9%2F0251-full.jpg&w=600" alt="Page 251" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.251 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690989d5cf28baa1b4cae1c9" data-idx="444">
+        <div class="book-header">
+          <span class="book-num">#445</span>
+          <h3>Pymander. Asclepius. De mysteriis Aegyptiorum. In Platonicum Alcibiadem, de anima &amp; daemone. De sacrificio</h3>
+          <span class="page-count">336 pp</span>
+          <a href="https://sourcelibrary.org/book/pymander-asclepius-on-the-mysteries-of-the-egyptians-on-trismegistus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690989d5cf28baa1b4cae1c9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690989d5cf28baa1b4cae1c9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690989d5cf28baa1b4cae1c9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690989d5cf28baa1b4cae1c9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690989d5cf28baa1b4cae1c9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690989d5cf28baa1b4cae1c9%2F34.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690989d5cf28baa1b4cae1c9%2F134.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690989d5cf28baa1b4cae1c9%2F202.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690989d5cf28baa1b4cae1c9%2F269.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690989d5cf28baa1b4cae1c9%2F302.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4188d2b0edf3eaa2dd39d" data-idx="445">
+        <div class="book-header">
+          <span class="book-num">#446</span>
+          <h3>Lapis Philosophicus (PH436)</h3>
+          <span class="page-count">104 pp</span>
+          <a href="https://sourcelibrary.org/book/philosopher-s-stone-liber-vere-aureus-pre-1626-erskine" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4188d2b0edf3eaa2dd39d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4188d2b0edf3eaa2dd39d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4188d2b0edf3eaa2dd39d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4188d2b0edf3eaa2dd39d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4188d2b0edf3eaa2dd39d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188d2b0edf3eaa2dd39d%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188d2b0edf3eaa2dd39d%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188d2b0edf3eaa2dd39d%2F62.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188d2b0edf3eaa2dd39d%2F83.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188d2b0edf3eaa2dd39d%2F94.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c858a16c6f3cc53c8542ee" data-idx="446">
+        <div class="book-header">
+          <span class="book-num">#447</span>
+          <h3>Eversio falsorum Aristotelis dogmatum</h3>
+          <span class="page-count">128 pp</span>
+          <a href="https://sourcelibrary.org/book/69c858a16c6f3cc53c8542ee" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c858a16c6f3cc53c8542ee', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c858a16c6f3cc53c8542ee', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c858a16c6f3cc53c8542ee', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c858a16c6f3cc53c8542ee', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c858a16c6f3cc53c8542ee', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858a16c6f3cc53c8542ee%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858a16c6f3cc53c8542ee%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858a16c6f3cc53c8542ee%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858a16c6f3cc53c8542ee%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858a16c6f3cc53c8542ee%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418fa2b0edf3eaa2de6dc" data-idx="447">
+        <div class="book-header">
+          <span class="book-num">#448</span>
+          <h3>Vaticinia — Joachim of Fiore (PH202)</h3>
+          <span class="page-count">161 pp</span>
+          <a href="https://sourcelibrary.org/book/joachim-of-fiore-prophecies-with-oracle-of-the-turk-17th-marsico" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418fa2b0edf3eaa2de6dc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418fa2b0edf3eaa2de6dc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418fa2b0edf3eaa2de6dc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418fa2b0edf3eaa2de6dc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418fa2b0edf3eaa2de6dc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418fa2b0edf3eaa2de6dc%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560163405131!ph202_0064.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560163405131!ph202_0097.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560163405131!ph202_0129.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560163405131!ph202_0145.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808356c6f3cc53c845c41" data-idx="448">
+        <div class="book-header">
+          <span class="book-num">#449</span>
+          <h3>Manuductio ad coelum chemicum. Das ist: Handleitung zu dem chemischen Himmel</h3>
+          <span class="page-count">127 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808356c6f3cc53c845c41" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808356c6f3cc53c845c41', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808356c6f3cc53c845c41', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808356c6f3cc53c845c41', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808356c6f3cc53c845c41', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808356c6f3cc53c845c41', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808356c6f3cc53c845c41%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808356c6f3cc53c845c41%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808356c6f3cc53c845c41%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808356c6f3cc53c845c41%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808356c6f3cc53c845c41%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418a92b0edf3eaa2dd84a" data-idx="449">
+        <div class="book-header">
+          <span class="book-num">#450</span>
+          <h3>Cabala Chymica. Concordantia Chymica (PH248)</h3>
+          <span class="page-count">251 pp</span>
+          <a href="https://sourcelibrary.org/book/chemical-kabbalah-kieser-paracelsus-albertus-magnus-post-magnus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418a92b0edf3eaa2dd84a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418a92b0edf3eaa2dd84a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418a92b0edf3eaa2dd84a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418a92b0edf3eaa2dd84a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418a92b0edf3eaa2dd84a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a92b0edf3eaa2dd84a%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a92b0edf3eaa2dd84a%2F100.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a92b0edf3eaa2dd84a%2F151.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a92b0edf3eaa2dd84a%2F201.jpg&w=600" alt="Page 201" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.201 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940512932905131!PH248_0226.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86e8a6c6f3cc53c856f01" data-idx="450">
+        <div class="book-header">
+          <span class="book-num">#451</span>
+          <h3>IIe geste esthétique. Catalogue officiel illustré de 160 dessins du second Salon de la Rose + Croix avec la règle esthétique et les constitutions de l'ordre. 28 Mars au 30 Avril 1893</h3>
+          <span class="page-count">113 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86e8a6c6f3cc53c856f01" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86e8a6c6f3cc53c856f01', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86e8a6c6f3cc53c856f01', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86e8a6c6f3cc53c856f01', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86e8a6c6f3cc53c856f01', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86e8a6c6f3cc53c856f01', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e8a6c6f3cc53c856f01%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e8a6c6f3cc53c856f01%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e8a6c6f3cc53c856f01%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e8a6c6f3cc53c856f01%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e8a6c6f3cc53c856f01%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ff196c6f3cc53c843a6a" data-idx="451">
+        <div class="book-header">
+          <span class="book-num">#452</span>
+          <h3>Protevangelion sive de natalibus Jesu Christi</h3>
+          <span class="page-count">214 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ff196c6f3cc53c843a6a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ff196c6f3cc53c843a6a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ff196c6f3cc53c843a6a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ff196c6f3cc53c843a6a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ff196c6f3cc53c843a6a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ff196c6f3cc53c843a6a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff196c6f3cc53c843a6a%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff196c6f3cc53c843a6a%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff196c6f3cc53c843a6a%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff196c6f3cc53c843a6a%2F0171-full.jpg&w=600" alt="Page 171" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.171 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff196c6f3cc53c843a6a%2F0193-full.jpg&w=600" alt="Page 193" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.193 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84cb16c6f3cc53c8524e5" data-idx="452">
+        <div class="book-header">
+          <span class="book-num">#453</span>
+          <h3>Spiegel der Misbräuche beym Predig-Amt im heutigen Christenthumb</h3>
+          <span class="page-count">393 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84cb16c6f3cc53c8524e5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84cb16c6f3cc53c8524e5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84cb16c6f3cc53c8524e5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84cb16c6f3cc53c8524e5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84cb16c6f3cc53c8524e5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84cb16c6f3cc53c8524e5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb16c6f3cc53c8524e5%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb16c6f3cc53c8524e5%2F0157-full.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb16c6f3cc53c8524e5%2F0236-full.jpg&w=600" alt="Page 236" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.236 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb16c6f3cc53c8524e5%2F0314-full.jpg&w=600" alt="Page 314" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.314 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84cb16c6f3cc53c8524e5%2F0354-full.jpg&w=600" alt="Page 354" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.354 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85e0a6c6f3cc53c8550c9" data-idx="453">
+        <div class="book-header">
+          <span class="book-num">#454</span>
+          <h3>Beytrag zur neuesten Geschichte des Freymaurerordens in neun Gesprächen</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85e0a6c6f3cc53c8550c9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85e0a6c6f3cc53c8550c9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85e0a6c6f3cc53c8550c9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85e0a6c6f3cc53c8550c9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85e0a6c6f3cc53c8550c9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85e0a6c6f3cc53c8550c9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e0a6c6f3cc53c8550c9%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e0a6c6f3cc53c8550c9%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e0a6c6f3cc53c8550c9%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e0a6c6f3cc53c8550c9%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85e0a6c6f3cc53c8550c9%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418ca2b0edf3eaa2dde61" data-idx="454">
+        <div class="book-header">
+          <span class="book-num">#455</span>
+          <h3>About the Macrocosm and the Microcosm — Jakob Böhme (PH334)</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/bohme-macrocosm-microcosm-18th-century-ms-bohme" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418ca2b0edf3eaa2dde61', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418ca2b0edf3eaa2dde61', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418ca2b0edf3eaa2dde61', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418ca2b0edf3eaa2dde61', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418ca2b0edf3eaa2dde61', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ca2b0edf3eaa2dde61%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ca2b0edf3eaa2dde61%2F27.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ca2b0edf3eaa2dde61%2F40.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ca2b0edf3eaa2dde61%2F54.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ca2b0edf3eaa2dde61%2F60.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87af26c6f3cc53c8587ab" data-idx="455">
+        <div class="book-header">
+          <span class="book-num">#456</span>
+          <h3>Illustrations of the book of Job</h3>
+          <span class="page-count">51 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87af26c6f3cc53c8587ab" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87af26c6f3cc53c8587ab', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87af26c6f3cc53c8587ab', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87af26c6f3cc53c8587ab', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87af26c6f3cc53c8587ab', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87af26c6f3cc53c8587ab', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87af26c6f3cc53c8587ab%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87af26c6f3cc53c8587ab%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87af26c6f3cc53c8587ab%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87af26c6f3cc53c8587ab%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87af26c6f3cc53c8587ab%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c64584b463eebe7caaca68" data-idx="456">
+        <div class="book-header">
+          <span class="book-num">#457</span>
+          <h3>Volkomene Nederlandtsche concordantie</h3>
+          <span class="page-count">539 pp</span>
+          <a href="https://sourcelibrary.org/book/69c64584b463eebe7caaca68" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c64584b463eebe7caaca68', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c64584b463eebe7caaca68', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c64584b463eebe7caaca68', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c64584b463eebe7caaca68', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c64584b463eebe7caaca68', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64584b463eebe7caaca68%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64584b463eebe7caaca68%2F0216-full.jpg&w=600" alt="Page 216" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.216 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64584b463eebe7caaca68%2F0323-full.jpg&w=600" alt="Page 323" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.323 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64584b463eebe7caaca68%2F0431-full.jpg&w=600" alt="Page 431" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.431 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c64584b463eebe7caaca68%2F0485-full.jpg&w=600" alt="Page 485" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.485 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c773e06a0f3d112faf9266" data-idx="457">
+        <div class="book-header">
+          <span class="book-num">#458</span>
+          <h3>Von den natürlichen und ubernatürlichen Dingen</h3>
+          <span class="page-count">70 pp</span>
+          <a href="https://sourcelibrary.org/book/69c773e06a0f3d112faf9266" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c773e06a0f3d112faf9266', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c773e06a0f3d112faf9266', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c773e06a0f3d112faf9266', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c773e06a0f3d112faf9266', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c773e06a0f3d112faf9266', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c773e06a0f3d112faf9266%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c773e06a0f3d112faf9266%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c773e06a0f3d112faf9266%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c773e06a0f3d112faf9266%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c773e06a0f3d112faf9266%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8682a6c6f3cc53c856671" data-idx="458">
+        <div class="book-header">
+          <span class="book-num">#459</span>
+          <h3>Anima magica abscondita; oder eine Rede von dem allgemeinen Geiste der Natur</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8682a6c6f3cc53c856671" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8682a6c6f3cc53c856671', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8682a6c6f3cc53c856671', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8682a6c6f3cc53c856671', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8682a6c6f3cc53c856671', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8682a6c6f3cc53c856671', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8682a6c6f3cc53c856671%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8682a6c6f3cc53c856671%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8682a6c6f3cc53c856671%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8682a6c6f3cc53c856671%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8682a6c6f3cc53c856671%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c851e96c6f3cc53c85325c" data-idx="459">
+        <div class="book-header">
+          <span class="book-num">#460</span>
+          <h3>Die Warheit des sensus communis oder des allgemeinen Sinnes, in den nach dem Grundtext erklärten Sprüchen und Prediger Salomo</h3>
+          <span class="page-count">419 pp</span>
+          <a href="https://sourcelibrary.org/book/69c851e96c6f3cc53c85325c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c851e96c6f3cc53c85325c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c851e96c6f3cc53c85325c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c851e96c6f3cc53c85325c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c851e96c6f3cc53c85325c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c851e96c6f3cc53c85325c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851e96c6f3cc53c85325c%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851e96c6f3cc53c85325c%2F0168-full.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851e96c6f3cc53c85325c%2F0251-full.jpg&w=600" alt="Page 251" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.251 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851e96c6f3cc53c85325c%2F0335-full.jpg&w=600" alt="Page 335" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.335 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851e96c6f3cc53c85325c%2F0377-full.jpg&w=600" alt="Page 377" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.377 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4189ce9bfda40a8a6c7b9" data-idx="460">
+        <div class="book-header">
+          <span class="book-num">#461</span>
+          <h3>Paracelsus — Arabic Translation (PH254)</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/paracelsus-in-arabic-kimiya-al-malakiyah-royal-chemistry-sallum" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4189ce9bfda40a8a6c7b9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4189ce9bfda40a8a6c7b9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4189ce9bfda40a8a6c7b9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4189ce9bfda40a8a6c7b9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4189ce9bfda40a8a6c7b9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189ce9bfda40a8a6c7b9%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189ce9bfda40a8a6c7b9%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189ce9bfda40a8a6c7b9%2F56.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189ce9bfda40a8a6c7b9%2F74.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4189ce9bfda40a8a6c7b9%2F84.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2b36c6f3cc53c85e4b3" data-idx="461">
+        <div class="book-header">
+          <span class="book-num">#462</span>
+          <h3>In memoriam William John Songhurst</h3>
+          <span class="page-count">10 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2b36c6f3cc53c85e4b3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2b36c6f3cc53c85e4b3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2b36c6f3cc53c85e4b3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2b36c6f3cc53c85e4b3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2b36c6f3cc53c85e4b3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2b36c6f3cc53c85e4b3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2b36c6f3cc53c85e4b3%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2b36c6f3cc53c85e4b3%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2b36c6f3cc53c85e4b3%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2b36c6f3cc53c85e4b3%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2b36c6f3cc53c85e4b3%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c830ab6c6f3cc53c84dace" data-idx="462">
+        <div class="book-header">
+          <span class="book-num">#463</span>
+          <h3>Medicina practica, or, practical physick. Shewing the method of curing the most usual diseases</h3>
+          <span class="page-count">398 pp</span>
+          <a href="https://sourcelibrary.org/book/69c830ab6c6f3cc53c84dace" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c830ab6c6f3cc53c84dace', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c830ab6c6f3cc53c84dace', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c830ab6c6f3cc53c84dace', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c830ab6c6f3cc53c84dace', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c830ab6c6f3cc53c84dace', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830ab6c6f3cc53c84dace%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830ab6c6f3cc53c84dace%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830ab6c6f3cc53c84dace%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830ab6c6f3cc53c84dace%2F0318-full.jpg&w=600" alt="Page 318" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.318 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830ab6c6f3cc53c84dace%2F0358-full.jpg&w=600" alt="Page 358" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.358 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c886076c6f3cc53c859cce" data-idx="463">
+        <div class="book-header">
+          <span class="book-num">#464</span>
+          <h3>Problems of the Fama</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c886076c6f3cc53c859cce" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c886076c6f3cc53c859cce', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c886076c6f3cc53c859cce', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c886076c6f3cc53c859cce', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c886076c6f3cc53c859cce', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c886076c6f3cc53c859cce', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886076c6f3cc53c859cce%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886076c6f3cc53c859cce%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886076c6f3cc53c859cce%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886076c6f3cc53c859cce%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886076c6f3cc53c859cce%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c73f1a6a0f3d112faf7a97" data-idx="464">
+        <div class="book-header">
+          <span class="book-num">#465</span>
+          <h3>Recherches sur l'origine des découvertes attribuées aux modernes</h3>
+          <span class="page-count">278 pp</span>
+          <a href="https://sourcelibrary.org/book/69c73f1a6a0f3d112faf7a97" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c73f1a6a0f3d112faf7a97', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c73f1a6a0f3d112faf7a97', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c73f1a6a0f3d112faf7a97', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c73f1a6a0f3d112faf7a97', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c73f1a6a0f3d112faf7a97', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73f1a6a0f3d112faf7a97%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73f1a6a0f3d112faf7a97%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73f1a6a0f3d112faf7a97%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73f1a6a0f3d112faf7a97%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73f1a6a0f3d112faf7a97%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418d12b0edf3eaa2ddfbc" data-idx="465">
+        <div class="book-header">
+          <span class="book-num">#466</span>
+          <h3>Silence after Clamours — Michael Maier (PH160)</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/michael-maier-silence-after-clamours-rosicrucian-apology-russell" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418d12b0edf3eaa2ddfbc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418d12b0edf3eaa2ddfbc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418d12b0edf3eaa2ddfbc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418d12b0edf3eaa2ddfbc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418d12b0edf3eaa2ddfbc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d12b0edf3eaa2ddfbc%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d12b0edf3eaa2ddfbc%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d12b0edf3eaa2ddfbc%2F27.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d12b0edf3eaa2ddfbc%2F36.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d12b0edf3eaa2ddfbc%2F41.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4194dddff1f043992a186" data-idx="466">
+        <div class="book-header">
+          <span class="book-num">#467</span>
+          <h3>Copies of Letters — Carl Joseph von Campagne (PH455D)</h3>
+          <span class="page-count">62 pp</span>
+          <a href="https://sourcelibrary.org/book/campagne-alchemical-correspondence-1822-1869-campagne" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4194dddff1f043992a186', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4194dddff1f043992a186', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4194dddff1f043992a186', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4194dddff1f043992a186', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4194dddff1f043992a186', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194dddff1f043992a186%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4194dddff1f043992a186%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940542941605131!PH455D_0037.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940542941605131!PH455D_0050.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940542941605131!PH455D_0056.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fc5a6c6f3cc53c84304b" data-idx="467">
+        <div class="book-header">
+          <span class="book-num">#468</span>
+          <h3>Journal für Freimaurerei</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fc5a6c6f3cc53c84304b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fc5a6c6f3cc53c84304b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fc5a6c6f3cc53c84304b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fc5a6c6f3cc53c84304b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fc5a6c6f3cc53c84304b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fc5a6c6f3cc53c84304b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc5a6c6f3cc53c84304b%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc5a6c6f3cc53c84304b%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc5a6c6f3cc53c84304b%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc5a6c6f3cc53c84304b%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fc5a6c6f3cc53c84304b%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="68679f27fc518f6dbf334eb6" data-idx="468">
+        <div class="book-header">
+          <span class="book-num">#469</span>
+          <h3>Ander Theil Gnothi Seauton. Nosce teipsum. Astrologia theologizata</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/know-thyself-o-man-astrology-theologized-weigel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('68679f27fc518f6dbf334eb6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('68679f27fc518f6dbf334eb6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('68679f27fc518f6dbf334eb6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('68679f27fc518f6dbf334eb6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('68679f27fc518f6dbf334eb6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68679f27fc518f6dbf334eb6%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68679f27fc518f6dbf334eb6%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68679f27fc518f6dbf334eb6%2F39.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68679f27fc518f6dbf334eb6%2F52.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68679f27fc518f6dbf334eb6%2F59.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82cb66c6f3cc53c84cf65" data-idx="469">
+        <div class="book-header">
+          <span class="book-num">#470</span>
+          <h3>De resurrectione mortuorum libri III</h3>
+          <span class="page-count">201 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82cb66c6f3cc53c84cf65" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82cb66c6f3cc53c84cf65', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82cb66c6f3cc53c84cf65', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82cb66c6f3cc53c84cf65', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82cb66c6f3cc53c84cf65', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82cb66c6f3cc53c84cf65', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb66c6f3cc53c84cf65%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb66c6f3cc53c84cf65%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb66c6f3cc53c84cf65%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb66c6f3cc53c84cf65%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82cb66c6f3cc53c84cf65%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897ec6c6f3cc53c85c965" data-idx="470">
+        <div class="book-header">
+          <span class="book-num">#471</span>
+          <h3>An essay upon the symbolic centre of the earth</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897ec6c6f3cc53c85c965" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897ec6c6f3cc53c85c965', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897ec6c6f3cc53c85c965', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897ec6c6f3cc53c85c965', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897ec6c6f3cc53c85c965', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897ec6c6f3cc53c85c965', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897ec6c6f3cc53c85c965%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897ec6c6f3cc53c85c965%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897ec6c6f3cc53c85c965%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897ec6c6f3cc53c85c965%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897ec6c6f3cc53c85c965%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c840356c6f3cc53c850672" data-idx="471">
+        <div class="book-header">
+          <span class="book-num">#472</span>
+          <h3>Libri octo graece et latine</h3>
+          <span class="page-count">417 pp</span>
+          <a href="https://sourcelibrary.org/book/69c840356c6f3cc53c850672" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c840356c6f3cc53c850672', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c840356c6f3cc53c850672', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c840356c6f3cc53c850672', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c840356c6f3cc53c850672', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c840356c6f3cc53c850672', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c840356c6f3cc53c850672%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c840356c6f3cc53c850672%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c840356c6f3cc53c850672%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c840356c6f3cc53c850672%2F0334-full.jpg&w=600" alt="Page 334" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.334 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c840356c6f3cc53c850672%2F0375-full.jpg&w=600" alt="Page 375" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.375 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86d8c6c6f3cc53c856d5f" data-idx="472">
+        <div class="book-header">
+          <span class="book-num">#473</span>
+          <h3>The book of wonders</h3>
+          <span class="page-count">47 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86d8c6c6f3cc53c856d5f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86d8c6c6f3cc53c856d5f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86d8c6c6f3cc53c856d5f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86d8c6c6f3cc53c856d5f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86d8c6c6f3cc53c856d5f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86d8c6c6f3cc53c856d5f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d8c6c6f3cc53c856d5f%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d8c6c6f3cc53c856d5f%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d8c6c6f3cc53c856d5f%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d8c6c6f3cc53c856d5f%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d8c6c6f3cc53c856d5f%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82d476c6f3cc53c84d1cc" data-idx="473">
+        <div class="book-header">
+          <span class="book-num">#474</span>
+          <h3>Inri Liber librorum, confessio Christianorum. Die heilige Schrifft als ein offentliches Glaubensbekäntniss</h3>
+          <span class="page-count">65 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82d476c6f3cc53c84d1cc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82d476c6f3cc53c84d1cc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82d476c6f3cc53c84d1cc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82d476c6f3cc53c84d1cc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82d476c6f3cc53c84d1cc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82d476c6f3cc53c84d1cc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d476c6f3cc53c84d1cc%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d476c6f3cc53c84d1cc%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d476c6f3cc53c84d1cc%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d476c6f3cc53c84d1cc%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d476c6f3cc53c84d1cc%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c878ca6c6f3cc53c858341" data-idx="474">
+        <div class="book-header">
+          <span class="book-num">#475</span>
+          <h3>The heavenly cloud now breaking. The Lord Christ's ascension-ladder sent down; to shew the way to reach the ascension and glorification, through the death and resurrection</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/69c878ca6c6f3cc53c858341" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c878ca6c6f3cc53c858341', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c878ca6c6f3cc53c858341', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c878ca6c6f3cc53c858341', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c878ca6c6f3cc53c858341', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c878ca6c6f3cc53c858341', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878ca6c6f3cc53c858341%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878ca6c6f3cc53c858341%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878ca6c6f3cc53c858341%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878ca6c6f3cc53c858341%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878ca6c6f3cc53c858341%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a24f6c6f3cc53c85e3cd" data-idx="475">
+        <div class="book-header">
+          <span class="book-num">#476</span>
+          <h3>Divination and its history</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a24f6c6f3cc53c85e3cd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a24f6c6f3cc53c85e3cd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a24f6c6f3cc53c85e3cd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a24f6c6f3cc53c85e3cd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a24f6c6f3cc53c85e3cd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a24f6c6f3cc53c85e3cd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a24f6c6f3cc53c85e3cd%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a24f6c6f3cc53c85e3cd%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a24f6c6f3cc53c85e3cd%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a24f6c6f3cc53c85e3cd%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a24f6c6f3cc53c85e3cd%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8940c6c6f3cc53c85c03f" data-idx="476">
+        <div class="book-header">
+          <span class="book-num">#477</span>
+          <h3>The Celtic druids</h3>
+          <span class="page-count">279 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8940c6c6f3cc53c85c03f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8940c6c6f3cc53c85c03f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8940c6c6f3cc53c85c03f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8940c6c6f3cc53c85c03f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8940c6c6f3cc53c85c03f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8940c6c6f3cc53c85c03f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8940c6c6f3cc53c85c03f%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8940c6c6f3cc53c85c03f%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8940c6c6f3cc53c85c03f%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8940c6c6f3cc53c85c03f%2F0223-full.jpg&w=600" alt="Page 223" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.223 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8940c6c6f3cc53c85c03f%2F0251-full.jpg&w=600" alt="Page 251" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.251 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8001f6c6f3cc53c843e25" data-idx="477">
+        <div class="book-header">
+          <span class="book-num">#478</span>
+          <h3>De rerum varietate</h3>
+          <span class="page-count">659 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8001f6c6f3cc53c843e25" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8001f6c6f3cc53c843e25', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8001f6c6f3cc53c843e25', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8001f6c6f3cc53c843e25', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8001f6c6f3cc53c843e25', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8001f6c6f3cc53c843e25', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001f6c6f3cc53c843e25%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001f6c6f3cc53c843e25%2F0264-full.jpg&w=600" alt="Page 264" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.264 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001f6c6f3cc53c843e25%2F0395-full.jpg&w=600" alt="Page 395" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.395 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001f6c6f3cc53c843e25%2F0527-full.jpg&w=600" alt="Page 527" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.527 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8001f6c6f3cc53c843e25%2F0593-full.jpg&w=600" alt="Page 593" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.593 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70242da9771c71631580e" data-idx="478">
+        <div class="book-header">
+          <span class="book-num">#479</span>
+          <h3>Zwei schöne chymische Tractetlein: De Mercurio alchimistarum. De lumine naturae</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70242da9771c71631580e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70242da9771c71631580e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70242da9771c71631580e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70242da9771c71631580e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70242da9771c71631580e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70242da9771c71631580e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70242da9771c71631580e%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70242da9771c71631580e%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70242da9771c71631580e%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70242da9771c71631580e%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70242da9771c71631580e%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89d346c6f3cc53c85d7af" data-idx="479">
+        <div class="book-header">
+          <span class="book-num">#480</span>
+          <h3>Lexidion codicis Nasaraei, cui Liber Adami nomen</h3>
+          <span class="page-count">233 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89d346c6f3cc53c85d7af" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89d346c6f3cc53c85d7af', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89d346c6f3cc53c85d7af', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89d346c6f3cc53c85d7af', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89d346c6f3cc53c85d7af', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89d346c6f3cc53c85d7af', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d346c6f3cc53c85d7af%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d346c6f3cc53c85d7af%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d346c6f3cc53c85d7af%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d346c6f3cc53c85d7af%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d346c6f3cc53c85d7af%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c72de46a0f3d112faf7013" data-idx="480">
+        <div class="book-header">
+          <span class="book-num">#481</span>
+          <h3>Abdita divinae cabalae mysteria, contra sophistarum logomachiam defensa</h3>
+          <span class="page-count">47 pp</span>
+          <a href="https://sourcelibrary.org/book/69c72de46a0f3d112faf7013" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c72de46a0f3d112faf7013', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c72de46a0f3d112faf7013', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c72de46a0f3d112faf7013', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c72de46a0f3d112faf7013', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c72de46a0f3d112faf7013', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72de46a0f3d112faf7013%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72de46a0f3d112faf7013%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72de46a0f3d112faf7013%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72de46a0f3d112faf7013%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72de46a0f3d112faf7013%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866496c6f3cc53c8563bc" data-idx="481">
+        <div class="book-header">
+          <span class="book-num">#482</span>
+          <h3>The aims and claims of the alchemists</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866496c6f3cc53c8563bc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866496c6f3cc53c8563bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866496c6f3cc53c8563bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866496c6f3cc53c8563bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866496c6f3cc53c8563bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866496c6f3cc53c8563bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866496c6f3cc53c8563bc%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866496c6f3cc53c8563bc%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866496c6f3cc53c8563bc%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866496c6f3cc53c8563bc%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866496c6f3cc53c8563bc%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898216c6f3cc53c85ca18" data-idx="482">
+        <div class="book-header">
+          <span class="book-num">#483</span>
+          <h3>Solve et coagula and the synthetic philosophy</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898216c6f3cc53c85ca18" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898216c6f3cc53c85ca18', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898216c6f3cc53c85ca18', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898216c6f3cc53c85ca18', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898216c6f3cc53c85ca18', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898216c6f3cc53c85ca18', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898216c6f3cc53c85ca18%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898216c6f3cc53c85ca18%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898216c6f3cc53c85ca18%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898216c6f3cc53c85ca18%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898216c6f3cc53c85ca18%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c809096c6f3cc53c845fb9" data-idx="483">
+        <div class="book-header">
+          <span class="book-num">#484</span>
+          <h3>El mayor thesoro. Tratado del arte de la alchimia, o chrysopoeya, que ofrece la entrada abierta, al cerrado palacio del rey</h3>
+          <span class="page-count">177 pp</span>
+          <a href="https://sourcelibrary.org/book/69c809096c6f3cc53c845fb9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c809096c6f3cc53c845fb9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c809096c6f3cc53c845fb9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c809096c6f3cc53c845fb9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c809096c6f3cc53c845fb9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c809096c6f3cc53c845fb9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809096c6f3cc53c845fb9%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809096c6f3cc53c845fb9%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809096c6f3cc53c845fb9%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809096c6f3cc53c845fb9%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809096c6f3cc53c845fb9%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c853c66c6f3cc53c8536f2" data-idx="484">
+        <div class="book-header">
+          <span class="book-num">#485</span>
+          <h3>Kirchen- oder Haus-Postill, über die Sonntags- und fürnehmste Fest-Evangelien durchs gantze Jahr</h3>
+          <span class="page-count">336 pp</span>
+          <a href="https://sourcelibrary.org/book/69c853c66c6f3cc53c8536f2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c853c66c6f3cc53c8536f2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c853c66c6f3cc53c8536f2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c853c66c6f3cc53c8536f2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c853c66c6f3cc53c8536f2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c853c66c6f3cc53c8536f2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853c66c6f3cc53c8536f2%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853c66c6f3cc53c8536f2%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853c66c6f3cc53c8536f2%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853c66c6f3cc53c8536f2%2F0269-full.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c853c66c6f3cc53c8536f2%2F0302-full.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c815276c6f3cc53c8484be" data-idx="485">
+        <div class="book-header">
+          <span class="book-num">#486</span>
+          <h3>Veritas sui vindex seu solennis fidei declaratio</h3>
+          <span class="page-count">144 pp</span>
+          <a href="https://sourcelibrary.org/book/69c815276c6f3cc53c8484be" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c815276c6f3cc53c8484be', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c815276c6f3cc53c8484be', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c815276c6f3cc53c8484be', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c815276c6f3cc53c8484be', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c815276c6f3cc53c8484be', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815276c6f3cc53c8484be%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815276c6f3cc53c8484be%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815276c6f3cc53c8484be%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815276c6f3cc53c8484be%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815276c6f3cc53c8484be%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418dc2b0edf3eaa2de112" data-idx="486">
+        <div class="book-header">
+          <span class="book-num">#487</span>
+          <h3>Rosicrucian Text (PH313)</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/rosicrucian-ms-17th-century-german" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418dc2b0edf3eaa2de112', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418dc2b0edf3eaa2de112', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418dc2b0edf3eaa2de112', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418dc2b0edf3eaa2de112', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418dc2b0edf3eaa2de112', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418dc2b0edf3eaa2de112%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418dc2b0edf3eaa2de112%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940500638405131!PH313_0026.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940500638405131!PH313_0034.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940500638405131!PH313_0039.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c702bcda9771c716315874" data-idx="487">
+        <div class="book-header">
+          <span class="book-num">#488</span>
+          <h3>Zwey rare chymische Tractätlein.   Sonnen-Blume der Weisen. Gründliche Antwort</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/69c702bcda9771c716315874" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c702bcda9771c716315874', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c702bcda9771c716315874', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c702bcda9771c716315874', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c702bcda9771c716315874', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c702bcda9771c716315874', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c702bcda9771c716315874%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c702bcda9771c716315874%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c702bcda9771c716315874%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c702bcda9771c716315874%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c702bcda9771c716315874%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c752786a0f3d112faf861a" data-idx="488">
+        <div class="book-header">
+          <span class="book-num">#489</span>
+          <h3>Catalogus librorum, quos Lazarus Zetznerus bibliopola argentoratens P.M. &amp; posteum, haeredes eius hactenus aut propriis sumptibus imprimi curarunt</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c752786a0f3d112faf861a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c752786a0f3d112faf861a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c752786a0f3d112faf861a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c752786a0f3d112faf861a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c752786a0f3d112faf861a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c752786a0f3d112faf861a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c752786a0f3d112faf861a%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c752786a0f3d112faf861a%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c752786a0f3d112faf861a%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c752786a0f3d112faf861a%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c752786a0f3d112faf861a%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c827616c6f3cc53c84c022" data-idx="489">
+        <div class="book-header">
+          <span class="book-num">#490</span>
+          <h3>Het regt gebruik der werelt beschouwingen, ter overtuiginge van ongodisten en ongelovigen</h3>
+          <span class="page-count">543 pp</span>
+          <a href="https://sourcelibrary.org/book/69c827616c6f3cc53c84c022" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c827616c6f3cc53c84c022', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c827616c6f3cc53c84c022', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c827616c6f3cc53c84c022', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c827616c6f3cc53c84c022', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c827616c6f3cc53c84c022', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827616c6f3cc53c84c022%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827616c6f3cc53c84c022%2F0217-full.jpg&w=600" alt="Page 217" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.217 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827616c6f3cc53c84c022%2F0326-full.jpg&w=600" alt="Page 326" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.326 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827616c6f3cc53c84c022%2F0434-full.jpg&w=600" alt="Page 434" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.434 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c827616c6f3cc53c84c022%2F0489-full.jpg&w=600" alt="Page 489" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.489 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fda46c6f3cc53c84349e" data-idx="490">
+        <div class="book-header">
+          <span class="book-num">#491</span>
+          <h3>Contes et fables indiennes de Bidpaï et de Lokman</h3>
+          <span class="page-count">236 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fda46c6f3cc53c84349e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fda46c6f3cc53c84349e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fda46c6f3cc53c84349e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fda46c6f3cc53c84349e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fda46c6f3cc53c84349e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fda46c6f3cc53c84349e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fda46c6f3cc53c84349e%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fda46c6f3cc53c84349e%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fda46c6f3cc53c84349e%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fda46c6f3cc53c84349e%2F0189-full.jpg&w=600" alt="Page 189" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.189 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fda46c6f3cc53c84349e%2F0212-full.jpg&w=600" alt="Page 212" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.212 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4190d2b0edf3eaa2dea16" data-idx="491">
+        <div class="book-header">
+          <span class="book-num">#492</span>
+          <h3>Bibliothèque des Sages — Basil Valentine, Khunrath, Hollandus et al. (PH243)</h3>
+          <span class="page-count">241 pp</span>
+          <a href="https://sourcelibrary.org/book/library-of-the-sages-valentine-khunrath-hollandus-bernard-trevisan" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4190d2b0edf3eaa2dea16', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4190d2b0edf3eaa2dea16', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4190d2b0edf3eaa2dea16', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4190d2b0edf3eaa2dea16', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4190d2b0edf3eaa2dea16', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4190d2b0edf3eaa2dea16%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4190d2b0edf3eaa2dea16%2F96.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4190d2b0edf3eaa2dea16%2F145.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4190d2b0edf3eaa2dea16%2F193.jpg&w=600" alt="Page 193" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.193 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940519440305131!PH243_0217.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 217" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.217 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c809c06c6f3cc53c84624a" data-idx="492">
+        <div class="book-header">
+          <span class="book-num">#493</span>
+          <h3>Opera omnia quibus tradidit Artis Raymundi Lulliu compendiosam explicationem</h3>
+          <span class="page-count">351 pp</span>
+          <a href="https://sourcelibrary.org/book/69c809c06c6f3cc53c84624a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c809c06c6f3cc53c84624a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c809c06c6f3cc53c84624a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c809c06c6f3cc53c84624a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c809c06c6f3cc53c84624a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c809c06c6f3cc53c84624a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809c06c6f3cc53c84624a%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809c06c6f3cc53c84624a%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809c06c6f3cc53c84624a%2F0211-full.jpg&w=600" alt="Page 211" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.211 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809c06c6f3cc53c84624a%2F0281-full.jpg&w=600" alt="Page 281" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.281 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809c06c6f3cc53c84624a%2F0316-full.jpg&w=600" alt="Page 316" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.316 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ad3625ec2ba5ccd7f19b" data-idx="493">
+        <div class="book-header">
+          <span class="book-num">#494</span>
+          <h3>In nomine Jesu. Majestas &amp; potentia, libertas &amp; justitia, spes &amp; victoria, triumphus &amp; gloria christianorum cum capite Christo. Das Wunder Geheimniss von der Christen Recht, Freyheit, Erbtheil, Gewalt, Reich, Herrschafft, Krafft [...] und mit Christo ihrem Könige über alles</h3>
+          <span class="page-count">47 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ad3625ec2ba5ccd7f19b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ad3625ec2ba5ccd7f19b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ad3625ec2ba5ccd7f19b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ad3625ec2ba5ccd7f19b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ad3625ec2ba5ccd7f19b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ad3625ec2ba5ccd7f19b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19b%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19b%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19b%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19b%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad3625ec2ba5ccd7f19b%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ac9e92b884e4f8173e9c" data-idx="494">
+        <div class="book-header">
+          <span class="book-num">#495</span>
+          <h3>Entretiens sur la pluralité des mondes</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ac9e92b884e4f8173e9c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ac9e92b884e4f8173e9c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ac9e92b884e4f8173e9c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ac9e92b884e4f8173e9c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ac9e92b884e4f8173e9c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ac9e92b884e4f8173e9c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ac9e92b884e4f8173e9c%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ac9e92b884e4f8173e9c%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ac9e92b884e4f8173e9c%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ac9e92b884e4f8173e9c%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ac9e92b884e4f8173e9c%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c3284e0787282ad5936c1" data-idx="495">
+        <div class="book-header">
+          <span class="book-num">#496</span>
+          <h3>Kennzeichen der wahren Wiedergeburt und des Erneuerung des Geistes</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/characteristics-of-the-true-rebirth-and-renewal-of-the-eisler" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c3284e0787282ad5936c1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c3284e0787282ad5936c1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c3284e0787282ad5936c1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c3284e0787282ad5936c1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c3284e0787282ad5936c1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3284e0787282ad5936c1%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3284e0787282ad5936c1%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3284e0787282ad5936c1%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3284e0787282ad5936c1%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3284e0787282ad5936c1%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89be56c6f3cc53c85d483" data-idx="496">
+        <div class="book-header">
+          <span class="book-num">#497</span>
+          <h3>Secrets of Nature and Science</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89be56c6f3cc53c85d483" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89be56c6f3cc53c85d483', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89be56c6f3cc53c85d483', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89be56c6f3cc53c85d483', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89be56c6f3cc53c85d483', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89be56c6f3cc53c85d483', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89be56c6f3cc53c85d483%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89be56c6f3cc53c85d483%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89be56c6f3cc53c85d483%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89be56c6f3cc53c85d483%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89be56c6f3cc53c85d483%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c857c16c6f3cc53c8540f8" data-idx="497">
+        <div class="book-header">
+          <span class="book-num">#498</span>
+          <h3>Gedächtniss-Rede bey Beerdigung des [...] Herrn Gottfried Arnold</h3>
+          <span class="page-count">255 pp</span>
+          <a href="https://sourcelibrary.org/book/69c857c16c6f3cc53c8540f8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c857c16c6f3cc53c8540f8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c857c16c6f3cc53c8540f8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c857c16c6f3cc53c8540f8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c857c16c6f3cc53c8540f8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c857c16c6f3cc53c8540f8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857c16c6f3cc53c8540f8%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857c16c6f3cc53c8540f8%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857c16c6f3cc53c8540f8%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857c16c6f3cc53c8540f8%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857c16c6f3cc53c8540f8%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a26f6c6f3cc53c85e418" data-idx="498">
+        <div class="book-header">
+          <span class="book-num">#499</span>
+          <h3>The prehistoric statues of Easter Island</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a26f6c6f3cc53c85e418" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a26f6c6f3cc53c85e418', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a26f6c6f3cc53c85e418', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a26f6c6f3cc53c85e418', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a26f6c6f3cc53c85e418', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a26f6c6f3cc53c85e418', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a26f6c6f3cc53c85e418%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a26f6c6f3cc53c85e418%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a26f6c6f3cc53c85e418%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a26f6c6f3cc53c85e418%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a26f6c6f3cc53c85e418%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418b22b0edf3eaa2dda8d" data-idx="499">
+        <div class="book-header">
+          <span class="book-num">#500</span>
+          <h3>Zecor Beni sive Clavicola Salomonis (PH297)</h3>
+          <span class="page-count">161 pp</span>
+          <a href="https://sourcelibrary.org/book/key-of-solomon-latin-ms-18th-c-colorni" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418b22b0edf3eaa2dda8d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418b22b0edf3eaa2dda8d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418b22b0edf3eaa2dda8d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418b22b0edf3eaa2dda8d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418b22b0edf3eaa2dda8d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b22b0edf3eaa2dda8d%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485728505131!PH297_064.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485728505131!PH297_097.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485728505131!PH297_129.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940485728505131!PH297_145.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html" class="active">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-6.html
+++ b/public/split-review-6.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 6/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html" class="active">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c88cce6c6f3cc53c85ad63" data-idx="500">
+        <div class="book-header">
+          <span class="book-num">#501</span>
+          <h3>The third book of wonders</h3>
+          <span class="page-count">33 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88cce6c6f3cc53c85ad63" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88cce6c6f3cc53c85ad63', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88cce6c6f3cc53c85ad63', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88cce6c6f3cc53c85ad63', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88cce6c6f3cc53c85ad63', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88cce6c6f3cc53c85ad63', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cce6c6f3cc53c85ad63%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cce6c6f3cc53c85ad63%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cce6c6f3cc53c85ad63%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cce6c6f3cc53c85ad63%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88cce6c6f3cc53c85ad63%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897636c6f3cc53c85c7eb" data-idx="501">
+        <div class="book-header">
+          <span class="book-num">#502</span>
+          <h3>Der sichtbare und der unsichtbare Mensch. Darstellung verschiedener Menschentypen, wie der geschulte Hellseher sie wahrnimmt</h3>
+          <span class="page-count">116 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897636c6f3cc53c85c7eb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897636c6f3cc53c85c7eb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897636c6f3cc53c85c7eb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897636c6f3cc53c85c7eb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897636c6f3cc53c85c7eb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897636c6f3cc53c85c7eb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897636c6f3cc53c85c7eb%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897636c6f3cc53c85c7eb%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897636c6f3cc53c85c7eb%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897636c6f3cc53c85c7eb%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897636c6f3cc53c85c7eb%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7835c6a0f3d112faf9786" data-idx="502">
+        <div class="book-header">
+          <span class="book-num">#503</span>
+          <h3>Dissertatio collectanea, De civitatibus Germaniae liberis, et mixtis</h3>
+          <span class="page-count">71 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7835c6a0f3d112faf9786" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7835c6a0f3d112faf9786', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7835c6a0f3d112faf9786', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7835c6a0f3d112faf9786', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7835c6a0f3d112faf9786', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7835c6a0f3d112faf9786', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7835c6a0f3d112faf9786%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7835c6a0f3d112faf9786%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7835c6a0f3d112faf9786%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7835c6a0f3d112faf9786%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7835c6a0f3d112faf9786%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c886236c6f3cc53c859d1d" data-idx="503">
+        <div class="book-header">
+          <span class="book-num">#504</span>
+          <h3>Qabbalah. The philosophical writings of Solomon Ben Yehuda Ibn Gebirol or Avicebron</h3>
+          <span class="page-count">278 pp</span>
+          <a href="https://sourcelibrary.org/book/69c886236c6f3cc53c859d1d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c886236c6f3cc53c859d1d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c886236c6f3cc53c859d1d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c886236c6f3cc53c859d1d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c886236c6f3cc53c859d1d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c886236c6f3cc53c859d1d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886236c6f3cc53c859d1d%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886236c6f3cc53c859d1d%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886236c6f3cc53c859d1d%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886236c6f3cc53c859d1d%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c886236c6f3cc53c859d1d%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6e84dda9771c7163145fd" data-idx="504">
+        <div class="book-header">
+          <span class="book-num">#505</span>
+          <h3>Über den wahren Ursprung der Rosenkreuzer und des Freymaurerordens</h3>
+          <span class="page-count">87 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6e84dda9771c7163145fd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6e84dda9771c7163145fd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6e84dda9771c7163145fd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6e84dda9771c7163145fd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6e84dda9771c7163145fd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6e84dda9771c7163145fd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fd%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fd%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fd%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fd%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fd%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909c9d0cf28baa1b4cafc1b" data-idx="505">
+        <div class="book-header">
+          <span class="book-num">#506</span>
+          <h3>Philosophia maturata, oder ein ausführlicher philosophischer Tractat</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/mature-philosophy-or-a-detailed-philosophical-treatise-colson" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909c9d0cf28baa1b4cafc1b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909c9d0cf28baa1b4cafc1b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909c9d0cf28baa1b4cafc1b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909c9d0cf28baa1b4cafc1b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909c9d0cf28baa1b4cafc1b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c9d0cf28baa1b4cafc1b%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c9d0cf28baa1b4cafc1b%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c9d0cf28baa1b4cafc1b%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c9d0cf28baa1b4cafc1b%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909c9d0cf28baa1b4cafc1b%2F48.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6fb29da9771c71631538c" data-idx="506">
+        <div class="book-header">
+          <span class="book-num">#507</span>
+          <h3>Zahlenlehre der Natur</h3>
+          <span class="page-count">221 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6fb29da9771c71631538c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6fb29da9771c71631538c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6fb29da9771c71631538c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6fb29da9771c71631538c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6fb29da9771c71631538c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6fb29da9771c71631538c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fb29da9771c71631538c%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fb29da9771c71631538c%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fb29da9771c71631538c%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fb29da9771c71631538c%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fb29da9771c71631538c%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f231f08a1a5ab805c03c" data-idx="507">
+        <div class="book-header">
+          <span class="book-num">#508</span>
+          <h3>De legibus Hebraeorum ritualibus et earum rationibus libri tres</h3>
+          <span class="page-count">809 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f231f08a1a5ab805c03c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f231f08a1a5ab805c03c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f231f08a1a5ab805c03c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f231f08a1a5ab805c03c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f231f08a1a5ab805c03c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f231f08a1a5ab805c03c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f231f08a1a5ab805c03c%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f231f08a1a5ab805c03c%2F0324-full.jpg&w=600" alt="Page 324" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.324 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f231f08a1a5ab805c03c%2F0485-full.jpg&w=600" alt="Page 485" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.485 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f231f08a1a5ab805c03c%2F0647-full.jpg&w=600" alt="Page 647" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.647 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f231f08a1a5ab805c03c%2F0728-full.jpg&w=600" alt="Page 728" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.728 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69099ab2cf28baa1b4cae97f" data-idx="508">
+        <div class="book-header">
+          <span class="book-num">#509</span>
+          <h3>Drey christliche Predigten von Versuchungen</h3>
+          <span class="page-count">189 pp</span>
+          <a href="https://sourcelibrary.org/book/three-christian-sermons-on-temptations-spener" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69099ab2cf28baa1b4cae97f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69099ab2cf28baa1b4cae97f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69099ab2cf28baa1b4cae97f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69099ab2cf28baa1b4cae97f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69099ab2cf28baa1b4cae97f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099ab2cf28baa1b4cae97f%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099ab2cf28baa1b4cae97f%2F76.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099ab2cf28baa1b4cae97f%2F113.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099ab2cf28baa1b4cae97f%2F151.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69099ab2cf28baa1b4cae97f%2F170.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7246301e1be0c9ac74b72" data-idx="509">
+        <div class="book-header">
+          <span class="book-num">#510</span>
+          <h3>Erster Entwurf eines Systems der Naturphilosophie</h3>
+          <span class="page-count">173 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7246301e1be0c9ac74b72" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7246301e1be0c9ac74b72', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7246301e1be0c9ac74b72', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7246301e1be0c9ac74b72', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7246301e1be0c9ac74b72', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7246301e1be0c9ac74b72', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7246301e1be0c9ac74b72%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7246301e1be0c9ac74b72%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7246301e1be0c9ac74b72%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7246301e1be0c9ac74b72%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7246301e1be0c9ac74b72%2F0156-full.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c881c06c6f3cc53c8593a3" data-idx="510">
+        <div class="book-header">
+          <span class="book-num">#511</span>
+          <h3>Origine de tous les cultes ou religion universelle</h3>
+          <span class="page-count">291 pp</span>
+          <a href="https://sourcelibrary.org/book/69c881c06c6f3cc53c8593a3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c881c06c6f3cc53c8593a3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c881c06c6f3cc53c8593a3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c881c06c6f3cc53c8593a3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c881c06c6f3cc53c8593a3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c881c06c6f3cc53c8593a3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881c06c6f3cc53c8593a3%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881c06c6f3cc53c8593a3%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881c06c6f3cc53c8593a3%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881c06c6f3cc53c8593a3%2F0233-full.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881c06c6f3cc53c8593a3%2F0262-full.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c703a9da9771c716315943" data-idx="511">
+        <div class="book-header">
+          <span class="book-num">#512</span>
+          <h3>Les aventures du philosophe inconnu, en la recherche &amp; en l'invention de la pierre philosophale</h3>
+          <span class="page-count">121 pp</span>
+          <a href="https://sourcelibrary.org/book/69c703a9da9771c716315943" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c703a9da9771c716315943', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c703a9da9771c716315943', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c703a9da9771c716315943', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c703a9da9771c716315943', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c703a9da9771c716315943', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703a9da9771c716315943%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703a9da9771c716315943%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703a9da9771c716315943%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703a9da9771c716315943%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703a9da9771c716315943%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81e8d6c6f3cc53c84a29b" data-idx="512">
+        <div class="book-header">
+          <span class="book-num">#513</span>
+          <h3>Relation auss Parnasso</h3>
+          <span class="page-count">98 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81e8d6c6f3cc53c84a29b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81e8d6c6f3cc53c84a29b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81e8d6c6f3cc53c84a29b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81e8d6c6f3cc53c84a29b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81e8d6c6f3cc53c84a29b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81e8d6c6f3cc53c84a29b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e8d6c6f3cc53c84a29b%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e8d6c6f3cc53c84a29b%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e8d6c6f3cc53c84a29b%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e8d6c6f3cc53c84a29b%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81e8d6c6f3cc53c84a29b%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898086c6f3cc53c85c9d0" data-idx="513">
+        <div class="book-header">
+          <span class="book-num">#514</span>
+          <h3>An introduction to the hermetic philosophy</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898086c6f3cc53c85c9d0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898086c6f3cc53c85c9d0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898086c6f3cc53c85c9d0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898086c6f3cc53c85c9d0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898086c6f3cc53c85c9d0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898086c6f3cc53c85c9d0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898086c6f3cc53c85c9d0%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898086c6f3cc53c85c9d0%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898086c6f3cc53c85c9d0%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898086c6f3cc53c85c9d0%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898086c6f3cc53c85c9d0%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8972c6c6f3cc53c85c744" data-idx="514">
+        <div class="book-header">
+          <span class="book-num">#515</span>
+          <h3>The tarot of the Bohemians. Absolute key to occult science</h3>
+          <span class="page-count">230 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8972c6c6f3cc53c85c744" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8972c6c6f3cc53c85c744', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8972c6c6f3cc53c85c744', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8972c6c6f3cc53c85c744', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8972c6c6f3cc53c85c744', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8972c6c6f3cc53c85c744', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8972c6c6f3cc53c85c744%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8972c6c6f3cc53c85c744%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8972c6c6f3cc53c85c744%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8972c6c6f3cc53c85c744%2F0184-full.jpg&w=600" alt="Page 184" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.184 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8972c6c6f3cc53c85c744%2F0207-full.jpg&w=600" alt="Page 207" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.207 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c880496c6f3cc53c859041" data-idx="515">
+        <div class="book-header">
+          <span class="book-num">#516</span>
+          <h3>Mythologiae christianae sive virtutum &amp; vitiorum vitae humanae imaginum libri tres</h3>
+          <span class="page-count">197 pp</span>
+          <a href="https://sourcelibrary.org/book/69c880496c6f3cc53c859041" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c880496c6f3cc53c859041', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c880496c6f3cc53c859041', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c880496c6f3cc53c859041', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c880496c6f3cc53c859041', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c880496c6f3cc53c859041', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880496c6f3cc53c859041%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880496c6f3cc53c859041%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880496c6f3cc53c859041%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880496c6f3cc53c859041%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880496c6f3cc53c859041%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2e26c6f3cc53c85e51f" data-idx="516">
+        <div class="book-header">
+          <span class="book-num">#517</span>
+          <h3>Hussiten Krieg</h3>
+          <span class="page-count">233 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2e26c6f3cc53c85e51f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2e26c6f3cc53c85e51f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2e26c6f3cc53c85e51f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2e26c6f3cc53c85e51f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2e26c6f3cc53c85e51f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2e26c6f3cc53c85e51f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2e26c6f3cc53c85e51f%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2e26c6f3cc53c85e51f%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2e26c6f3cc53c85e51f%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2e26c6f3cc53c85e51f%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2e26c6f3cc53c85e51f%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c784016a0f3d112faf9849" data-idx="517">
+        <div class="book-header">
+          <span class="book-num">#518</span>
+          <h3>[Greek: Mysterion apokatastaseos artes panton], das ist: das Geheimniss der Wiederbringung aller Dinge</h3>
+          <span class="page-count">1083 pp</span>
+          <a href="https://sourcelibrary.org/book/69c784016a0f3d112faf9849" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c784016a0f3d112faf9849', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c784016a0f3d112faf9849', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c784016a0f3d112faf9849', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c784016a0f3d112faf9849', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c784016a0f3d112faf9849', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c784016a0f3d112faf9849%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c784016a0f3d112faf9849%2F0433-full.jpg&w=600" alt="Page 433" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.433 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c784016a0f3d112faf9849%2F0650-full.jpg&w=600" alt="Page 650" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.650 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c784016a0f3d112faf9849%2F0866-full.jpg&w=600" alt="Page 866" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.866 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c784016a0f3d112faf9849%2F0975-full.jpg&w=600" alt="Page 975" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.975 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f3ea6c6f3cc53c841670" data-idx="518">
+        <div class="book-header">
+          <span class="book-num">#519</span>
+          <h3>Opere</h3>
+          <span class="page-count">213 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f3ea6c6f3cc53c841670" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f3ea6c6f3cc53c841670', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f3ea6c6f3cc53c841670', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f3ea6c6f3cc53c841670', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f3ea6c6f3cc53c841670', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f3ea6c6f3cc53c841670', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ea6c6f3cc53c841670%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ea6c6f3cc53c841670%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ea6c6f3cc53c841670%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ea6c6f3cc53c841670%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3ea6c6f3cc53c841670%2F0192-full.jpg&w=600" alt="Page 192" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.192 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8681f6c6f3cc53c856667" data-idx="519">
+        <div class="book-header">
+          <span class="book-num">#520</span>
+          <h3>Ander Theil [Greek: Gnothi seauton]. Nosce teipsum [!]. Erkenne dich selber O Mensch: heisset Astrologia theologizata</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8681f6c6f3cc53c856667" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8681f6c6f3cc53c856667', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8681f6c6f3cc53c856667', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8681f6c6f3cc53c856667', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8681f6c6f3cc53c856667', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8681f6c6f3cc53c856667', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8681f6c6f3cc53c856667%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8681f6c6f3cc53c856667%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8681f6c6f3cc53c856667%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8681f6c6f3cc53c856667%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8681f6c6f3cc53c856667%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8330b6c6f3cc53c84e140" data-idx="520">
+        <div class="book-header">
+          <span class="book-num">#521</span>
+          <h3>Ausführliche Nachricht von seinen eigenen Schrifften [...] der Welt-Weissheit</h3>
+          <span class="page-count">357 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8330b6c6f3cc53c84e140" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8330b6c6f3cc53c84e140', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8330b6c6f3cc53c84e140', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8330b6c6f3cc53c84e140', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8330b6c6f3cc53c84e140', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8330b6c6f3cc53c84e140', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8330b6c6f3cc53c84e140%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8330b6c6f3cc53c84e140%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8330b6c6f3cc53c84e140%2F0214-full.jpg&w=600" alt="Page 214" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.214 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8330b6c6f3cc53c84e140%2F0286-full.jpg&w=600" alt="Page 286" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.286 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8330b6c6f3cc53c84e140%2F0321-full.jpg&w=600" alt="Page 321" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.321 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8592b6c6f3cc53c854494" data-idx="521">
+        <div class="book-header">
+          <span class="book-num">#522</span>
+          <h3>Horologium Hebraeum</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8592b6c6f3cc53c854494" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8592b6c6f3cc53c854494', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8592b6c6f3cc53c854494', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8592b6c6f3cc53c854494', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8592b6c6f3cc53c854494', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8592b6c6f3cc53c854494', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8592b6c6f3cc53c854494%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8592b6c6f3cc53c854494%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8592b6c6f3cc53c854494%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8592b6c6f3cc53c854494%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8592b6c6f3cc53c854494%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866786c6f3cc53c85640c" data-idx="522">
+        <div class="book-header">
+          <span class="book-num">#523</span>
+          <h3>Alchemistische und chemische Zeichen</h3>
+          <span class="page-count">98 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866786c6f3cc53c85640c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866786c6f3cc53c85640c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866786c6f3cc53c85640c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866786c6f3cc53c85640c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866786c6f3cc53c85640c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866786c6f3cc53c85640c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866786c6f3cc53c85640c%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866786c6f3cc53c85640c%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866786c6f3cc53c85640c%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866786c6f3cc53c85640c%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c866786c6f3cc53c85640c%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83c916c6f3cc53c84f9f1" data-idx="523">
+        <div class="book-header">
+          <span class="book-num">#524</span>
+          <h3>The absolute unlawfulness of the stage entertainment fully demonstrated</h3>
+          <span class="page-count">33 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83c916c6f3cc53c84f9f1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83c916c6f3cc53c84f9f1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83c916c6f3cc53c84f9f1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83c916c6f3cc53c84f9f1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83c916c6f3cc53c84f9f1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83c916c6f3cc53c84f9f1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c916c6f3cc53c84f9f1%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c916c6f3cc53c84f9f1%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c916c6f3cc53c84f9f1%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c916c6f3cc53c84f9f1%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83c916c6f3cc53c84f9f1%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88ce76c6f3cc53c85ad8f" data-idx="524">
+        <div class="book-header">
+          <span class="book-num">#525</span>
+          <h3>Transactions of the Blavatsky Lodge of the Theosophical Society. Discussions on the stanzas of the first volume of The secret doctrine</h3>
+          <span class="page-count">40 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88ce76c6f3cc53c85ad8f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88ce76c6f3cc53c85ad8f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88ce76c6f3cc53c85ad8f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88ce76c6f3cc53c85ad8f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88ce76c6f3cc53c85ad8f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88ce76c6f3cc53c85ad8f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ce76c6f3cc53c85ad8f%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ce76c6f3cc53c85ad8f%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ce76c6f3cc53c85ad8f%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ce76c6f3cc53c85ad8f%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88ce76c6f3cc53c85ad8f%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83eb36c6f3cc53c850242" data-idx="525">
+        <div class="book-header">
+          <span class="book-num">#526</span>
+          <h3>Tabula aurea. Darinnen er den andern Theil seiner Philosophiae novae proponiren und fürstellen thut</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83eb36c6f3cc53c850242" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83eb36c6f3cc53c850242', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83eb36c6f3cc53c850242', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83eb36c6f3cc53c850242', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83eb36c6f3cc53c850242', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83eb36c6f3cc53c850242', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83eb36c6f3cc53c850242%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83eb36c6f3cc53c850242%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83eb36c6f3cc53c850242%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83eb36c6f3cc53c850242%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83eb36c6f3cc53c850242%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c804886c6f3cc53c844ebe" data-idx="526">
+        <div class="book-header">
+          <span class="book-num">#527</span>
+          <h3>The absolute unlawfulness of the stage entertainment fully demonstrated</h3>
+          <span class="page-count">191 pp</span>
+          <a href="https://sourcelibrary.org/book/69c804886c6f3cc53c844ebe" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c804886c6f3cc53c844ebe', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c804886c6f3cc53c844ebe', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c804886c6f3cc53c844ebe', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c804886c6f3cc53c844ebe', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c804886c6f3cc53c844ebe', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804886c6f3cc53c844ebe%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804886c6f3cc53c844ebe%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804886c6f3cc53c844ebe%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804886c6f3cc53c844ebe%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804886c6f3cc53c844ebe%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c769d76a0f3d112faf8f58" data-idx="527">
+        <div class="book-header">
+          <span class="book-num">#528</span>
+          <h3>Histoire des Celtes</h3>
+          <span class="page-count">366 pp</span>
+          <a href="https://sourcelibrary.org/book/69c769d76a0f3d112faf8f58" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c769d76a0f3d112faf8f58', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c769d76a0f3d112faf8f58', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c769d76a0f3d112faf8f58', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c769d76a0f3d112faf8f58', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c769d76a0f3d112faf8f58', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c769d76a0f3d112faf8f58%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c769d76a0f3d112faf8f58%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c769d76a0f3d112faf8f58%2F0220-full.jpg&w=600" alt="Page 220" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.220 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c769d76a0f3d112faf8f58%2F0293-full.jpg&w=600" alt="Page 293" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.293 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c769d76a0f3d112faf8f58%2F0329-full.jpg&w=600" alt="Page 329" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.329 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ed1bda9771c7163149b5" data-idx="528">
+        <div class="book-header">
+          <span class="book-num">#529</span>
+          <h3>The way to Christ discovered</h3>
+          <span class="page-count">185 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ed1bda9771c7163149b5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ed1bda9771c7163149b5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ed1bda9771c7163149b5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ed1bda9771c7163149b5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ed1bda9771c7163149b5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ed1bda9771c7163149b5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed1bda9771c7163149b5%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed1bda9771c7163149b5%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed1bda9771c7163149b5%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed1bda9771c7163149b5%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ed1bda9771c7163149b5%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80b756c6f3cc53c84678b" data-idx="529">
+        <div class="book-header">
+          <span class="book-num">#530</span>
+          <h3>Offenbarung der Natur und natürlicher Dingen auch mancherley subtiler Würckungen</h3>
+          <span class="page-count">502 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80b756c6f3cc53c84678b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80b756c6f3cc53c84678b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80b756c6f3cc53c84678b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80b756c6f3cc53c84678b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80b756c6f3cc53c84678b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80b756c6f3cc53c84678b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b756c6f3cc53c84678b%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b756c6f3cc53c84678b%2F0201-full.jpg&w=600" alt="Page 201" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.201 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b756c6f3cc53c84678b%2F0301-full.jpg&w=600" alt="Page 301" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.301 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b756c6f3cc53c84678b%2F0402-full.jpg&w=600" alt="Page 402" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.402 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80b756c6f3cc53c84678b%2F0452-full.jpg&w=600" alt="Page 452" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.452 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f67b6c6f3cc53c841e8a" data-idx="530">
+        <div class="book-header">
+          <span class="book-num">#531</span>
+          <h3>Ecclesiologia oder Kirche-Beschreibung</h3>
+          <span class="page-count">653 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f67b6c6f3cc53c841e8a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f67b6c6f3cc53c841e8a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f67b6c6f3cc53c841e8a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f67b6c6f3cc53c841e8a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f67b6c6f3cc53c841e8a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f67b6c6f3cc53c841e8a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f67b6c6f3cc53c841e8a%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f67b6c6f3cc53c841e8a%2F0261-full.jpg&w=600" alt="Page 261" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.261 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f67b6c6f3cc53c841e8a%2F0392-full.jpg&w=600" alt="Page 392" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.392 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f67b6c6f3cc53c841e8a%2F0522-full.jpg&w=600" alt="Page 522" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.522 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f67b6c6f3cc53c841e8a%2F0588-full.jpg&w=600" alt="Page 588" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.588 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee610d" data-idx="531">
+        <div class="book-header">
+          <span class="book-num">#532</span>
+          <h3>Das mineralische Gluten</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee610d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee610d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee610d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee610d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee610d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee610d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610d%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610d%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610d%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610d%2F42.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee610d%2F48.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41877f1200e2ab53cf94e" data-idx="532">
+        <div class="book-header">
+          <span class="book-num">#533</span>
+          <h3>Collection of Alchemical Texts (PH286)</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-anthology-17th-century-german-ms-various" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41877f1200e2ab53cf94e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41877f1200e2ab53cf94e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41877f1200e2ab53cf94e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41877f1200e2ab53cf94e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41877f1200e2ab53cf94e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41877f1200e2ab53cf94e%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41877f1200e2ab53cf94e%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41877f1200e2ab53cf94e%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41877f1200e2ab53cf94e%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41877f1200e2ab53cf94e%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fa7e6c6f3cc53c842ac3" data-idx="533">
+        <div class="book-header">
+          <span class="book-num">#534</span>
+          <h3>Der Weisheit Morgenröthe</h3>
+          <span class="page-count">127 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fa7e6c6f3cc53c842ac3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fa7e6c6f3cc53c842ac3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fa7e6c6f3cc53c842ac3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fa7e6c6f3cc53c842ac3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fa7e6c6f3cc53c842ac3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fa7e6c6f3cc53c842ac3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa7e6c6f3cc53c842ac3%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa7e6c6f3cc53c842ac3%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa7e6c6f3cc53c842ac3%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa7e6c6f3cc53c842ac3%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fa7e6c6f3cc53c842ac3%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81c706c6f3cc53c849c78" data-idx="534">
+        <div class="book-header">
+          <span class="book-num">#535</span>
+          <h3>Les trois livres de la vie</h3>
+          <span class="page-count">222 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81c706c6f3cc53c849c78" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81c706c6f3cc53c849c78', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81c706c6f3cc53c849c78', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81c706c6f3cc53c849c78', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81c706c6f3cc53c849c78', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81c706c6f3cc53c849c78', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c706c6f3cc53c849c78%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c706c6f3cc53c849c78%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c706c6f3cc53c849c78%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c706c6f3cc53c849c78%2F0178-full.jpg&w=600" alt="Page 178" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.178 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81c706c6f3cc53c849c78%2F0200-full.jpg&w=600" alt="Page 200" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.200 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e32e2f948a050a5056" data-idx="535">
+        <div class="book-header">
+          <span class="book-num">#536</span>
+          <h3>Uraltes chymisches Werck</h3>
+          <span class="page-count">171 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e32e2f948a050a5056" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e32e2f948a050a5056', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e32e2f948a050a5056', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e32e2f948a050a5056', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e32e2f948a050a5056', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e32e2f948a050a5056', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5056%2F69c5853dc98d811e9ba62b8f.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5056%2F69c58dd5c0348e077113fa70.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5056%2F69c5924a3e1fe3ca8142835b.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5056%2F69c596adea7c37ad2600a148.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5056%2F69c599afaf3ab52019a8933b.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85f626c6f3cc53c855514" data-idx="536">
+        <div class="book-header">
+          <span class="book-num">#537</span>
+          <h3>Mirabilium divinorum humanorumque volumina quattuor</h3>
+          <span class="page-count">165 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85f626c6f3cc53c855514" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85f626c6f3cc53c855514', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85f626c6f3cc53c855514', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85f626c6f3cc53c855514', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85f626c6f3cc53c855514', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85f626c6f3cc53c855514', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f626c6f3cc53c855514%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f626c6f3cc53c855514%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f626c6f3cc53c855514%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f626c6f3cc53c855514%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f626c6f3cc53c855514%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c824666c6f3cc53c84b438" data-idx="537">
+        <div class="book-header">
+          <span class="book-num">#538</span>
+          <h3>Disputatio de auro potabili</h3>
+          <span class="page-count">102 pp</span>
+          <a href="https://sourcelibrary.org/book/69c824666c6f3cc53c84b438" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c824666c6f3cc53c84b438', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c824666c6f3cc53c84b438', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c824666c6f3cc53c84b438', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c824666c6f3cc53c84b438', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c824666c6f3cc53c84b438', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824666c6f3cc53c84b438%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824666c6f3cc53c84b438%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824666c6f3cc53c84b438%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824666c6f3cc53c84b438%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824666c6f3cc53c84b438%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c864146c6f3cc53c855e89" data-idx="538">
+        <div class="book-header">
+          <span class="book-num">#539</span>
+          <h3>Curationum empericarum &amp; historicarum ... centuria sexta</h3>
+          <span class="page-count">117 pp</span>
+          <a href="https://sourcelibrary.org/book/69c864146c6f3cc53c855e89" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c864146c6f3cc53c855e89', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c864146c6f3cc53c855e89', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c864146c6f3cc53c855e89', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c864146c6f3cc53c855e89', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c864146c6f3cc53c855e89', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c864146c6f3cc53c855e89%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864146c6f3cc53c855e89%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864146c6f3cc53c855e89%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864146c6f3cc53c855e89%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864146c6f3cc53c855e89%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6902ed49583dd7d2641408a5" data-idx="539">
+        <div class="book-header">
+          <span class="book-num">#540</span>
+          <h3>Morgenroete im Aufgang</h3>
+          <span class="page-count">447 pp</span>
+          <a href="https://sourcelibrary.org/book/dawn-rising-boehme" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6902ed49583dd7d2641408a5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6902ed49583dd7d2641408a5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6902ed49583dd7d2641408a5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6902ed49583dd7d2641408a5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6902ed49583dd7d2641408a5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6902ed49583dd7d2641408a5%2F45.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6902ed49583dd7d2641408a5%2F179.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6902ed49583dd7d2641408a5%2F268.jpg&w=600" alt="Page 268" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.268 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6902ed49583dd7d2641408a5%2F358.jpg&w=600" alt="Page 358" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.358 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6902ed49583dd7d2641408a5%2F402.jpg&w=600" alt="Page 402" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.402 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87bb76c6f3cc53c8588ed" data-idx="540">
+        <div class="book-header">
+          <span class="book-num">#541</span>
+          <h3>Lamps of western mysticism. Essays on the life of the soul in God</h3>
+          <span class="page-count">177 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87bb76c6f3cc53c8588ed" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87bb76c6f3cc53c8588ed', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87bb76c6f3cc53c8588ed', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87bb76c6f3cc53c8588ed', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87bb76c6f3cc53c8588ed', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87bb76c6f3cc53c8588ed', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bb76c6f3cc53c8588ed%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bb76c6f3cc53c8588ed%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bb76c6f3cc53c8588ed%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bb76c6f3cc53c8588ed%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87bb76c6f3cc53c8588ed%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c807126c6f3cc53c84575f" data-idx="541">
+        <div class="book-header">
+          <span class="book-num">#542</span>
+          <h3>Le Timée. De la creation de l'ame</h3>
+          <span class="page-count">178 pp</span>
+          <a href="https://sourcelibrary.org/book/69c807126c6f3cc53c84575f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c807126c6f3cc53c84575f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c807126c6f3cc53c84575f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c807126c6f3cc53c84575f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c807126c6f3cc53c84575f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c807126c6f3cc53c84575f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807126c6f3cc53c84575f%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807126c6f3cc53c84575f%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807126c6f3cc53c84575f%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807126c6f3cc53c84575f%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807126c6f3cc53c84575f%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8982a6c6f3cc53c85ca35" data-idx="542">
+        <div class="book-header">
+          <span class="book-num">#543</span>
+          <h3>The hermetic succession</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8982a6c6f3cc53c85ca35" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8982a6c6f3cc53c85ca35', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8982a6c6f3cc53c85ca35', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8982a6c6f3cc53c85ca35', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8982a6c6f3cc53c85ca35', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8982a6c6f3cc53c85ca35', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982a6c6f3cc53c85ca35%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982a6c6f3cc53c85ca35%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982a6c6f3cc53c85ca35%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982a6c6f3cc53c85ca35%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8982a6c6f3cc53c85ca35%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87b3d6c6f3cc53c858819" data-idx="543">
+        <div class="book-header">
+          <span class="book-num">#544</span>
+          <h3>In memory of Robert Fludd. An address to the Rosicrucians assembled at Bearstead, in Kent, on September 14, 1907</h3>
+          <span class="page-count">10 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87b3d6c6f3cc53c858819" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87b3d6c6f3cc53c858819', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87b3d6c6f3cc53c858819', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87b3d6c6f3cc53c858819', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87b3d6c6f3cc53c858819', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87b3d6c6f3cc53c858819', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b3d6c6f3cc53c858819%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b3d6c6f3cc53c858819%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b3d6c6f3cc53c858819%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b3d6c6f3cc53c858819%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87b3d6c6f3cc53c858819%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e5c5fb10016c3f389ba4" data-idx="544">
+        <div class="book-header">
+          <span class="book-num">#545</span>
+          <h3>Adversus Valentini, &amp; similium gnosticorum haereses, libri quinque</h3>
+          <span class="page-count">324 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e5c5fb10016c3f389ba4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e5c5fb10016c3f389ba4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e5c5fb10016c3f389ba4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e5c5fb10016c3f389ba4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e5c5fb10016c3f389ba4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e5c5fb10016c3f389ba4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e5c5fb10016c3f389ba4%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e5c5fb10016c3f389ba4%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e5c5fb10016c3f389ba4%2F0194-full.jpg&w=600" alt="Page 194" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.194 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e5c5fb10016c3f389ba4%2F0259-full.jpg&w=600" alt="Page 259" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.259 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e5c5fb10016c3f389ba4%2F0292-full.jpg&w=600" alt="Page 292" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.292 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c806756c6f3cc53c845548" data-idx="545">
+        <div class="book-header">
+          <span class="book-num">#546</span>
+          <h3>Vorpforte der Schul-Unterweisung</h3>
+          <span class="page-count">161 pp</span>
+          <a href="https://sourcelibrary.org/book/69c806756c6f3cc53c845548" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c806756c6f3cc53c845548', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c806756c6f3cc53c845548', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c806756c6f3cc53c845548', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c806756c6f3cc53c845548', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c806756c6f3cc53c845548', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806756c6f3cc53c845548%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806756c6f3cc53c845548%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806756c6f3cc53c845548%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806756c6f3cc53c845548%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c806756c6f3cc53c845548%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7bee025ec2ba5ccd7fa5d" data-idx="546">
+        <div class="book-header">
+          <span class="book-num">#547</span>
+          <h3>De macrocosmus, en microcosmus, ofte de wonderen van de groote en kleyne werelt</h3>
+          <span class="page-count">179 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7bee025ec2ba5ccd7fa5d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7bee025ec2ba5ccd7fa5d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7bee025ec2ba5ccd7fa5d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7bee025ec2ba5ccd7fa5d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7bee025ec2ba5ccd7fa5d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7bee025ec2ba5ccd7fa5d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bee025ec2ba5ccd7fa5d%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bee025ec2ba5ccd7fa5d%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bee025ec2ba5ccd7fa5d%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bee025ec2ba5ccd7fa5d%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bee025ec2ba5ccd7fa5d%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86e2d6c6f3cc53c856e3d" data-idx="547">
+        <div class="book-header">
+          <span class="book-num">#548</span>
+          <h3>[Blockbook] Calendarium magistri Johannis de Gamundia de 1439</h3>
+          <span class="page-count">10 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86e2d6c6f3cc53c856e3d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86e2d6c6f3cc53c856e3d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86e2d6c6f3cc53c856e3d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86e2d6c6f3cc53c856e3d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86e2d6c6f3cc53c856e3d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86e2d6c6f3cc53c856e3d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e2d6c6f3cc53c856e3d%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e2d6c6f3cc53c856e3d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e2d6c6f3cc53c856e3d%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e2d6c6f3cc53c856e3d%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86e2d6c6f3cc53c856e3d%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fefd6c6f3cc53c843a03" data-idx="548">
+        <div class="book-header">
+          <span class="book-num">#549</span>
+          <h3>Cosmographicae disciplinae compendium</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fefd6c6f3cc53c843a03" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fefd6c6f3cc53c843a03', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fefd6c6f3cc53c843a03', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fefd6c6f3cc53c843a03', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fefd6c6f3cc53c843a03', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fefd6c6f3cc53c843a03', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fefd6c6f3cc53c843a03%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fefd6c6f3cc53c843a03%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fefd6c6f3cc53c843a03%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fefd6c6f3cc53c843a03%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fefd6c6f3cc53c843a03%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80aee6c6f3cc53c8465ce" data-idx="549">
+        <div class="book-header">
+          <span class="book-num">#550</span>
+          <h3>Dante con l'espositione di Christoforo Landino et di Alessandro Vellutello</h3>
+          <span class="page-count">430 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80aee6c6f3cc53c8465ce" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80aee6c6f3cc53c8465ce', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80aee6c6f3cc53c8465ce', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80aee6c6f3cc53c8465ce', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80aee6c6f3cc53c8465ce', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80aee6c6f3cc53c8465ce', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80aee6c6f3cc53c8465ce%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80aee6c6f3cc53c8465ce%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80aee6c6f3cc53c8465ce%2F0258-full.jpg&w=600" alt="Page 258" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.258 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80aee6c6f3cc53c8465ce%2F0344-full.jpg&w=600" alt="Page 344" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.344 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80aee6c6f3cc53c8465ce%2F0387-full.jpg&w=600" alt="Page 387" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.387 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8937c6c6f3cc53c85beb8" data-idx="550">
+        <div class="book-header">
+          <span class="book-num">#551</span>
+          <h3>Rosa mystica</h3>
+          <span class="page-count">152 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8937c6c6f3cc53c85beb8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8937c6c6f3cc53c85beb8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8937c6c6f3cc53c85beb8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8937c6c6f3cc53c85beb8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8937c6c6f3cc53c85beb8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8937c6c6f3cc53c85beb8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8937c6c6f3cc53c85beb8%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8937c6c6f3cc53c85beb8%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8937c6c6f3cc53c85beb8%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8937c6c6f3cc53c85beb8%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8937c6c6f3cc53c85beb8%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f9496c6f3cc53c84261b" data-idx="551">
+        <div class="book-header">
+          <span class="book-num">#552</span>
+          <h3>Erzählungen zum Vergnügen und zur Seelenbildung</h3>
+          <span class="page-count">214 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f9496c6f3cc53c84261b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f9496c6f3cc53c84261b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f9496c6f3cc53c84261b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f9496c6f3cc53c84261b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f9496c6f3cc53c84261b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f9496c6f3cc53c84261b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9496c6f3cc53c84261b%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9496c6f3cc53c84261b%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9496c6f3cc53c84261b%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9496c6f3cc53c84261b%2F0171-full.jpg&w=600" alt="Page 171" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.171 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9496c6f3cc53c84261b%2F0193-full.jpg&w=600" alt="Page 193" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.193 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7053eda9771c716315aae" data-idx="552">
+        <div class="book-header">
+          <span class="book-num">#553</span>
+          <h3>Ausführliche Untersuchung der Gründe für die Aechtheit und Glaubwürdigkeit der schriftlichen Urkunden des Christenthums</h3>
+          <span class="page-count">185 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7053eda9771c716315aae" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7053eda9771c716315aae', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7053eda9771c716315aae', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7053eda9771c716315aae', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7053eda9771c716315aae', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7053eda9771c716315aae', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7053eda9771c716315aae%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7053eda9771c716315aae%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7053eda9771c716315aae%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7053eda9771c716315aae%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7053eda9771c716315aae%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c825006c6f3cc53c84b72d" data-idx="553">
+        <div class="book-header">
+          <span class="book-num">#554</span>
+          <h3>Deutsches theatrum chemicum</h3>
+          <span class="page-count">562 pp</span>
+          <a href="https://sourcelibrary.org/book/69c825006c6f3cc53c84b72d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c825006c6f3cc53c84b72d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c825006c6f3cc53c84b72d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c825006c6f3cc53c84b72d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c825006c6f3cc53c84b72d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c825006c6f3cc53c84b72d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825006c6f3cc53c84b72d%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825006c6f3cc53c84b72d%2F0225-full.jpg&w=600" alt="Page 225" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.225 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825006c6f3cc53c84b72d%2F0337-full.jpg&w=600" alt="Page 337" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.337 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825006c6f3cc53c84b72d%2F0450-full.jpg&w=600" alt="Page 450" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.450 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825006c6f3cc53c84b72d%2F0506-full.jpg&w=600" alt="Page 506" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.506 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f4d8da9771c716314f6f" data-idx="554">
+        <div class="book-header">
+          <span class="book-num">#555</span>
+          <h3>D.O.M.A. Wolmeinendes Bedencken, von der Fama, und Confession der Brüderschafft dess RosenCreutzes</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f4d8da9771c716314f6f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f4d8da9771c716314f6f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f4d8da9771c716314f6f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f4d8da9771c716314f6f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f4d8da9771c716314f6f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f4d8da9771c716314f6f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4d8da9771c716314f6f%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4d8da9771c716314f6f%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4d8da9771c716314f6f%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4d8da9771c716314f6f%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f4d8da9771c716314f6f%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ffd06c6f3cc53c843cdd" data-idx="555">
+        <div class="book-header">
+          <span class="book-num">#556</span>
+          <h3>Liber octo quaestionum ad Maximilianum Caesarem</h3>
+          <span class="page-count">72 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ffd06c6f3cc53c843cdd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ffd06c6f3cc53c843cdd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ffd06c6f3cc53c843cdd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ffd06c6f3cc53c843cdd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ffd06c6f3cc53c843cdd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ffd06c6f3cc53c843cdd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffd06c6f3cc53c843cdd%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffd06c6f3cc53c843cdd%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffd06c6f3cc53c843cdd%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffd06c6f3cc53c843cdd%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ffd06c6f3cc53c843cdd%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c844736c6f3cc53c8512f5" data-idx="556">
+        <div class="book-header">
+          <span class="book-num">#557</span>
+          <h3>Unpartheyische Gedancken, uber eines so genannten Schwedischen Theologi Kurtzen Bericht von Pietisten etc</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/69c844736c6f3cc53c8512f5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c844736c6f3cc53c8512f5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c844736c6f3cc53c8512f5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c844736c6f3cc53c8512f5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c844736c6f3cc53c8512f5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c844736c6f3cc53c8512f5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844736c6f3cc53c8512f5%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844736c6f3cc53c8512f5%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844736c6f3cc53c8512f5%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844736c6f3cc53c8512f5%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844736c6f3cc53c8512f5%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c73a1c6a0f3d112faf7920" data-idx="557">
+        <div class="book-header">
+          <span class="book-num">#558</span>
+          <h3>De la triple vie de l'homme</h3>
+          <span class="page-count">293 pp</span>
+          <a href="https://sourcelibrary.org/book/69c73a1c6a0f3d112faf7920" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c73a1c6a0f3d112faf7920', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c73a1c6a0f3d112faf7920', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c73a1c6a0f3d112faf7920', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c73a1c6a0f3d112faf7920', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c73a1c6a0f3d112faf7920', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a1c6a0f3d112faf7920%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a1c6a0f3d112faf7920%2F0117-full.jpg&w=600" alt="Page 117" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.117 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a1c6a0f3d112faf7920%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a1c6a0f3d112faf7920%2F0234-full.jpg&w=600" alt="Page 234" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.234 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c73a1c6a0f3d112faf7920%2F0264-full.jpg&w=600" alt="Page 264" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.264 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e48e295ea01b70c8d988" data-idx="558">
+        <div class="book-header">
+          <span class="book-num">#559</span>
+          <h3>Geometrie practique</h3>
+          <span class="page-count">80 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e48e295ea01b70c8d988" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e48e295ea01b70c8d988', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e48e295ea01b70c8d988', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e48e295ea01b70c8d988', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e48e295ea01b70c8d988', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e48e295ea01b70c8d988', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e48e295ea01b70c8d988%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e48e295ea01b70c8d988%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e48e295ea01b70c8d988%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e48e295ea01b70c8d988%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e48e295ea01b70c8d988%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88efc6c6f3cc53c85b25e" data-idx="559">
+        <div class="book-header">
+          <span class="book-num">#560</span>
+          <h3>[Greek] De vita Pythagorae</h3>
+          <span class="page-count">256 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88efc6c6f3cc53c85b25e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88efc6c6f3cc53c85b25e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88efc6c6f3cc53c85b25e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88efc6c6f3cc53c85b25e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88efc6c6f3cc53c85b25e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88efc6c6f3cc53c85b25e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88efc6c6f3cc53c85b25e%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88efc6c6f3cc53c85b25e%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88efc6c6f3cc53c85b25e%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88efc6c6f3cc53c85b25e%2F0205-full.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88efc6c6f3cc53c85b25e%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c878566c6f3cc53c8581e9" data-idx="560">
+        <div class="book-header">
+          <span class="book-num">#561</span>
+          <h3>Gedancken von der Wiederbringung aller Dinge</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c878566c6f3cc53c8581e9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c878566c6f3cc53c8581e9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c878566c6f3cc53c8581e9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c878566c6f3cc53c8581e9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c878566c6f3cc53c8581e9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c878566c6f3cc53c8581e9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581e9%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581e9%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581e9%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581e9%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c878566c6f3cc53c8581e9%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c72caa6a0f3d112faf6f71" data-idx="561">
+        <div class="book-header">
+          <span class="book-num">#562</span>
+          <h3>Preclara Francorum facinora varia</h3>
+          <span class="page-count">67 pp</span>
+          <a href="https://sourcelibrary.org/book/69c72caa6a0f3d112faf6f71" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c72caa6a0f3d112faf6f71', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c72caa6a0f3d112faf6f71', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c72caa6a0f3d112faf6f71', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c72caa6a0f3d112faf6f71', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c72caa6a0f3d112faf6f71', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72caa6a0f3d112faf6f71%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72caa6a0f3d112faf6f71%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72caa6a0f3d112faf6f71%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72caa6a0f3d112faf6f71%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72caa6a0f3d112faf6f71%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c27e6e0787282ad593281" data-idx="562">
+        <div class="book-header">
+          <span class="book-num">#563</span>
+          <h3>Die Lehren der Rosenkreuzer aus dem 16ten und 17ten Jahrhundert. Oder einfältig ABC Büchlein für junge Schüler</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/the-teachings-of-the-rosicrucians-from-the-16th-and-17th-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c27e6e0787282ad593281', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c27e6e0787282ad593281', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c27e6e0787282ad593281', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c27e6e0787282ad593281', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c27e6e0787282ad593281', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c27e6e0787282ad593281%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c27e6e0787282ad593281%2F24.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c27e6e0787282ad593281%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c27e6e0787282ad593281%2F49.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c27e6e0787282ad593281%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87ff96c6f3cc53c858fd5" data-idx="563">
+        <div class="book-header">
+          <span class="book-num">#564</span>
+          <h3>De mystica theologia lib. I. Commentarios pro theologia negativa</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87ff96c6f3cc53c858fd5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87ff96c6f3cc53c858fd5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87ff96c6f3cc53c858fd5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87ff96c6f3cc53c858fd5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87ff96c6f3cc53c858fd5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87ff96c6f3cc53c858fd5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ff96c6f3cc53c858fd5%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ff96c6f3cc53c858fd5%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ff96c6f3cc53c858fd5%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ff96c6f3cc53c858fd5%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87ff96c6f3cc53c858fd5%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896866c6f3cc53c85c57b" data-idx="564">
+        <div class="book-header">
+          <span class="book-num">#565</span>
+          <h3>The key to the Tarot. Being fragments of a secret tradition under the veil of divination</h3>
+          <span class="page-count">109 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896866c6f3cc53c85c57b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896866c6f3cc53c85c57b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896866c6f3cc53c85c57b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896866c6f3cc53c85c57b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896866c6f3cc53c85c57b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896866c6f3cc53c85c57b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896866c6f3cc53c85c57b%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896866c6f3cc53c85c57b%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896866c6f3cc53c85c57b%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896866c6f3cc53c85c57b%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896866c6f3cc53c85c57b%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c828026c6f3cc53c84c221" data-idx="565">
+        <div class="book-header">
+          <span class="book-num">#566</span>
+          <h3>Docimastice metallica</h3>
+          <span class="page-count">31 pp</span>
+          <a href="https://sourcelibrary.org/book/69c828026c6f3cc53c84c221" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c828026c6f3cc53c84c221', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c828026c6f3cc53c84c221', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c828026c6f3cc53c84c221', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c828026c6f3cc53c84c221', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c828026c6f3cc53c84c221', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828026c6f3cc53c84c221%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828026c6f3cc53c84c221%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828026c6f3cc53c84c221%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828026c6f3cc53c84c221%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828026c6f3cc53c84c221%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c812996c6f3cc53c847c13" data-idx="566">
+        <div class="book-header">
+          <span class="book-num">#567</span>
+          <h3>Traité des trois imposteurs</h3>
+          <span class="page-count">81 pp</span>
+          <a href="https://sourcelibrary.org/book/69c812996c6f3cc53c847c13" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c812996c6f3cc53c847c13', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c812996c6f3cc53c847c13', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c812996c6f3cc53c847c13', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c812996c6f3cc53c847c13', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c812996c6f3cc53c847c13', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812996c6f3cc53c847c13%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812996c6f3cc53c847c13%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812996c6f3cc53c847c13%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812996c6f3cc53c847c13%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812996c6f3cc53c847c13%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89dd16c6f3cc53c85d909" data-idx="567">
+        <div class="book-header">
+          <span class="book-num">#568</span>
+          <h3>Het achtste boeck des autheurs. De genadige verkiesing</h3>
+          <span class="page-count">177 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89dd16c6f3cc53c85d909" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89dd16c6f3cc53c85d909', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89dd16c6f3cc53c85d909', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89dd16c6f3cc53c85d909', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89dd16c6f3cc53c85d909', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89dd16c6f3cc53c85d909', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89dd16c6f3cc53c85d909%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89dd16c6f3cc53c85d909%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89dd16c6f3cc53c85d909%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89dd16c6f3cc53c85d909%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89dd16c6f3cc53c85d909%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c890196c6f3cc53c85b551" data-idx="568">
+        <div class="book-header">
+          <span class="book-num">#569</span>
+          <h3>Die Wahrheit des sensus communis</h3>
+          <span class="page-count">361 pp</span>
+          <a href="https://sourcelibrary.org/book/69c890196c6f3cc53c85b551" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c890196c6f3cc53c85b551', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c890196c6f3cc53c85b551', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c890196c6f3cc53c85b551', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c890196c6f3cc53c85b551', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c890196c6f3cc53c85b551', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890196c6f3cc53c85b551%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890196c6f3cc53c85b551%2F0144-full.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890196c6f3cc53c85b551%2F0217-full.jpg&w=600" alt="Page 217" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.217 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890196c6f3cc53c85b551%2F0289-full.jpg&w=600" alt="Page 289" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.289 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890196c6f3cc53c85b551%2F0325-full.jpg&w=600" alt="Page 325" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.325 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a4ca92b884e4f8173a7a" data-idx="569">
+        <div class="book-header">
+          <span class="book-num">#570</span>
+          <h3>An exposition of the seven epistles to the seven churches</h3>
+          <span class="page-count">211 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a4ca92b884e4f8173a7a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a4ca92b884e4f8173a7a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a4ca92b884e4f8173a7a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a4ca92b884e4f8173a7a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a4ca92b884e4f8173a7a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a4ca92b884e4f8173a7a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a4ca92b884e4f8173a7a%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a4ca92b884e4f8173a7a%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a4ca92b884e4f8173a7a%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a4ca92b884e4f8173a7a%2F0169-full.jpg&w=600" alt="Page 169" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.169 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a4ca92b884e4f8173a7a%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c865b76c6f3cc53c856277" data-idx="570">
+        <div class="book-header">
+          <span class="book-num">#571</span>
+          <h3>De 12 gemmis</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c865b76c6f3cc53c856277" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c865b76c6f3cc53c856277', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c865b76c6f3cc53c856277', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c865b76c6f3cc53c856277', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c865b76c6f3cc53c856277', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c865b76c6f3cc53c856277', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c865b76c6f3cc53c856277%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c865b76c6f3cc53c856277%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865b76c6f3cc53c856277%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865b76c6f3cc53c856277%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865b76c6f3cc53c856277%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f4dd6c6f3cc53c841a68" data-idx="571">
+        <div class="book-header">
+          <span class="book-num">#572</span>
+          <h3>Verklaring van de evangelische parabolen</h3>
+          <span class="page-count">414 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f4dd6c6f3cc53c841a68" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f4dd6c6f3cc53c841a68', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f4dd6c6f3cc53c841a68', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f4dd6c6f3cc53c841a68', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f4dd6c6f3cc53c841a68', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f4dd6c6f3cc53c841a68', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4dd6c6f3cc53c841a68%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4dd6c6f3cc53c841a68%2F0166-full.jpg&w=600" alt="Page 166" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.166 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4dd6c6f3cc53c841a68%2F0248-full.jpg&w=600" alt="Page 248" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.248 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4dd6c6f3cc53c841a68%2F0331-full.jpg&w=600" alt="Page 331" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.331 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4dd6c6f3cc53c841a68%2F0373-full.jpg&w=600" alt="Page 373" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.373 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88e706c6f3cc53c85b0f4" data-idx="572">
+        <div class="book-header">
+          <span class="book-num">#573</span>
+          <h3>Die vierundzwanzig Alten, oder Der goldne Thron</h3>
+          <span class="page-count">219 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88e706c6f3cc53c85b0f4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88e706c6f3cc53c85b0f4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88e706c6f3cc53c85b0f4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88e706c6f3cc53c85b0f4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88e706c6f3cc53c85b0f4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88e706c6f3cc53c85b0f4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e706c6f3cc53c85b0f4%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e706c6f3cc53c85b0f4%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e706c6f3cc53c85b0f4%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e706c6f3cc53c85b0f4%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e706c6f3cc53c85b0f4%2F0197-full.jpg&w=600" alt="Page 197" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.197 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88b0a6c6f3cc53c85a824" data-idx="573">
+        <div class="book-header">
+          <span class="book-num">#574</span>
+          <h3>Le tableau des riches inventions qui sont representees dans le songe de Poliphile</h3>
+          <span class="page-count">189 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88b0a6c6f3cc53c85a824" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88b0a6c6f3cc53c85a824', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88b0a6c6f3cc53c85a824', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88b0a6c6f3cc53c85a824', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88b0a6c6f3cc53c85a824', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88b0a6c6f3cc53c85a824', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b0a6c6f3cc53c85a824%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b0a6c6f3cc53c85a824%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b0a6c6f3cc53c85a824%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b0a6c6f3cc53c85a824%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88b0a6c6f3cc53c85a824%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88e086c6f3cc53c85b005" data-idx="574">
+        <div class="book-header">
+          <span class="book-num">#575</span>
+          <h3>Vetustissimae tabulae Aeneae sacris Aegyptiorum simulachris coelatae accurata explicatio</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88e086c6f3cc53c85b005" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88e086c6f3cc53c85b005', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88e086c6f3cc53c85b005', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88e086c6f3cc53c85b005', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88e086c6f3cc53c85b005', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88e086c6f3cc53c85b005', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e086c6f3cc53c85b005%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e086c6f3cc53c85b005%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e086c6f3cc53c85b005%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e086c6f3cc53c85b005%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e086c6f3cc53c85b005%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418a42b0edf3eaa2dd797" data-idx="575">
+        <div class="book-header">
+          <span class="book-num">#576</span>
+          <h3>Introduttione alla theorica e prattica della scienza di cabala (PH181)</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/introduction-to-kabbalistic-science-johann-pistorius-17th-c-pistorius" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418a42b0edf3eaa2dd797', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418a42b0edf3eaa2dd797', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418a42b0edf3eaa2dd797', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418a42b0edf3eaa2dd797', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418a42b0edf3eaa2dd797', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a42b0edf3eaa2dd797%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a42b0edf3eaa2dd797%2F35.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a42b0edf3eaa2dd797%2F53.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a42b0edf3eaa2dd797%2F70.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a42b0edf3eaa2dd797%2F79.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a07c6c6f3cc53c85dfff" data-idx="576">
+        <div class="book-header">
+          <span class="book-num">#577</span>
+          <h3>[Hebrew: Mishpat HaMelech] Jus regium Hebraeorum, et tenebris rabbinicis</h3>
+          <span class="page-count">274 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a07c6c6f3cc53c85dfff" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a07c6c6f3cc53c85dfff', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a07c6c6f3cc53c85dfff', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a07c6c6f3cc53c85dfff', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a07c6c6f3cc53c85dfff', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a07c6c6f3cc53c85dfff', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07c6c6f3cc53c85dfff%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07c6c6f3cc53c85dfff%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07c6c6f3cc53c85dfff%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07c6c6f3cc53c85dfff%2F0219-full.jpg&w=600" alt="Page 219" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.219 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a07c6c6f3cc53c85dfff%2F0247-full.jpg&w=600" alt="Page 247" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.247 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83e356c6f3cc53c84ff88" data-idx="577">
+        <div class="book-header">
+          <span class="book-num">#578</span>
+          <h3>Trismegistus christianus</h3>
+          <span class="page-count">343 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83e356c6f3cc53c84ff88" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83e356c6f3cc53c84ff88', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83e356c6f3cc53c84ff88', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83e356c6f3cc53c84ff88', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83e356c6f3cc53c84ff88', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83e356c6f3cc53c84ff88', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e356c6f3cc53c84ff88%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e356c6f3cc53c84ff88%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e356c6f3cc53c84ff88%2F0206-full.jpg&w=600" alt="Page 206" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.206 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e356c6f3cc53c84ff88%2F0274-full.jpg&w=600" alt="Page 274" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.274 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83e356c6f3cc53c84ff88%2F0309-full.jpg&w=600" alt="Page 309" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.309 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85edf6c6f3cc53c85532c" data-idx="578">
+        <div class="book-header">
+          <span class="book-num">#579</span>
+          <h3>Brief aan den heer Fredericus Spanhemius ... waarin de leere der Doopsgesinden nader uytgelegt en verdedigt werdt</h3>
+          <span class="page-count">81 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85edf6c6f3cc53c85532c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85edf6c6f3cc53c85532c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85edf6c6f3cc53c85532c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85edf6c6f3cc53c85532c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85edf6c6f3cc53c85532c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85edf6c6f3cc53c85532c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85edf6c6f3cc53c85532c%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85edf6c6f3cc53c85532c%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85edf6c6f3cc53c85532c%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85edf6c6f3cc53c85532c%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85edf6c6f3cc53c85532c%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63cd593cbf3c0fd742523" data-idx="579">
+        <div class="book-header">
+          <span class="book-num">#580</span>
+          <h3>Les vies des plus celèbres et anciens poètes provensaux</h3>
+          <span class="page-count">143 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63cd593cbf3c0fd742523" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63cd593cbf3c0fd742523', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63cd593cbf3c0fd742523', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63cd593cbf3c0fd742523', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63cd593cbf3c0fd742523', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63cd593cbf3c0fd742523', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742523%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742523%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742523%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742523%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742523%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c805876c6f3cc53c84522d" data-idx="580">
+        <div class="book-header">
+          <span class="book-num">#581</span>
+          <h3>Christliches Examen vor dem Gebrauch des heiligen Abendmahls</h3>
+          <span class="page-count">31 pp</span>
+          <a href="https://sourcelibrary.org/book/69c805876c6f3cc53c84522d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c805876c6f3cc53c84522d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c805876c6f3cc53c84522d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c805876c6f3cc53c84522d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c805876c6f3cc53c84522d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c805876c6f3cc53c84522d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805876c6f3cc53c84522d%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805876c6f3cc53c84522d%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805876c6f3cc53c84522d%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805876c6f3cc53c84522d%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805876c6f3cc53c84522d%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ff506c6f3cc53c843b2c" data-idx="581">
+        <div class="book-header">
+          <span class="book-num">#582</span>
+          <h3>[Greek: Panoplia dogmatike]</h3>
+          <span class="page-count">189 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ff506c6f3cc53c843b2c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ff506c6f3cc53c843b2c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ff506c6f3cc53c843b2c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ff506c6f3cc53c843b2c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ff506c6f3cc53c843b2c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ff506c6f3cc53c843b2c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff506c6f3cc53c843b2c%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff506c6f3cc53c843b2c%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff506c6f3cc53c843b2c%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff506c6f3cc53c843b2c%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ff506c6f3cc53c843b2c%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8059e6c6f3cc53c845290" data-idx="582">
+        <div class="book-header">
+          <span class="book-num">#583</span>
+          <h3>Kennzeichen der wahren Wiedergeburt und des Erneuerung des Geistes</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8059e6c6f3cc53c845290" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8059e6c6f3cc53c845290', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8059e6c6f3cc53c845290', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8059e6c6f3cc53c845290', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8059e6c6f3cc53c845290', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8059e6c6f3cc53c845290', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845290%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845290%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845290%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845290%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8059e6c6f3cc53c845290%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c731e76a0f3d112faf7338" data-idx="583">
+        <div class="book-header">
+          <span class="book-num">#584</span>
+          <h3>Recueil précieux de la maçonnerie adonhiramite</h3>
+          <span class="page-count">228 pp</span>
+          <a href="https://sourcelibrary.org/book/69c731e76a0f3d112faf7338" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c731e76a0f3d112faf7338', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c731e76a0f3d112faf7338', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c731e76a0f3d112faf7338', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c731e76a0f3d112faf7338', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c731e76a0f3d112faf7338', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731e76a0f3d112faf7338%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731e76a0f3d112faf7338%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731e76a0f3d112faf7338%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731e76a0f3d112faf7338%2F0182-full.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c731e76a0f3d112faf7338%2F0205-full.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897c76c6f3cc53c85c8f8" data-idx="584">
+        <div class="book-header">
+          <span class="book-num">#585</span>
+          <h3>Who are the Rosicrucians?</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897c76c6f3cc53c85c8f8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897c76c6f3cc53c85c8f8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897c76c6f3cc53c85c8f8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897c76c6f3cc53c85c8f8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897c76c6f3cc53c85c8f8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897c76c6f3cc53c85c8f8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897c76c6f3cc53c85c8f8%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897c76c6f3cc53c85c8f8%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897c76c6f3cc53c85c8f8%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897c76c6f3cc53c85c8f8%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897c76c6f3cc53c85c8f8%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c892b96c6f3cc53c85bcff" data-idx="585">
+        <div class="book-header">
+          <span class="book-num">#586</span>
+          <h3>Sound an alarm in my holy mountain</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/69c892b96c6f3cc53c85bcff" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c892b96c6f3cc53c85bcff', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c892b96c6f3cc53c85bcff', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c892b96c6f3cc53c85bcff', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c892b96c6f3cc53c85bcff', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c892b96c6f3cc53c85bcff', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892b96c6f3cc53c85bcff%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892b96c6f3cc53c85bcff%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892b96c6f3cc53c85bcff%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892b96c6f3cc53c85bcff%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c892b96c6f3cc53c85bcff%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896076c6f3cc53c85c466" data-idx="586">
+        <div class="book-header">
+          <span class="book-num">#587</span>
+          <h3>Prince Starbeam. A tale of fairlyland</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896076c6f3cc53c85c466" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896076c6f3cc53c85c466', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896076c6f3cc53c85c466', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896076c6f3cc53c85c466', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896076c6f3cc53c85c466', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896076c6f3cc53c85c466', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896076c6f3cc53c85c466%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896076c6f3cc53c85c466%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896076c6f3cc53c85c466%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896076c6f3cc53c85c466%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896076c6f3cc53c85c466%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418e92b0edf3eaa2de2c3" data-idx="587">
+        <div class="book-header">
+          <span class="book-num">#588</span>
+          <h3>Unterricht von Bereitung des Stains der Weisen — Basilius Valentinus (PH187)</h3>
+          <span class="page-count">276 pp</span>
+          <a href="https://sourcelibrary.org/book/basil-valentine-preparation-of-the-philosopher-s-stone-1643-valentinus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418e92b0edf3eaa2de2c3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418e92b0edf3eaa2de2c3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418e92b0edf3eaa2de2c3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418e92b0edf3eaa2de2c3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418e92b0edf3eaa2de2c3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e92b0edf3eaa2de2c3%2F28.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e92b0edf3eaa2de2c3%2F110.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418e92b0edf3eaa2de2c3%2F166.jpg&w=600" alt="Page 166" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.166 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940500738705131!ph187_0221.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 221" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.221 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940500738705131!ph187_0248.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 248" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.248 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c859ca6c6f3cc53c8546e8" data-idx="588">
+        <div class="book-header">
+          <span class="book-num">#589</span>
+          <h3>Christianus Democritus autocatacritus, das ist: der sich selbst verurtheilende Democritus</h3>
+          <span class="page-count">605 pp</span>
+          <a href="https://sourcelibrary.org/book/69c859ca6c6f3cc53c8546e8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c859ca6c6f3cc53c8546e8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c859ca6c6f3cc53c8546e8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c859ca6c6f3cc53c8546e8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c859ca6c6f3cc53c8546e8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c859ca6c6f3cc53c8546e8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859ca6c6f3cc53c8546e8%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859ca6c6f3cc53c8546e8%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859ca6c6f3cc53c8546e8%2F0363-full.jpg&w=600" alt="Page 363" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.363 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859ca6c6f3cc53c8546e8%2F0484-full.jpg&w=600" alt="Page 484" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.484 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859ca6c6f3cc53c8546e8%2F0545-full.jpg&w=600" alt="Page 545" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.545 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c725fe01e1be0c9ac74cde" data-idx="589">
+        <div class="book-header">
+          <span class="book-num">#590</span>
+          <h3>[Greek: Phaenomena et Diosemeia]</h3>
+          <span class="page-count">76 pp</span>
+          <a href="https://sourcelibrary.org/book/69c725fe01e1be0c9ac74cde" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c725fe01e1be0c9ac74cde', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c725fe01e1be0c9ac74cde', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c725fe01e1be0c9ac74cde', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c725fe01e1be0c9ac74cde', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c725fe01e1be0c9ac74cde', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c725fe01e1be0c9ac74cde%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c725fe01e1be0c9ac74cde%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c725fe01e1be0c9ac74cde%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c725fe01e1be0c9ac74cde%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c725fe01e1be0c9ac74cde%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8410e6c6f3cc53c850941" data-idx="590">
+        <div class="book-header">
+          <span class="book-num">#591</span>
+          <h3>De veritate religionis christianae liber</h3>
+          <span class="page-count">373 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8410e6c6f3cc53c850941" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8410e6c6f3cc53c850941', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8410e6c6f3cc53c850941', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8410e6c6f3cc53c850941', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8410e6c6f3cc53c850941', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8410e6c6f3cc53c850941', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8410e6c6f3cc53c850941%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8410e6c6f3cc53c850941%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8410e6c6f3cc53c850941%2F0224-full.jpg&w=600" alt="Page 224" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.224 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8410e6c6f3cc53c850941%2F0298-full.jpg&w=600" alt="Page 298" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.298 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8410e6c6f3cc53c850941%2F0336-full.jpg&w=600" alt="Page 336" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.336 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f42d6c6f3cc53c841781" data-idx="591">
+        <div class="book-header">
+          <span class="book-num">#592</span>
+          <h3>Kleine Metaphysik</h3>
+          <span class="page-count">60 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f42d6c6f3cc53c841781" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f42d6c6f3cc53c841781', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f42d6c6f3cc53c841781', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f42d6c6f3cc53c841781', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f42d6c6f3cc53c841781', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f42d6c6f3cc53c841781', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f42d6c6f3cc53c841781%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f42d6c6f3cc53c841781%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f42d6c6f3cc53c841781%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f42d6c6f3cc53c841781%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f42d6c6f3cc53c841781%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3354cca56a12bc605" data-idx="592">
+        <div class="book-header">
+          <span class="book-num">#593</span>
+          <h3>Vermeerderde en doorgaans verbeterde hemelsche liefdes-kus</h3>
+          <span class="page-count">476 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3354cca56a12bc605" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3354cca56a12bc605', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3354cca56a12bc605', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3354cca56a12bc605', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3354cca56a12bc605', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3354cca56a12bc605', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc605%2F69c59544c2be7a6fad56b7fb.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc605%2F69c5c643acba876fa4e05443.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e3354cca56a12bc605%2F0286-full.jpg&w=600" alt="Page 286" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.286 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e3354cca56a12bc605%2F0381-full.jpg&w=600" alt="Page 381" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.381 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fpages%2F69c581e3354cca56a12bc605%2F0428-full.jpg&w=600" alt="Page 428" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.428 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c857326c6f3cc53c853fc7" data-idx="593">
+        <div class="book-header">
+          <span class="book-num">#594</span>
+          <h3>Recueil de divers traitez de theologie mystique, qui entrent dans la celebre dispute du Quietisme</h3>
+          <span class="page-count">283 pp</span>
+          <a href="https://sourcelibrary.org/book/69c857326c6f3cc53c853fc7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c857326c6f3cc53c853fc7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c857326c6f3cc53c853fc7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c857326c6f3cc53c853fc7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c857326c6f3cc53c853fc7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c857326c6f3cc53c853fc7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857326c6f3cc53c853fc7%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857326c6f3cc53c853fc7%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857326c6f3cc53c853fc7%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857326c6f3cc53c853fc7%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857326c6f3cc53c853fc7%2F0255-full.jpg&w=600" alt="Page 255" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.255 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418a62b0edf3eaa2dd7f1" data-idx="594">
+        <div class="book-header">
+          <span class="book-num">#595</span>
+          <h3>Cabbalistic Texts — Christoph Froschmayr von Scheibenhof (PH239)</h3>
+          <span class="page-count">87 pp</span>
+          <a href="https://sourcelibrary.org/book/kabbalistic-texts-froschmayr-von-scheibenhof-18th-c-scheibenhof" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418a62b0edf3eaa2dd7f1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418a62b0edf3eaa2dd7f1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418a62b0edf3eaa2dd7f1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418a62b0edf3eaa2dd7f1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418a62b0edf3eaa2dd7f1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a62b0edf3eaa2dd7f1%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a62b0edf3eaa2dd7f1%2F35.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a62b0edf3eaa2dd7f1%2F52.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a62b0edf3eaa2dd7f1%2F70.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a62b0edf3eaa2dd7f1%2F78.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c816166c6f3cc53c848928" data-idx="595">
+        <div class="book-header">
+          <span class="book-num">#596</span>
+          <h3>Vaticinia seu praedictiones illustrium virorum... Vaticini overo predittioni d' huomini illustri</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c816166c6f3cc53c848928" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c816166c6f3cc53c848928', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c816166c6f3cc53c848928', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c816166c6f3cc53c848928', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c816166c6f3cc53c848928', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c816166c6f3cc53c848928', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816166c6f3cc53c848928%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816166c6f3cc53c848928%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816166c6f3cc53c848928%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816166c6f3cc53c848928%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c816166c6f3cc53c848928%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c888556c6f3cc53c85a2c0" data-idx="596">
+        <div class="book-header">
+          <span class="book-num">#597</span>
+          <h3>Sarsena oder der vollkommene Baumeister, enthaltend die Geschichte und Entstehung des Freimaurerordens</h3>
+          <span class="page-count">133 pp</span>
+          <a href="https://sourcelibrary.org/book/69c888556c6f3cc53c85a2c0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c888556c6f3cc53c85a2c0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c888556c6f3cc53c85a2c0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c888556c6f3cc53c85a2c0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c888556c6f3cc53c85a2c0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c888556c6f3cc53c85a2c0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888556c6f3cc53c85a2c0%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888556c6f3cc53c85a2c0%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888556c6f3cc53c85a2c0%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888556c6f3cc53c85a2c0%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c888556c6f3cc53c85a2c0%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c771db6a0f3d112faf91b6" data-idx="597">
+        <div class="book-header">
+          <span class="book-num">#598</span>
+          <h3>In Dionysii Areopagitae De mystica theologia</h3>
+          <span class="page-count">173 pp</span>
+          <a href="https://sourcelibrary.org/book/69c771db6a0f3d112faf91b6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c771db6a0f3d112faf91b6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c771db6a0f3d112faf91b6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c771db6a0f3d112faf91b6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c771db6a0f3d112faf91b6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c771db6a0f3d112faf91b6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771db6a0f3d112faf91b6%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771db6a0f3d112faf91b6%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771db6a0f3d112faf91b6%2F0104-full.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771db6a0f3d112faf91b6%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c771db6a0f3d112faf91b6%2F0156-full.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c74e3d6a0f3d112faf83a2" data-idx="598">
+        <div class="book-header">
+          <span class="book-num">#599</span>
+          <h3>Lettres philosophiques sur la formation des sels et des crystaux</h3>
+          <span class="page-count">216 pp</span>
+          <a href="https://sourcelibrary.org/book/69c74e3d6a0f3d112faf83a2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c74e3d6a0f3d112faf83a2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c74e3d6a0f3d112faf83a2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c74e3d6a0f3d112faf83a2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c74e3d6a0f3d112faf83a2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c74e3d6a0f3d112faf83a2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74e3d6a0f3d112faf83a2%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74e3d6a0f3d112faf83a2%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74e3d6a0f3d112faf83a2%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74e3d6a0f3d112faf83a2%2F0173-full.jpg&w=600" alt="Page 173" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.173 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74e3d6a0f3d112faf83a2%2F0194-full.jpg&w=600" alt="Page 194" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.194 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a29b6c6f3cc53c85e47d" data-idx="599">
+        <div class="book-header">
+          <span class="book-num">#600</span>
+          <h3>The Golden Age and others</h3>
+          <span class="page-count">11 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a29b6c6f3cc53c85e47d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a29b6c6f3cc53c85e47d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a29b6c6f3cc53c85e47d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a29b6c6f3cc53c85e47d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a29b6c6f3cc53c85e47d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a29b6c6f3cc53c85e47d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a29b6c6f3cc53c85e47d%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a29b6c6f3cc53c85e47d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a29b6c6f3cc53c85e47d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a29b6c6f3cc53c85e47d%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a29b6c6f3cc53c85e47d%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html" class="active">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-7.html
+++ b/public/split-review-7.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 7/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html" class="active">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c7f5406c6f3cc53c841b77" data-idx="600">
+        <div class="book-header">
+          <span class="book-num">#601</span>
+          <h3>[Greek] Omnia quae extant opera</h3>
+          <span class="page-count">647 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f5406c6f3cc53c841b77" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f5406c6f3cc53c841b77', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f5406c6f3cc53c841b77', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f5406c6f3cc53c841b77', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f5406c6f3cc53c841b77', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f5406c6f3cc53c841b77', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5406c6f3cc53c841b77%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5406c6f3cc53c841b77%2F0259-full.jpg&w=600" alt="Page 259" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.259 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5406c6f3cc53c841b77%2F0388-full.jpg&w=600" alt="Page 388" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.388 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5406c6f3cc53c841b77%2F0518-full.jpg&w=600" alt="Page 518" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.518 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5406c6f3cc53c841b77%2F0582-full.jpg&w=600" alt="Page 582" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.582 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70731da9771c716315c1a" data-idx="601">
+        <div class="book-header">
+          <span class="book-num">#602</span>
+          <h3>Über die wichtigsten Mysterien der Religion</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70731da9771c716315c1a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70731da9771c716315c1a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70731da9771c716315c1a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70731da9771c716315c1a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70731da9771c716315c1a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70731da9771c716315c1a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70731da9771c716315c1a%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70731da9771c716315c1a%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70731da9771c716315c1a%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70731da9771c716315c1a%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70731da9771c716315c1a%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e43954e1ebf355ef93" data-idx="602">
+        <div class="book-header">
+          <span class="book-num">#603</span>
+          <h3>Der verlangete dritte Anfang der mineralischen Dinge</h3>
+          <span class="page-count">32 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e43954e1ebf355ef93" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e43954e1ebf355ef93', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e43954e1ebf355ef93', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e43954e1ebf355ef93', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e43954e1ebf355ef93', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e43954e1ebf355ef93', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e43954e1ebf355ef93%2F69c58247985d8148794a7205.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e43954e1ebf355ef93%2F69c5840f08274a1bd5803efe.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e43954e1ebf355ef93%2F69c58537ed8a1ad8d3e80e5a.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e43954e1ebf355ef93%2F69c5865035776c9b1a874633.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e43954e1ebf355ef93%2F69c586b493958885ee0b0006.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6867a87bfc518f6dbf33510a" data-idx="603">
+        <div class="book-header">
+          <span class="book-num">#604</span>
+          <h3>Complementum Astrologiae</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/supplement-to-astrology-and-detailed-explanation-of-the-nagel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867a87bfc518f6dbf33510a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867a87bfc518f6dbf33510a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867a87bfc518f6dbf33510a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867a87bfc518f6dbf33510a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867a87bfc518f6dbf33510a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a87bfc518f6dbf33510a%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a87bfc518f6dbf33510a%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a87bfc518f6dbf33510a%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a87bfc518f6dbf33510a%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867a87bfc518f6dbf33510a%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81f706c6f3cc53c84a56d" data-idx="604">
+        <div class="book-header">
+          <span class="book-num">#605</span>
+          <h3>De perenni philosophia</h3>
+          <span class="page-count">320 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81f706c6f3cc53c84a56d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81f706c6f3cc53c84a56d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81f706c6f3cc53c84a56d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81f706c6f3cc53c84a56d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81f706c6f3cc53c84a56d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81f706c6f3cc53c84a56d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f706c6f3cc53c84a56d%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f706c6f3cc53c84a56d%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f706c6f3cc53c84a56d%2F0192-full.jpg&w=600" alt="Page 192" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.192 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f706c6f3cc53c84a56d%2F0256-full.jpg&w=600" alt="Page 256" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.256 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f706c6f3cc53c84a56d%2F0288-full.jpg&w=600" alt="Page 288" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.288 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89ea66c6f3cc53c85da9f" data-idx="605">
+        <div class="book-header">
+          <span class="book-num">#606</span>
+          <h3>Die Macht der Kinder in der letzten Zeit</h3>
+          <span class="page-count">164 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89ea66c6f3cc53c85da9f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89ea66c6f3cc53c85da9f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89ea66c6f3cc53c85da9f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89ea66c6f3cc53c85da9f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89ea66c6f3cc53c85da9f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89ea66c6f3cc53c85da9f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ea66c6f3cc53c85da9f%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ea66c6f3cc53c85da9f%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ea66c6f3cc53c85da9f%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ea66c6f3cc53c85da9f%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89ea66c6f3cc53c85da9f%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6867c831aadfee9e955ecc6a" data-idx="606">
+        <div class="book-header">
+          <span class="book-num">#607</span>
+          <h3>Anleitung zur primitiven gabalistischen Wissenschaft</h3>
+          <span class="page-count">250 pp</span>
+          <a href="https://sourcelibrary.org/book/introduction-to-primitive-cabalistic-science-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867c831aadfee9e955ecc6a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867c831aadfee9e955ecc6a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867c831aadfee9e955ecc6a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867c831aadfee9e955ecc6a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867c831aadfee9e955ecc6a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c831aadfee9e955ecc6a%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c831aadfee9e955ecc6a%2F100.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c831aadfee9e955ecc6a%2F150.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c831aadfee9e955ecc6a%2F200.jpg&w=600" alt="Page 200" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.200 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867c831aadfee9e955ecc6a%2F225.jpg&w=600" alt="Page 225" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.225 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c858e96c6f3cc53c8543dc" data-idx="607">
+        <div class="book-header">
+          <span class="book-num">#608</span>
+          <h3>Unterschiedliche, theils verteutschte, theils selbst verfertigte Schrifften</h3>
+          <span class="page-count">291 pp</span>
+          <a href="https://sourcelibrary.org/book/69c858e96c6f3cc53c8543dc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c858e96c6f3cc53c8543dc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c858e96c6f3cc53c8543dc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c858e96c6f3cc53c8543dc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c858e96c6f3cc53c8543dc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c858e96c6f3cc53c8543dc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858e96c6f3cc53c8543dc%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858e96c6f3cc53c8543dc%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858e96c6f3cc53c8543dc%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858e96c6f3cc53c8543dc%2F0233-full.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c858e96c6f3cc53c8543dc%2F0262-full.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7efa4fb10016c3f38a001" data-idx="608">
+        <div class="book-header">
+          <span class="book-num">#609</span>
+          <h3>Bouquet composé des plus belles fleurs chimiques</h3>
+          <span class="page-count">524 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7efa4fb10016c3f38a001" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7efa4fb10016c3f38a001', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7efa4fb10016c3f38a001', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7efa4fb10016c3f38a001', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7efa4fb10016c3f38a001', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7efa4fb10016c3f38a001', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7efa4fb10016c3f38a001%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7efa4fb10016c3f38a001%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7efa4fb10016c3f38a001%2F0314-full.jpg&w=600" alt="Page 314" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.314 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7efa4fb10016c3f38a001%2F0419-full.jpg&w=600" alt="Page 419" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.419 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7efa4fb10016c3f38a001%2F0472-full.jpg&w=600" alt="Page 472" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.472 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c828246c6f3cc53c84c283" data-idx="609">
+        <div class="book-header">
+          <span class="book-num">#610</span>
+          <h3>Einleitung zur Alchimie</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/69c828246c6f3cc53c84c283" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c828246c6f3cc53c84c283', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c828246c6f3cc53c84c283', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c828246c6f3cc53c84c283', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c828246c6f3cc53c84c283', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c828246c6f3cc53c84c283', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828246c6f3cc53c84c283%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828246c6f3cc53c84c283%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828246c6f3cc53c84c283%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828246c6f3cc53c84c283%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828246c6f3cc53c84c283%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c894346c6f3cc53c85c090" data-idx="610">
+        <div class="book-header">
+          <span class="book-num">#611</span>
+          <h3>Clef absolue de la science occulte. Le tarot des Bohémiens le plus ancien livre du monde. A l'usage exclusif des initiés</h3>
+          <span class="page-count">206 pp</span>
+          <a href="https://sourcelibrary.org/book/69c894346c6f3cc53c85c090" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c894346c6f3cc53c85c090', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c894346c6f3cc53c85c090', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c894346c6f3cc53c85c090', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c894346c6f3cc53c85c090', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c894346c6f3cc53c85c090', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894346c6f3cc53c85c090%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894346c6f3cc53c85c090%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894346c6f3cc53c85c090%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894346c6f3cc53c85c090%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894346c6f3cc53c85c090%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e34cc41628b775aa86" data-idx="611">
+        <div class="book-header">
+          <span class="book-num">#612</span>
+          <h3>De usu et mysteriis notarum liber</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e34cc41628b775aa86" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e34cc41628b775aa86', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e34cc41628b775aa86', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e34cc41628b775aa86', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e34cc41628b775aa86', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e34cc41628b775aa86', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa86%2F69c5827a985d8148794a720a.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa86%2F69c584c1902d5f78bbe4197c.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa86%2F69c5864593958885ee0afffa.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa86%2F69c587bab643d8b1c29daa16.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e34cc41628b775aa86%2F69c588759ee51e419b7b85e3.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c828516c6f3cc53c84c30f" data-idx="612">
+        <div class="book-header">
+          <span class="book-num">#613</span>
+          <h3>Zodiacus vitae</h3>
+          <span class="page-count">181 pp</span>
+          <a href="https://sourcelibrary.org/book/69c828516c6f3cc53c84c30f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c828516c6f3cc53c84c30f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c828516c6f3cc53c84c30f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c828516c6f3cc53c84c30f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c828516c6f3cc53c84c30f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c828516c6f3cc53c84c30f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828516c6f3cc53c84c30f%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828516c6f3cc53c84c30f%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828516c6f3cc53c84c30f%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828516c6f3cc53c84c30f%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828516c6f3cc53c84c30f%2F0163-full.jpg&w=600" alt="Page 163" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.163 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8569d6c6f3cc53c853ea4" data-idx="613">
+        <div class="book-header">
+          <span class="book-num">#614</span>
+          <h3>Pinax microcosmographicus in quo certissimum anatomiae compendium proponitur</h3>
+          <span class="page-count">10 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8569d6c6f3cc53c853ea4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8569d6c6f3cc53c853ea4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8569d6c6f3cc53c853ea4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8569d6c6f3cc53c853ea4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8569d6c6f3cc53c853ea4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8569d6c6f3cc53c853ea4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8569d6c6f3cc53c853ea4%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8569d6c6f3cc53c853ea4%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8569d6c6f3cc53c853ea4%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8569d6c6f3cc53c853ea4%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8569d6c6f3cc53c853ea4%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8600b6c6f3cc53c8556fb" data-idx="614">
+        <div class="book-header">
+          <span class="book-num">#615</span>
+          <h3>Sanctae Paginae Encomium, in quo breviter loco suo de Praeadamitis</h3>
+          <span class="page-count">81 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8600b6c6f3cc53c8556fb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8600b6c6f3cc53c8556fb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8600b6c6f3cc53c8556fb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8600b6c6f3cc53c8556fb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8600b6c6f3cc53c8556fb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8600b6c6f3cc53c8556fb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8600b6c6f3cc53c8556fb%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8600b6c6f3cc53c8556fb%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8600b6c6f3cc53c8556fb%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8600b6c6f3cc53c8556fb%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8600b6c6f3cc53c8556fb%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83fc16c6f3cc53c85053b" data-idx="615">
+        <div class="book-header">
+          <span class="book-num">#616</span>
+          <h3>Mysterium sigillorum, herbarum &amp; lapidum oder: Vollkommene Cur und Heilung aller Kranckheiten</h3>
+          <span class="page-count">107 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83fc16c6f3cc53c85053b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83fc16c6f3cc53c85053b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83fc16c6f3cc53c85053b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83fc16c6f3cc53c85053b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83fc16c6f3cc53c85053b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83fc16c6f3cc53c85053b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83fc16c6f3cc53c85053b%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83fc16c6f3cc53c85053b%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83fc16c6f3cc53c85053b%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83fc16c6f3cc53c85053b%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83fc16c6f3cc53c85053b%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41960f6141ca31143b7a0" data-idx="616">
+        <div class="book-header">
+          <span class="book-num">#617</span>
+          <h3>Wenn die Sonne nordwärts geht — Mabel Collins (PH3335)</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/mabel-collins-master-hymns-from-history-of-the-year-collins" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41960f6141ca31143b7a0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41960f6141ca31143b7a0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41960f6141ca31143b7a0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41960f6141ca31143b7a0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41960f6141ca31143b7a0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940891047405131!PH3335_0004.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940891047405131!PH3335_0015.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940891047405131!PH3335_0022.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940891047405131!PH3335_0030.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940891047405131!PH3335_0033.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82de66c6f3cc53c84d4bf" data-idx="617">
+        <div class="book-header">
+          <span class="book-num">#618</span>
+          <h3>Specimen philologicum de veterum gentilium et judaeorum theologia mythica</h3>
+          <span class="page-count">135 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82de66c6f3cc53c84d4bf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82de66c6f3cc53c84d4bf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82de66c6f3cc53c84d4bf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82de66c6f3cc53c84d4bf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82de66c6f3cc53c84d4bf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82de66c6f3cc53c84d4bf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82de66c6f3cc53c84d4bf%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82de66c6f3cc53c84d4bf%2F0054-full.jpg&w=600" alt="Page 54" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.54 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82de66c6f3cc53c84d4bf%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82de66c6f3cc53c84d4bf%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82de66c6f3cc53c84d4bf%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c889b46c6f3cc53c85a494" data-idx="618">
+        <div class="book-header">
+          <span class="book-num">#619</span>
+          <h3>Sepher Ietzirah ([Hebrew: Sefer jezirah]). Traduction du livre cabalistique de la création</h3>
+          <span class="page-count">51 pp</span>
+          <a href="https://sourcelibrary.org/book/69c889b46c6f3cc53c85a494" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c889b46c6f3cc53c85a494', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c889b46c6f3cc53c85a494', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c889b46c6f3cc53c85a494', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c889b46c6f3cc53c85a494', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c889b46c6f3cc53c85a494', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889b46c6f3cc53c85a494%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889b46c6f3cc53c85a494%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889b46c6f3cc53c85a494%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889b46c6f3cc53c85a494%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889b46c6f3cc53c85a494%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c849176c6f3cc53c851dbf" data-idx="619">
+        <div class="book-header">
+          <span class="book-num">#620</span>
+          <h3>Opera. oder alle Bücher und Schrifften</h3>
+          <span class="page-count">309 pp</span>
+          <a href="https://sourcelibrary.org/book/69c849176c6f3cc53c851dbf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c849176c6f3cc53c851dbf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c849176c6f3cc53c851dbf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c849176c6f3cc53c851dbf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c849176c6f3cc53c851dbf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c849176c6f3cc53c851dbf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849176c6f3cc53c851dbf%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849176c6f3cc53c851dbf%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849176c6f3cc53c851dbf%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849176c6f3cc53c851dbf%2F0247-full.jpg&w=600" alt="Page 247" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.247 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849176c6f3cc53c851dbf%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c859a36c6f3cc53c854669" data-idx="620">
+        <div class="book-header">
+          <span class="book-num">#621</span>
+          <h3>Die Seligkeit der gemeinen Leute</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c859a36c6f3cc53c854669" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c859a36c6f3cc53c854669', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c859a36c6f3cc53c854669', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c859a36c6f3cc53c854669', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c859a36c6f3cc53c854669', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c859a36c6f3cc53c854669', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859a36c6f3cc53c854669%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859a36c6f3cc53c854669%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859a36c6f3cc53c854669%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859a36c6f3cc53c854669%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c859a36c6f3cc53c854669%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f61a6c6f3cc53c841d70" data-idx="621">
+        <div class="book-header">
+          <span class="book-num">#622</span>
+          <h3>Judicium de judicio Valeriani Magni Mediolanensis super catholicorum et acatholicorum credendi regula</h3>
+          <span class="page-count">148 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f61a6c6f3cc53c841d70" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f61a6c6f3cc53c841d70', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f61a6c6f3cc53c841d70', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f61a6c6f3cc53c841d70', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f61a6c6f3cc53c841d70', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f61a6c6f3cc53c841d70', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f61a6c6f3cc53c841d70%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f61a6c6f3cc53c841d70%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f61a6c6f3cc53c841d70%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f61a6c6f3cc53c841d70%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f61a6c6f3cc53c841d70%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897d66c6f3cc53c85c922" data-idx="622">
+        <div class="book-header">
+          <span class="book-num">#623</span>
+          <h3>The symbolism of the Zelator ritual</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897d66c6f3cc53c85c922" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897d66c6f3cc53c85c922', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897d66c6f3cc53c85c922', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897d66c6f3cc53c85c922', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897d66c6f3cc53c85c922', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897d66c6f3cc53c85c922', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897d66c6f3cc53c85c922%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897d66c6f3cc53c85c922%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897d66c6f3cc53c85c922%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897d66c6f3cc53c85c922%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897d66c6f3cc53c85c922%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c842b16c6f3cc53c850d4d" data-idx="623">
+        <div class="book-header">
+          <span class="book-num">#624</span>
+          <h3>Ueber die Lehre von den Gründen und Ursachen aller Dinge</h3>
+          <span class="page-count">159 pp</span>
+          <a href="https://sourcelibrary.org/book/69c842b16c6f3cc53c850d4d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c842b16c6f3cc53c850d4d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c842b16c6f3cc53c850d4d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c842b16c6f3cc53c850d4d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c842b16c6f3cc53c850d4d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c842b16c6f3cc53c850d4d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b16c6f3cc53c850d4d%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b16c6f3cc53c850d4d%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b16c6f3cc53c850d4d%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b16c6f3cc53c850d4d%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c842b16c6f3cc53c850d4d%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7bf9525ec2ba5ccd7fbf0" data-idx="624">
+        <div class="book-header">
+          <span class="book-num">#625</span>
+          <h3>Le Parnasse assiégé ou la guerre declarée entre les philosophes anciens &amp; modernes</h3>
+          <span class="page-count">89 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7bf9525ec2ba5ccd7fbf0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7bf9525ec2ba5ccd7fbf0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7bf9525ec2ba5ccd7fbf0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7bf9525ec2ba5ccd7fbf0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7bf9525ec2ba5ccd7fbf0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7bf9525ec2ba5ccd7fbf0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bf9525ec2ba5ccd7fbf0%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bf9525ec2ba5ccd7fbf0%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bf9525ec2ba5ccd7fbf0%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bf9525ec2ba5ccd7fbf0%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bf9525ec2ba5ccd7fbf0%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87da36c6f3cc53c858bae" data-idx="625">
+        <div class="book-header">
+          <span class="book-num">#626</span>
+          <h3>Lives of alchemystical philosophers. Based on materials collected in 1815 and supplemented by recent researches</h3>
+          <span class="page-count">165 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87da36c6f3cc53c858bae" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87da36c6f3cc53c858bae', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87da36c6f3cc53c858bae', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87da36c6f3cc53c858bae', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87da36c6f3cc53c858bae', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87da36c6f3cc53c858bae', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da36c6f3cc53c858bae%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da36c6f3cc53c858bae%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da36c6f3cc53c858bae%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da36c6f3cc53c858bae%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87da36c6f3cc53c858bae%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e32e2f948a050a5054" data-idx="626">
+        <div class="book-header">
+          <span class="book-num">#627</span>
+          <h3>Les secrets les plus cachés de la philosophie des anciens</h3>
+          <span class="page-count">183 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e32e2f948a050a5054" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e32e2f948a050a5054', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e32e2f948a050a5054', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e32e2f948a050a5054', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e32e2f948a050a5054', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e32e2f948a050a5054', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5054%2F69c583da3cb3e789005912c4.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5054%2F69c58bab5b57418d7396d5d1.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5054%2F69c5910a411a914f8b3cea03.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5054%2F69c595f4f9451672ad76defc.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5054%2F69c598f2796f6c5aee604983.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c860096c6f3cc53c8556f9" data-idx="627">
+        <div class="book-header">
+          <span class="book-num">#628</span>
+          <h3>Kirchen oder Hauspostill, über die Sonntags und fürnembsten Fest Evangelien durchs gantze Jahr</h3>
+          <span class="page-count">371 pp</span>
+          <a href="https://sourcelibrary.org/book/69c860096c6f3cc53c8556f9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c860096c6f3cc53c8556f9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c860096c6f3cc53c8556f9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c860096c6f3cc53c8556f9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c860096c6f3cc53c8556f9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c860096c6f3cc53c8556f9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860096c6f3cc53c8556f9%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860096c6f3cc53c8556f9%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860096c6f3cc53c8556f9%2F0223-full.jpg&w=600" alt="Page 223" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.223 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860096c6f3cc53c8556f9%2F0297-full.jpg&w=600" alt="Page 297" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.297 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860096c6f3cc53c8556f9%2F0334-full.jpg&w=600" alt="Page 334" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.334 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855196c6f3cc53c853a38" data-idx="628">
+        <div class="book-header">
+          <span class="book-num">#629</span>
+          <h3>Die nothwendige Vollendung der geistlichen Reinigung und Heiligung, entweder bey Leibes Leben, oder Nach dem Tode</h3>
+          <span class="page-count">43 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855196c6f3cc53c853a38" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855196c6f3cc53c853a38', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855196c6f3cc53c853a38', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855196c6f3cc53c853a38', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855196c6f3cc53c853a38', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855196c6f3cc53c853a38', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855196c6f3cc53c853a38%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855196c6f3cc53c853a38%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855196c6f3cc53c853a38%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855196c6f3cc53c853a38%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855196c6f3cc53c853a38%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c899d56c6f3cc53c85cfb2" data-idx="629">
+        <div class="book-header">
+          <span class="book-num">#630</span>
+          <h3>Sermonum ... ad populum</h3>
+          <span class="page-count">82 pp</span>
+          <a href="https://sourcelibrary.org/book/69c899d56c6f3cc53c85cfb2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c899d56c6f3cc53c85cfb2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c899d56c6f3cc53c85cfb2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c899d56c6f3cc53c85cfb2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c899d56c6f3cc53c85cfb2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c899d56c6f3cc53c85cfb2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899d56c6f3cc53c85cfb2%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899d56c6f3cc53c85cfb2%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899d56c6f3cc53c85cfb2%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899d56c6f3cc53c85cfb2%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899d56c6f3cc53c85cfb2%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85f436c6f3cc53c8554a8" data-idx="630">
+        <div class="book-header">
+          <span class="book-num">#631</span>
+          <h3>[Hebrew] De stemme des bruydegoms ter middernacht</h3>
+          <span class="page-count">244 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85f436c6f3cc53c8554a8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85f436c6f3cc53c8554a8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85f436c6f3cc53c8554a8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85f436c6f3cc53c8554a8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85f436c6f3cc53c8554a8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85f436c6f3cc53c8554a8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f436c6f3cc53c8554a8%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f436c6f3cc53c8554a8%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f436c6f3cc53c8554a8%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f436c6f3cc53c8554a8%2F0195-full.jpg&w=600" alt="Page 195" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.195 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f436c6f3cc53c8554a8%2F0220-full.jpg&w=600" alt="Page 220" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.220 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89cb16c6f3cc53c85d634" data-idx="631">
+        <div class="book-header">
+          <span class="book-num">#632</span>
+          <h3>L'Homme de desir</h3>
+          <span class="page-count">213 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89cb16c6f3cc53c85d634" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89cb16c6f3cc53c85d634', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89cb16c6f3cc53c85d634', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89cb16c6f3cc53c85d634', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89cb16c6f3cc53c85d634', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89cb16c6f3cc53c85d634', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cb16c6f3cc53c85d634%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cb16c6f3cc53c85d634%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cb16c6f3cc53c85d634%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cb16c6f3cc53c85d634%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cb16c6f3cc53c85d634%2F0192-full.jpg&w=600" alt="Page 192" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.192 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c899506c6f3cc53c85cda1" data-idx="632">
+        <div class="book-header">
+          <span class="book-num">#633</span>
+          <h3>Naturalia &amp; prophetica de anima</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c899506c6f3cc53c85cda1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c899506c6f3cc53c85cda1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c899506c6f3cc53c85cda1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c899506c6f3cc53c85cda1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c899506c6f3cc53c85cda1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c899506c6f3cc53c85cda1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899506c6f3cc53c85cda1%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899506c6f3cc53c85cda1%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899506c6f3cc53c85cda1%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899506c6f3cc53c85cda1%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c899506c6f3cc53c85cda1%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c884a06c6f3cc53c8599e5" data-idx="633">
+        <div class="book-header">
+          <span class="book-num">#634</span>
+          <h3>Pistis sophia. A gnostic gospel (with extracts from the books of the saviour appended)</h3>
+          <span class="page-count">225 pp</span>
+          <a href="https://sourcelibrary.org/book/69c884a06c6f3cc53c8599e5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c884a06c6f3cc53c8599e5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c884a06c6f3cc53c8599e5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c884a06c6f3cc53c8599e5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c884a06c6f3cc53c8599e5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c884a06c6f3cc53c8599e5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884a06c6f3cc53c8599e5%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884a06c6f3cc53c8599e5%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884a06c6f3cc53c8599e5%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884a06c6f3cc53c8599e5%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c884a06c6f3cc53c8599e5%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c2476e0787282ad5930dd" data-idx="634">
+        <div class="book-header">
+          <span class="book-num">#635</span>
+          <h3>Lebensbeschreibungen berühmter Männer aus den Zeiten der Wiederherstellung der Wissenschaften</h3>
+          <span class="page-count">209 pp</span>
+          <a href="https://sourcelibrary.org/book/biographies-of-famous-men-from-the-times-of-the-revival-of-meiners" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c2476e0787282ad5930dd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c2476e0787282ad5930dd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c2476e0787282ad5930dd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c2476e0787282ad5930dd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c2476e0787282ad5930dd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2476e0787282ad5930dd%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2476e0787282ad5930dd%2F84.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2476e0787282ad5930dd%2F125.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2476e0787282ad5930dd%2F167.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2476e0787282ad5930dd%2F188.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909b22fcf28baa1b4caf185" data-idx="635">
+        <div class="book-header">
+          <span class="book-num">#636</span>
+          <h3>Philosophia pia</h3>
+          <span class="page-count">130 pp</span>
+          <a href="https://sourcelibrary.org/book/pious-philosophy-glanvill" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909b22fcf28baa1b4caf185', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909b22fcf28baa1b4caf185', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909b22fcf28baa1b4caf185', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909b22fcf28baa1b4caf185', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909b22fcf28baa1b4caf185', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b22fcf28baa1b4caf185%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b22fcf28baa1b4caf185%2F52.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b22fcf28baa1b4caf185%2F78.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b22fcf28baa1b4caf185%2F104.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909b22fcf28baa1b4caf185%2F117.jpg&w=600" alt="Page 117" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.117 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84e886c6f3cc53c852936" data-idx="636">
+        <div class="book-header">
+          <span class="book-num">#637</span>
+          <h3>Cosmus in microcosmo. Hoc est: mundus opere sex dierum creatus</h3>
+          <span class="page-count">86 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84e886c6f3cc53c852936" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84e886c6f3cc53c852936', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84e886c6f3cc53c852936', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84e886c6f3cc53c852936', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84e886c6f3cc53c852936', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84e886c6f3cc53c852936', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e886c6f3cc53c852936%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e886c6f3cc53c852936%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e886c6f3cc53c852936%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e886c6f3cc53c852936%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84e886c6f3cc53c852936%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a4276c6f3cc53c85e819" data-idx="637">
+        <div class="book-header">
+          <span class="book-num">#638</span>
+          <h3>Kurzer aber doch hinlänglicher Auszug</h3>
+          <span class="page-count">153 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a4276c6f3cc53c85e819" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a4276c6f3cc53c85e819', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a4276c6f3cc53c85e819', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a4276c6f3cc53c85e819', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a4276c6f3cc53c85e819', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a4276c6f3cc53c85e819', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a4276c6f3cc53c85e819%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a4276c6f3cc53c85e819%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a4276c6f3cc53c85e819%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a4276c6f3cc53c85e819%2F0122-full.jpg&w=600" alt="Page 122" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.122 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a4276c6f3cc53c85e819%2F0138-full.jpg&w=600" alt="Page 138" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.138 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c822426c6f3cc53c84ac6b" data-idx="638">
+        <div class="book-header">
+          <span class="book-num">#639</span>
+          <h3>Catalogus van alle de principaelste rariteyten die op de anatomie-kamer binnen de stad Leyden vertoont worden</h3>
+          <span class="page-count">18 pp</span>
+          <a href="https://sourcelibrary.org/book/69c822426c6f3cc53c84ac6b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c822426c6f3cc53c84ac6b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c822426c6f3cc53c84ac6b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c822426c6f3cc53c84ac6b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c822426c6f3cc53c84ac6b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c822426c6f3cc53c84ac6b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822426c6f3cc53c84ac6b%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822426c6f3cc53c84ac6b%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822426c6f3cc53c84ac6b%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822426c6f3cc53c84ac6b%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c822426c6f3cc53c84ac6b%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2246c6f3cc53c85e367" data-idx="639">
+        <div class="book-header">
+          <span class="book-num">#640</span>
+          <h3>Dreams</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2246c6f3cc53c85e367" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2246c6f3cc53c85e367', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2246c6f3cc53c85e367', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2246c6f3cc53c85e367', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2246c6f3cc53c85e367', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2246c6f3cc53c85e367', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2246c6f3cc53c85e367%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2246c6f3cc53c85e367%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2246c6f3cc53c85e367%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2246c6f3cc53c85e367%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2246c6f3cc53c85e367%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c734076a0f3d112faf750d" data-idx="640">
+        <div class="book-header">
+          <span class="book-num">#641</span>
+          <h3>[Hebrew: Ayelet ahavim. Perush al shir ha-shirim]</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/69c734076a0f3d112faf750d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c734076a0f3d112faf750d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c734076a0f3d112faf750d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c734076a0f3d112faf750d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c734076a0f3d112faf750d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c734076a0f3d112faf750d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734076a0f3d112faf750d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734076a0f3d112faf750d%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734076a0f3d112faf750d%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734076a0f3d112faf750d%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734076a0f3d112faf750d%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c793e46a0f3d112faf9e08" data-idx="641">
+        <div class="book-header">
+          <span class="book-num">#642</span>
+          <h3>Die Samaritinn, Jesus gelindete Bekehrungsweise</h3>
+          <span class="page-count">201 pp</span>
+          <a href="https://sourcelibrary.org/book/69c793e46a0f3d112faf9e08" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c793e46a0f3d112faf9e08', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c793e46a0f3d112faf9e08', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c793e46a0f3d112faf9e08', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c793e46a0f3d112faf9e08', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c793e46a0f3d112faf9e08', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c793e46a0f3d112faf9e08%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c793e46a0f3d112faf9e08%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c793e46a0f3d112faf9e08%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c793e46a0f3d112faf9e08%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c793e46a0f3d112faf9e08%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855a66c6f3cc53c853b48" data-idx="642">
+        <div class="book-header">
+          <span class="book-num">#643</span>
+          <h3>Signa temporum</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855a66c6f3cc53c853b48" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855a66c6f3cc53c853b48', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855a66c6f3cc53c853b48', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855a66c6f3cc53c853b48', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855a66c6f3cc53c853b48', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855a66c6f3cc53c853b48', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855a66c6f3cc53c853b48%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855a66c6f3cc53c853b48%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855a66c6f3cc53c853b48%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855a66c6f3cc53c853b48%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855a66c6f3cc53c853b48%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7840b6a0f3d112faf98b9" data-idx="643">
+        <div class="book-header">
+          <span class="book-num">#644</span>
+          <h3>Anti-Saint-Nicaise. Ein Turnier im XVIII. Jahrhundert gehalten</h3>
+          <span class="page-count">118 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7840b6a0f3d112faf98b9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7840b6a0f3d112faf98b9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7840b6a0f3d112faf98b9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7840b6a0f3d112faf98b9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7840b6a0f3d112faf98b9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7840b6a0f3d112faf98b9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7840b6a0f3d112faf98b9%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7840b6a0f3d112faf98b9%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7840b6a0f3d112faf98b9%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7840b6a0f3d112faf98b9%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7840b6a0f3d112faf98b9%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86b016c6f3cc53c856ab5" data-idx="644">
+        <div class="book-header">
+          <span class="book-num">#645</span>
+          <h3>Ausslegung des Evangelii, Matth.V</h3>
+          <span class="page-count">38 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86b016c6f3cc53c856ab5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86b016c6f3cc53c856ab5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86b016c6f3cc53c856ab5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86b016c6f3cc53c856ab5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86b016c6f3cc53c856ab5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86b016c6f3cc53c856ab5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b016c6f3cc53c856ab5%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b016c6f3cc53c856ab5%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b016c6f3cc53c856ab5%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b016c6f3cc53c856ab5%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86b016c6f3cc53c856ab5%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c815ea6c6f3cc53c84885b" data-idx="645">
+        <div class="book-header">
+          <span class="book-num">#646</span>
+          <h3>D'academie der geleerde theologanten</h3>
+          <span class="page-count">340 pp</span>
+          <a href="https://sourcelibrary.org/book/69c815ea6c6f3cc53c84885b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c815ea6c6f3cc53c84885b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c815ea6c6f3cc53c84885b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c815ea6c6f3cc53c84885b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c815ea6c6f3cc53c84885b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c815ea6c6f3cc53c84885b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815ea6c6f3cc53c84885b%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815ea6c6f3cc53c84885b%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815ea6c6f3cc53c84885b%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815ea6c6f3cc53c84885b%2F0272-full.jpg&w=600" alt="Page 272" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.272 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c815ea6c6f3cc53c84885b%2F0306-full.jpg&w=600" alt="Page 306" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.306 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6e6d0500fb263739553cd" data-idx="646">
+        <div class="book-header">
+          <span class="book-num">#647</span>
+          <h3>Wahre Abbildung des inwendigen Christenthums</h3>
+          <span class="page-count">461 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6e6d0500fb263739553cd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6e6d0500fb263739553cd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6e6d0500fb263739553cd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6e6d0500fb263739553cd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6e6d0500fb263739553cd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6e6d0500fb263739553cd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cd%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cd%2F0184-full.jpg&w=600" alt="Page 184" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.184 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cd%2F0277-full.jpg&w=600" alt="Page 277" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.277 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cd%2F0369-full.jpg&w=600" alt="Page 369" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.369 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cd%2F0415-full.jpg&w=600" alt="Page 415" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.415 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6e6d0500fb263739553cf" data-idx="647">
+        <div class="book-header">
+          <span class="book-num">#648</span>
+          <h3>[Hebrew: Kabbalah] oder: die wahre und richtige Cabalah</h3>
+          <span class="page-count">50 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6e6d0500fb263739553cf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6e6d0500fb263739553cf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6e6d0500fb263739553cf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6e6d0500fb263739553cf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6e6d0500fb263739553cf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6e6d0500fb263739553cf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cf%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cf%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cf%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cf%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553cf%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83f236c6f3cc53c850396" data-idx="648">
+        <div class="book-header">
+          <span class="book-num">#649</span>
+          <h3>De medicinali materia libri sex</h3>
+          <span class="page-count">428 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83f236c6f3cc53c850396" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83f236c6f3cc53c850396', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83f236c6f3cc53c850396', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83f236c6f3cc53c850396', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83f236c6f3cc53c850396', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83f236c6f3cc53c850396', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83f236c6f3cc53c850396%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83f236c6f3cc53c850396%2F0171-full.jpg&w=600" alt="Page 171" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.171 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83f236c6f3cc53c850396%2F0257-full.jpg&w=600" alt="Page 257" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.257 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83f236c6f3cc53c850396%2F0342-full.jpg&w=600" alt="Page 342" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.342 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83f236c6f3cc53c850396%2F0385-full.jpg&w=600" alt="Page 385" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.385 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b0ec25ec2ba5ccd7f3f3" data-idx="649">
+        <div class="book-header">
+          <span class="book-num">#650</span>
+          <h3>[Hebrew: Sefer asis rimmonim]</h3>
+          <span class="page-count">75 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b0ec25ec2ba5ccd7f3f3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b0ec25ec2ba5ccd7f3f3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b0ec25ec2ba5ccd7f3f3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b0ec25ec2ba5ccd7f3f3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b0ec25ec2ba5ccd7f3f3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b0ec25ec2ba5ccd7f3f3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b0ec25ec2ba5ccd7f3f3%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b0ec25ec2ba5ccd7f3f3%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b0ec25ec2ba5ccd7f3f3%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b0ec25ec2ba5ccd7f3f3%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b0ec25ec2ba5ccd7f3f3%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83edd6c6f3cc53c8502c3" data-idx="650">
+        <div class="book-header">
+          <span class="book-num">#651</span>
+          <h3>Triumph Wagen antimonii</h3>
+          <span class="page-count">258 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83edd6c6f3cc53c8502c3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83edd6c6f3cc53c8502c3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83edd6c6f3cc53c8502c3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83edd6c6f3cc53c8502c3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83edd6c6f3cc53c8502c3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83edd6c6f3cc53c8502c3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83edd6c6f3cc53c8502c3%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83edd6c6f3cc53c8502c3%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83edd6c6f3cc53c8502c3%2F0155-full.jpg&w=600" alt="Page 155" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.155 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83edd6c6f3cc53c8502c3%2F0206-full.jpg&w=600" alt="Page 206" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.206 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83edd6c6f3cc53c8502c3%2F0232-full.jpg&w=600" alt="Page 232" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.232 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86a4c6c6f3cc53c8569b3" data-idx="651">
+        <div class="book-header">
+          <span class="book-num">#652</span>
+          <h3>Arithmetica</h3>
+          <span class="page-count">147 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86a4c6c6f3cc53c8569b3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86a4c6c6f3cc53c8569b3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86a4c6c6f3cc53c8569b3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86a4c6c6f3cc53c8569b3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86a4c6c6f3cc53c8569b3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86a4c6c6f3cc53c8569b3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86a4c6c6f3cc53c8569b3%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86a4c6c6f3cc53c8569b3%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86a4c6c6f3cc53c8569b3%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86a4c6c6f3cc53c8569b3%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86a4c6c6f3cc53c8569b3%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6edbdda9771c716314a48" data-idx="652">
+        <div class="book-header">
+          <span class="book-num">#653</span>
+          <h3>Der Weg des Friedens</h3>
+          <span class="page-count">377 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6edbdda9771c716314a48" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6edbdda9771c716314a48', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6edbdda9771c716314a48', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6edbdda9771c716314a48', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6edbdda9771c716314a48', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6edbdda9771c716314a48', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6edbdda9771c716314a48%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6edbdda9771c716314a48%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6edbdda9771c716314a48%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6edbdda9771c716314a48%2F0302-full.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6edbdda9771c716314a48%2F0339-full.jpg&w=600" alt="Page 339" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.339 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f3d4da9771c716314e93" data-idx="653">
+        <div class="book-header">
+          <span class="book-num">#654</span>
+          <h3>Die Wolke ueber dem Heiligthum</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f3d4da9771c716314e93" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f3d4da9771c716314e93', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f3d4da9771c716314e93', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f3d4da9771c716314e93', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f3d4da9771c716314e93', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f3d4da9771c716314e93', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e93%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e93%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e93%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e93%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e93%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4193f2b0edf3eaa2df265" data-idx="654">
+        <div class="book-header">
+          <span class="book-num">#655</span>
+          <h3>De Trinitatis Erroribus — Michael Servetus (PH474)</h3>
+          <span class="page-count">82 pp</span>
+          <a href="https://sourcelibrary.org/book/servetus-errors-of-the-trinity-17th-century-ms-copy-servetus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4193f2b0edf3eaa2df265', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4193f2b0edf3eaa2df265', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4193f2b0edf3eaa2df265', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4193f2b0edf3eaa2df265', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4193f2b0edf3eaa2df265', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193f2b0edf3eaa2df265%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193f2b0edf3eaa2df265%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193f2b0edf3eaa2df265%2F49.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193f2b0edf3eaa2df265%2F66.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193f2b0edf3eaa2df265%2F74.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8696e6c6f3cc53c856876" data-idx="655">
+        <div class="book-header">
+          <span class="book-num">#656</span>
+          <h3>An answer to the world</h3>
+          <span class="page-count">50 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8696e6c6f3cc53c856876" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8696e6c6f3cc53c856876', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8696e6c6f3cc53c856876', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8696e6c6f3cc53c856876', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8696e6c6f3cc53c856876', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8696e6c6f3cc53c856876', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8696e6c6f3cc53c856876%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8696e6c6f3cc53c856876%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8696e6c6f3cc53c856876%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8696e6c6f3cc53c856876%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8696e6c6f3cc53c856876%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909bf46cf28baa1b4caf6b5" data-idx="656">
+        <div class="book-header">
+          <span class="book-num">#657</span>
+          <h3>Histoire curieuse de la vie, de la conduite, &amp; des vrais sentiments du Sr. Jean de Labadie</h3>
+          <span class="page-count">196 pp</span>
+          <a href="https://sourcelibrary.org/book/curious-history-of-the-life-conduct-and-true-sentiments-of-marets" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909bf46cf28baa1b4caf6b5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909bf46cf28baa1b4caf6b5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909bf46cf28baa1b4caf6b5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909bf46cf28baa1b4caf6b5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909bf46cf28baa1b4caf6b5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf46cf28baa1b4caf6b5%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf46cf28baa1b4caf6b5%2F78.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf46cf28baa1b4caf6b5%2F118.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf46cf28baa1b4caf6b5%2F157.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909bf46cf28baa1b4caf6b5%2F176.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4188b2b0edf3eaa2dd387" data-idx="657">
+        <div class="book-header">
+          <span class="book-num">#658</span>
+          <h3>Collection of Alchemical and Mystical Drawings (PH434)</h3>
+          <span class="page-count">20 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-mystical-drawings-19th-century-german-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4188b2b0edf3eaa2dd387', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4188b2b0edf3eaa2dd387', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4188b2b0edf3eaa2dd387', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4188b2b0edf3eaa2dd387', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4188b2b0edf3eaa2dd387', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188b2b0edf3eaa2dd387%2F2.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188b2b0edf3eaa2dd387%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188b2b0edf3eaa2dd387%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188b2b0edf3eaa2dd387%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4188b2b0edf3eaa2dd387%2F18.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86bfe6c6f3cc53c856bb8" data-idx="658">
+        <div class="book-header">
+          <span class="book-num">#659</span>
+          <h3>Belle and the dragon. An elfin comedy</h3>
+          <span class="page-count">103 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86bfe6c6f3cc53c856bb8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86bfe6c6f3cc53c856bb8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86bfe6c6f3cc53c856bb8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86bfe6c6f3cc53c856bb8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86bfe6c6f3cc53c856bb8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86bfe6c6f3cc53c856bb8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86bfe6c6f3cc53c856bb8%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86bfe6c6f3cc53c856bb8%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86bfe6c6f3cc53c856bb8%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86bfe6c6f3cc53c856bb8%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86bfe6c6f3cc53c856bb8%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63cd593cbf3c0fd742522" data-idx="659">
+        <div class="book-header">
+          <span class="book-num">#660</span>
+          <h3>De viribus et usu auri et argenti debite praeparati. Das ist: vom Nutz und Gebrauch der wahren Gold- und Silber Artzneyen</h3>
+          <span class="page-count">30 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63cd593cbf3c0fd742522" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63cd593cbf3c0fd742522', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63cd593cbf3c0fd742522', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63cd593cbf3c0fd742522', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63cd593cbf3c0fd742522', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63cd593cbf3c0fd742522', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742522%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742522%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742522%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742522%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63cd593cbf3c0fd742522%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419352b0edf3eaa2defb6" data-idx="660">
+        <div class="book-header">
+          <span class="book-num">#661</span>
+          <h3>Sanguis Naturae — George Moulin (PH212)</h3>
+          <span class="page-count">75 pp</span>
+          <a href="https://sourcelibrary.org/book/blood-of-nature-george-moulin-post-1689-english-ms-moulin" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419352b0edf3eaa2defb6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419352b0edf3eaa2defb6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419352b0edf3eaa2defb6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419352b0edf3eaa2defb6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419352b0edf3eaa2defb6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419352b0edf3eaa2defb6%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940482136105131!ph212_0030.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940482136105131!ph212_0045.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940482136105131!ph212_0060.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940482136105131!ph212_0068.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e32e2f948a050a5058" data-idx="661">
+        <div class="book-header">
+          <span class="book-num">#662</span>
+          <h3>Versuch einer Geschichte des Tempelherrenordens</h3>
+          <span class="page-count">178 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e32e2f948a050a5058" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e32e2f948a050a5058', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e32e2f948a050a5058', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e32e2f948a050a5058', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e32e2f948a050a5058', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e32e2f948a050a5058', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5058%2F69c584714dc3caea675560da.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5058%2F69c58dfbaf891ea7aa52754b.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5058%2F69c5934cfcaffcaf109e48d7.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5058%2F69c5982a1f0fabc28663ce1d.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a5058%2F69c59b40c4ce7c7099fc66d3.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89f386c6f3cc53c85dc0d" data-idx="662">
+        <div class="book-header">
+          <span class="book-num">#663</span>
+          <h3>The Hermetic and alchemical writings of Aureolus Philippus Theophrastus Bombast, of Hohenheim, called Paracelsus the Great. Now for the first time faithfully and accurately translated into English</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89f386c6f3cc53c85dc0d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89f386c6f3cc53c85dc0d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89f386c6f3cc53c85dc0d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89f386c6f3cc53c85dc0d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89f386c6f3cc53c85dc0d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89f386c6f3cc53c85dc0d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f386c6f3cc53c85dc0d%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f386c6f3cc53c85dc0d%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f386c6f3cc53c85dc0d%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f386c6f3cc53c85dc0d%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f386c6f3cc53c85dc0d%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8576e6c6f3cc53c854059" data-idx="663">
+        <div class="book-header">
+          <span class="book-num">#664</span>
+          <h3>Catoptrum microcosmicum</h3>
+          <span class="page-count">22 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8576e6c6f3cc53c854059" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8576e6c6f3cc53c854059', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8576e6c6f3cc53c854059', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8576e6c6f3cc53c854059', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8576e6c6f3cc53c854059', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8576e6c6f3cc53c854059', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8576e6c6f3cc53c854059%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8576e6c6f3cc53c854059%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8576e6c6f3cc53c854059%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8576e6c6f3cc53c854059%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8576e6c6f3cc53c854059%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7dd28bae5db59ace1a067" data-idx="664">
+        <div class="book-header">
+          <span class="book-num">#665</span>
+          <h3>Heutiger, langwieriger, verwirreter teutscher Krieg, in einem nachdencklichen, gründtlichen Gespräch vorgestellt</h3>
+          <span class="page-count">294 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7dd28bae5db59ace1a067" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7dd28bae5db59ace1a067', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7dd28bae5db59ace1a067', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7dd28bae5db59ace1a067', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7dd28bae5db59ace1a067', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7dd28bae5db59ace1a067', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a067%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a067%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a067%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a067%2F0235-full.jpg&w=600" alt="Page 235" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.235 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7dd28bae5db59ace1a067%2F0265-full.jpg&w=600" alt="Page 265" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.265 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418d92b0edf3eaa2de092" data-idx="665">
+        <div class="book-header">
+          <span class="book-num">#666</span>
+          <h3>Julius Sperber — Rosicrucian Text (PH312)</h3>
+          <span class="page-count">126 pp</span>
+          <a href="https://sourcelibrary.org/book/julius-sperber-rosicrucian-ms-pre-1680-sperber" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418d92b0edf3eaa2de092', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418d92b0edf3eaa2de092', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418d92b0edf3eaa2de092', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418d92b0edf3eaa2de092', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418d92b0edf3eaa2de092', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d92b0edf3eaa2de092%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d92b0edf3eaa2de092%2F50.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d92b0edf3eaa2de092%2F76.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d92b0edf3eaa2de092%2F101.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418d92b0edf3eaa2de092%2F113.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81edd6c6f3cc53c84a370" data-idx="666">
+        <div class="book-header">
+          <span class="book-num">#667</span>
+          <h3>Desperat. Oder blöder, geängstigter Politicus</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81edd6c6f3cc53c84a370" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81edd6c6f3cc53c84a370', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81edd6c6f3cc53c84a370', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81edd6c6f3cc53c84a370', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81edd6c6f3cc53c84a370', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81edd6c6f3cc53c84a370', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81edd6c6f3cc53c84a370%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81edd6c6f3cc53c84a370%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81edd6c6f3cc53c84a370%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81edd6c6f3cc53c84a370%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81edd6c6f3cc53c84a370%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c3840e0787282ad59386d" data-idx="667">
+        <div class="book-header">
+          <span class="book-num">#668</span>
+          <h3>Silentium post clamores, das ist, Apologi und Verantwortung</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/silence-after-the-clamors-that-is-apology-and-responsibility-maier" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c3840e0787282ad59386d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c3840e0787282ad59386d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c3840e0787282ad59386d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c3840e0787282ad59386d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c3840e0787282ad59386d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3840e0787282ad59386d%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3840e0787282ad59386d%2F40.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3840e0787282ad59386d%2F61.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3840e0787282ad59386d%2F81.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3840e0787282ad59386d%2F91.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c841336c6f3cc53c8509a7" data-idx="668">
+        <div class="book-header">
+          <span class="book-num">#669</span>
+          <h3>La philosophie chrétienne</h3>
+          <span class="page-count">296 pp</span>
+          <a href="https://sourcelibrary.org/book/69c841336c6f3cc53c8509a7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c841336c6f3cc53c8509a7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c841336c6f3cc53c8509a7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c841336c6f3cc53c8509a7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c841336c6f3cc53c8509a7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c841336c6f3cc53c8509a7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841336c6f3cc53c8509a7%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841336c6f3cc53c8509a7%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841336c6f3cc53c8509a7%2F0178-full.jpg&w=600" alt="Page 178" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.178 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841336c6f3cc53c8509a7%2F0237-full.jpg&w=600" alt="Page 237" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.237 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c841336c6f3cc53c8509a7%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c877d46c6f3cc53c8580e7" data-idx="669">
+        <div class="book-header">
+          <span class="book-num">#670</span>
+          <h3>Fünf und funfzig Briefe</h3>
+          <span class="page-count">87 pp</span>
+          <a href="https://sourcelibrary.org/book/69c877d46c6f3cc53c8580e7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c877d46c6f3cc53c8580e7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c877d46c6f3cc53c8580e7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c877d46c6f3cc53c8580e7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c877d46c6f3cc53c8580e7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c877d46c6f3cc53c8580e7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877d46c6f3cc53c8580e7%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877d46c6f3cc53c8580e7%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877d46c6f3cc53c8580e7%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877d46c6f3cc53c8580e7%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877d46c6f3cc53c8580e7%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a31192b884e4f81738fd" data-idx="670">
+        <div class="book-header">
+          <span class="book-num">#671</span>
+          <h3>Histoire de la religion des Banians</h3>
+          <span class="page-count">159 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a31192b884e4f81738fd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a31192b884e4f81738fd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a31192b884e4f81738fd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a31192b884e4f81738fd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a31192b884e4f81738fd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a31192b884e4f81738fd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a31192b884e4f81738fd%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a31192b884e4f81738fd%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a31192b884e4f81738fd%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a31192b884e4f81738fd%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a31192b884e4f81738fd%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7cc4325ec2ba5ccd80104" data-idx="671">
+        <div class="book-header">
+          <span class="book-num">#672</span>
+          <h3>Die erste Liebe. Das ist: wahre Abbildung der ersten Christen</h3>
+          <span class="page-count">278 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7cc4325ec2ba5ccd80104" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7cc4325ec2ba5ccd80104', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7cc4325ec2ba5ccd80104', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7cc4325ec2ba5ccd80104', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7cc4325ec2ba5ccd80104', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7cc4325ec2ba5ccd80104', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cc4325ec2ba5ccd80104%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cc4325ec2ba5ccd80104%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cc4325ec2ba5ccd80104%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cc4325ec2ba5ccd80104%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7cc4325ec2ba5ccd80104%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a0a892b884e4f8173817" data-idx="672">
+        <div class="book-header">
+          <span class="book-num">#673</span>
+          <h3>Zohar chadash</h3>
+          <span class="page-count">95 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a0a892b884e4f8173817" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a0a892b884e4f8173817', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a0a892b884e4f8173817', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a0a892b884e4f8173817', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a0a892b884e4f8173817', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a0a892b884e4f8173817', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a0a892b884e4f8173817%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a0a892b884e4f8173817%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a0a892b884e4f8173817%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a0a892b884e4f8173817%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a0a892b884e4f8173817%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6e6d0500fb263739553ce" data-idx="673">
+        <div class="book-header">
+          <span class="book-num">#674</span>
+          <h3>Wahre göttliche Hierarchie, oder Grund-Riss des himmlischen Neuen Jerusalems</h3>
+          <span class="page-count">89 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6e6d0500fb263739553ce" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6e6d0500fb263739553ce', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6e6d0500fb263739553ce', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6e6d0500fb263739553ce', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6e6d0500fb263739553ce', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6e6d0500fb263739553ce', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553ce%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553ce%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553ce%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553ce%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e6d0500fb263739553ce%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c800f16c6f3cc53c844114" data-idx="674">
+        <div class="book-header">
+          <span class="book-num">#675</span>
+          <h3>Contra libellum Calvini in quo ostendere conatur haereticos jure gladii coercendos esse</h3>
+          <span class="page-count">132 pp</span>
+          <a href="https://sourcelibrary.org/book/69c800f16c6f3cc53c844114" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c800f16c6f3cc53c844114', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c800f16c6f3cc53c844114', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c800f16c6f3cc53c844114', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c800f16c6f3cc53c844114', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c800f16c6f3cc53c844114', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800f16c6f3cc53c844114%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800f16c6f3cc53c844114%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800f16c6f3cc53c844114%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800f16c6f3cc53c844114%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c800f16c6f3cc53c844114%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="d850a255-4633-43d5-8383-7c67a7e55144" data-idx="675">
+        <div class="book-header">
+          <span class="book-num">#676</span>
+          <h3>Incipit: Ex Ilss. quodam Philosophi R.C. extractum</h3>
+          <span class="page-count">91 pp</span>
+          <a href="https://sourcelibrary.org/book/incipit-from-a-certain-manuscript-of-the-philosopher-r-c-anonymous" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('d850a255-4633-43d5-8383-7c67a7e55144', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('d850a255-4633-43d5-8383-7c67a7e55144', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('d850a255-4633-43d5-8383-7c67a7e55144', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('d850a255-4633-43d5-8383-7c67a7e55144', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('d850a255-4633-43d5-8383-7c67a7e55144', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fd850a255-4633-43d5-8383-7c67a7e55144%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fd850a255-4633-43d5-8383-7c67a7e55144%2F36.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fd850a255-4633-43d5-8383-7c67a7e55144%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fd850a255-4633-43d5-8383-7c67a7e55144%2F73.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2Fd850a255-4633-43d5-8383-7c67a7e55144%2F82.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f95e6c6f3cc53c84266e" data-idx="676">
+        <div class="book-header">
+          <span class="book-num">#677</span>
+          <h3>Das krancke Römische Reich dessen Ursach, und glaubwürdige Artzney dargegen</h3>
+          <span class="page-count">24 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f95e6c6f3cc53c84266e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f95e6c6f3cc53c84266e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f95e6c6f3cc53c84266e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f95e6c6f3cc53c84266e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f95e6c6f3cc53c84266e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f95e6c6f3cc53c84266e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f95e6c6f3cc53c84266e%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f95e6c6f3cc53c84266e%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f95e6c6f3cc53c84266e%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f95e6c6f3cc53c84266e%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f95e6c6f3cc53c84266e%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418a12b0edf3eaa2dd755" data-idx="677">
+        <div class="book-header">
+          <span class="book-num">#678</span>
+          <h3>Liber de tribus facultatibus — Alexander von Suchten &amp; Paracelsus (PH449)</h3>
+          <span class="page-count">64 pp</span>
+          <a href="https://sourcelibrary.org/book/three-faculties-magical-invention-suchten-paracelsus-16th-c-paracelsus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418a12b0edf3eaa2dd755', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418a12b0edf3eaa2dd755', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418a12b0edf3eaa2dd755', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418a12b0edf3eaa2dd755', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418a12b0edf3eaa2dd755', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a12b0edf3eaa2dd755%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a12b0edf3eaa2dd755%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a12b0edf3eaa2dd755%2F38.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a12b0edf3eaa2dd755%2F51.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418a12b0edf3eaa2dd755%2F58.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84d3b6c6f3cc53c8526bc" data-idx="678">
+        <div class="book-header">
+          <span class="book-num">#679</span>
+          <h3>Cosmotheoria, libros duos complexa</h3>
+          <span class="page-count">59 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84d3b6c6f3cc53c8526bc" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84d3b6c6f3cc53c8526bc', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84d3b6c6f3cc53c8526bc', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84d3b6c6f3cc53c8526bc', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84d3b6c6f3cc53c8526bc', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84d3b6c6f3cc53c8526bc', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84d3b6c6f3cc53c8526bc%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84d3b6c6f3cc53c8526bc%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84d3b6c6f3cc53c8526bc%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84d3b6c6f3cc53c8526bc%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84d3b6c6f3cc53c8526bc%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82f726c6f3cc53c84d882" data-idx="679">
+        <div class="book-header">
+          <span class="book-num">#680</span>
+          <h3>Ermanunge zum waren und selig machende Erkanthnus Christi</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82f726c6f3cc53c84d882" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82f726c6f3cc53c84d882', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82f726c6f3cc53c84d882', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82f726c6f3cc53c84d882', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82f726c6f3cc53c84d882', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82f726c6f3cc53c84d882', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82f726c6f3cc53c84d882%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82f726c6f3cc53c84d882%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82f726c6f3cc53c84d882%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82f726c6f3cc53c84d882%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82f726c6f3cc53c84d882%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419152b0edf3eaa2deba7" data-idx="680">
+        <div class="book-header">
+          <span class="book-num">#681</span>
+          <h3>Le devoilement des tableaux mistiques de l'antiquité — Guillaume de Paris (PH159)</h3>
+          <span class="page-count">126 pp</span>
+          <a href="https://sourcelibrary.org/book/unveiling-the-mystic-paintings-of-antiquity-pseudo-paris" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419152b0edf3eaa2deba7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419152b0edf3eaa2deba7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419152b0edf3eaa2deba7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419152b0edf3eaa2deba7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419152b0edf3eaa2deba7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419152b0edf3eaa2deba7%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419152b0edf3eaa2deba7%2F50.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419152b0edf3eaa2deba7%2F76.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419152b0edf3eaa2deba7%2F101.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419152b0edf3eaa2deba7%2F113.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c821446c6f3cc53c84aa06" data-idx="681">
+        <div class="book-header">
+          <span class="book-num">#682</span>
+          <h3>Opera didactica omnia</h3>
+          <span class="page-count">598 pp</span>
+          <a href="https://sourcelibrary.org/book/69c821446c6f3cc53c84aa06" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c821446c6f3cc53c84aa06', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c821446c6f3cc53c84aa06', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c821446c6f3cc53c84aa06', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c821446c6f3cc53c84aa06', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c821446c6f3cc53c84aa06', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c821446c6f3cc53c84aa06%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c821446c6f3cc53c84aa06%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c821446c6f3cc53c84aa06%2F0359-full.jpg&w=600" alt="Page 359" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.359 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c821446c6f3cc53c84aa06%2F0478-full.jpg&w=600" alt="Page 478" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.478 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c821446c6f3cc53c84aa06%2F0538-full.jpg&w=600" alt="Page 538" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.538 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8981d6c6f3cc53c85ca0d" data-idx="682">
+        <div class="book-header">
+          <span class="book-num">#683</span>
+          <h3>Serpent lore and symbols of deity</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8981d6c6f3cc53c85ca0d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8981d6c6f3cc53c85ca0d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8981d6c6f3cc53c85ca0d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8981d6c6f3cc53c85ca0d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8981d6c6f3cc53c85ca0d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8981d6c6f3cc53c85ca0d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8981d6c6f3cc53c85ca0d%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8981d6c6f3cc53c85ca0d%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8981d6c6f3cc53c85ca0d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8981d6c6f3cc53c85ca0d%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8981d6c6f3cc53c85ca0d%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c866d86c6f3cc53c856482" data-idx="683">
+        <div class="book-header">
+          <span class="book-num">#684</span>
+          <h3>A.P.S. Allgemeine pansophische Schule. Mss. A. III. Vor-Instruktion für Neu-Aufgenommene</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c866d86c6f3cc53c856482" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c866d86c6f3cc53c856482', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c866d86c6f3cc53c856482', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c866d86c6f3cc53c856482', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c866d86c6f3cc53c856482', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c866d86c6f3cc53c856482', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866d86c6f3cc53c856482%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866d86c6f3cc53c856482%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866d86c6f3cc53c856482%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866d86c6f3cc53c856482%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c866d86c6f3cc53c856482%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83d4b6c6f3cc53c84fbe6" data-idx="684">
+        <div class="book-header">
+          <span class="book-num">#685</span>
+          <h3>Geistliche Correspondentz</h3>
+          <span class="page-count">465 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83d4b6c6f3cc53c84fbe6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83d4b6c6f3cc53c84fbe6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83d4b6c6f3cc53c84fbe6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83d4b6c6f3cc53c84fbe6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83d4b6c6f3cc53c84fbe6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83d4b6c6f3cc53c84fbe6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d4b6c6f3cc53c84fbe6%2F0047-full.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d4b6c6f3cc53c84fbe6%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d4b6c6f3cc53c84fbe6%2F0279-full.jpg&w=600" alt="Page 279" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.279 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d4b6c6f3cc53c84fbe6%2F0372-full.jpg&w=600" alt="Page 372" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.372 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83d4b6c6f3cc53c84fbe6%2F0419-full.jpg&w=600" alt="Page 419" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.419 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c864ca6c6f3cc53c85609c" data-idx="685">
+        <div class="book-header">
+          <span class="book-num">#686</span>
+          <h3>Tableau naturel des rapports qui existent entre dieu, l'homme et l'univers</h3>
+          <span class="page-count">270 pp</span>
+          <a href="https://sourcelibrary.org/book/69c864ca6c6f3cc53c85609c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c864ca6c6f3cc53c85609c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c864ca6c6f3cc53c85609c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c864ca6c6f3cc53c85609c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c864ca6c6f3cc53c85609c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c864ca6c6f3cc53c85609c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864ca6c6f3cc53c85609c%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864ca6c6f3cc53c85609c%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864ca6c6f3cc53c85609c%2F0162-full.jpg&w=600" alt="Page 162" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.162 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864ca6c6f3cc53c85609c%2F0216-full.jpg&w=600" alt="Page 216" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.216 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c864ca6c6f3cc53c85609c%2F0243-full.jpg&w=600" alt="Page 243" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.243 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4186f2b0edf3eaa2dd2f7" data-idx="686">
+        <div class="book-header">
+          <span class="book-num">#687</span>
+          <h3>Das Blut der Natur (PH475 C)</h3>
+          <span class="page-count">81 pp</span>
+          <a href="https://sourcelibrary.org/book/blood-of-nature-anonymus-von-schwartzfuss-1706-schwartzfuss" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4186f2b0edf3eaa2dd2f7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4186f2b0edf3eaa2dd2f7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4186f2b0edf3eaa2dd2f7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4186f2b0edf3eaa2dd2f7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4186f2b0edf3eaa2dd2f7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186f2b0edf3eaa2dd2f7%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186f2b0edf3eaa2dd2f7%2F32.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186f2b0edf3eaa2dd2f7%2F49.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186f2b0edf3eaa2dd2f7%2F65.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186f2b0edf3eaa2dd2f7%2F73.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c880846c6f3cc53c8590b1" data-idx="687">
+        <div class="book-header">
+          <span class="book-num">#688</span>
+          <h3>Neu-angezündt-hell-brennendes Feuer oder Mercurial-Liecht</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/69c880846c6f3cc53c8590b1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c880846c6f3cc53c8590b1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c880846c6f3cc53c8590b1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c880846c6f3cc53c8590b1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c880846c6f3cc53c8590b1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c880846c6f3cc53c8590b1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880846c6f3cc53c8590b1%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880846c6f3cc53c8590b1%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880846c6f3cc53c8590b1%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880846c6f3cc53c8590b1%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880846c6f3cc53c8590b1%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2c76c6f3cc53c85e4e1" data-idx="688">
+        <div class="book-header">
+          <span class="book-num">#689</span>
+          <h3>Confessio fraternitatis and its objects</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2c76c6f3cc53c85e4e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2c76c6f3cc53c85e4e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2c76c6f3cc53c85e4e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2c76c6f3cc53c85e4e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2c76c6f3cc53c85e4e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2c76c6f3cc53c85e4e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2c76c6f3cc53c85e4e1%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2c76c6f3cc53c85e4e1%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2c76c6f3cc53c85e4e1%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2c76c6f3cc53c85e4e1%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2c76c6f3cc53c85e4e1%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418b52b0edf3eaa2ddb30" data-idx="689">
+        <div class="book-header">
+          <span class="book-num">#690</span>
+          <h3>Clavicules de Salomon (PH298)</h3>
+          <span class="page-count">92 pp</span>
+          <a href="https://sourcelibrary.org/book/keys-of-solomon-1641-french-ms-from-guaita-collection-pseudo-solomon" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418b52b0edf3eaa2ddb30', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418b52b0edf3eaa2ddb30', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418b52b0edf3eaa2ddb30', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418b52b0edf3eaa2ddb30', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418b52b0edf3eaa2ddb30', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b52b0edf3eaa2ddb30%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b52b0edf3eaa2ddb30%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b52b0edf3eaa2ddb30%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b52b0edf3eaa2ddb30%2F74.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418b52b0edf3eaa2ddb30%2F83.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80cd76c6f3cc53c846b49" data-idx="690">
+        <div class="book-header">
+          <span class="book-num">#691</span>
+          <h3>Der Weeg zu Christo</h3>
+          <span class="page-count">150 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80cd76c6f3cc53c846b49" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80cd76c6f3cc53c846b49', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80cd76c6f3cc53c846b49', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80cd76c6f3cc53c846b49', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80cd76c6f3cc53c846b49', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80cd76c6f3cc53c846b49', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80cd76c6f3cc53c846b49%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80cd76c6f3cc53c846b49%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80cd76c6f3cc53c846b49%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80cd76c6f3cc53c846b49%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80cd76c6f3cc53c846b49%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419262b0edf3eaa2dedd8" data-idx="691">
+        <div class="book-header">
+          <span class="book-num">#692</span>
+          <h3>Collection of Prayers, Quotations and Charms (PH233)</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/prayers-gospel-quotations-charms-italian-ms-18th-c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419262b0edf3eaa2dedd8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419262b0edf3eaa2dedd8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419262b0edf3eaa2dedd8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419262b0edf3eaa2dedd8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419262b0edf3eaa2dedd8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419262b0edf3eaa2dedd8%2F3.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419262b0edf3eaa2dedd8%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419262b0edf3eaa2dedd8%2F17.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419262b0edf3eaa2dedd8%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419262b0edf3eaa2dedd8%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c891b36c6f3cc53c85ba9b" data-idx="692">
+        <div class="book-header">
+          <span class="book-num">#693</span>
+          <h3>Simon Magus. An essay</h3>
+          <span class="page-count">55 pp</span>
+          <a href="https://sourcelibrary.org/book/69c891b36c6f3cc53c85ba9b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c891b36c6f3cc53c85ba9b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c891b36c6f3cc53c85ba9b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c891b36c6f3cc53c85ba9b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c891b36c6f3cc53c85ba9b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c891b36c6f3cc53c85ba9b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891b36c6f3cc53c85ba9b%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891b36c6f3cc53c85ba9b%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891b36c6f3cc53c85ba9b%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891b36c6f3cc53c85ba9b%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c891b36c6f3cc53c85ba9b%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85f796c6f3cc53c855555" data-idx="693">
+        <div class="book-header">
+          <span class="book-num">#694</span>
+          <h3>Vollständige Erklärung des Hohen Liedes Salomonis</h3>
+          <span class="page-count">111 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85f796c6f3cc53c855555" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85f796c6f3cc53c855555', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85f796c6f3cc53c855555', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85f796c6f3cc53c855555', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85f796c6f3cc53c855555', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85f796c6f3cc53c855555', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f796c6f3cc53c855555%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f796c6f3cc53c855555%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f796c6f3cc53c855555%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f796c6f3cc53c855555%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85f796c6f3cc53c855555%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c812c46c6f3cc53c847c97" data-idx="694">
+        <div class="book-header">
+          <span class="book-num">#695</span>
+          <h3>Het leeven van Hai Ebn Yokdan</h3>
+          <span class="page-count">183 pp</span>
+          <a href="https://sourcelibrary.org/book/69c812c46c6f3cc53c847c97" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c812c46c6f3cc53c847c97', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c812c46c6f3cc53c847c97', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c812c46c6f3cc53c847c97', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c812c46c6f3cc53c847c97', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c812c46c6f3cc53c847c97', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812c46c6f3cc53c847c97%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812c46c6f3cc53c847c97%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812c46c6f3cc53c847c97%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812c46c6f3cc53c847c97%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812c46c6f3cc53c847c97%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c805b36c6f3cc53c8452d9" data-idx="695">
+        <div class="book-header">
+          <span class="book-num">#696</span>
+          <h3>Theodicee of proeven over Gods goedheid, 's menschen vryheid, en den oorsprong van het kwaad</h3>
+          <span class="page-count">383 pp</span>
+          <a href="https://sourcelibrary.org/book/69c805b36c6f3cc53c8452d9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c805b36c6f3cc53c8452d9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c805b36c6f3cc53c8452d9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c805b36c6f3cc53c8452d9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c805b36c6f3cc53c8452d9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c805b36c6f3cc53c8452d9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805b36c6f3cc53c8452d9%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805b36c6f3cc53c8452d9%2F0153-full.jpg&w=600" alt="Page 153" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.153 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805b36c6f3cc53c8452d9%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805b36c6f3cc53c8452d9%2F0306-full.jpg&w=600" alt="Page 306" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.306 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805b36c6f3cc53c8452d9%2F0345-full.jpg&w=600" alt="Page 345" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.345 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c80da56c6f3cc53c846d9e" data-idx="696">
+        <div class="book-header">
+          <span class="book-num">#697</span>
+          <h3>Einer gläubigen Seele vertrauter Umgang mit Gott</h3>
+          <span class="page-count">291 pp</span>
+          <a href="https://sourcelibrary.org/book/69c80da56c6f3cc53c846d9e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c80da56c6f3cc53c846d9e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c80da56c6f3cc53c846d9e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c80da56c6f3cc53c846d9e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c80da56c6f3cc53c846d9e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c80da56c6f3cc53c846d9e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80da56c6f3cc53c846d9e%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80da56c6f3cc53c846d9e%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80da56c6f3cc53c846d9e%2F0175-full.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80da56c6f3cc53c846d9e%2F0233-full.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c80da56c6f3cc53c846d9e%2F0262-full.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897546c6f3cc53c85c7bb" data-idx="697">
+        <div class="book-header">
+          <span class="book-num">#698</span>
+          <h3>The general book of the tarot. Containing the astrological key to the tarot-system, published for the first time</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897546c6f3cc53c85c7bb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897546c6f3cc53c85c7bb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897546c6f3cc53c85c7bb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897546c6f3cc53c85c7bb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897546c6f3cc53c85c7bb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897546c6f3cc53c85c7bb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897546c6f3cc53c85c7bb%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897546c6f3cc53c85c7bb%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897546c6f3cc53c85c7bb%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897546c6f3cc53c85c7bb%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897546c6f3cc53c85c7bb%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b03b25ec2ba5ccd7f355" data-idx="698">
+        <div class="book-header">
+          <span class="book-num">#699</span>
+          <h3>Labyrinth der Welt, nebst glücklichem Ausgang aus demselben</h3>
+          <span class="page-count">141 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b03b25ec2ba5ccd7f355" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b03b25ec2ba5ccd7f355', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b03b25ec2ba5ccd7f355', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b03b25ec2ba5ccd7f355', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b03b25ec2ba5ccd7f355', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b03b25ec2ba5ccd7f355', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b03b25ec2ba5ccd7f355%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b03b25ec2ba5ccd7f355%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b03b25ec2ba5ccd7f355%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b03b25ec2ba5ccd7f355%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b03b25ec2ba5ccd7f355%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c829de6c6f3cc53c84c6c2" data-idx="699">
+        <div class="book-header">
+          <span class="book-num">#700</span>
+          <h3>Réflexions sur la premotion physique</h3>
+          <span class="page-count">187 pp</span>
+          <a href="https://sourcelibrary.org/book/69c829de6c6f3cc53c84c6c2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c829de6c6f3cc53c84c6c2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c829de6c6f3cc53c84c6c2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c829de6c6f3cc53c84c6c2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c829de6c6f3cc53c84c6c2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c829de6c6f3cc53c84c6c2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829de6c6f3cc53c84c6c2%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829de6c6f3cc53c84c6c2%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829de6c6f3cc53c84c6c2%2F0112-full.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829de6c6f3cc53c84c6c2%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c829de6c6f3cc53c84c6c2%2F0168-full.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html" class="active">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-8.html
+++ b/public/split-review-8.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 8/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html" class="active">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="69c7d03425ec2ba5ccd8031c" data-idx="700">
+        <div class="book-header">
+          <span class="book-num">#701</span>
+          <h3>L'Homme de désir</h3>
+          <span class="page-count">213 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7d03425ec2ba5ccd8031c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7d03425ec2ba5ccd8031c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7d03425ec2ba5ccd8031c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7d03425ec2ba5ccd8031c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7d03425ec2ba5ccd8031c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7d03425ec2ba5ccd8031c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03425ec2ba5ccd8031c%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03425ec2ba5ccd8031c%2F0085-full.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03425ec2ba5ccd8031c%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03425ec2ba5ccd8031c%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7d03425ec2ba5ccd8031c%2F0192-full.jpg&w=600" alt="Page 192" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.192 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63eb2b463eebe7caac65f" data-idx="701">
+        <div class="book-header">
+          <span class="book-num">#702</span>
+          <h3>Vita et fabellae cum interpretatione latina</h3>
+          <span class="page-count">155 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63eb2b463eebe7caac65f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63eb2b463eebe7caac65f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63eb2b463eebe7caac65f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63eb2b463eebe7caac65f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63eb2b463eebe7caac65f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63eb2b463eebe7caac65f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63eb2b463eebe7caac65f%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63eb2b463eebe7caac65f%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63eb2b463eebe7caac65f%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63eb2b463eebe7caac65f%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63eb2b463eebe7caac65f%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896646c6f3cc53c85c52e" data-idx="702">
+        <div class="book-header">
+          <span class="book-num">#703</span>
+          <h3>A book of mystery and vision</h3>
+          <span class="page-count">138 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896646c6f3cc53c85c52e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896646c6f3cc53c85c52e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896646c6f3cc53c85c52e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896646c6f3cc53c85c52e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896646c6f3cc53c85c52e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896646c6f3cc53c85c52e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896646c6f3cc53c85c52e%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896646c6f3cc53c85c52e%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896646c6f3cc53c85c52e%2F0083-full.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896646c6f3cc53c85c52e%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896646c6f3cc53c85c52e%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c807c86c6f3cc53c8459e4" data-idx="703">
+        <div class="book-header">
+          <span class="book-num">#704</span>
+          <h3>Der entlarvte Gualdus, sive Fridericus Gualdus, ex seipso mendacii &amp; imposturae convictus, das ist: aussführlicher Beweiss</h3>
+          <span class="page-count">54 pp</span>
+          <a href="https://sourcelibrary.org/book/69c807c86c6f3cc53c8459e4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c807c86c6f3cc53c8459e4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c807c86c6f3cc53c8459e4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c807c86c6f3cc53c8459e4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c807c86c6f3cc53c8459e4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c807c86c6f3cc53c8459e4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807c86c6f3cc53c8459e4%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807c86c6f3cc53c8459e4%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807c86c6f3cc53c8459e4%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807c86c6f3cc53c8459e4%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c807c86c6f3cc53c8459e4%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71d84da9771c716316a06" data-idx="704">
+        <div class="book-header">
+          <span class="book-num">#705</span>
+          <h3>Ain schöner christlicher sendbrieff und bericht</h3>
+          <span class="page-count">23 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71d84da9771c716316a06" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71d84da9771c716316a06', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71d84da9771c716316a06', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71d84da9771c716316a06', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71d84da9771c716316a06', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71d84da9771c716316a06', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71d84da9771c716316a06%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71d84da9771c716316a06%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71d84da9771c716316a06%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71d84da9771c716316a06%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71d84da9771c716316a06%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7427f6a0f3d112faf7e16" data-idx="705">
+        <div class="book-header">
+          <span class="book-num">#706</span>
+          <h3>Pulcherrimum sapientie horologium</h3>
+          <span class="page-count">163 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7427f6a0f3d112faf7e16" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7427f6a0f3d112faf7e16', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7427f6a0f3d112faf7e16', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7427f6a0f3d112faf7e16', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7427f6a0f3d112faf7e16', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7427f6a0f3d112faf7e16', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7427f6a0f3d112faf7e16%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7427f6a0f3d112faf7e16%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7427f6a0f3d112faf7e16%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7427f6a0f3d112faf7e16%2F0130-full.jpg&w=600" alt="Page 130" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.130 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7427f6a0f3d112faf7e16%2F0147-full.jpg&w=600" alt="Page 147" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.147 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6ea61da9771c716314778" data-idx="706">
+        <div class="book-header">
+          <span class="book-num">#707</span>
+          <h3>Wasserstein der Weisen  Via veritatis</h3>
+          <span class="page-count">108 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6ea61da9771c716314778" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6ea61da9771c716314778', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6ea61da9771c716314778', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6ea61da9771c716314778', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6ea61da9771c716314778', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6ea61da9771c716314778', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ea61da9771c716314778%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ea61da9771c716314778%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ea61da9771c716314778%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ea61da9771c716314778%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6ea61da9771c716314778%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c74aec6a0f3d112faf8263" data-idx="707">
+        <div class="book-header">
+          <span class="book-num">#708</span>
+          <h3>[Arabic] Evangelium infantiae vel liber apocryphus de infantia servatoris</h3>
+          <span class="page-count">148 pp</span>
+          <a href="https://sourcelibrary.org/book/69c74aec6a0f3d112faf8263" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c74aec6a0f3d112faf8263', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c74aec6a0f3d112faf8263', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c74aec6a0f3d112faf8263', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c74aec6a0f3d112faf8263', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c74aec6a0f3d112faf8263', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74aec6a0f3d112faf8263%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74aec6a0f3d112faf8263%2F0059-full.jpg&w=600" alt="Page 59" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.59 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74aec6a0f3d112faf8263%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74aec6a0f3d112faf8263%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c74aec6a0f3d112faf8263%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41ae6a4a45dfe81845ec2" data-idx="708">
+        <div class="book-header">
+          <span class="book-num">#709</span>
+          <h3>Theatrum Chemicum — Alchemical Compilation (PH150)</h3>
+          <span class="page-count">266 pp</span>
+          <a href="https://sourcelibrary.org/book/theatrum-chemicum-alchemical-compilation-manuscript-various" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41ae6a4a45dfe81845ec2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41ae6a4a45dfe81845ec2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41ae6a4a45dfe81845ec2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41ae6a4a45dfe81845ec2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41ae6a4a45dfe81845ec2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41ae6a4a45dfe81845ec2%2F27.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41ae6a4a45dfe81845ec2%2F106.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41ae6a4a45dfe81845ec2%2F160.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581321605131!213_bph163_aa5820_106r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940581321605131!239_bph163_aa5820_119r.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8726c6c6f3cc53c85786f" data-idx="709">
+        <div class="book-header">
+          <span class="book-num">#710</span>
+          <h3>Disputationum de nova medicina Philippi Paracelsi</h3>
+          <span class="page-count">617 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8726c6c6f3cc53c85786f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8726c6c6f3cc53c85786f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8726c6c6f3cc53c85786f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8726c6c6f3cc53c85786f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8726c6c6f3cc53c85786f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8726c6c6f3cc53c85786f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8726c6c6f3cc53c85786f%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8726c6c6f3cc53c85786f%2F0247-full.jpg&w=600" alt="Page 247" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.247 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8726c6c6f3cc53c85786f%2F0370-full.jpg&w=600" alt="Page 370" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.370 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8726c6c6f3cc53c85786f%2F0494-full.jpg&w=600" alt="Page 494" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.494 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8726c6c6f3cc53c85786f%2F0555-full.jpg&w=600" alt="Page 555" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.555 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87d586c6f3cc53c858b1f" data-idx="710">
+        <div class="book-header">
+          <span class="book-num">#711</span>
+          <h3>Libri apologetici, oder Schutz-Schriften</h3>
+          <span class="page-count">231 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87d586c6f3cc53c858b1f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87d586c6f3cc53c858b1f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87d586c6f3cc53c858b1f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87d586c6f3cc53c858b1f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87d586c6f3cc53c858b1f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87d586c6f3cc53c858b1f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d586c6f3cc53c858b1f%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d586c6f3cc53c858b1f%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d586c6f3cc53c858b1f%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d586c6f3cc53c858b1f%2F0185-full.jpg&w=600" alt="Page 185" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.185 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87d586c6f3cc53c858b1f%2F0208-full.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c802546c6f3cc53c8446a0" data-idx="711">
+        <div class="book-header">
+          <span class="book-num">#712</span>
+          <h3>Teleskop des Zoroasters oder Schlüssel zur grossen wahrsagenden Kabala der Magier</h3>
+          <span class="page-count">88 pp</span>
+          <a href="https://sourcelibrary.org/book/69c802546c6f3cc53c8446a0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c802546c6f3cc53c8446a0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c802546c6f3cc53c8446a0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c802546c6f3cc53c8446a0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c802546c6f3cc53c8446a0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c802546c6f3cc53c8446a0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802546c6f3cc53c8446a0%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802546c6f3cc53c8446a0%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802546c6f3cc53c8446a0%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802546c6f3cc53c8446a0%2F0070-full.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c802546c6f3cc53c8446a0%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a81892b884e4f8173d17" data-idx="712">
+        <div class="book-header">
+          <span class="book-num">#713</span>
+          <h3>Erklärte Offenbarung Johannis und vielmehr Jesu Christi</h3>
+          <span class="page-count">613 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a81892b884e4f8173d17" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a81892b884e4f8173d17', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a81892b884e4f8173d17', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a81892b884e4f8173d17', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a81892b884e4f8173d17', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a81892b884e4f8173d17', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a81892b884e4f8173d17%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a81892b884e4f8173d17%2F0245-full.jpg&w=600" alt="Page 245" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.245 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a81892b884e4f8173d17%2F0368-full.jpg&w=600" alt="Page 368" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.368 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a81892b884e4f8173d17%2F0490-full.jpg&w=600" alt="Page 490" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.490 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a81892b884e4f8173d17%2F0552-full.jpg&w=600" alt="Page 552" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.552 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81dec6c6f3cc53c84a0e5" data-idx="713">
+        <div class="book-header">
+          <span class="book-num">#714</span>
+          <h3>Principia philosophiae more geometrico demonstrata</h3>
+          <span class="page-count">143 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81dec6c6f3cc53c84a0e5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81dec6c6f3cc53c84a0e5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81dec6c6f3cc53c84a0e5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81dec6c6f3cc53c84a0e5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81dec6c6f3cc53c84a0e5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81dec6c6f3cc53c84a0e5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81dec6c6f3cc53c84a0e5%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81dec6c6f3cc53c84a0e5%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81dec6c6f3cc53c84a0e5%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81dec6c6f3cc53c84a0e5%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81dec6c6f3cc53c84a0e5%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c812496c6f3cc53c847b2d" data-idx="714">
+        <div class="book-header">
+          <span class="book-num">#715</span>
+          <h3>Hoplocrisma-spongus: or, a sponge to wipe away the weapon-salve</h3>
+          <span class="page-count">40 pp</span>
+          <a href="https://sourcelibrary.org/book/69c812496c6f3cc53c847b2d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c812496c6f3cc53c847b2d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c812496c6f3cc53c847b2d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c812496c6f3cc53c847b2d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c812496c6f3cc53c847b2d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c812496c6f3cc53c847b2d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812496c6f3cc53c847b2d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812496c6f3cc53c847b2d%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812496c6f3cc53c847b2d%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812496c6f3cc53c847b2d%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c812496c6f3cc53c847b2d%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88a576c6f3cc53c85a601" data-idx="715">
+        <div class="book-header">
+          <span class="book-num">#716</span>
+          <h3>Die Sonne von Osten, oder die tiefen Geheimnisse der Kette des goldenen Vliesses, des Kreuzes der Ritterorden der Tempelherren, Johanniter und Deutschherren, mit den dazu gehörigen kabbalistischen Figuren</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88a576c6f3cc53c85a601" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88a576c6f3cc53c85a601', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88a576c6f3cc53c85a601', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88a576c6f3cc53c85a601', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88a576c6f3cc53c85a601', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88a576c6f3cc53c85a601', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a576c6f3cc53c85a601%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a576c6f3cc53c85a601%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a576c6f3cc53c85a601%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a576c6f3cc53c85a601%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88a576c6f3cc53c85a601%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89cc26c6f3cc53c85d65c" data-idx="716">
+        <div class="book-header">
+          <span class="book-num">#717</span>
+          <h3>De laudibus sanctissime matris Anne</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89cc26c6f3cc53c85d65c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89cc26c6f3cc53c85d65c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89cc26c6f3cc53c85d65c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89cc26c6f3cc53c85d65c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89cc26c6f3cc53c85d65c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89cc26c6f3cc53c85d65c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc26c6f3cc53c85d65c%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc26c6f3cc53c85d65c%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc26c6f3cc53c85d65c%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc26c6f3cc53c85d65c%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89cc26c6f3cc53c85d65c%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6e84dda9771c7163145fe" data-idx="717">
+        <div class="book-header">
+          <span class="book-num">#718</span>
+          <h3>Wahrheit der Religion</h3>
+          <span class="page-count">253 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6e84dda9771c7163145fe" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6e84dda9771c7163145fe', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6e84dda9771c7163145fe', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6e84dda9771c7163145fe', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6e84dda9771c7163145fe', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6e84dda9771c7163145fe', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fe%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fe%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fe%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fe%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6e84dda9771c7163145fe%2F0228-full.jpg&w=600" alt="Page 228" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.228 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85d376c6f3cc53c854e7c" data-idx="718">
+        <div class="book-header">
+          <span class="book-num">#719</span>
+          <h3>Briefe ... an den Frey-Herrn von Metternich</h3>
+          <span class="page-count">185 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85d376c6f3cc53c854e7c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85d376c6f3cc53c854e7c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85d376c6f3cc53c854e7c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85d376c6f3cc53c854e7c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85d376c6f3cc53c854e7c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85d376c6f3cc53c854e7c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d376c6f3cc53c854e7c%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d376c6f3cc53c854e7c%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d376c6f3cc53c854e7c%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d376c6f3cc53c854e7c%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85d376c6f3cc53c854e7c%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c843136c6f3cc53c850e95" data-idx="719">
+        <div class="book-header">
+          <span class="book-num">#720</span>
+          <h3>Alphabetum ebraicum vetus</h3>
+          <span class="page-count">33 pp</span>
+          <a href="https://sourcelibrary.org/book/69c843136c6f3cc53c850e95" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c843136c6f3cc53c850e95', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c843136c6f3cc53c850e95', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c843136c6f3cc53c850e95', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c843136c6f3cc53c850e95', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c843136c6f3cc53c850e95', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843136c6f3cc53c850e95%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843136c6f3cc53c850e95%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843136c6f3cc53c850e95%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843136c6f3cc53c850e95%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c843136c6f3cc53c850e95%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70f9dda9771c71631622d" data-idx="720">
+        <div class="book-header">
+          <span class="book-num">#721</span>
+          <h3>[Greek: Mikropresbytikon]. Veterum quorundam brevium theologorum</h3>
+          <span class="page-count">348 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70f9dda9771c71631622d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70f9dda9771c71631622d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70f9dda9771c71631622d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70f9dda9771c71631622d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70f9dda9771c71631622d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70f9dda9771c71631622d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70f9dda9771c71631622d%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70f9dda9771c71631622d%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70f9dda9771c71631622d%2F0209-full.jpg&w=600" alt="Page 209" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.209 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70f9dda9771c71631622d%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70f9dda9771c71631622d%2F0313-full.jpg&w=600" alt="Page 313" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.313 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84dda6c6f3cc53c8527eb" data-idx="721">
+        <div class="book-header">
+          <span class="book-num">#722</span>
+          <h3>Lehr und geistreiche [...] Predigten</h3>
+          <span class="page-count">498 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84dda6c6f3cc53c8527eb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84dda6c6f3cc53c8527eb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84dda6c6f3cc53c8527eb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84dda6c6f3cc53c8527eb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84dda6c6f3cc53c8527eb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84dda6c6f3cc53c8527eb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84dda6c6f3cc53c8527eb%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84dda6c6f3cc53c8527eb%2F0199-full.jpg&w=600" alt="Page 199" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.199 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84dda6c6f3cc53c8527eb%2F0299-full.jpg&w=600" alt="Page 299" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.299 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84dda6c6f3cc53c8527eb%2F0398-full.jpg&w=600" alt="Page 398" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.398 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84dda6c6f3cc53c8527eb%2F0448-full.jpg&w=600" alt="Page 448" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.448 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c870796c6f3cc53c8572ee" data-idx="722">
+        <div class="book-header">
+          <span class="book-num">#723</span>
+          <h3>Coelestis hierarchia. Ecclesiastica hierarchia. Divina nomina. Mystica theologia. Undecim epistolae. Undecim epistolae. Epistola una</h3>
+          <span class="page-count">227 pp</span>
+          <a href="https://sourcelibrary.org/book/69c870796c6f3cc53c8572ee" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c870796c6f3cc53c8572ee', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c870796c6f3cc53c8572ee', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c870796c6f3cc53c8572ee', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c870796c6f3cc53c8572ee', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c870796c6f3cc53c8572ee', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870796c6f3cc53c8572ee%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870796c6f3cc53c8572ee%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870796c6f3cc53c8572ee%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870796c6f3cc53c8572ee%2F0182-full.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870796c6f3cc53c8572ee%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f4546c6f3cc53c841836" data-idx="723">
+        <div class="book-header">
+          <span class="book-num">#724</span>
+          <h3>[Hebrew: Sefer neveh shalom]</h3>
+          <span class="page-count">239 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f4546c6f3cc53c841836" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f4546c6f3cc53c841836', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f4546c6f3cc53c841836', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f4546c6f3cc53c841836', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f4546c6f3cc53c841836', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f4546c6f3cc53c841836', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4546c6f3cc53c841836%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4546c6f3cc53c841836%2F0096-full.jpg&w=600" alt="Page 96" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.96 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4546c6f3cc53c841836%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4546c6f3cc53c841836%2F0191-full.jpg&w=600" alt="Page 191" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.191 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f4546c6f3cc53c841836%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c851046c6f3cc53c852f6f" data-idx="724">
+        <div class="book-header">
+          <span class="book-num">#725</span>
+          <h3>Kleines Probier-Steinlein des Wohls und Wehes der heutigen so genannten Christenheit</h3>
+          <span class="page-count">102 pp</span>
+          <a href="https://sourcelibrary.org/book/69c851046c6f3cc53c852f6f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c851046c6f3cc53c852f6f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c851046c6f3cc53c852f6f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c851046c6f3cc53c852f6f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c851046c6f3cc53c852f6f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c851046c6f3cc53c852f6f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851046c6f3cc53c852f6f%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851046c6f3cc53c852f6f%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851046c6f3cc53c852f6f%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851046c6f3cc53c852f6f%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851046c6f3cc53c852f6f%2F0092-full.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419122b0edf3eaa2deb6f" data-idx="725">
+        <div class="book-header">
+          <span class="book-num">#726</span>
+          <h3>Epitome des merveilles de nature et de l'art hermetique (PH144)</h3>
+          <span class="page-count">54 pp</span>
+          <a href="https://sourcelibrary.org/book/epitome-of-the-marvels-of-nature-hermetic-art-16th-century" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419122b0edf3eaa2deb6f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419122b0edf3eaa2deb6f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419122b0edf3eaa2deb6f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419122b0edf3eaa2deb6f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419122b0edf3eaa2deb6f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419122b0edf3eaa2deb6f%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419122b0edf3eaa2deb6f%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940537340105131!ph144_032.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940537340105131!ph144_043.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940537340105131!ph144_049.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8514e6c6f3cc53c853097" data-idx="726">
+        <div class="book-header">
+          <span class="book-num">#727</span>
+          <h3>Azalaïs et Le Gentil Aimar: Histoire Provençale; traduite d'un ancien manuscrit provençal</h3>
+          <span class="page-count">314 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8514e6c6f3cc53c853097" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8514e6c6f3cc53c853097', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8514e6c6f3cc53c853097', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8514e6c6f3cc53c853097', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8514e6c6f3cc53c853097', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8514e6c6f3cc53c853097', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8514e6c6f3cc53c853097%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8514e6c6f3cc53c853097%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8514e6c6f3cc53c853097%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8514e6c6f3cc53c853097%2F0251-full.jpg&w=600" alt="Page 251" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.251 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8514e6c6f3cc53c853097%2F0283-full.jpg&w=600" alt="Page 283" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.283 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82c856c6f3cc53c84ce82" data-idx="727">
+        <div class="book-header">
+          <span class="book-num">#728</span>
+          <h3>Die Schlange Mosis, die alle andere verschlingt, oder nie entdeckte chymische Geheimnisse</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82c856c6f3cc53c84ce82" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82c856c6f3cc53c84ce82', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82c856c6f3cc53c84ce82', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82c856c6f3cc53c84ce82', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82c856c6f3cc53c84ce82', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82c856c6f3cc53c84ce82', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c856c6f3cc53c84ce82%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c856c6f3cc53c84ce82%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c856c6f3cc53c84ce82%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c856c6f3cc53c84ce82%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82c856c6f3cc53c84ce82%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8158a6c6f3cc53c84868b" data-idx="728">
+        <div class="book-header">
+          <span class="book-num">#729</span>
+          <h3>La vie, mort et doctrine de Iean Calvin ... ensemble de la vie de Iean de Labadie</h3>
+          <span class="page-count">96 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8158a6c6f3cc53c84868b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8158a6c6f3cc53c84868b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8158a6c6f3cc53c84868b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8158a6c6f3cc53c84868b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8158a6c6f3cc53c84868b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8158a6c6f3cc53c84868b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158a6c6f3cc53c84868b%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158a6c6f3cc53c84868b%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158a6c6f3cc53c84868b%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158a6c6f3cc53c84868b%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8158a6c6f3cc53c84868b%2F0086-full.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6103" data-idx="729">
+        <div class="book-header">
+          <span class="book-num">#730</span>
+          <h3>Les plus secrets mystères des hauts grades de la maçonnerie dévoilés</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6103" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6103', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6103', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6103', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6103', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6103', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6103%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6103%2F40.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6103%2F61.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6103%2F81.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6103%2F91.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4185af1200e2ab53cf4bb" data-idx="730">
+        <div class="book-header">
+          <span class="book-num">#731</span>
+          <h3>Book of Hours (BPH 151)</h3>
+          <span class="page-count">342 pp</span>
+          <a href="https://sourcelibrary.org/book/book-of-hours-masters-of-the-dark-eyes-1465-1470-eyes" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4185af1200e2ab53cf4bb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4185af1200e2ab53cf4bb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4185af1200e2ab53cf4bb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4185af1200e2ab53cf4bb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4185af1200e2ab53cf4bb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4185af1200e2ab53cf4bb%2F34.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4185af1200e2ab53cf4bb%2F137.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4185af1200e2ab53cf4bb%2F205.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940576620705131!274_bph151_aa5816_134v.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 274" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.274 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940576620705131!308_bph151_aa5816_151v.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 308" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.308 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c738036a0f3d112faf7744" data-idx="731">
+        <div class="book-header">
+          <span class="book-num">#732</span>
+          <h3>Honor doctoralis theologicus, auspice Deo tri-uno, favente Eberhardo Wirtembergiae principe serenissimo: ab incluta facultate theologica Tubingensi, Johan-Valentino Andreae, Herrenberg</h3>
+          <span class="page-count">101 pp</span>
+          <a href="https://sourcelibrary.org/book/69c738036a0f3d112faf7744" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c738036a0f3d112faf7744', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c738036a0f3d112faf7744', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c738036a0f3d112faf7744', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c738036a0f3d112faf7744', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c738036a0f3d112faf7744', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738036a0f3d112faf7744%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738036a0f3d112faf7744%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738036a0f3d112faf7744%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738036a0f3d112faf7744%2F0081-full.jpg&w=600" alt="Page 81" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.81 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c738036a0f3d112faf7744%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c869d06c6f3cc53c8568f7" data-idx="732">
+        <div class="book-header">
+          <span class="book-num">#733</span>
+          <h3>Architecturae cosmicae oder des Welt-Gebaeudes</h3>
+          <span class="page-count">224 pp</span>
+          <a href="https://sourcelibrary.org/book/69c869d06c6f3cc53c8568f7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c869d06c6f3cc53c8568f7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c869d06c6f3cc53c8568f7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c869d06c6f3cc53c8568f7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c869d06c6f3cc53c8568f7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c869d06c6f3cc53c8568f7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869d06c6f3cc53c8568f7%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869d06c6f3cc53c8568f7%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869d06c6f3cc53c8568f7%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869d06c6f3cc53c8568f7%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c869d06c6f3cc53c8568f7%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7b90c25ec2ba5ccd7f800" data-idx="733">
+        <div class="book-header">
+          <span class="book-num">#734</span>
+          <h3>Libelli duo, in quorum altero aenigmata pleraque antiquorum, in altero Pythagorae symbola ... sunt explicata</h3>
+          <span class="page-count">179 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7b90c25ec2ba5ccd7f800" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7b90c25ec2ba5ccd7f800', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7b90c25ec2ba5ccd7f800', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7b90c25ec2ba5ccd7f800', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7b90c25ec2ba5ccd7f800', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7b90c25ec2ba5ccd7f800', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b90c25ec2ba5ccd7f800%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b90c25ec2ba5ccd7f800%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b90c25ec2ba5ccd7f800%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b90c25ec2ba5ccd7f800%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7b90c25ec2ba5ccd7f800%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8792d6c6f3cc53c858414" data-idx="734">
+        <div class="book-header">
+          <span class="book-num">#735</span>
+          <h3>Histoire de la magie avec une exposition claire et précise de ses procédés, de ses rites et de ses mystères</h3>
+          <span class="page-count">311 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8792d6c6f3cc53c858414" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8792d6c6f3cc53c858414', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8792d6c6f3cc53c858414', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8792d6c6f3cc53c858414', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8792d6c6f3cc53c858414', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8792d6c6f3cc53c858414', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8792d6c6f3cc53c858414%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8792d6c6f3cc53c858414%2F0124-full.jpg&w=600" alt="Page 124" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.124 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8792d6c6f3cc53c858414%2F0187-full.jpg&w=600" alt="Page 187" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.187 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8792d6c6f3cc53c858414%2F0249-full.jpg&w=600" alt="Page 249" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.249 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8792d6c6f3cc53c858414%2F0280-full.jpg&w=600" alt="Page 280" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.280 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="698420e1f1fb376a3d580618" data-idx="735">
+        <div class="book-header">
+          <span class="book-num">#736</span>
+          <h3>L'Ombre ideale de la sagesse universelle</h3>
+          <span class="page-count">94 pp</span>
+          <a href="https://sourcelibrary.org/book/the-ideal-shadow-of-universal-wisdom-sabbathier" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('698420e1f1fb376a3d580618', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('698420e1f1fb376a3d580618', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('698420e1f1fb376a3d580618', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('698420e1f1fb376a3d580618', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('698420e1f1fb376a3d580618', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F698420e1f1fb376a3d580618%2F698421ff0831894474766b78.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F698420e1f1fb376a3d580618%2F698428eb99197638649173ba.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F698420e1f1fb376a3d580618%2F69842d8b6a22b04121f63708.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F698420e1f1fb376a3d580618%2F6984324ed9fb3f293c56ee3b.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F698420e1f1fb376a3d580618%2F698434b6e497fc722520738d.jpg&w=600" alt="Page 85" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.85 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88f316c6f3cc53c85b2ea" data-idx="736">
+        <div class="book-header">
+          <span class="book-num">#737</span>
+          <h3>The voice of the silence and other chosen fragments from the Book of the golden precepts</h3>
+          <span class="page-count">50 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88f316c6f3cc53c85b2ea" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88f316c6f3cc53c85b2ea', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88f316c6f3cc53c85b2ea', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88f316c6f3cc53c85b2ea', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88f316c6f3cc53c85b2ea', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88f316c6f3cc53c85b2ea', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f316c6f3cc53c85b2ea%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f316c6f3cc53c85b2ea%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f316c6f3cc53c85b2ea%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f316c6f3cc53c85b2ea%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88f316c6f3cc53c85b2ea%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c818926c6f3cc53c84911e" data-idx="737">
+        <div class="book-header">
+          <span class="book-num">#738</span>
+          <h3>Janua linguarum reserata</h3>
+          <span class="page-count">343 pp</span>
+          <a href="https://sourcelibrary.org/book/69c818926c6f3cc53c84911e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c818926c6f3cc53c84911e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c818926c6f3cc53c84911e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c818926c6f3cc53c84911e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c818926c6f3cc53c84911e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c818926c6f3cc53c84911e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c818926c6f3cc53c84911e%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c818926c6f3cc53c84911e%2F0137-full.jpg&w=600" alt="Page 137" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.137 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c818926c6f3cc53c84911e%2F0206-full.jpg&w=600" alt="Page 206" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.206 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c818926c6f3cc53c84911e%2F0274-full.jpg&w=600" alt="Page 274" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.274 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c818926c6f3cc53c84911e%2F0309-full.jpg&w=600" alt="Page 309" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.309 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c844be6c6f3cc53c85138b" data-idx="738">
+        <div class="book-header">
+          <span class="book-num">#739</span>
+          <h3>Neuer Kern wahrer Geistes-Gebete</h3>
+          <span class="page-count">404 pp</span>
+          <a href="https://sourcelibrary.org/book/69c844be6c6f3cc53c85138b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c844be6c6f3cc53c85138b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c844be6c6f3cc53c85138b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c844be6c6f3cc53c85138b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c844be6c6f3cc53c85138b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c844be6c6f3cc53c85138b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844be6c6f3cc53c85138b%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844be6c6f3cc53c85138b%2F0162-full.jpg&w=600" alt="Page 162" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.162 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844be6c6f3cc53c85138b%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844be6c6f3cc53c85138b%2F0323-full.jpg&w=600" alt="Page 323" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.323 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c844be6c6f3cc53c85138b%2F0364-full.jpg&w=600" alt="Page 364" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.364 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f1caf08a1a5ab805bff9" data-idx="739">
+        <div class="book-header">
+          <span class="book-num">#740</span>
+          <h3>De Juliani imperat. apostasia</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f1caf08a1a5ab805bff9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f1caf08a1a5ab805bff9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f1caf08a1a5ab805bff9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f1caf08a1a5ab805bff9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f1caf08a1a5ab805bff9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f1caf08a1a5ab805bff9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff9%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff9%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff9%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff9%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f1caf08a1a5ab805bff9%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c734936a0f3d112faf7595" data-idx="740">
+        <div class="book-header">
+          <span class="book-num">#741</span>
+          <h3>[Hebrew:] Sefer me'ulefet sapirim</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/69c734936a0f3d112faf7595" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c734936a0f3d112faf7595', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c734936a0f3d112faf7595', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c734936a0f3d112faf7595', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c734936a0f3d112faf7595', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c734936a0f3d112faf7595', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734936a0f3d112faf7595%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734936a0f3d112faf7595%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734936a0f3d112faf7595%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734936a0f3d112faf7595%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c734936a0f3d112faf7595%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8168e6c6f3cc53c848b0c" data-idx="741">
+        <div class="book-header">
+          <span class="book-num">#742</span>
+          <h3>Opera</h3>
+          <span class="page-count">319 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8168e6c6f3cc53c848b0c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8168e6c6f3cc53c848b0c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8168e6c6f3cc53c848b0c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8168e6c6f3cc53c848b0c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8168e6c6f3cc53c848b0c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8168e6c6f3cc53c848b0c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8168e6c6f3cc53c848b0c%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8168e6c6f3cc53c848b0c%2F0128-full.jpg&w=600" alt="Page 128" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.128 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8168e6c6f3cc53c848b0c%2F0191-full.jpg&w=600" alt="Page 191" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.191 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8168e6c6f3cc53c848b0c%2F0255-full.jpg&w=600" alt="Page 255" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.255 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8168e6c6f3cc53c848b0c%2F0287-full.jpg&w=600" alt="Page 287" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.287 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f073da9771c716314c67" data-idx="742">
+        <div class="book-header">
+          <span class="book-num">#743</span>
+          <h3>Die Welt im Feuer</h3>
+          <span class="page-count">113 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f073da9771c716314c67" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f073da9771c716314c67', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f073da9771c716314c67', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f073da9771c716314c67', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f073da9771c716314c67', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f073da9771c716314c67', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f073da9771c716314c67%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f073da9771c716314c67%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f073da9771c716314c67%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f073da9771c716314c67%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f073da9771c716314c67%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86d366c6f3cc53c856cd5" data-idx="743">
+        <div class="book-header">
+          <span class="book-num">#744</span>
+          <h3>Opera nova contemplativa per ogni fidel christiano</h3>
+          <span class="page-count">72 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86d366c6f3cc53c856cd5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86d366c6f3cc53c856cd5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86d366c6f3cc53c856cd5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86d366c6f3cc53c856cd5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86d366c6f3cc53c856cd5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86d366c6f3cc53c856cd5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d366c6f3cc53c856cd5%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d366c6f3cc53c856cd5%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d366c6f3cc53c856cd5%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d366c6f3cc53c856cd5%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86d366c6f3cc53c856cd5%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84b0e6c6f3cc53c852100" data-idx="744">
+        <div class="book-header">
+          <span class="book-num">#745</span>
+          <h3>Das Leben und Offenbahrungen [...] Ans Licht gebracht durch [...] Joannes Landspergius</h3>
+          <span class="page-count">429 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84b0e6c6f3cc53c852100" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84b0e6c6f3cc53c852100', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84b0e6c6f3cc53c852100', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84b0e6c6f3cc53c852100', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84b0e6c6f3cc53c852100', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84b0e6c6f3cc53c852100', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b0e6c6f3cc53c852100%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b0e6c6f3cc53c852100%2F0172-full.jpg&w=600" alt="Page 172" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.172 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b0e6c6f3cc53c852100%2F0257-full.jpg&w=600" alt="Page 257" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.257 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b0e6c6f3cc53c852100%2F0343-full.jpg&w=600" alt="Page 343" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.343 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b0e6c6f3cc53c852100%2F0386-full.jpg&w=600" alt="Page 386" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.386 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3354cca56a12bc603" data-idx="745">
+        <div class="book-header">
+          <span class="book-num">#746</span>
+          <h3>Unterredungen ueber die geheimen Wissenschaften</h3>
+          <span class="page-count">92 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3354cca56a12bc603" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3354cca56a12bc603', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3354cca56a12bc603', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3354cca56a12bc603', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3354cca56a12bc603', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3354cca56a12bc603', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc603%2F69c582eed4f81fc7c18b4c70.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc603%2F69c587514e35d33f94168cfd.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc603%2F69c58a221707ccac215631a7.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc603%2F69c58c65acee2e482db37b89.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc603%2F69c58d6facee2e482db37bae.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41879f1200e2ab53cf975" data-idx="746">
+        <div class="book-header">
+          <span class="book-num">#747</span>
+          <h3>Alchemical Texts (PH291)</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-collection-late-17th-century-german-ms-various" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41879f1200e2ab53cf975', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41879f1200e2ab53cf975', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41879f1200e2ab53cf975', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41879f1200e2ab53cf975', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41879f1200e2ab53cf975', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41879f1200e2ab53cf975%2F7.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41879f1200e2ab53cf975%2F28.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41879f1200e2ab53cf975%2F41.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41879f1200e2ab53cf975%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41879f1200e2ab53cf975%2F62.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c811be6c6f3cc53c84798b" data-idx="747">
+        <div class="book-header">
+          <span class="book-num">#748</span>
+          <h3>Les merveilles du ciel et de l'enfer</h3>
+          <span class="page-count">402 pp</span>
+          <a href="https://sourcelibrary.org/book/69c811be6c6f3cc53c84798b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c811be6c6f3cc53c84798b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c811be6c6f3cc53c84798b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c811be6c6f3cc53c84798b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c811be6c6f3cc53c84798b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c811be6c6f3cc53c84798b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811be6c6f3cc53c84798b%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811be6c6f3cc53c84798b%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811be6c6f3cc53c84798b%2F0241-full.jpg&w=600" alt="Page 241" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.241 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811be6c6f3cc53c84798b%2F0322-full.jpg&w=600" alt="Page 322" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.322 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811be6c6f3cc53c84798b%2F0362-full.jpg&w=600" alt="Page 362" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.362 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c804966c6f3cc53c844ef0" data-idx="748">
+        <div class="book-header">
+          <span class="book-num">#749</span>
+          <h3>Zusätze zu der teutschen Uebersetzung von Fludds Schutzschrift für die Rosenkreuzer</h3>
+          <span class="page-count">127 pp</span>
+          <a href="https://sourcelibrary.org/book/69c804966c6f3cc53c844ef0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c804966c6f3cc53c844ef0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c804966c6f3cc53c844ef0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c804966c6f3cc53c844ef0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c804966c6f3cc53c844ef0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c804966c6f3cc53c844ef0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804966c6f3cc53c844ef0%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804966c6f3cc53c844ef0%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804966c6f3cc53c844ef0%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804966c6f3cc53c844ef0%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c804966c6f3cc53c844ef0%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c636f53e8cae136d149961" data-idx="749">
+        <div class="book-header">
+          <span class="book-num">#750</span>
+          <h3>Versuch ueber die Sekte der Illuminaten</h3>
+          <span class="page-count">109 pp</span>
+          <a href="https://sourcelibrary.org/book/69c636f53e8cae136d149961" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c636f53e8cae136d149961', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c636f53e8cae136d149961', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c636f53e8cae136d149961', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c636f53e8cae136d149961', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c636f53e8cae136d149961', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c636f53e8cae136d149961%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c636f53e8cae136d149961%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c636f53e8cae136d149961%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c636f53e8cae136d149961%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c636f53e8cae136d149961%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8839e6c6f3cc53c8597e3" data-idx="750">
+        <div class="book-header">
+          <span class="book-num">#751</span>
+          <h3>Ein philosophischer und chemischer Tractat: genannt Der kleine Baur</h3>
+          <span class="page-count">210 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8839e6c6f3cc53c8597e3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8839e6c6f3cc53c8597e3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8839e6c6f3cc53c8597e3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8839e6c6f3cc53c8597e3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8839e6c6f3cc53c8597e3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8839e6c6f3cc53c8597e3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8839e6c6f3cc53c8597e3%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8839e6c6f3cc53c8597e3%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8839e6c6f3cc53c8597e3%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8839e6c6f3cc53c8597e3%2F0168-full.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8839e6c6f3cc53c8597e3%2F0189-full.jpg&w=600" alt="Page 189" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.189 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c881926c6f3cc53c85932f" data-idx="751">
+        <div class="book-header">
+          <span class="book-num">#752</span>
+          <h3>Opera. Veteris et nove translationis</h3>
+          <span class="page-count">340 pp</span>
+          <a href="https://sourcelibrary.org/book/69c881926c6f3cc53c85932f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c881926c6f3cc53c85932f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c881926c6f3cc53c85932f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c881926c6f3cc53c85932f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c881926c6f3cc53c85932f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c881926c6f3cc53c85932f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881926c6f3cc53c85932f%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881926c6f3cc53c85932f%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881926c6f3cc53c85932f%2F0204-full.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881926c6f3cc53c85932f%2F0272-full.jpg&w=600" alt="Page 272" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.272 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c881926c6f3cc53c85932f%2F0306-full.jpg&w=600" alt="Page 306" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.306 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4193a2b0edf3eaa2df0d7" data-idx="752">
+        <div class="book-header">
+          <span class="book-num">#753</span>
+          <h3>Palladis Chymicae Arcana Detecta — Marengus (PH292)</h3>
+          <span class="page-count">227 pp</span>
+          <a href="https://sourcelibrary.org/book/marengus-chemical-pallas-ca-1675-multilingual-ms-marengus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4193a2b0edf3eaa2df0d7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4193a2b0edf3eaa2df0d7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4193a2b0edf3eaa2df0d7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4193a2b0edf3eaa2df0d7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4193a2b0edf3eaa2df0d7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193a2b0edf3eaa2df0d7%2F23.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193a2b0edf3eaa2df0d7%2F91.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193a2b0edf3eaa2df0d7%2F136.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193a2b0edf3eaa2df0d7%2F182.jpg&w=600" alt="Page 182" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.182 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4193a2b0edf3eaa2df0d7%2F204.jpg&w=600" alt="Page 204" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.204 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89f516c6f3cc53c85dc4c" data-idx="753">
+        <div class="book-header">
+          <span class="book-num">#754</span>
+          <h3>Magiae naturalis libri viginti</h3>
+          <span class="page-count">358 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89f516c6f3cc53c85dc4c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89f516c6f3cc53c85dc4c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89f516c6f3cc53c85dc4c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89f516c6f3cc53c85dc4c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89f516c6f3cc53c85dc4c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89f516c6f3cc53c85dc4c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f516c6f3cc53c85dc4c%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f516c6f3cc53c85dc4c%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f516c6f3cc53c85dc4c%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f516c6f3cc53c85dc4c%2F0286-full.jpg&w=600" alt="Page 286" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.286 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89f516c6f3cc53c85dc4c%2F0322-full.jpg&w=600" alt="Page 322" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.322 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8244f6c6f3cc53c84b3cf" data-idx="754">
+        <div class="book-header">
+          <span class="book-num">#755</span>
+          <h3>Brunnen der Weisheit und Erkänntniss der Natur</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8244f6c6f3cc53c84b3cf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8244f6c6f3cc53c84b3cf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8244f6c6f3cc53c84b3cf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8244f6c6f3cc53c84b3cf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8244f6c6f3cc53c84b3cf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8244f6c6f3cc53c84b3cf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8244f6c6f3cc53c84b3cf%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8244f6c6f3cc53c84b3cf%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8244f6c6f3cc53c84b3cf%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8244f6c6f3cc53c84b3cf%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8244f6c6f3cc53c84b3cf%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c735f26a0f3d112faf75cb" data-idx="755">
+        <div class="book-header">
+          <span class="book-num">#756</span>
+          <h3>Diatribe theologica de Antichristo</h3>
+          <span class="page-count">146 pp</span>
+          <a href="https://sourcelibrary.org/book/69c735f26a0f3d112faf75cb" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c735f26a0f3d112faf75cb', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c735f26a0f3d112faf75cb', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c735f26a0f3d112faf75cb', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c735f26a0f3d112faf75cb', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c735f26a0f3d112faf75cb', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c735f26a0f3d112faf75cb%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c735f26a0f3d112faf75cb%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c735f26a0f3d112faf75cb%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c735f26a0f3d112faf75cb%2F0117-full.jpg&w=600" alt="Page 117" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.117 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c735f26a0f3d112faf75cb%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84b6e6c6f3cc53c8521c7" data-idx="756">
+        <div class="book-header">
+          <span class="book-num">#757</span>
+          <h3>Die stete Freude des Geistes</h3>
+          <span class="page-count">273 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84b6e6c6f3cc53c8521c7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84b6e6c6f3cc53c8521c7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84b6e6c6f3cc53c8521c7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84b6e6c6f3cc53c8521c7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84b6e6c6f3cc53c8521c7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84b6e6c6f3cc53c8521c7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b6e6c6f3cc53c8521c7%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b6e6c6f3cc53c8521c7%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b6e6c6f3cc53c8521c7%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b6e6c6f3cc53c8521c7%2F0218-full.jpg&w=600" alt="Page 218" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.218 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84b6e6c6f3cc53c8521c7%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6462f5dec4c2fa41d36aa" data-idx="757">
+        <div class="book-header">
+          <span class="book-num">#758</span>
+          <h3>Vorläufige Darstellung des heutigen Jesuitismus, der Rosenkreuzerey, Proselytenmacherey und Religionsvereinigung</h3>
+          <span class="page-count">284 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6462f5dec4c2fa41d36aa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6462f5dec4c2fa41d36aa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6462f5dec4c2fa41d36aa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6462f5dec4c2fa41d36aa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6462f5dec4c2fa41d36aa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6462f5dec4c2fa41d36aa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36aa%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36aa%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36aa%2F0170-full.jpg&w=600" alt="Page 170" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.170 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36aa%2F0227-full.jpg&w=600" alt="Page 227" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.227 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36aa%2F0256-full.jpg&w=600" alt="Page 256" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.256 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82d9c6c6f3cc53c84d36a" data-idx="758">
+        <div class="book-header">
+          <span class="book-num">#759</span>
+          <h3>In nomine Jesu. Mysterium magnum, Christus in nobis. Das unaussforschliche, und für aller Welt verborgene Geheimnüsz von der gnaden reichen Einwohnung Christi in uns</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82d9c6c6f3cc53c84d36a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82d9c6c6f3cc53c84d36a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82d9c6c6f3cc53c84d36a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82d9c6c6f3cc53c84d36a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82d9c6c6f3cc53c84d36a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82d9c6c6f3cc53c84d36a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d9c6c6f3cc53c84d36a%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d9c6c6f3cc53c84d36a%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d9c6c6f3cc53c84d36a%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d9c6c6f3cc53c84d36a%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82d9c6c6f3cc53c84d36a%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a6b092b884e4f8173c12" data-idx="759">
+        <div class="book-header">
+          <span class="book-num">#760</span>
+          <h3>Tractatus posthumus juris publici De origine, et successione, variisque imperii Romani mutationibus</h3>
+          <span class="page-count">188 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a6b092b884e4f8173c12" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a6b092b884e4f8173c12', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a6b092b884e4f8173c12', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a6b092b884e4f8173c12', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a6b092b884e4f8173c12', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a6b092b884e4f8173c12', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6b092b884e4f8173c12%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6b092b884e4f8173c12%2F0075-full.jpg&w=600" alt="Page 75" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.75 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6b092b884e4f8173c12%2F0113-full.jpg&w=600" alt="Page 113" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.113 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6b092b884e4f8173c12%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a6b092b884e4f8173c12%2F0169-full.jpg&w=600" alt="Page 169" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.169 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8675f6c6f3cc53c85655d" data-idx="760">
+        <div class="book-header">
+          <span class="book-num">#761</span>
+          <h3>Ein altes, sehr schönes und herrliches Tractätlein von dem Gebenedeyeten Stein</h3>
+          <span class="page-count">61 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8675f6c6f3cc53c85655d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8675f6c6f3cc53c85655d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8675f6c6f3cc53c85655d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8675f6c6f3cc53c85655d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8675f6c6f3cc53c85655d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8675f6c6f3cc53c85655d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c8675f6c6f3cc53c85655d%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8675f6c6f3cc53c85655d%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8675f6c6f3cc53c85655d%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8675f6c6f3cc53c85655d%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8675f6c6f3cc53c85655d%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c870626c6f3cc53c857299" data-idx="761">
+        <div class="book-header">
+          <span class="book-num">#762</span>
+          <h3>Explanation of the Rosicrucian certificate and the seal of the Supreme Magus with Kabbalistic notes</h3>
+          <span class="page-count">17 pp</span>
+          <a href="https://sourcelibrary.org/book/69c870626c6f3cc53c857299" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c870626c6f3cc53c857299', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c870626c6f3cc53c857299', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c870626c6f3cc53c857299', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c870626c6f3cc53c857299', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c870626c6f3cc53c857299', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870626c6f3cc53c857299%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870626c6f3cc53c857299%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870626c6f3cc53c857299%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870626c6f3cc53c857299%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c870626c6f3cc53c857299%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c895c26c6f3cc53c85c3e2" data-idx="762">
+        <div class="book-header">
+          <span class="book-num">#763</span>
+          <h3>Nouvel essai sur la table Isiaque</h3>
+          <span class="page-count">45 pp</span>
+          <a href="https://sourcelibrary.org/book/69c895c26c6f3cc53c85c3e2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c895c26c6f3cc53c85c3e2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c895c26c6f3cc53c85c3e2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c895c26c6f3cc53c85c3e2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c895c26c6f3cc53c85c3e2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c895c26c6f3cc53c85c3e2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895c26c6f3cc53c85c3e2%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895c26c6f3cc53c85c3e2%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895c26c6f3cc53c85c3e2%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895c26c6f3cc53c85c3e2%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c895c26c6f3cc53c85c3e2%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c648c1b2d26d717d1aaa40" data-idx="763">
+        <div class="book-header">
+          <span class="book-num">#764</span>
+          <h3>Vortrab, vorhabender aussführung, auss was Grundt, Anfang, Mittel und Ende, die gute Stadt Magdeburg zu dem erbärmlichen Untergang voranlasset, befordert, und vollständig gebracht worden</h3>
+          <span class="page-count">19 pp</span>
+          <a href="https://sourcelibrary.org/book/69c648c1b2d26d717d1aaa40" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c648c1b2d26d717d1aaa40', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c648c1b2d26d717d1aaa40', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c648c1b2d26d717d1aaa40', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c648c1b2d26d717d1aaa40', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c648c1b2d26d717d1aaa40', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa40%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa40%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa40%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa40%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c648c1b2d26d717d1aaa40%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c79e8492b884e4f81736f3" data-idx="764">
+        <div class="book-header">
+          <span class="book-num">#765</span>
+          <h3>[Hebrew: Sefer hadrat melech]</h3>
+          <span class="page-count">128 pp</span>
+          <a href="https://sourcelibrary.org/book/69c79e8492b884e4f81736f3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c79e8492b884e4f81736f3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c79e8492b884e4f81736f3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c79e8492b884e4f81736f3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c79e8492b884e4f81736f3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c79e8492b884e4f81736f3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f3%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f3%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f3%2F0077-full.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f3%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c79e8492b884e4f81736f3%2F0115-full.jpg&w=600" alt="Page 115" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.115 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c880ee6c6f3cc53c8591c4" data-idx="765">
+        <div class="book-header">
+          <span class="book-num">#766</span>
+          <h3>Notes on Nirvana</h3>
+          <span class="page-count">21 pp</span>
+          <a href="https://sourcelibrary.org/book/69c880ee6c6f3cc53c8591c4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c880ee6c6f3cc53c8591c4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c880ee6c6f3cc53c8591c4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c880ee6c6f3cc53c8591c4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c880ee6c6f3cc53c8591c4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c880ee6c6f3cc53c8591c4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880ee6c6f3cc53c8591c4%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880ee6c6f3cc53c8591c4%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880ee6c6f3cc53c8591c4%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880ee6c6f3cc53c8591c4%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c880ee6c6f3cc53c8591c4%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c871276c6f3cc53c8574e2" data-idx="766">
+        <div class="book-header">
+          <span class="book-num">#767</span>
+          <h3>A continuation of the controversy</h3>
+          <span class="page-count">32 pp</span>
+          <a href="https://sourcelibrary.org/book/69c871276c6f3cc53c8574e2" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c871276c6f3cc53c8574e2', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c871276c6f3cc53c8574e2', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c871276c6f3cc53c8574e2', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c871276c6f3cc53c8574e2', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c871276c6f3cc53c8574e2', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871276c6f3cc53c8574e2%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871276c6f3cc53c8574e2%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871276c6f3cc53c8574e2%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871276c6f3cc53c8574e2%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c871276c6f3cc53c8574e2%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f3d4da9771c716314e92" data-idx="767">
+        <div class="book-header">
+          <span class="book-num">#768</span>
+          <h3>Wohlangerichtetes aerarium chymicum oder reichlich vermehrte chymische Schatz-Kammer</h3>
+          <span class="page-count">114 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f3d4da9771c716314e92" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f3d4da9771c716314e92', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f3d4da9771c716314e92', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f3d4da9771c716314e92', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f3d4da9771c716314e92', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f3d4da9771c716314e92', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e92%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e92%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e92%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e92%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f3d4da9771c716314e92%2F0103-full.jpg&w=600" alt="Page 103" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.103 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c805396c6f3cc53c8450d1" data-idx="768">
+        <div class="book-header">
+          <span class="book-num">#769</span>
+          <h3>La vie de B. de Spinoza</h3>
+          <span class="page-count">97 pp</span>
+          <a href="https://sourcelibrary.org/book/69c805396c6f3cc53c8450d1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c805396c6f3cc53c8450d1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c805396c6f3cc53c8450d1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c805396c6f3cc53c8450d1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c805396c6f3cc53c8450d1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c805396c6f3cc53c8450d1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805396c6f3cc53c8450d1%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805396c6f3cc53c8450d1%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805396c6f3cc53c8450d1%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805396c6f3cc53c8450d1%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c805396c6f3cc53c8450d1%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4191f2b0edf3eaa2ded29" data-idx="769">
+        <div class="book-header">
+          <span class="book-num">#770</span>
+          <h3>La nature à decouvert — Pierre Trudon du Tilleul (PH279)</h3>
+          <span class="page-count">75 pp</span>
+          <a href="https://sourcelibrary.org/book/nature-uncovered-trudon-du-tilleul-18th-century-ms-tilleul" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4191f2b0edf3eaa2ded29', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4191f2b0edf3eaa2ded29', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4191f2b0edf3eaa2ded29', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4191f2b0edf3eaa2ded29', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4191f2b0edf3eaa2ded29', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191f2b0edf3eaa2ded29%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191f2b0edf3eaa2ded29%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191f2b0edf3eaa2ded29%2F45.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191f2b0edf3eaa2ded29%2F60.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4191f2b0edf3eaa2ded29%2F68.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c894dc6c6f3cc53c85c1c8" data-idx="770">
+        <div class="book-header">
+          <span class="book-num">#771</span>
+          <h3>Der fuer die einfaeltigen epitomirte nicht tunckel, sondern klar und deutlich, redende hocherleuchtete Jacob Boehme: oder seraphinisch Blumen-Gaertlein</h3>
+          <span class="page-count">185 pp</span>
+          <a href="https://sourcelibrary.org/book/69c894dc6c6f3cc53c85c1c8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c894dc6c6f3cc53c85c1c8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c894dc6c6f3cc53c85c1c8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c894dc6c6f3cc53c85c1c8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c894dc6c6f3cc53c85c1c8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c894dc6c6f3cc53c85c1c8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894dc6c6f3cc53c85c1c8%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894dc6c6f3cc53c85c1c8%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894dc6c6f3cc53c85c1c8%2F0111-full.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894dc6c6f3cc53c85c1c8%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c894dc6c6f3cc53c85c1c8%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419292b0edf3eaa2dedf6" data-idx="771">
+        <div class="book-header">
+          <span class="book-num">#772</span>
+          <h3>Liber Saturni — Michael Sendivogius (PH335)</h3>
+          <span class="page-count">117 pp</span>
+          <a href="https://sourcelibrary.org/book/sendivogius-book-of-saturn-18th-century-german-ms-sendivogius" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419292b0edf3eaa2dedf6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419292b0edf3eaa2dedf6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419292b0edf3eaa2dedf6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419292b0edf3eaa2dedf6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419292b0edf3eaa2dedf6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419292b0edf3eaa2dedf6%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540270605131!ph335_bph_mog_3_047.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540270605131!ph335_bph_mog_3_070.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 70" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.70 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540270605131!ph335_bph_mog_3_094.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940540270605131!ph335_bph_mog_3_105.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e32e2f948a050a505a" data-idx="772">
+        <div class="book-header">
+          <span class="book-num">#773</span>
+          <h3>Untersuchung über das Geheimnis und die Gebräuche der Tempelherren</h3>
+          <span class="page-count">35 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e32e2f948a050a505a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e32e2f948a050a505a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e32e2f948a050a505a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e32e2f948a050a505a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e32e2f948a050a505a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e32e2f948a050a505a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505a%2F69c5826b4b88e3439a24e466.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505a%2F69c584a831747c75e8c498c2.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505a%2F69c5865804ba13b8af5757f8.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505a%2F69c587c91ea82a3c387eeed2.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e32e2f948a050a505a%2F69c5889862ff3ddc150cdf50.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c835746c6f3cc53c84e900" data-idx="773">
+        <div class="book-header">
+          <span class="book-num">#774</span>
+          <h3>Nachrichten von den Begebenheiten und Schriften berümter Gelehrter</h3>
+          <span class="page-count">266 pp</span>
+          <a href="https://sourcelibrary.org/book/69c835746c6f3cc53c84e900" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c835746c6f3cc53c84e900', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c835746c6f3cc53c84e900', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c835746c6f3cc53c84e900', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c835746c6f3cc53c84e900', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c835746c6f3cc53c84e900', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835746c6f3cc53c84e900%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835746c6f3cc53c84e900%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835746c6f3cc53c84e900%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835746c6f3cc53c84e900%2F0213-full.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c835746c6f3cc53c84e900%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c703c5da9771c716315965" data-idx="774">
+        <div class="book-header">
+          <span class="book-num">#775</span>
+          <h3>[Greek: Orpheos argonaitika ymnoi kai peri lithon] Argonautica hymni et de lapidibus</h3>
+          <span class="page-count">183 pp</span>
+          <a href="https://sourcelibrary.org/book/69c703c5da9771c716315965" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c703c5da9771c716315965', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c703c5da9771c716315965', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c703c5da9771c716315965', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c703c5da9771c716315965', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c703c5da9771c716315965', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c5da9771c716315965%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c5da9771c716315965%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c5da9771c716315965%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c5da9771c716315965%2F0146-full.jpg&w=600" alt="Page 146" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.146 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c703c5da9771c716315965%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898026c6f3cc53c85c9b4" data-idx="775">
+        <div class="book-header">
+          <span class="book-num">#776</span>
+          <h3>Mithraism</h3>
+          <span class="page-count">13 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898026c6f3cc53c85c9b4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898026c6f3cc53c85c9b4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898026c6f3cc53c85c9b4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898026c6f3cc53c85c9b4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898026c6f3cc53c85c9b4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898026c6f3cc53c85c9b4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898026c6f3cc53c85c9b4%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898026c6f3cc53c85c9b4%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898026c6f3cc53c85c9b4%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898026c6f3cc53c85c9b4%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898026c6f3cc53c85c9b4%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f9646c6f3cc53c842683" data-idx="776">
+        <div class="book-header">
+          <span class="book-num">#777</span>
+          <h3>Ueber das Leben und die Verdienste Johann von Dalbergs</h3>
+          <span class="page-count">44 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f9646c6f3cc53c842683" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f9646c6f3cc53c842683', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f9646c6f3cc53c842683', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f9646c6f3cc53c842683', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f9646c6f3cc53c842683', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f9646c6f3cc53c842683', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9646c6f3cc53c842683%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9646c6f3cc53c842683%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9646c6f3cc53c842683%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9646c6f3cc53c842683%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f9646c6f3cc53c842683%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7a2c492b884e4f81738e1" data-idx="777">
+        <div class="book-header">
+          <span class="book-num">#778</span>
+          <h3>Doctrine du baptême et sa pure administration</h3>
+          <span class="page-count">220 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7a2c492b884e4f81738e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7a2c492b884e4f81738e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7a2c492b884e4f81738e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7a2c492b884e4f81738e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7a2c492b884e4f81738e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7a2c492b884e4f81738e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a2c492b884e4f81738e1%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a2c492b884e4f81738e1%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a2c492b884e4f81738e1%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a2c492b884e4f81738e1%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7a2c492b884e4f81738e1%2F0198-full.jpg&w=600" alt="Page 198" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.198 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c896326c6f3cc53c85c4c5" data-idx="778">
+        <div class="book-header">
+          <span class="book-num">#779</span>
+          <h3>The interior life from the standpoint of the mystics. An address delivered before the London spiritualist alliance ... December 16th, 1890</h3>
+          <span class="page-count">15 pp</span>
+          <a href="https://sourcelibrary.org/book/69c896326c6f3cc53c85c4c5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c896326c6f3cc53c85c4c5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c896326c6f3cc53c85c4c5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c896326c6f3cc53c85c4c5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c896326c6f3cc53c85c4c5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c896326c6f3cc53c85c4c5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896326c6f3cc53c85c4c5%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896326c6f3cc53c85c4c5%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896326c6f3cc53c85c4c5%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896326c6f3cc53c85c4c5%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c896326c6f3cc53c85c4c5%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8936e6c6f3cc53c85be9d" data-idx="779">
+        <div class="book-header">
+          <span class="book-num">#780</span>
+          <h3>Fundamentals of Vedanta philosophy and the Qabalah</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8936e6c6f3cc53c85be9d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8936e6c6f3cc53c85be9d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8936e6c6f3cc53c85be9d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8936e6c6f3cc53c85be9d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8936e6c6f3cc53c85be9d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8936e6c6f3cc53c85be9d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8936e6c6f3cc53c85be9d%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8936e6c6f3cc53c85be9d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8936e6c6f3cc53c85be9d%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8936e6c6f3cc53c85be9d%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8936e6c6f3cc53c85be9d%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f72ada9771c71631512e" data-idx="780">
+        <div class="book-header">
+          <span class="book-num">#781</span>
+          <h3>The works of Jacob Behmen. With figures by William Law</h3>
+          <span class="page-count">333 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f72ada9771c71631512e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f72ada9771c71631512e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f72ada9771c71631512e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f72ada9771c71631512e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f72ada9771c71631512e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f72ada9771c71631512e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f72ada9771c71631512e%2F0033-full.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f72ada9771c71631512e%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f72ada9771c71631512e%2F0200-full.jpg&w=600" alt="Page 200" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.200 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f72ada9771c71631512e%2F0266-full.jpg&w=600" alt="Page 266" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.266 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f72ada9771c71631512e%2F0300-full.jpg&w=600" alt="Page 300" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.300 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6418ab463eebe7caac807" data-idx="781">
+        <div class="book-header">
+          <span class="book-num">#782</span>
+          <h3>De vitis philosophorum et sophistarum</h3>
+          <span class="page-count">211 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6418ab463eebe7caac807" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6418ab463eebe7caac807', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6418ab463eebe7caac807', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6418ab463eebe7caac807', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6418ab463eebe7caac807', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6418ab463eebe7caac807', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6418ab463eebe7caac807%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6418ab463eebe7caac807%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6418ab463eebe7caac807%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6418ab463eebe7caac807%2F0169-full.jpg&w=600" alt="Page 169" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.169 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6418ab463eebe7caac807%2F0190-full.jpg&w=600" alt="Page 190" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.190 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7eeb6fb10016c3f389f35" data-idx="782">
+        <div class="book-header">
+          <span class="book-num">#783</span>
+          <h3>Tractatus chymicus antiquissimus &amp; vere aureus</h3>
+          <span class="page-count">27 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7eeb6fb10016c3f389f35" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7eeb6fb10016c3f389f35', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7eeb6fb10016c3f389f35', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7eeb6fb10016c3f389f35', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7eeb6fb10016c3f389f35', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7eeb6fb10016c3f389f35', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eeb6fb10016c3f389f35%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eeb6fb10016c3f389f35%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eeb6fb10016c3f389f35%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eeb6fb10016c3f389f35%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eeb6fb10016c3f389f35%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c889796c6f3cc53c85a445" data-idx="783">
+        <div class="book-header">
+          <span class="book-num">#784</span>
+          <h3>Secretioris naturae secretorum scrutinium chymicum</h3>
+          <span class="page-count">84 pp</span>
+          <a href="https://sourcelibrary.org/book/69c889796c6f3cc53c85a445" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c889796c6f3cc53c85a445', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c889796c6f3cc53c85a445', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c889796c6f3cc53c85a445', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c889796c6f3cc53c85a445', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c889796c6f3cc53c85a445', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889796c6f3cc53c85a445%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889796c6f3cc53c85a445%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889796c6f3cc53c85a445%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889796c6f3cc53c85a445%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c889796c6f3cc53c85a445%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418932b0edf3eaa2dd59a" data-idx="784">
+        <div class="book-header">
+          <span class="book-num">#785</span>
+          <h3>Hermetis philosophi de revolutionibus nativitatum (PH216)</h3>
+          <span class="page-count">186 pp</span>
+          <a href="https://sourcelibrary.org/book/hermes-trismegistus-on-the-revolutions-of-nativities-trismegistus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418932b0edf3eaa2dd59a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418932b0edf3eaa2dd59a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418932b0edf3eaa2dd59a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418932b0edf3eaa2dd59a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418932b0edf3eaa2dd59a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418932b0edf3eaa2dd59a%2F19.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486131905131!PH216_0074.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486131905131!PH216_0112.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 112" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.112 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486131905131!PH216_0149.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940486131905131!PH216_0167.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b41865f1200e2ab53cf7f4" data-idx="785">
+        <div class="book-header">
+          <span class="book-num">#786</span>
+          <h3>Compendiolum de praeparatione auri potabilis (PH153 bis)</h3>
+          <span class="page-count">118 pp</span>
+          <a href="https://sourcelibrary.org/book/preparation-of-drinkable-gold-marcus-eugenius-bonacina-bonacina" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b41865f1200e2ab53cf7f4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b41865f1200e2ab53cf7f4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b41865f1200e2ab53cf7f4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b41865f1200e2ab53cf7f4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b41865f1200e2ab53cf7f4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41865f1200e2ab53cf7f4%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41865f1200e2ab53cf7f4%2F47.jpg&w=600" alt="Page 47" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.47 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41865f1200e2ab53cf7f4%2F71.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41865f1200e2ab53cf7f4%2F94.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b41865f1200e2ab53cf7f4%2F106.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8779b6c6f3cc53c85807f" data-idx="786">
+        <div class="book-header">
+          <span class="book-num">#787</span>
+          <h3>The first order of the Rosy Cross [...] Part 1</h3>
+          <span class="page-count">31 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8779b6c6f3cc53c85807f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8779b6c6f3cc53c85807f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8779b6c6f3cc53c85807f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8779b6c6f3cc53c85807f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8779b6c6f3cc53c85807f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8779b6c6f3cc53c85807f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8779b6c6f3cc53c85807f%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8779b6c6f3cc53c85807f%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8779b6c6f3cc53c85807f%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8779b6c6f3cc53c85807f%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8779b6c6f3cc53c85807f%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c84c2e6c6f3cc53c852356" data-idx="787">
+        <div class="book-header">
+          <span class="book-num">#788</span>
+          <h3>Tomus I. Annalium Hirsaugiensium</h3>
+          <span class="page-count">705 pp</span>
+          <a href="https://sourcelibrary.org/book/69c84c2e6c6f3cc53c852356" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c84c2e6c6f3cc53c852356', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c84c2e6c6f3cc53c852356', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c84c2e6c6f3cc53c852356', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c84c2e6c6f3cc53c852356', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c84c2e6c6f3cc53c852356', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84c2e6c6f3cc53c852356%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84c2e6c6f3cc53c852356%2F0282-full.jpg&w=600" alt="Page 282" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.282 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84c2e6c6f3cc53c852356%2F0423-full.jpg&w=600" alt="Page 423" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.423 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84c2e6c6f3cc53c852356%2F0564-full.jpg&w=600" alt="Page 564" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.564 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c84c2e6c6f3cc53c852356%2F0635-full.jpg&w=600" alt="Page 635" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.635 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c868986c6f3cc53c856721" data-idx="788">
+        <div class="book-header">
+          <span class="book-num">#789</span>
+          <h3>Annales mac[onniques]</h3>
+          <span class="page-count">133 pp</span>
+          <a href="https://sourcelibrary.org/book/69c868986c6f3cc53c856721" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c868986c6f3cc53c856721', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c868986c6f3cc53c856721', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c868986c6f3cc53c856721', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c868986c6f3cc53c856721', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c868986c6f3cc53c856721', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c868986c6f3cc53c856721%2F13.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868986c6f3cc53c856721%2F0053-full.jpg&w=600" alt="Page 53" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.53 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868986c6f3cc53c856721%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868986c6f3cc53c856721%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c868986c6f3cc53c856721%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4186af1200e2ab53cf871" data-idx="789">
+        <div class="book-header">
+          <span class="book-num">#790</span>
+          <h3>Antimonii Mysteria Gemina (PH418 B)</h3>
+          <span class="page-count">76 pp</span>
+          <a href="https://sourcelibrary.org/book/mysteries-of-antimony-alexander-von-suchten-1604-tholde" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4186af1200e2ab53cf871', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4186af1200e2ab53cf871', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4186af1200e2ab53cf871', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4186af1200e2ab53cf871', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4186af1200e2ab53cf871', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186af1200e2ab53cf871%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186af1200e2ab53cf871%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186af1200e2ab53cf871%2F46.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186af1200e2ab53cf871%2F61.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4186af1200e2ab53cf871%2F68.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8717b6c6f3cc53c8575ae" data-idx="790">
+        <div class="book-header">
+          <span class="book-num">#791</span>
+          <h3>Data of the history of the Rosicrucians</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8717b6c6f3cc53c8575ae" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8717b6c6f3cc53c8575ae', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8717b6c6f3cc53c8575ae', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8717b6c6f3cc53c8575ae', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8717b6c6f3cc53c8575ae', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8717b6c6f3cc53c8575ae', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8717b6c6f3cc53c8575ae%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8717b6c6f3cc53c8575ae%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8717b6c6f3cc53c8575ae%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8717b6c6f3cc53c8575ae%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8717b6c6f3cc53c8575ae%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6115" data-idx="791">
+        <div class="book-header">
+          <span class="book-num">#792</span>
+          <h3>Les plus secrets mystères des hauts grades de la maçonnerie dévoilés</h3>
+          <span class="page-count">96 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6115" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6115', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6115', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6115', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6115', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6115', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6115%2F69c559e807f13b5a2f082925.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6115%2F69c560112fd09fb58e9256da.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6115%2F69c56437cdc93d861798ee14.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6115%2F69c56798c25253c5fb651560.jpg&w=600" alt="Page 77" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.77 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee6115%2F69c5691a160f55f98931920c.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ae7925ec2ba5ccd7f25b" data-idx="792">
+        <div class="book-header">
+          <span class="book-num">#793</span>
+          <h3>Mémoire sur la découverte du magnétisme animal</h3>
+          <span class="page-count">51 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ae7925ec2ba5ccd7f25b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ae7925ec2ba5ccd7f25b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ae7925ec2ba5ccd7f25b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ae7925ec2ba5ccd7f25b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ae7925ec2ba5ccd7f25b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ae7925ec2ba5ccd7f25b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ae7925ec2ba5ccd7f25b%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ae7925ec2ba5ccd7f25b%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ae7925ec2ba5ccd7f25b%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ae7925ec2ba5ccd7f25b%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ae7925ec2ba5ccd7f25b%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88d266c6f3cc53c85ae04" data-idx="793">
+        <div class="book-header">
+          <span class="book-num">#794</span>
+          <h3>The unknown world. A magazine devoted to the occult sciences, magic, mystical philosophy, alchemy, hermetic archaeology, and the hidden problems of science, literature, speculation and history</h3>
+          <span class="page-count">290 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88d266c6f3cc53c85ae04" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88d266c6f3cc53c85ae04', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88d266c6f3cc53c85ae04', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88d266c6f3cc53c85ae04', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88d266c6f3cc53c85ae04', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88d266c6f3cc53c85ae04', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d266c6f3cc53c85ae04%2F0029-full.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d266c6f3cc53c85ae04%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d266c6f3cc53c85ae04%2F0174-full.jpg&w=600" alt="Page 174" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.174 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d266c6f3cc53c85ae04%2F0232-full.jpg&w=600" alt="Page 232" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.232 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88d266c6f3cc53c85ae04%2F0261-full.jpg&w=600" alt="Page 261" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.261 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c727966a0f3d112faf6ed0" data-idx="794">
+        <div class="book-header">
+          <span class="book-num">#795</span>
+          <h3>Historie des Himmels</h3>
+          <span class="page-count">673 pp</span>
+          <a href="https://sourcelibrary.org/book/69c727966a0f3d112faf6ed0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c727966a0f3d112faf6ed0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c727966a0f3d112faf6ed0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c727966a0f3d112faf6ed0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c727966a0f3d112faf6ed0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c727966a0f3d112faf6ed0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed0%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed0%2F0269-full.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed0%2F0404-full.jpg&w=600" alt="Page 404" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.404 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed0%2F0538-full.jpg&w=600" alt="Page 538" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.538 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed0%2F0606-full.jpg&w=600" alt="Page 606" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.606 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee6111" data-idx="795">
+        <div class="book-header">
+          <span class="book-num">#796</span>
+          <h3>Metaphysische Kezereien</h3>
+          <span class="page-count">196 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee6111" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee6111', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee6111', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee6111', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee6111', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee6111', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6111%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6111%2F78.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6111%2F118.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6111%2F157.jpg&w=600" alt="Page 157" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.157 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee6111%2F176.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7fdea6c6f3cc53c84359c" data-idx="796">
+        <div class="book-header">
+          <span class="book-num">#797</span>
+          <h3>Leben Antichristi</h3>
+          <span class="page-count">256 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7fdea6c6f3cc53c84359c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7fdea6c6f3cc53c84359c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7fdea6c6f3cc53c84359c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7fdea6c6f3cc53c84359c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7fdea6c6f3cc53c84359c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7fdea6c6f3cc53c84359c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdea6c6f3cc53c84359c%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdea6c6f3cc53c84359c%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdea6c6f3cc53c84359c%2F0154-full.jpg&w=600" alt="Page 154" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.154 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdea6c6f3cc53c84359c%2F0205-full.jpg&w=600" alt="Page 205" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.205 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7fdea6c6f3cc53c84359c%2F0230-full.jpg&w=600" alt="Page 230" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.230 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c865e06c6f3cc53c8562d1" data-idx="797">
+        <div class="book-header">
+          <span class="book-num">#798</span>
+          <h3>Abschiedsrede eines Bruders wahrer und ächter Maurerey alten Systems</h3>
+          <span class="page-count">53 pp</span>
+          <a href="https://sourcelibrary.org/book/69c865e06c6f3cc53c8562d1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c865e06c6f3cc53c8562d1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c865e06c6f3cc53c8562d1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c865e06c6f3cc53c8562d1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c865e06c6f3cc53c8562d1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c865e06c6f3cc53c8562d1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c865e06c6f3cc53c8562d1%2F5.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865e06c6f3cc53c8562d1%2F0021-full.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865e06c6f3cc53c8562d1%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865e06c6f3cc53c8562d1%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c865e06c6f3cc53c8562d1%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418902b0edf3eaa2dd408" data-idx="798">
+        <div class="book-header">
+          <span class="book-num">#799</span>
+          <h3>Das Buch der Warheitt und der Philosophen (PH293)</h3>
+          <span class="page-count">400 pp</span>
+          <a href="https://sourcelibrary.org/book/book-of-truth-and-the-philosophers-1664-german-ms" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418902b0edf3eaa2dd408', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418902b0edf3eaa2dd408', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418902b0edf3eaa2dd408', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418902b0edf3eaa2dd408', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418902b0edf3eaa2dd408', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418902b0edf3eaa2dd408%2F40.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418902b0edf3eaa2dd408%2F160.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418902b0edf3eaa2dd408%2F240.jpg&w=600" alt="Page 240" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.240 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940525034105131!ph293_0320.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 320" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.320 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940525034105131!ph293_0360.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 360" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.360 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c851cc6c6f3cc53c853217" data-idx="799">
+        <div class="book-header">
+          <span class="book-num">#800</span>
+          <h3>Materiam de principio et principiato, causa et causato in genere</h3>
+          <span class="page-count">17 pp</span>
+          <a href="https://sourcelibrary.org/book/69c851cc6c6f3cc53c853217" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c851cc6c6f3cc53c853217', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c851cc6c6f3cc53c853217', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c851cc6c6f3cc53c853217', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c851cc6c6f3cc53c853217', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c851cc6c6f3cc53c853217', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851cc6c6f3cc53c853217%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851cc6c6f3cc53c853217%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851cc6c6f3cc53c853217%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851cc6c6f3cc53c853217%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851cc6c6f3cc53c853217%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html" class="active">Page 8</a> <a href="split-review-9.html">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>

--- a/public/split-review-9.html
+++ b/public/split-review-9.html
@@ -1,0 +1,6015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BPH Split Review — Page 9/11</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0a;
+    color: #ccc;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    padding: 20px;
+  }
+  h1 { text-align: center; margin-bottom: 4px; font-size: 1.4rem; color: #fff; }
+  .subtitle { text-align: center; color: #666; margin-bottom: 16px; font-size: 0.85rem; }
+  .stats { text-align: center; color: #888; margin-bottom: 20px; font-size: 0.85rem; }
+  .stats span { margin: 0 8px; }
+  .pagination { text-align: center; margin-bottom: 20px; }
+  .pagination a { color: #6b9fff; margin: 0 6px; text-decoration: none; }
+  .pagination a.active { color: #fff; font-weight: bold; text-decoration: underline; }
+  .controls { text-align: center; margin-bottom: 20px; }
+  .controls button {
+    padding: 6px 14px; margin: 0 4px;
+    background: #222; color: #aaa; border: 1px solid #444;
+    border-radius: 4px; cursor: pointer; font-size: 0.8rem;
+  }
+  .controls button:hover { background: #333; }
+  .controls button.active { background: #444; color: #fff; border-color: #666; }
+
+  .book-card {
+    background: #141414;
+    border: 1px solid #222;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+  .book-card.flagged-ok { border-color: #2a6b2a; }
+  .book-card.flagged-angled { border-color: #8b6b00; }
+  .book-card.flagged-tight { border-color: #8b3a00; }
+  .book-card.flagged-off-center { border-color: #8b0040; }
+  .book-card.flagged-other { border-color: #6b4b8b; }
+  .book-card.hidden-by-filter { display: none; }
+
+  .book-header {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; flex-wrap: wrap;
+  }
+  .book-num { color: #555; font-size: 0.8rem; font-weight: bold; min-width: 35px; }
+  .book-header h3 { font-size: 0.9rem; color: #ccc; flex: 1; min-width: 150px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .page-count { color: #555; font-size: 0.8rem; white-space: nowrap; }
+  .book-link { color: #4a7fcf; text-decoration: none; font-size: 0.8rem; }
+  .book-link:hover { text-decoration: underline; }
+
+  .flag-buttons { display: flex; gap: 4px; }
+  .flag-btn {
+    padding: 3px 8px; font-size: 0.7rem; border-radius: 3px;
+    border: 1px solid #333; background: #1a1a1a; color: #888;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .flag-btn:hover { background: #252525; }
+  .flag-btn.selected { font-weight: bold; }
+  .flag-btn.ok.selected { background: #1a3a1a; color: #6b6; border-color: #3a5a3a; }
+  .flag-btn.angled.selected { background: #3a3000; color: #cc9; border-color: #5a4a00; }
+  .flag-btn.tight.selected { background: #3a1a00; color: #c96; border-color: #5a3000; }
+  .flag-btn.off-center.selected { background: #3a0020; color: #c6a; border-color: #5a0040; }
+  .flag-btn.other.selected { background: #2a1a3a; color: #a8c; border-color: #4a3a5a; }
+
+  .pages-row {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+  }
+  .page-slot { min-width: 0; }
+  .no-image {
+    display: flex; align-items: center; justify-content: center;
+    min-height: 120px; background: #0f0f0f; border-radius: 3px;
+    color: #444; font-size: 0.75rem; text-align: center;
+  }
+  .spread-container {
+    position: relative; overflow: hidden; border-radius: 3px;
+    background: #0f0f0f;
+  }
+  .spread-container img { width: 100%; display: block; }
+  .split-line {
+    position: absolute; top: 0; left: 50%; width: 2px; height: 100%;
+    background: rgba(255, 50, 50, 0.6);
+    pointer-events: none; transform: translateX(-1px);
+  }
+  .page-label {
+    text-align: center; font-size: 0.7rem; color: #555; margin-top: 3px;
+  }
+
+  .export-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #1a1a1a; border-top: 1px solid #333;
+    padding: 10px 20px; display: flex; align-items: center; gap: 16px;
+    z-index: 100;
+  }
+  .export-bar button {
+    padding: 6px 16px; background: #2a5a9a; color: #fff;
+    border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+  }
+  .export-bar button:hover { background: #3a6aaa; }
+  .export-bar .summary { color: #888; font-size: 0.85rem; }
+  body { padding-bottom: 60px; }
+</style>
+</head>
+<body>
+  <h1>BPH Split Review</h1>
+  <p class="subtitle">1089 books needing split — pages sampled at 10%, 40%, 60%, 80%, 90% — red line = naive 50% split</p>
+  <div class="stats" id="stats">
+    <span id="stat-ok">OK: 0</span>
+    <span id="stat-angled">Angled: 0</span>
+    <span id="stat-tight">Tight: 0</span>
+    <span id="stat-off-center">Off-center: 0</span>
+    <span id="stat-other">Other: 0</span>
+    <span id="stat-unreviewed">Unreviewed: 100</span>
+  </div>
+  <div class="controls">
+    <button onclick="filterBooks('all')" class="active" data-filter="all">Show all</button>
+    <button onclick="filterBooks('unreviewed')" data-filter="unreviewed">Unreviewed</button>
+    <button onclick="filterBooks('ok')" data-filter="ok">OK only</button>
+    <button onclick="filterBooks('flagged')" data-filter="flagged">Flagged only</button>
+  </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html" class="active">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  
+      <div class="book-card" data-book-id="6867aa3e009d20a23245ab41" data-idx="800">
+        <div class="book-header">
+          <span class="book-num">#801</span>
+          <h3>Ausführlicher Bericht vom Gebrauch desz Instruments so titulirt physico astrologicum instrumentum</h3>
+          <span class="page-count">37 pp</span>
+          <a href="https://sourcelibrary.org/book/detailed-report-on-the-use-of-the-physico-astrological-hafenreffer" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867aa3e009d20a23245ab41', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867aa3e009d20a23245ab41', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867aa3e009d20a23245ab41', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867aa3e009d20a23245ab41', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867aa3e009d20a23245ab41', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867aa3e009d20a23245ab41%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867aa3e009d20a23245ab41%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867aa3e009d20a23245ab41%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867aa3e009d20a23245ab41%2F30.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867aa3e009d20a23245ab41%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89d066c6f3cc53c85d71a" data-idx="801">
+        <div class="book-header">
+          <span class="book-num">#802</span>
+          <h3>Das ewige Evangelium</h3>
+          <span class="page-count">71 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89d066c6f3cc53c85d71a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89d066c6f3cc53c85d71a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89d066c6f3cc53c85d71a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89d066c6f3cc53c85d71a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89d066c6f3cc53c85d71a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89d066c6f3cc53c85d71a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d066c6f3cc53c85d71a%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d066c6f3cc53c85d71a%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d066c6f3cc53c85d71a%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d066c6f3cc53c85d71a%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d066c6f3cc53c85d71a%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c801696c6f3cc53c844309" data-idx="802">
+        <div class="book-header">
+          <span class="book-num">#803</span>
+          <h3>Das grosse Geheimnis der Offenbahrung Jesu Christi in uns</h3>
+          <span class="page-count">399 pp</span>
+          <a href="https://sourcelibrary.org/book/69c801696c6f3cc53c844309" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c801696c6f3cc53c844309', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c801696c6f3cc53c844309', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c801696c6f3cc53c844309', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c801696c6f3cc53c844309', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c801696c6f3cc53c844309', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801696c6f3cc53c844309%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801696c6f3cc53c844309%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801696c6f3cc53c844309%2F0239-full.jpg&w=600" alt="Page 239" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.239 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801696c6f3cc53c844309%2F0319-full.jpg&w=600" alt="Page 319" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.319 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c801696c6f3cc53c844309%2F0359-full.jpg&w=600" alt="Page 359" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.359 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7eed4fb10016c3f389f51" data-idx="803">
+        <div class="book-header">
+          <span class="book-num">#804</span>
+          <h3>Histoire des Albigeois: touchant leur doctrine &amp; religion, contre les faux bruits qui ont esté semés d'eux</h3>
+          <span class="page-count">137 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7eed4fb10016c3f389f51" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7eed4fb10016c3f389f51', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7eed4fb10016c3f389f51', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7eed4fb10016c3f389f51', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7eed4fb10016c3f389f51', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7eed4fb10016c3f389f51', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eed4fb10016c3f389f51%2F0014-full.jpg&w=600" alt="Page 14" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.14 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eed4fb10016c3f389f51%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eed4fb10016c3f389f51%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eed4fb10016c3f389f51%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7eed4fb10016c3f389f51%2F0123-full.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418c72b0edf3eaa2ddcf7" data-idx="804">
+        <div class="book-header">
+          <span class="book-num">#805</span>
+          <h3>De Misterio Magno — Jakob Böhme (PH354)</h3>
+          <span class="page-count">360 pp</span>
+          <a href="https://sourcelibrary.org/book/bohme-mysterium-magnum-pre-1640-ms-copy-bohme" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418c72b0edf3eaa2ddcf7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418c72b0edf3eaa2ddcf7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418c72b0edf3eaa2ddcf7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418c72b0edf3eaa2ddcf7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418c72b0edf3eaa2ddcf7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565481905131!PH354_0036.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565481905131!PH354_0144.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565481905131!PH354_0216.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 216" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.216 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565481905131!PH354_0288.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 288" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.288 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940565481905131!PH354_0324.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 324" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.324 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c795636a0f3d112fafa029" data-idx="805">
+        <div class="book-header">
+          <span class="book-num">#806</span>
+          <h3>Aperta arca arcani artificiosissimi. Das ist: eröffneter unnd offenstehender Kasten</h3>
+          <span class="page-count">131 pp</span>
+          <a href="https://sourcelibrary.org/book/69c795636a0f3d112fafa029" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c795636a0f3d112fafa029', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c795636a0f3d112fafa029', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c795636a0f3d112fafa029', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c795636a0f3d112fafa029', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c795636a0f3d112fafa029', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795636a0f3d112fafa029%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795636a0f3d112fafa029%2F0052-full.jpg&w=600" alt="Page 52" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.52 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795636a0f3d112fafa029%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795636a0f3d112fafa029%2F0105-full.jpg&w=600" alt="Page 105" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.105 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c795636a0f3d112fafa029%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c832ee6c6f3cc53c84e0d3" data-idx="806">
+        <div class="book-header">
+          <span class="book-num">#807</span>
+          <h3>An account of virtue</h3>
+          <span class="page-count">145 pp</span>
+          <a href="https://sourcelibrary.org/book/69c832ee6c6f3cc53c84e0d3" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c832ee6c6f3cc53c84e0d3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c832ee6c6f3cc53c84e0d3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c832ee6c6f3cc53c84e0d3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c832ee6c6f3cc53c84e0d3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c832ee6c6f3cc53c84e0d3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832ee6c6f3cc53c84e0d3%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832ee6c6f3cc53c84e0d3%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832ee6c6f3cc53c84e0d3%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832ee6c6f3cc53c84e0d3%2F0116-full.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c832ee6c6f3cc53c84e0d3%2F0131-full.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2ab6c6f3cc53c85e4a1" data-idx="807">
+        <div class="book-header">
+          <span class="book-num">#808</span>
+          <h3>Man's blood and generation</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2ab6c6f3cc53c85e4a1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2ab6c6f3cc53c85e4a1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2ab6c6f3cc53c85e4a1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2ab6c6f3cc53c85e4a1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2ab6c6f3cc53c85e4a1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2ab6c6f3cc53c85e4a1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2ab6c6f3cc53c85e4a1%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2ab6c6f3cc53c85e4a1%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2ab6c6f3cc53c85e4a1%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2ab6c6f3cc53c85e4a1%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2ab6c6f3cc53c85e4a1%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81efc6c6f3cc53c84a3cd" data-idx="808">
+        <div class="book-header">
+          <span class="book-num">#809</span>
+          <h3>Duldung und Menschenliebe</h3>
+          <span class="page-count">199 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81efc6c6f3cc53c84a3cd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81efc6c6f3cc53c84a3cd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81efc6c6f3cc53c84a3cd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81efc6c6f3cc53c84a3cd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81efc6c6f3cc53c84a3cd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81efc6c6f3cc53c84a3cd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81efc6c6f3cc53c84a3cd%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81efc6c6f3cc53c84a3cd%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81efc6c6f3cc53c84a3cd%2F0119-full.jpg&w=600" alt="Page 119" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.119 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81efc6c6f3cc53c84a3cd%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81efc6c6f3cc53c84a3cd%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c83ed06c6f3cc53c85029f" data-idx="809">
+        <div class="book-header">
+          <span class="book-num">#810</span>
+          <h3>Contra haereses libri quinque</h3>
+          <span class="page-count">233 pp</span>
+          <a href="https://sourcelibrary.org/book/69c83ed06c6f3cc53c85029f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c83ed06c6f3cc53c85029f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c83ed06c6f3cc53c85029f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c83ed06c6f3cc53c85029f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c83ed06c6f3cc53c85029f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c83ed06c6f3cc53c85029f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83ed06c6f3cc53c85029f%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83ed06c6f3cc53c85029f%2F0093-full.jpg&w=600" alt="Page 93" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.93 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83ed06c6f3cc53c85029f%2F0140-full.jpg&w=600" alt="Page 140" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.140 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83ed06c6f3cc53c85029f%2F0186-full.jpg&w=600" alt="Page 186" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.186 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c83ed06c6f3cc53c85029f%2F0210-full.jpg&w=600" alt="Page 210" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.210 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88c706c6f3cc53c85ac11" data-idx="810">
+        <div class="book-header">
+          <span class="book-num">#811</span>
+          <h3>Theoretischer und praktischer Unterricht ueber das Buch Thot</h3>
+          <span class="page-count">161 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88c706c6f3cc53c85ac11" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88c706c6f3cc53c85ac11', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88c706c6f3cc53c85ac11', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88c706c6f3cc53c85ac11', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88c706c6f3cc53c85ac11', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88c706c6f3cc53c85ac11', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c706c6f3cc53c85ac11%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c706c6f3cc53c85ac11%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c706c6f3cc53c85ac11%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c706c6f3cc53c85ac11%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88c706c6f3cc53c85ac11%2F0145-full.jpg&w=600" alt="Page 145" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.145 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8406f6c6f3cc53c85071a" data-idx="811">
+        <div class="book-header">
+          <span class="book-num">#812</span>
+          <h3>Einige Originalschriften des Illuminatenordens</h3>
+          <span class="page-count">220 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8406f6c6f3cc53c85071a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8406f6c6f3cc53c85071a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8406f6c6f3cc53c85071a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8406f6c6f3cc53c85071a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8406f6c6f3cc53c85071a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8406f6c6f3cc53c85071a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8406f6c6f3cc53c85071a%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8406f6c6f3cc53c85071a%2F0088-full.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8406f6c6f3cc53c85071a%2F0132-full.jpg&w=600" alt="Page 132" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.132 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8406f6c6f3cc53c85071a%2F0176-full.jpg&w=600" alt="Page 176" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.176 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8406f6c6f3cc53c85071a%2F0198-full.jpg&w=600" alt="Page 198" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.198 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c4ec33a3a4a7c546ee611d" data-idx="812">
+        <div class="book-header">
+          <span class="book-num">#813</span>
+          <h3>Magni philosophorum arcani revelator</h3>
+          <span class="page-count">260 pp</span>
+          <a href="https://sourcelibrary.org/book/69c4ec33a3a4a7c546ee611d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c4ec33a3a4a7c546ee611d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c4ec33a3a4a7c546ee611d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c4ec33a3a4a7c546ee611d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c4ec33a3a4a7c546ee611d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c4ec33a3a4a7c546ee611d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee611d%2F26.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee611d%2F104.jpg&w=600" alt="Page 104" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.104 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c4ec33a3a4a7c546ee611d%2F156.jpg&w=600" alt="Page 156" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.156 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611d%2F69c551442c6b40ad50f1f3c3.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c4ec33a3a4a7c546ee611d%2F69c554142c6b40ad50f1f411.jpg&w=600" alt="Page 234" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.234 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8133e6c6f3cc53c847e6e" data-idx="813">
+        <div class="book-header">
+          <span class="book-num">#814</span>
+          <h3>Tractatus theologico-politicus</h3>
+          <span class="page-count">313 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8133e6c6f3cc53c847e6e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8133e6c6f3cc53c847e6e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8133e6c6f3cc53c847e6e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8133e6c6f3cc53c847e6e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8133e6c6f3cc53c847e6e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8133e6c6f3cc53c847e6e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8133e6c6f3cc53c847e6e%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8133e6c6f3cc53c847e6e%2F0125-full.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8133e6c6f3cc53c847e6e%2F0188-full.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8133e6c6f3cc53c847e6e%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8133e6c6f3cc53c847e6e%2F0282-full.jpg&w=600" alt="Page 282" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.282 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c825ba6c6f3cc53c84ba26" data-idx="814">
+        <div class="book-header">
+          <span class="book-num">#815</span>
+          <h3>Essais de theodicée sur la bonté de Dieu</h3>
+          <span class="page-count">322 pp</span>
+          <a href="https://sourcelibrary.org/book/69c825ba6c6f3cc53c84ba26" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c825ba6c6f3cc53c84ba26', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c825ba6c6f3cc53c84ba26', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c825ba6c6f3cc53c84ba26', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c825ba6c6f3cc53c84ba26', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c825ba6c6f3cc53c84ba26', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825ba6c6f3cc53c84ba26%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825ba6c6f3cc53c84ba26%2F0129-full.jpg&w=600" alt="Page 129" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.129 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825ba6c6f3cc53c84ba26%2F0193-full.jpg&w=600" alt="Page 193" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.193 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825ba6c6f3cc53c84ba26%2F0258-full.jpg&w=600" alt="Page 258" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.258 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c825ba6c6f3cc53c84ba26%2F0290-full.jpg&w=600" alt="Page 290" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.290 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6332f3e8cae136d1496fd" data-idx="815">
+        <div class="book-header">
+          <span class="book-num">#816</span>
+          <h3>Versuch über die Beschuldigungen welche dem Tempelherrenorden gemacht worden, und über dessen Geheimniss</h3>
+          <span class="page-count">252 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6332f3e8cae136d1496fd" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6332f3e8cae136d1496fd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6332f3e8cae136d1496fd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6332f3e8cae136d1496fd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6332f3e8cae136d1496fd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6332f3e8cae136d1496fd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6332f3e8cae136d1496fd%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6332f3e8cae136d1496fd%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6332f3e8cae136d1496fd%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6332f3e8cae136d1496fd%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6332f3e8cae136d1496fd%2F0227-full.jpg&w=600" alt="Page 227" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.227 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c741606a0f3d112faf7d28" data-idx="816">
+        <div class="book-header">
+          <span class="book-num">#817</span>
+          <h3>Zwölf Briefe eines Mitgliedes der suchenden Gesellschaft</h3>
+          <span class="page-count">27 pp</span>
+          <a href="https://sourcelibrary.org/book/69c741606a0f3d112faf7d28" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c741606a0f3d112faf7d28', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c741606a0f3d112faf7d28', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c741606a0f3d112faf7d28', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c741606a0f3d112faf7d28', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c741606a0f3d112faf7d28', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741606a0f3d112faf7d28%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741606a0f3d112faf7d28%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741606a0f3d112faf7d28%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741606a0f3d112faf7d28%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c741606a0f3d112faf7d28%2F0024-full.jpg&w=600" alt="Page 24" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.24 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8068e6c6f3cc53c8455a0" data-idx="817">
+        <div class="book-header">
+          <span class="book-num">#818</span>
+          <h3>Dissertatio academica, de Eddis Islandicis</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8068e6c6f3cc53c8455a0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8068e6c6f3cc53c8455a0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8068e6c6f3cc53c8455a0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8068e6c6f3cc53c8455a0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8068e6c6f3cc53c8455a0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8068e6c6f3cc53c8455a0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8068e6c6f3cc53c8455a0%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8068e6c6f3cc53c8455a0%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8068e6c6f3cc53c8455a0%2F0094-full.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8068e6c6f3cc53c8455a0%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8068e6c6f3cc53c8455a0%2F0141-full.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c763606a0f3d112faf8d46" data-idx="818">
+        <div class="book-header">
+          <span class="book-num">#819</span>
+          <h3>Histoire des oracles</h3>
+          <span class="page-count">179 pp</span>
+          <a href="https://sourcelibrary.org/book/69c763606a0f3d112faf8d46" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c763606a0f3d112faf8d46', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c763606a0f3d112faf8d46', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c763606a0f3d112faf8d46', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c763606a0f3d112faf8d46', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c763606a0f3d112faf8d46', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c763606a0f3d112faf8d46%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c763606a0f3d112faf8d46%2F0072-full.jpg&w=600" alt="Page 72" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.72 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c763606a0f3d112faf8d46%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c763606a0f3d112faf8d46%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c763606a0f3d112faf8d46%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c846cf6c6f3cc53c85181f" data-idx="819">
+        <div class="book-header">
+          <span class="book-num">#820</span>
+          <h3>Alchimisten Spiegel, das ist: etlicher denckwürdigen, hochgelehrten Philosophorum Sprüche</h3>
+          <span class="page-count">112 pp</span>
+          <a href="https://sourcelibrary.org/book/69c846cf6c6f3cc53c85181f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c846cf6c6f3cc53c85181f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c846cf6c6f3cc53c85181f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c846cf6c6f3cc53c85181f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c846cf6c6f3cc53c85181f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c846cf6c6f3cc53c85181f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846cf6c6f3cc53c85181f%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846cf6c6f3cc53c85181f%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846cf6c6f3cc53c85181f%2F0067-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846cf6c6f3cc53c85181f%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c846cf6c6f3cc53c85181f%2F0101-full.jpg&w=600" alt="Page 101" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.101 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c71b82da9771c7163168b6" data-idx="820">
+        <div class="book-header">
+          <span class="book-num">#821</span>
+          <h3>Ausspruch der alten Jüdischen Kirchen</h3>
+          <span class="page-count">458 pp</span>
+          <a href="https://sourcelibrary.org/book/69c71b82da9771c7163168b6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c71b82da9771c7163168b6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c71b82da9771c7163168b6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c71b82da9771c7163168b6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c71b82da9771c7163168b6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c71b82da9771c7163168b6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b82da9771c7163168b6%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b82da9771c7163168b6%2F0183-full.jpg&w=600" alt="Page 183" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.183 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b82da9771c7163168b6%2F0275-full.jpg&w=600" alt="Page 275" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.275 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b82da9771c7163168b6%2F0366-full.jpg&w=600" alt="Page 366" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.366 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c71b82da9771c7163168b6%2F0412-full.jpg&w=600" alt="Page 412" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.412 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c70a0eda9771c716315eac" data-idx="821">
+        <div class="book-header">
+          <span class="book-num">#822</span>
+          <h3>Le roman de la rose</h3>
+          <span class="page-count">224 pp</span>
+          <a href="https://sourcelibrary.org/book/69c70a0eda9771c716315eac" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c70a0eda9771c716315eac', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c70a0eda9771c716315eac', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c70a0eda9771c716315eac', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c70a0eda9771c716315eac', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c70a0eda9771c716315eac', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a0eda9771c716315eac%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a0eda9771c716315eac%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a0eda9771c716315eac%2F0134-full.jpg&w=600" alt="Page 134" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.134 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a0eda9771c716315eac%2F0179-full.jpg&w=600" alt="Page 179" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.179 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c70a0eda9771c716315eac%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c897de6c6f3cc53c85c93a" data-idx="822">
+        <div class="book-header">
+          <span class="book-num">#823</span>
+          <h3>Early history of the S.R.I.A</h3>
+          <span class="page-count">22 pp</span>
+          <a href="https://sourcelibrary.org/book/69c897de6c6f3cc53c85c93a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c897de6c6f3cc53c85c93a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c897de6c6f3cc53c85c93a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c897de6c6f3cc53c85c93a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c897de6c6f3cc53c85c93a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c897de6c6f3cc53c85c93a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897de6c6f3cc53c85c93a%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897de6c6f3cc53c85c93a%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897de6c6f3cc53c85c93a%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897de6c6f3cc53c85c93a%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c897de6c6f3cc53c85c93a%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="697c8e0fbaa544415f85b6b6" data-idx="823">
+        <div class="book-header">
+          <span class="book-num">#824</span>
+          <h3>Die geistliche Hertzens-Einbildungen, in zwey hundert und fünfftzig biblischen Figur-Sprüchen vorgestellet</h3>
+          <span class="page-count">422 pp</span>
+          <a href="https://sourcelibrary.org/book/spiritual-heart-imaginations-mattsperger" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('697c8e0fbaa544415f85b6b6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('697c8e0fbaa544415f85b6b6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('697c8e0fbaa544415f85b6b6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('697c8e0fbaa544415f85b6b6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('697c8e0fbaa544415f85b6b6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F697c8e0fbaa544415f85b6b6%2F697c9959eaf0398faf6a47b6.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F697c8e0fbaa544415f85b6b6%2F697cb8b56b5848cdf5d35d4f.jpg&w=600" alt="Page 169" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.169 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F697c8e0fbaa544415f85b6b6%2F697ccdd357321e5b48071def.jpg&w=600" alt="Page 253" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.253 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F697c8e0fbaa544415f85b6b6%2F697ce110849df1617bac8548.jpg&w=600" alt="Page 338" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.338 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fuploads%2F697c8e0fbaa544415f85b6b6%2F697ce8fea21f7dcb8db9855b.jpg&w=600" alt="Page 380" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.380 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c809d46c6f3cc53c84629a" data-idx="824">
+        <div class="book-header">
+          <span class="book-num">#825</span>
+          <h3>Vitruvius teutsch</h3>
+          <span class="page-count">347 pp</span>
+          <a href="https://sourcelibrary.org/book/69c809d46c6f3cc53c84629a" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c809d46c6f3cc53c84629a', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c809d46c6f3cc53c84629a', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c809d46c6f3cc53c84629a', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c809d46c6f3cc53c84629a', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c809d46c6f3cc53c84629a', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809d46c6f3cc53c84629a%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809d46c6f3cc53c84629a%2F0139-full.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809d46c6f3cc53c84629a%2F0208-full.jpg&w=600" alt="Page 208" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.208 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809d46c6f3cc53c84629a%2F0278-full.jpg&w=600" alt="Page 278" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.278 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809d46c6f3cc53c84629a%2F0312-full.jpg&w=600" alt="Page 312" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.312 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7703d6a0f3d112faf902b" data-idx="825">
+        <div class="book-header">
+          <span class="book-num">#826</span>
+          <h3>De calido innato sive igne animali</h3>
+          <span class="page-count">159 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7703d6a0f3d112faf902b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7703d6a0f3d112faf902b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7703d6a0f3d112faf902b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7703d6a0f3d112faf902b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7703d6a0f3d112faf902b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7703d6a0f3d112faf902b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7703d6a0f3d112faf902b%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7703d6a0f3d112faf902b%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7703d6a0f3d112faf902b%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7703d6a0f3d112faf902b%2F0127-full.jpg&w=600" alt="Page 127" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.127 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7703d6a0f3d112faf902b%2F0143-full.jpg&w=600" alt="Page 143" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.143 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c85eca6c6f3cc53c8552ec" data-idx="826">
+        <div class="book-header">
+          <span class="book-num">#827</span>
+          <h3>Allerneuste Geheimnisse der Freijmaurer. deren Sitten und Gebräuche beij ihrer Versammlungen und Aufnehmen, der Brüder, Diener, Lehrlinge, Gesellen, Meister u, Obermeister. Mit Kupfern</h3>
+          <span class="page-count">166 pp</span>
+          <a href="https://sourcelibrary.org/book/69c85eca6c6f3cc53c8552ec" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c85eca6c6f3cc53c8552ec', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c85eca6c6f3cc53c8552ec', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c85eca6c6f3cc53c8552ec', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c85eca6c6f3cc53c8552ec', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c85eca6c6f3cc53c8552ec', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85eca6c6f3cc53c8552ec%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85eca6c6f3cc53c8552ec%2F0066-full.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85eca6c6f3cc53c8552ec%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85eca6c6f3cc53c8552ec%2F0133-full.jpg&w=600" alt="Page 133" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.133 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c85eca6c6f3cc53c8552ec%2F0149-full.jpg&w=600" alt="Page 149" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.149 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3354cca56a12bc609" data-idx="827">
+        <div class="book-header">
+          <span class="book-num">#828</span>
+          <h3>Unpartheyische und christliche Erwegung ... ein Hirt und eine Heerde</h3>
+          <span class="page-count">100 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3354cca56a12bc609" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3354cca56a12bc609', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3354cca56a12bc609', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3354cca56a12bc609', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3354cca56a12bc609', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3354cca56a12bc609', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc609%2F69c58319985d8148794a7222.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc609%2F69c5881162ff3ddc150cdf3d.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc609%2F69c58ba075ea6ad4b10acf6a.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc609%2F69c58e948434e17cc9dbb302.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3354cca56a12bc609%2F69c5903fa9e246bdd8702417.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6462f5dec4c2fa41d36ab" data-idx="828">
+        <div class="book-header">
+          <span class="book-num">#829</span>
+          <h3>Der Vorhof am Tempel des Herrn</h3>
+          <span class="page-count">355 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6462f5dec4c2fa41d36ab" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6462f5dec4c2fa41d36ab', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6462f5dec4c2fa41d36ab', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6462f5dec4c2fa41d36ab', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6462f5dec4c2fa41d36ab', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6462f5dec4c2fa41d36ab', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36ab%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36ab%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36ab%2F0213-full.jpg&w=600" alt="Page 213" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.213 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36ab%2F0284-full.jpg&w=600" alt="Page 284" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.284 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6462f5dec4c2fa41d36ab%2F0320-full.jpg&w=600" alt="Page 320" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.320 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c727966a0f3d112faf6ed1" data-idx="829">
+        <div class="book-header">
+          <span class="book-num">#830</span>
+          <h3>Le pelerinage de l'homme</h3>
+          <span class="page-count">119 pp</span>
+          <a href="https://sourcelibrary.org/book/69c727966a0f3d112faf6ed1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c727966a0f3d112faf6ed1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c727966a0f3d112faf6ed1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c727966a0f3d112faf6ed1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c727966a0f3d112faf6ed1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c727966a0f3d112faf6ed1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed1%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed1%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed1%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed1%2F0095-full.jpg&w=600" alt="Page 95" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.95 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c727966a0f3d112faf6ed1%2F0107-full.jpg&w=600" alt="Page 107" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.107 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6fd8ada9771c7163154e1" data-idx="830">
+        <div class="book-header">
+          <span class="book-num">#831</span>
+          <h3>Ueber den Zauberglauben und andere Schwärmereien</h3>
+          <span class="page-count">200 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6fd8ada9771c7163154e1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6fd8ada9771c7163154e1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6fd8ada9771c7163154e1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6fd8ada9771c7163154e1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6fd8ada9771c7163154e1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6fd8ada9771c7163154e1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e1%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e1%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e1%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e1%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6fd8ada9771c7163154e1%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89a786c6f3cc53c85d18d" data-idx="831">
+        <div class="book-header">
+          <span class="book-num">#832</span>
+          <h3>Le serpent de la Genèse. Seconde septaine (livre II). La clef de la magie noire</h3>
+          <span class="page-count">449 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89a786c6f3cc53c85d18d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89a786c6f3cc53c85d18d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89a786c6f3cc53c85d18d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89a786c6f3cc53c85d18d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89a786c6f3cc53c85d18d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89a786c6f3cc53c85d18d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a786c6f3cc53c85d18d%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a786c6f3cc53c85d18d%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a786c6f3cc53c85d18d%2F0269-full.jpg&w=600" alt="Page 269" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.269 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a786c6f3cc53c85d18d%2F0359-full.jpg&w=600" alt="Page 359" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.359 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89a786c6f3cc53c85d18d%2F0404-full.jpg&w=600" alt="Page 404" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.404 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="68611c716122a466ae2491ab" data-idx="832">
+        <div class="book-header">
+          <span class="book-num">#833</span>
+          <h3>Plantarum seu Stirpium Icones (preface)</h3>
+          <span class="page-count">10 pp</span>
+          <a href="https://sourcelibrary.org/book/icons-of-plants-or-herbs-plantin" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('68611c716122a466ae2491ab', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('68611c716122a466ae2491ab', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('68611c716122a466ae2491ab', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('68611c716122a466ae2491ab', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('68611c716122a466ae2491ab', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68611c716122a466ae2491ab%2F1.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68611c716122a466ae2491ab%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68611c716122a466ae2491ab%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68611c716122a466ae2491ab%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68611c716122a466ae2491ab%2F9.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c847856c6f3cc53c8519f9" data-idx="833">
+        <div class="book-header">
+          <span class="book-num">#834</span>
+          <h3>Segen-volles Andencken der theuresten auserwählten Frau, Frau Sophien Elisabeth, gebornen Kösseltin, Herrn Christian Balthasar Kütemeyers [...] Ehegenossin</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/69c847856c6f3cc53c8519f9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c847856c6f3cc53c8519f9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c847856c6f3cc53c8519f9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c847856c6f3cc53c8519f9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c847856c6f3cc53c8519f9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c847856c6f3cc53c8519f9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847856c6f3cc53c8519f9%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847856c6f3cc53c8519f9%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847856c6f3cc53c8519f9%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847856c6f3cc53c8519f9%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c847856c6f3cc53c8519f9%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419382b0edf3eaa2df003" data-idx="834">
+        <div class="book-header">
+          <span class="book-num">#835</span>
+          <h3>Palladis Chymicae Arcana Detecta — Marengus (PH165)</h3>
+          <span class="page-count">210 pp</span>
+          <a href="https://sourcelibrary.org/book/marengus-secrets-of-chemical-pallas-revealed-ca-1700-marengus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419382b0edf3eaa2df003', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419382b0edf3eaa2df003', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419382b0edf3eaa2df003', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419382b0edf3eaa2df003', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419382b0edf3eaa2df003', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419382b0edf3eaa2df003%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419382b0edf3eaa2df003%2F84.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419382b0edf3eaa2df003%2F126.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419382b0edf3eaa2df003%2F168.jpg&w=600" alt="Page 168" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.168 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419382b0edf3eaa2df003%2F189.jpg&w=600" alt="Page 189" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.189 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88e4f6c6f3cc53c85b0a7" data-idx="835">
+        <div class="book-header">
+          <span class="book-num">#836</span>
+          <h3>De la vie d'Apollonius Thyanéen</h3>
+          <span class="page-count">885 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88e4f6c6f3cc53c85b0a7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88e4f6c6f3cc53c85b0a7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88e4f6c6f3cc53c85b0a7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88e4f6c6f3cc53c85b0a7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88e4f6c6f3cc53c85b0a7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88e4f6c6f3cc53c85b0a7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e4f6c6f3cc53c85b0a7%2F0089-full.jpg&w=600" alt="Page 89" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.89 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e4f6c6f3cc53c85b0a7%2F0354-full.jpg&w=600" alt="Page 354" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.354 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e4f6c6f3cc53c85b0a7%2F0531-full.jpg&w=600" alt="Page 531" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.531 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e4f6c6f3cc53c85b0a7%2F0708-full.jpg&w=600" alt="Page 708" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.708 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88e4f6c6f3cc53c85b0a7%2F0797-full.jpg&w=600" alt="Page 797" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.797 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909f75fcf28baa1b4cb0f71" data-idx="836">
+        <div class="book-header">
+          <span class="book-num">#837</span>
+          <h3>Histoire d'un voyage aux isles Malouines</h3>
+          <span class="page-count">201 pp</span>
+          <a href="https://sourcelibrary.org/book/history-of-a-voyage-to-the-falkland-islands-pernety" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909f75fcf28baa1b4cb0f71', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909f75fcf28baa1b4cb0f71', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909f75fcf28baa1b4cb0f71', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909f75fcf28baa1b4cb0f71', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909f75fcf28baa1b4cb0f71', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f75fcf28baa1b4cb0f71%2F20.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f75fcf28baa1b4cb0f71%2F80.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f75fcf28baa1b4cb0f71%2F121.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f75fcf28baa1b4cb0f71%2F161.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909f75fcf28baa1b4cb0f71%2F181.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c860796c6f3cc53c8557d5" data-idx="837">
+        <div class="book-header">
+          <span class="book-num">#838</span>
+          <h3>scripture thesauros pandens, denuo possa eliata: atque ubi truncata pri habebat supplemento integrata diligenter atque ez archetypo emendata</h3>
+          <span class="page-count">377 pp</span>
+          <a href="https://sourcelibrary.org/book/69c860796c6f3cc53c8557d5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c860796c6f3cc53c8557d5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c860796c6f3cc53c8557d5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c860796c6f3cc53c8557d5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c860796c6f3cc53c8557d5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c860796c6f3cc53c8557d5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860796c6f3cc53c8557d5%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860796c6f3cc53c8557d5%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860796c6f3cc53c8557d5%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860796c6f3cc53c8557d5%2F0302-full.jpg&w=600" alt="Page 302" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.302 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860796c6f3cc53c8557d5%2F0339-full.jpg&w=600" alt="Page 339" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.339 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7e2ae295ea01b70c8d8a7" data-idx="838">
+        <div class="book-header">
+          <span class="book-num">#839</span>
+          <h3>De prophetarum vita &amp; interitu commentarius graecus</h3>
+          <span class="page-count">113 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7e2ae295ea01b70c8d8a7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7e2ae295ea01b70c8d8a7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7e2ae295ea01b70c8d8a7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7e2ae295ea01b70c8d8a7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7e2ae295ea01b70c8d8a7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7e2ae295ea01b70c8d8a7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ae295ea01b70c8d8a7%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ae295ea01b70c8d8a7%2F0045-full.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ae295ea01b70c8d8a7%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ae295ea01b70c8d8a7%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7e2ae295ea01b70c8d8a7%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88aac6c6f3cc53c85a71c" data-idx="839">
+        <div class="book-header">
+          <span class="book-num">#840</span>
+          <h3>Suite des erreurs et de la verite</h3>
+          <span class="page-count">225 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88aac6c6f3cc53c85a71c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88aac6c6f3cc53c85a71c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88aac6c6f3cc53c85a71c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88aac6c6f3cc53c85a71c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88aac6c6f3cc53c85a71c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88aac6c6f3cc53c85a71c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aac6c6f3cc53c85a71c%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aac6c6f3cc53c85a71c%2F0090-full.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aac6c6f3cc53c85a71c%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aac6c6f3cc53c85a71c%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88aac6c6f3cc53c85a71c%2F0203-full.jpg&w=600" alt="Page 203" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.203 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8252f6c6f3cc53c84b7fa" data-idx="840">
+        <div class="book-header">
+          <span class="book-num">#841</span>
+          <h3>Recueil des plus curieux et rares secrets</h3>
+          <span class="page-count">201 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8252f6c6f3cc53c84b7fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8252f6c6f3cc53c84b7fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8252f6c6f3cc53c84b7fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8252f6c6f3cc53c84b7fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8252f6c6f3cc53c84b7fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8252f6c6f3cc53c84b7fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8252f6c6f3cc53c84b7fa%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8252f6c6f3cc53c84b7fa%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8252f6c6f3cc53c84b7fa%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8252f6c6f3cc53c84b7fa%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8252f6c6f3cc53c84b7fa%2F0181-full.jpg&w=600" alt="Page 181" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.181 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c808fb6c6f3cc53c845f8e" data-idx="841">
+        <div class="book-header">
+          <span class="book-num">#842</span>
+          <h3>Von der Scheidung der vier Elementen aus dem ersten Chaos</h3>
+          <span class="page-count">190 pp</span>
+          <a href="https://sourcelibrary.org/book/69c808fb6c6f3cc53c845f8e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c808fb6c6f3cc53c845f8e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c808fb6c6f3cc53c845f8e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c808fb6c6f3cc53c845f8e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c808fb6c6f3cc53c845f8e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c808fb6c6f3cc53c845f8e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808fb6c6f3cc53c845f8e%2F0019-full.jpg&w=600" alt="Page 19" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.19 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808fb6c6f3cc53c845f8e%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808fb6c6f3cc53c845f8e%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808fb6c6f3cc53c845f8e%2F0152-full.jpg&w=600" alt="Page 152" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.152 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c808fb6c6f3cc53c845f8e%2F0171-full.jpg&w=600" alt="Page 171" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.171 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8934f6c6f3cc53c85be6b" data-idx="842">
+        <div class="book-header">
+          <span class="book-num">#843</span>
+          <h3>Hellsehen (Clairvoyance)</h3>
+          <span class="page-count">69 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8934f6c6f3cc53c85be6b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8934f6c6f3cc53c85be6b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8934f6c6f3cc53c85be6b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8934f6c6f3cc53c85be6b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8934f6c6f3cc53c85be6b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8934f6c6f3cc53c85be6b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8934f6c6f3cc53c85be6b%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8934f6c6f3cc53c85be6b%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8934f6c6f3cc53c85be6b%2F0041-full.jpg&w=600" alt="Page 41" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.41 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8934f6c6f3cc53c85be6b%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8934f6c6f3cc53c85be6b%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6494471add5d9cc49ab68" data-idx="843">
+        <div class="book-header">
+          <span class="book-num">#844</span>
+          <h3>De vrije-metzelarij in haren eigendomlijken luister hersteld</h3>
+          <span class="page-count">121 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6494471add5d9cc49ab68" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6494471add5d9cc49ab68', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6494471add5d9cc49ab68', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6494471add5d9cc49ab68', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6494471add5d9cc49ab68', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6494471add5d9cc49ab68', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab68%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab68%2F0048-full.jpg&w=600" alt="Page 48" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.48 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab68%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab68%2F0097-full.jpg&w=600" alt="Page 97" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.97 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6494471add5d9cc49ab68%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c87c636c6f3cc53c8589e4" data-idx="844">
+        <div class="book-header">
+          <span class="book-num">#845</span>
+          <h3>[Cyrillisch:] De leer der getallen</h3>
+          <span class="page-count">177 pp</span>
+          <a href="https://sourcelibrary.org/book/69c87c636c6f3cc53c8589e4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c87c636c6f3cc53c8589e4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c87c636c6f3cc53c8589e4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c87c636c6f3cc53c8589e4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c87c636c6f3cc53c8589e4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c87c636c6f3cc53c8589e4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87c636c6f3cc53c8589e4%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87c636c6f3cc53c8589e4%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87c636c6f3cc53c8589e4%2F0106-full.jpg&w=600" alt="Page 106" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.106 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87c636c6f3cc53c8589e4%2F0142-full.jpg&w=600" alt="Page 142" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.142 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c87c636c6f3cc53c8589e4%2F0159-full.jpg&w=600" alt="Page 159" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.159 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6911cf678cb6d2ae494a1061" data-idx="845">
+        <div class="book-header">
+          <span class="book-num">#846</span>
+          <h3>Sefer ha-bahir</h3>
+          <span class="page-count">41 pp</span>
+          <a href="https://sourcelibrary.org/book/the-book-of-brightness-hakana" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6911cf678cb6d2ae494a1061', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6911cf678cb6d2ae494a1061', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6911cf678cb6d2ae494a1061', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6911cf678cb6d2ae494a1061', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6911cf678cb6d2ae494a1061', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6911cf678cb6d2ae494a1061%2F4.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6911cf678cb6d2ae494a1061%2F14.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6911cf678cb6d2ae494a1061%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6911cf678cb6d2ae494a1061%2F33.jpg&w=600" alt="Page 33" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.33 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6911cf678cb6d2ae494a1061%2F37.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c63918881bf48c13c42648" data-idx="846">
+        <div class="book-header">
+          <span class="book-num">#847</span>
+          <h3>Vie de Laurent de Medicis</h3>
+          <span class="page-count">275 pp</span>
+          <a href="https://sourcelibrary.org/book/69c63918881bf48c13c42648" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c63918881bf48c13c42648', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c63918881bf48c13c42648', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c63918881bf48c13c42648', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c63918881bf48c13c42648', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c63918881bf48c13c42648', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42648%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42648%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42648%2F0165-full.jpg&w=600" alt="Page 165" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.165 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42648%2F0220-full.jpg&w=600" alt="Page 220" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.220 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c63918881bf48c13c42648%2F0248-full.jpg&w=600" alt="Page 248" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.248 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c824ab6c6f3cc53c84b586" data-idx="847">
+        <div class="book-header">
+          <span class="book-num">#848</span>
+          <h3>Unterhaltungen über die auffallendsten neuern Geistererscheinungen, Träume und Ahnungen</h3>
+          <span class="page-count">97 pp</span>
+          <a href="https://sourcelibrary.org/book/69c824ab6c6f3cc53c84b586" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c824ab6c6f3cc53c84b586', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c824ab6c6f3cc53c84b586', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c824ab6c6f3cc53c84b586', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c824ab6c6f3cc53c84b586', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c824ab6c6f3cc53c84b586', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824ab6c6f3cc53c84b586%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824ab6c6f3cc53c84b586%2F0039-full.jpg&w=600" alt="Page 39" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.39 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824ab6c6f3cc53c84b586%2F0058-full.jpg&w=600" alt="Page 58" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.58 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824ab6c6f3cc53c84b586%2F0078-full.jpg&w=600" alt="Page 78" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.78 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c824ab6c6f3cc53c84b586%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c88fd76c6f3cc53c85b497" data-idx="848">
+        <div class="book-header">
+          <span class="book-num">#849</span>
+          <h3>[Cyrillisch: The freemason without a mask]</h3>
+          <span class="page-count">71 pp</span>
+          <a href="https://sourcelibrary.org/book/69c88fd76c6f3cc53c85b497" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c88fd76c6f3cc53c85b497', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c88fd76c6f3cc53c85b497', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c88fd76c6f3cc53c85b497', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c88fd76c6f3cc53c85b497', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c88fd76c6f3cc53c85b497', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88fd76c6f3cc53c85b497%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88fd76c6f3cc53c85b497%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88fd76c6f3cc53c85b497%2F0043-full.jpg&w=600" alt="Page 43" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.43 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88fd76c6f3cc53c85b497%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c88fd76c6f3cc53c85b497%2F0064-full.jpg&w=600" alt="Page 64" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.64 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c811ed6c6f3cc53c847a07" data-idx="849">
+        <div class="book-header">
+          <span class="book-num">#850</span>
+          <h3>Nachrichten von einem grossen aber unsichtbaren Bunde gegen die christliche Religion und die monarchischen Staaten</h3>
+          <span class="page-count">127 pp</span>
+          <a href="https://sourcelibrary.org/book/69c811ed6c6f3cc53c847a07" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c811ed6c6f3cc53c847a07', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c811ed6c6f3cc53c847a07', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c811ed6c6f3cc53c847a07', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c811ed6c6f3cc53c847a07', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c811ed6c6f3cc53c847a07', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811ed6c6f3cc53c847a07%2F0013-full.jpg&w=600" alt="Page 13" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.13 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811ed6c6f3cc53c847a07%2F0051-full.jpg&w=600" alt="Page 51" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.51 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811ed6c6f3cc53c847a07%2F0076-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811ed6c6f3cc53c847a07%2F0102-full.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c811ed6c6f3cc53c847a07%2F0114-full.jpg&w=600" alt="Page 114" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.114 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909eb1acf28baa1b4cb0943" data-idx="850">
+        <div class="book-header">
+          <span class="book-num">#851</span>
+          <h3>Essai sur le feu sacré et sur les Vestales</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/essay-on-the-sacred-fire-and-on-the-vestals-dubois-fontanelle" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909eb1acf28baa1b4cb0943', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909eb1acf28baa1b4cb0943', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909eb1acf28baa1b4cb0943', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909eb1acf28baa1b4cb0943', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909eb1acf28baa1b4cb0943', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909eb1acf28baa1b4cb0943%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909eb1acf28baa1b4cb0943%2F25.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909eb1acf28baa1b4cb0943%2F38.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909eb1acf28baa1b4cb0943%2F50.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909eb1acf28baa1b4cb0943%2F57.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c2b8fe0787282ad593441" data-idx="851">
+        <div class="book-header">
+          <span class="book-num">#852</span>
+          <h3>Opera</h3>
+          <span class="page-count">632 pp</span>
+          <a href="https://sourcelibrary.org/book/opera-alexandrinus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c2b8fe0787282ad593441', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c2b8fe0787282ad593441', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c2b8fe0787282ad593441', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c2b8fe0787282ad593441', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c2b8fe0787282ad593441', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2b8fe0787282ad593441%2F63.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2b8fe0787282ad593441%2F253.jpg&w=600" alt="Page 253" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.253 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2b8fe0787282ad593441%2F379.jpg&w=600" alt="Page 379" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.379 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2b8fe0787282ad593441%2F506.jpg&w=600" alt="Page 506" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.506 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c2b8fe0787282ad593441%2F569.jpg&w=600" alt="Page 569" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.569 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f78a6c6f3cc53c8420ed" data-idx="852">
+        <div class="book-header">
+          <span class="book-num">#853</span>
+          <h3>Prognosticon theologicon, oder theologische Weissagung, vom jüngsten Tage</h3>
+          <span class="page-count">109 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f78a6c6f3cc53c8420ed" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f78a6c6f3cc53c8420ed', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f78a6c6f3cc53c8420ed', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f78a6c6f3cc53c8420ed', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f78a6c6f3cc53c8420ed', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f78a6c6f3cc53c8420ed', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f78a6c6f3cc53c8420ed%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f78a6c6f3cc53c8420ed%2F0044-full.jpg&w=600" alt="Page 44" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.44 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f78a6c6f3cc53c8420ed%2F0065-full.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f78a6c6f3cc53c8420ed%2F0087-full.jpg&w=600" alt="Page 87" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.87 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f78a6c6f3cc53c8420ed%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c851df6c6f3cc53c853242" data-idx="853">
+        <div class="book-header">
+          <span class="book-num">#854</span>
+          <h3>Disputatio theologica inauguralis qua theologiae fanaticae fundamentum de tribus partibus hominis corpore anima et spiritu</h3>
+          <span class="page-count">25 pp</span>
+          <a href="https://sourcelibrary.org/book/69c851df6c6f3cc53c853242" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c851df6c6f3cc53c853242', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c851df6c6f3cc53c853242', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c851df6c6f3cc53c853242', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c851df6c6f3cc53c853242', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c851df6c6f3cc53c853242', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851df6c6f3cc53c853242%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851df6c6f3cc53c853242%2F0010-full.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851df6c6f3cc53c853242%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851df6c6f3cc53c853242%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c851df6c6f3cc53c853242%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c855d06c6f3cc53c853bba" data-idx="854">
+        <div class="book-header">
+          <span class="book-num">#855</span>
+          <h3>The sacred theory of the earth</h3>
+          <span class="page-count">273 pp</span>
+          <a href="https://sourcelibrary.org/book/69c855d06c6f3cc53c853bba" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c855d06c6f3cc53c853bba', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c855d06c6f3cc53c853bba', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c855d06c6f3cc53c853bba', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c855d06c6f3cc53c853bba', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c855d06c6f3cc53c853bba', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855d06c6f3cc53c853bba%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855d06c6f3cc53c853bba%2F0109-full.jpg&w=600" alt="Page 109" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.109 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855d06c6f3cc53c853bba%2F0164-full.jpg&w=600" alt="Page 164" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.164 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855d06c6f3cc53c853bba%2F0218-full.jpg&w=600" alt="Page 218" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.218 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c855d06c6f3cc53c853bba%2F0246-full.jpg&w=600" alt="Page 246" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.246 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6eb51da9771c71631482d" data-idx="855">
+        <div class="book-header">
+          <span class="book-num">#856</span>
+          <h3>Wasserstein der Weisen.  Via veritatis</h3>
+          <span class="page-count">122 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6eb51da9771c71631482d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6eb51da9771c71631482d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6eb51da9771c71631482d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6eb51da9771c71631482d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6eb51da9771c71631482d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6eb51da9771c71631482d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6eb51da9771c71631482d%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6eb51da9771c71631482d%2F0049-full.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6eb51da9771c71631482d%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6eb51da9771c71631482d%2F0098-full.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6eb51da9771c71631482d%2F0110-full.jpg&w=600" alt="Page 110" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.110 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f3eb6c6f3cc53c841671" data-idx="856">
+        <div class="book-header">
+          <span class="book-num">#857</span>
+          <h3>Les souffleurs, comédie</h3>
+          <span class="page-count">92 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f3eb6c6f3cc53c841671" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f3eb6c6f3cc53c841671', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f3eb6c6f3cc53c841671', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f3eb6c6f3cc53c841671', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f3eb6c6f3cc53c841671', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f3eb6c6f3cc53c841671', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3eb6c6f3cc53c841671%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3eb6c6f3cc53c841671%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3eb6c6f3cc53c841671%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3eb6c6f3cc53c841671%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f3eb6c6f3cc53c841671%2F0083-full.jpg&w=600" alt="Page 83" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.83 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7bb1525ec2ba5ccd7f9e4" data-idx="857">
+        <div class="book-header">
+          <span class="book-num">#858</span>
+          <h3>Opera omnia medico-chymica</h3>
+          <span class="page-count">374 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7bb1525ec2ba5ccd7f9e4" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7bb1525ec2ba5ccd7f9e4', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7bb1525ec2ba5ccd7f9e4', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7bb1525ec2ba5ccd7f9e4', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7bb1525ec2ba5ccd7f9e4', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7bb1525ec2ba5ccd7f9e4', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1525ec2ba5ccd7f9e4%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1525ec2ba5ccd7f9e4%2F0150-full.jpg&w=600" alt="Page 150" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.150 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1525ec2ba5ccd7f9e4%2F0224-full.jpg&w=600" alt="Page 224" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.224 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1525ec2ba5ccd7f9e4%2F0299-full.jpg&w=600" alt="Page 299" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.299 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bb1525ec2ba5ccd7f9e4%2F0337-full.jpg&w=600" alt="Page 337" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.337 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c6f0c6da9771c716314ca8" data-idx="858">
+        <div class="book-header">
+          <span class="book-num">#859</span>
+          <h3>Widerlegung der Predicanten Antwort zu Zürch auff Hern Johann Brenssen Testament</h3>
+          <span class="page-count">91 pp</span>
+          <a href="https://sourcelibrary.org/book/69c6f0c6da9771c716314ca8" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c6f0c6da9771c716314ca8', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c6f0c6da9771c716314ca8', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c6f0c6da9771c716314ca8', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c6f0c6da9771c716314ca8', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c6f0c6da9771c716314ca8', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f0c6da9771c716314ca8%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f0c6da9771c716314ca8%2F0036-full.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f0c6da9771c716314ca8%2F0055-full.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f0c6da9771c716314ca8%2F0073-full.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c6f0c6da9771c716314ca8%2F0082-full.jpg&w=600" alt="Page 82" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.82 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418cf2b0edf3eaa2ddf20" data-idx="859">
+        <div class="book-header">
+          <span class="book-num">#860</span>
+          <h3>Van de betragting des leuens Christi — Valentin Weigel (PH395)</h3>
+          <span class="page-count">154 pp</span>
+          <a href="https://sourcelibrary.org/book/weigel-contemplation-of-the-life-of-christ-early-1700s-weigel" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418cf2b0edf3eaa2ddf20', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418cf2b0edf3eaa2ddf20', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418cf2b0edf3eaa2ddf20', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418cf2b0edf3eaa2ddf20', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418cf2b0edf3eaa2ddf20', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418cf2b0edf3eaa2ddf20%2F15.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524729205131!PH395_0062.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524729205131!PH395_0092.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 92" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.92 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524729205131!PH395_0123.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 123" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.123 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524729205131!PH395_0139.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 139" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.139 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c81f916c6f3cc53c84a5d1" data-idx="860">
+        <div class="book-header">
+          <span class="book-num">#861</span>
+          <h3>Archidoxa. Von heymligkeyten der Natur. Zehen Bücher</h3>
+          <span class="page-count">247 pp</span>
+          <a href="https://sourcelibrary.org/book/69c81f916c6f3cc53c84a5d1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c81f916c6f3cc53c84a5d1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c81f916c6f3cc53c84a5d1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c81f916c6f3cc53c84a5d1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c81f916c6f3cc53c84a5d1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c81f916c6f3cc53c84a5d1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f916c6f3cc53c84a5d1%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f916c6f3cc53c84a5d1%2F0099-full.jpg&w=600" alt="Page 99" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.99 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f916c6f3cc53c84a5d1%2F0148-full.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f916c6f3cc53c84a5d1%2F0198-full.jpg&w=600" alt="Page 198" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.198 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c81f916c6f3cc53c84a5d1%2F0222-full.jpg&w=600" alt="Page 222" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.222 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b4187cf1200e2ab53cf9bd" data-idx="861">
+        <div class="book-header">
+          <span class="book-num">#862</span>
+          <h3>Collection of Alchemical Texts (PH301)</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/alchemical-anthology-post-1686-german-ms-various" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b4187cf1200e2ab53cf9bd', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b4187cf1200e2ab53cf9bd', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b4187cf1200e2ab53cf9bd', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b4187cf1200e2ab53cf9bd', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b4187cf1200e2ab53cf9bd', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187cf1200e2ab53cf9bd%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187cf1200e2ab53cf9bd%2F63.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187cf1200e2ab53cf9bd%2F94.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187cf1200e2ab53cf9bd%2F126.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b4187cf1200e2ab53cf9bd%2F141.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c89d966c6f3cc53c85d88d" data-idx="862">
+        <div class="book-header">
+          <span class="book-num">#863</span>
+          <h3>De maximis theologiae</h3>
+          <span class="page-count">44 pp</span>
+          <a href="https://sourcelibrary.org/book/69c89d966c6f3cc53c85d88d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c89d966c6f3cc53c85d88d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c89d966c6f3cc53c85d88d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c89d966c6f3cc53c85d88d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c89d966c6f3cc53c85d88d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c89d966c6f3cc53c85d88d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d966c6f3cc53c85d88d%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d966c6f3cc53c85d88d%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d966c6f3cc53c85d88d%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d966c6f3cc53c85d88d%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c89d966c6f3cc53c85d88d%2F0040-full.jpg&w=600" alt="Page 40" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.40 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419052b0edf3eaa2de888" data-idx="863">
+        <div class="book-header">
+          <span class="book-num">#864</span>
+          <h3>Liber Experimentorum — Johannes Trithemius (PH206)</h3>
+          <span class="page-count">81 pp</span>
+          <a href="https://sourcelibrary.org/book/trithemius-book-of-experiments-17th-century-latin-ms-trithemius" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419052b0edf3eaa2de888', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419052b0edf3eaa2de888', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419052b0edf3eaa2de888', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419052b0edf3eaa2de888', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419052b0edf3eaa2de888', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419052b0edf3eaa2de888%2F8.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940559853605131!ph206_0032.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940559853605131!ph206_0049.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940559853605131!ph206_0065.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 65" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.65 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940559853605131!ph206_0073.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 73" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.73 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c830506c6f3cc53c84da00" data-idx="864">
+        <div class="book-header">
+          <span class="book-num">#865</span>
+          <h3>Schola sapientum, das ist: Schul der Weisen</h3>
+          <span class="page-count">417 pp</span>
+          <a href="https://sourcelibrary.org/book/69c830506c6f3cc53c84da00" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c830506c6f3cc53c84da00', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c830506c6f3cc53c84da00', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c830506c6f3cc53c84da00', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c830506c6f3cc53c84da00', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c830506c6f3cc53c84da00', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830506c6f3cc53c84da00%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830506c6f3cc53c84da00%2F0167-full.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830506c6f3cc53c84da00%2F0250-full.jpg&w=600" alt="Page 250" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.250 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830506c6f3cc53c84da00%2F0334-full.jpg&w=600" alt="Page 334" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.334 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c830506c6f3cc53c84da00%2F0375-full.jpg&w=600" alt="Page 375" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.375 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c75d616a0f3d112faf8af7" data-idx="865">
+        <div class="book-header">
+          <span class="book-num">#866</span>
+          <h3>Ueber Verstand und Herz</h3>
+          <span class="page-count">28 pp</span>
+          <a href="https://sourcelibrary.org/book/69c75d616a0f3d112faf8af7" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c75d616a0f3d112faf8af7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c75d616a0f3d112faf8af7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c75d616a0f3d112faf8af7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c75d616a0f3d112faf8af7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c75d616a0f3d112faf8af7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d616a0f3d112faf8af7%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d616a0f3d112faf8af7%2F0011-full.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d616a0f3d112faf8af7%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d616a0f3d112faf8af7%2F0022-full.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c75d616a0f3d112faf8af7%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c860306c6f3cc53c855748" data-idx="866">
+        <div class="book-header">
+          <span class="book-num">#867</span>
+          <h3>Raphael oder Artzt-Engel</h3>
+          <span class="page-count">29 pp</span>
+          <a href="https://sourcelibrary.org/book/69c860306c6f3cc53c855748" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c860306c6f3cc53c855748', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c860306c6f3cc53c855748', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c860306c6f3cc53c855748', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c860306c6f3cc53c855748', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c860306c6f3cc53c855748', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860306c6f3cc53c855748%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860306c6f3cc53c855748%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860306c6f3cc53c855748%2F0017-full.jpg&w=600" alt="Page 17" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.17 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860306c6f3cc53c855748%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c860306c6f3cc53c855748%2F0026-full.jpg&w=600" alt="Page 26" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.26 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c72aca6a0f3d112faf6f49" data-idx="867">
+        <div class="book-header">
+          <span class="book-num">#868</span>
+          <h3>Adumbratio kabbalae Christianae id est syncatabasis hebraizans</h3>
+          <span class="page-count">39 pp</span>
+          <a href="https://sourcelibrary.org/book/69c72aca6a0f3d112faf6f49" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c72aca6a0f3d112faf6f49', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c72aca6a0f3d112faf6f49', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c72aca6a0f3d112faf6f49', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c72aca6a0f3d112faf6f49', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c72aca6a0f3d112faf6f49', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72aca6a0f3d112faf6f49%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72aca6a0f3d112faf6f49%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72aca6a0f3d112faf6f49%2F0023-full.jpg&w=600" alt="Page 23" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.23 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72aca6a0f3d112faf6f49%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72aca6a0f3d112faf6f49%2F0035-full.jpg&w=600" alt="Page 35" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.35 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c828ae6c6f3cc53c84c46c" data-idx="868">
+        <div class="book-header">
+          <span class="book-num">#869</span>
+          <h3>Superstitions anciennes et modernes</h3>
+          <span class="page-count">200 pp</span>
+          <a href="https://sourcelibrary.org/book/69c828ae6c6f3cc53c84c46c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c828ae6c6f3cc53c84c46c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c828ae6c6f3cc53c84c46c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c828ae6c6f3cc53c84c46c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c828ae6c6f3cc53c84c46c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c828ae6c6f3cc53c84c46c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828ae6c6f3cc53c84c46c%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828ae6c6f3cc53c84c46c%2F0080-full.jpg&w=600" alt="Page 80" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.80 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828ae6c6f3cc53c84c46c%2F0120-full.jpg&w=600" alt="Page 120" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.120 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828ae6c6f3cc53c84c46c%2F0160-full.jpg&w=600" alt="Page 160" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.160 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c828ae6c6f3cc53c84c46c%2F0180-full.jpg&w=600" alt="Page 180" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.180 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a2786c6f3cc53c85e42c" data-idx="869">
+        <div class="book-header">
+          <span class="book-num">#870</span>
+          <h3>Time and space</h3>
+          <span class="page-count">7 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a2786c6f3cc53c85e42c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a2786c6f3cc53c85e42c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a2786c6f3cc53c85e42c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a2786c6f3cc53c85e42c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a2786c6f3cc53c85e42c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a2786c6f3cc53c85e42c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2786c6f3cc53c85e42c%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2786c6f3cc53c85e42c%2F0003-full.jpg&w=600" alt="Page 3" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.3 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2786c6f3cc53c85e42c%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2786c6f3cc53c85e42c%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a2786c6f3cc53c85e42c%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c8a20c6c6f3cc53c85e32c" data-idx="870">
+        <div class="book-header">
+          <span class="book-num">#871</span>
+          <h3>The inner vision: some notes on mysticism</h3>
+          <span class="page-count">10 pp</span>
+          <a href="https://sourcelibrary.org/book/69c8a20c6c6f3cc53c85e32c" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c8a20c6c6f3cc53c85e32c', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c8a20c6c6f3cc53c85e32c', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c8a20c6c6f3cc53c85e32c', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c8a20c6c6f3cc53c85e32c', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c8a20c6c6f3cc53c85e32c', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a20c6c6f3cc53c85e32c%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a20c6c6f3cc53c85e32c%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a20c6c6f3cc53c85e32c%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a20c6c6f3cc53c85e32c%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c8a20c6c6f3cc53c85e32c%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c803536c6f3cc53c844af1" data-idx="871">
+        <div class="book-header">
+          <span class="book-num">#872</span>
+          <h3>Alcoran</h3>
+          <span class="page-count">315 pp</span>
+          <a href="https://sourcelibrary.org/book/69c803536c6f3cc53c844af1" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c803536c6f3cc53c844af1', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c803536c6f3cc53c844af1', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c803536c6f3cc53c844af1', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c803536c6f3cc53c844af1', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c803536c6f3cc53c844af1', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803536c6f3cc53c844af1%2F0032-full.jpg&w=600" alt="Page 32" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.32 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803536c6f3cc53c844af1%2F0126-full.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803536c6f3cc53c844af1%2F0189-full.jpg&w=600" alt="Page 189" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.189 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803536c6f3cc53c844af1%2F0252-full.jpg&w=600" alt="Page 252" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.252 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c803536c6f3cc53c844af1%2F0284-full.jpg&w=600" alt="Page 284" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.284 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="68fa138e6bd5e42f9c120538" data-idx="872">
+        <div class="book-header">
+          <span class="book-num">#873</span>
+          <h3>Historisch-theologische Betrachtungen merckwürdiger Wahrheiten, auf Veranlassung derer bissherigen Einwürfe gegen G. Arnolds Schrifften</h3>
+          <span class="page-count">361 pp</span>
+          <a href="https://sourcelibrary.org/book/historical-theological-considerations-of-remarkable-truths-arnold" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('68fa138e6bd5e42f9c120538', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('68fa138e6bd5e42f9c120538', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('68fa138e6bd5e42f9c120538', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('68fa138e6bd5e42f9c120538', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('68fa138e6bd5e42f9c120538', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fa138e6bd5e42f9c120538%2F36.jpg&w=600" alt="Page 36" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.36 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fa138e6bd5e42f9c120538%2F144.jpg&w=600" alt="Page 144" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.144 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fa138e6bd5e42f9c120538%2F217.jpg&w=600" alt="Page 217" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.217 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fa138e6bd5e42f9c120538%2F289.jpg&w=600" alt="Page 289" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.289 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F68fa138e6bd5e42f9c120538%2F325.jpg&w=600" alt="Page 325" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.325 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690c3ec7e0787282ad593b41" data-idx="873">
+        <div class="book-header">
+          <span class="book-num">#874</span>
+          <h3>A christian and heavenly treatise. Containing physicke for the soule</h3>
+          <span class="page-count">549 pp</span>
+          <a href="https://sourcelibrary.org/book/a-christian-and-heavenly-treatise-containing-medicine-for-abernethy" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690c3ec7e0787282ad593b41', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690c3ec7e0787282ad593b41', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690c3ec7e0787282ad593b41', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690c3ec7e0787282ad593b41', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690c3ec7e0787282ad593b41', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3ec7e0787282ad593b41%2F55.jpg&w=600" alt="Page 55" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.55 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3ec7e0787282ad593b41%2F220.jpg&w=600" alt="Page 220" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.220 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3ec7e0787282ad593b41%2F329.jpg&w=600" alt="Page 329" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.329 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3ec7e0787282ad593b41%2F439.jpg&w=600" alt="Page 439" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.439 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690c3ec7e0787282ad593b41%2F494.jpg&w=600" alt="Page 494" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.494 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c867a96c6f3cc53c8565d9" data-idx="874">
+        <div class="book-header">
+          <span class="book-num">#875</span>
+          <h3>Locorum aliquot ex Osee, &amp; Ezechiele prophetis</h3>
+          <span class="page-count">62 pp</span>
+          <a href="https://sourcelibrary.org/book/69c867a96c6f3cc53c8565d9" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c867a96c6f3cc53c8565d9', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c867a96c6f3cc53c8565d9', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c867a96c6f3cc53c8565d9', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c867a96c6f3cc53c8565d9', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c867a96c6f3cc53c8565d9', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69c867a96c6f3cc53c8565d9%2F6.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a96c6f3cc53c8565d9%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a96c6f3cc53c8565d9%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a96c6f3cc53c8565d9%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c867a96c6f3cc53c8565d9%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6867bf5a009d20a23245ac0d" data-idx="875">
+        <div class="book-header">
+          <span class="book-num">#876</span>
+          <h3>Das Buch Meteororum</h3>
+          <span class="page-count">113 pp</span>
+          <a href="https://sourcelibrary.org/book/the-book-of-meteors-fourth-book-of-paramirum-on-the-matrix-paracelsus" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6867bf5a009d20a23245ac0d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6867bf5a009d20a23245ac0d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6867bf5a009d20a23245ac0d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6867bf5a009d20a23245ac0d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6867bf5a009d20a23245ac0d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867bf5a009d20a23245ac0d%2F11.jpg&w=600" alt="Page 11" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.11 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867bf5a009d20a23245ac0d%2F45.jpg&w=600" alt="Page 45" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.45 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867bf5a009d20a23245ac0d%2F68.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867bf5a009d20a23245ac0d%2F90.jpg&w=600" alt="Page 90" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.90 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6867bf5a009d20a23245ac0d%2F102.jpg&w=600" alt="Page 102" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.102 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82ddb6c6f3cc53c84d494" data-idx="876">
+        <div class="book-header">
+          <span class="book-num">#877</span>
+          <h3>Philo's endliche Erklärung und Antwort, auf verschiedene Anforderungen und Fragen, die an ihn ergangen, seine Verbindung mit dem Orden der Illuminaten beterffend</h3>
+          <span class="page-count">77 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82ddb6c6f3cc53c84d494" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82ddb6c6f3cc53c84d494', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82ddb6c6f3cc53c84d494', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82ddb6c6f3cc53c84d494', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82ddb6c6f3cc53c84d494', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82ddb6c6f3cc53c84d494', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddb6c6f3cc53c84d494%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddb6c6f3cc53c84d494%2F0031-full.jpg&w=600" alt="Page 31" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.31 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddb6c6f3cc53c84d494%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddb6c6f3cc53c84d494%2F0062-full.jpg&w=600" alt="Page 62" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.62 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82ddb6c6f3cc53c84d494%2F0069-full.jpg&w=600" alt="Page 69" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.69 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e3551fbd40b95eaa3e" data-idx="877">
+        <div class="book-header">
+          <span class="book-num">#878</span>
+          <h3>Versuch einer Geschichte des Arianismus</h3>
+          <span class="page-count">164 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e3551fbd40b95eaa3e" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e3551fbd40b95eaa3e', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e3551fbd40b95eaa3e', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e3551fbd40b95eaa3e', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e3551fbd40b95eaa3e', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e3551fbd40b95eaa3e', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3e%2F69c58486d55283299efc2063.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3e%2F69c58ef6ffc1193fdce25ab6.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3e%2F69c594c7a89c55aa728c3bd3.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3e%2F69c59bd3db9c647a15af0c04.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e3551fbd40b95eaa3e%2F69c59e397db2841b119badf5.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b419022b0edf3eaa2de827" data-idx="878">
+        <div class="book-header">
+          <span class="book-num">#879</span>
+          <h3>Collection of Works — Tommaso Campanella (PH196)</h3>
+          <span class="page-count">95 pp</span>
+          <a href="https://sourcelibrary.org/book/campanella-collected-works-ca-1600-italian-ms-campanella" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b419022b0edf3eaa2de827', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b419022b0edf3eaa2de827', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b419022b0edf3eaa2de827', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b419022b0edf3eaa2de827', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b419022b0edf3eaa2de827', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b419022b0edf3eaa2de827%2F10.jpg&w=600" alt="Page 10" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.10 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560062305131!ph196_038.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560062305131!ph196_057.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560062305131!ph196_076.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940560062305131!ph196_086.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 86" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.86 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418962b0edf3eaa2dd656" data-idx="879">
+        <div class="book-header">
+          <span class="book-num">#880</span>
+          <h3>Corpus Hermeticum (PH460)</h3>
+          <span class="page-count">219 pp</span>
+          <a href="https://sourcelibrary.org/book/corpus-hermeticum-17th-century-english-translation-ms-imming" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418962b0edf3eaa2dd656', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418962b0edf3eaa2dd656', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418962b0edf3eaa2dd656', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418962b0edf3eaa2dd656', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418962b0edf3eaa2dd656', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418962b0edf3eaa2dd656%2F22.jpg&w=600" alt="Page 22" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.22 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563881505131!PH460_0088.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 88" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.88 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563881505131!PH460_0131.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563881505131!PH460_0175.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940563881505131!PH460_0197.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 197" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.197 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c809cd6c6f3cc53c84627f" data-idx="880">
+        <div class="book-header">
+          <span class="book-num">#881</span>
+          <h3>De sexcentum et tredecim mosaice sanctionis edictis. Philosophica prophetica ac talmudistica. In cabalistarum ... ysagogae. De novem doctrinarum ordinibus ... oratio cabala</h3>
+          <span class="page-count">151 pp</span>
+          <a href="https://sourcelibrary.org/book/69c809cd6c6f3cc53c84627f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c809cd6c6f3cc53c84627f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c809cd6c6f3cc53c84627f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c809cd6c6f3cc53c84627f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c809cd6c6f3cc53c84627f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c809cd6c6f3cc53c84627f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809cd6c6f3cc53c84627f%2F0015-full.jpg&w=600" alt="Page 15" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.15 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809cd6c6f3cc53c84627f%2F0060-full.jpg&w=600" alt="Page 60" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.60 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809cd6c6f3cc53c84627f%2F0091-full.jpg&w=600" alt="Page 91" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.91 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809cd6c6f3cc53c84627f%2F0121-full.jpg&w=600" alt="Page 121" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.121 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c809cd6c6f3cc53c84627f%2F0136-full.jpg&w=600" alt="Page 136" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.136 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="690986dccf28baa1b4cae0e3" data-idx="881">
+        <div class="book-header">
+          <span class="book-num">#882</span>
+          <h3>Novum lumen chymicum</h3>
+          <span class="page-count">209 pp</span>
+          <a href="https://sourcelibrary.org/book/new-chemical-light-sendivogius" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('690986dccf28baa1b4cae0e3', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('690986dccf28baa1b4cae0e3', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('690986dccf28baa1b4cae0e3', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('690986dccf28baa1b4cae0e3', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('690986dccf28baa1b4cae0e3', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690986dccf28baa1b4cae0e3%2F21.jpg&w=600" alt="Page 21" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.21 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690986dccf28baa1b4cae0e3%2F84.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690986dccf28baa1b4cae0e3%2F125.jpg&w=600" alt="Page 125" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.125 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690986dccf28baa1b4cae0e3%2F167.jpg&w=600" alt="Page 167" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.167 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F690986dccf28baa1b4cae0e3%2F188.jpg&w=600" alt="Page 188" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.188 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c898cb6c6f3cc53c85cc0d" data-idx="882">
+        <div class="book-header">
+          <span class="book-num">#883</span>
+          <h3>Catalogue des livres rares et précieux du cabinet de feu M. de Saint-Martin</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c898cb6c6f3cc53c85cc0d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c898cb6c6f3cc53c85cc0d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c898cb6c6f3cc53c85cc0d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c898cb6c6f3cc53c85cc0d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c898cb6c6f3cc53c85cc0d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c898cb6c6f3cc53c85cc0d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898cb6c6f3cc53c85cc0d%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898cb6c6f3cc53c85cc0d%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898cb6c6f3cc53c85cc0d%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898cb6c6f3cc53c85cc0d%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c898cb6c6f3cc53c85cc0d%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c581e48e452b634cbc3698" data-idx="883">
+        <div class="book-header">
+          <span class="book-num">#884</span>
+          <h3>Der unterwiesene Anfänger in der Chymie hermetisches Sendschreiben</h3>
+          <span class="page-count">157 pp</span>
+          <a href="https://sourcelibrary.org/book/69c581e48e452b634cbc3698" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c581e48e452b634cbc3698', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c581e48e452b634cbc3698', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c581e48e452b634cbc3698', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c581e48e452b634cbc3698', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c581e48e452b634cbc3698', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e48e452b634cbc3698%2F69c584c7a7ef8ca7dd9a8e8f.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e48e452b634cbc3698%2F69c58c485b57418d7396d5e3.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e48e452b634cbc3698%2F69c590c9e931bfe7dc78f6eb.jpg&w=600" alt="Page 94" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.94 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e48e452b634cbc3698%2F69c595ec8404806ef6258196.jpg&w=600" alt="Page 126" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.126 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%0A%2Fuploads%2F69c581e48e452b634cbc3698%2F69c598431f0fabc28663ce1e.jpg&w=600" alt="Page 141" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.141 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c86f6c6c6f3cc53c8570c0" data-idx="884">
+        <div class="book-header">
+          <span class="book-num">#885</span>
+          <h3>The chakras. A monograph</h3>
+          <span class="page-count">70 pp</span>
+          <a href="https://sourcelibrary.org/book/69c86f6c6c6f3cc53c8570c0" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c86f6c6c6f3cc53c8570c0', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c86f6c6c6f3cc53c8570c0', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c86f6c6c6f3cc53c8570c0', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c86f6c6c6f3cc53c8570c0', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c86f6c6c6f3cc53c8570c0', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86f6c6c6f3cc53c8570c0%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86f6c6c6f3cc53c8570c0%2F0028-full.jpg&w=600" alt="Page 28" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.28 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86f6c6c6f3cc53c8570c0%2F0042-full.jpg&w=600" alt="Page 42" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.42 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86f6c6c6f3cc53c8570c0%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c86f6c6c6f3cc53c8570c0%2F0063-full.jpg&w=600" alt="Page 63" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.63 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c833c96c6f3cc53c84e32f" data-idx="885">
+        <div class="book-header">
+          <span class="book-num">#886</span>
+          <h3>Complement bon' avisorum. Special neue Avisen, welche der Postilion des grossen Löwens vom geschlecht Juda hat gesehen</h3>
+          <span class="page-count">9 pp</span>
+          <a href="https://sourcelibrary.org/book/69c833c96c6f3cc53c84e32f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c833c96c6f3cc53c84e32f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c833c96c6f3cc53c84e32f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c833c96c6f3cc53c84e32f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c833c96c6f3cc53c84e32f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c833c96c6f3cc53c84e32f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833c96c6f3cc53c84e32f%2F0001-full.jpg&w=600" alt="Page 1" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.1 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833c96c6f3cc53c84e32f%2F0004-full.jpg&w=600" alt="Page 4" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.4 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833c96c6f3cc53c84e32f%2F0005-full.jpg&w=600" alt="Page 5" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.5 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833c96c6f3cc53c84e32f%2F0007-full.jpg&w=600" alt="Page 7" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.7 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c833c96c6f3cc53c84e32f%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418ff2b0edf3eaa2de7aa" data-idx="886">
+        <div class="book-header">
+          <span class="book-num">#887</span>
+          <h3>Of the Infinite Universe and Innumerable Worlds — Giordano Bruno (PH218)</h3>
+          <span class="page-count">123 pp</span>
+          <a href="https://sourcelibrary.org/book/giordano-bruno-infinite-universe-17th-century-english-ms-bruno" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418ff2b0edf3eaa2de7aa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418ff2b0edf3eaa2de7aa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418ff2b0edf3eaa2de7aa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418ff2b0edf3eaa2de7aa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418ff2b0edf3eaa2de7aa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F69b418ff2b0edf3eaa2de7aa%2F12.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940464940005131!PH218_0049.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 49" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.49 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940464940005131!PH218_0074.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940464940005131!PH218_0098.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940464940005131!PH218_0111.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 111" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.111 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c890fa6c6f3cc53c85b864" data-idx="887">
+        <div class="book-header">
+          <span class="book-num">#888</span>
+          <h3>Von der Weltseele</h3>
+          <span class="page-count">197 pp</span>
+          <a href="https://sourcelibrary.org/book/69c890fa6c6f3cc53c85b864" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c890fa6c6f3cc53c85b864', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c890fa6c6f3cc53c85b864', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c890fa6c6f3cc53c85b864', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c890fa6c6f3cc53c85b864', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c890fa6c6f3cc53c85b864', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890fa6c6f3cc53c85b864%2F0020-full.jpg&w=600" alt="Page 20" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.20 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890fa6c6f3cc53c85b864%2F0079-full.jpg&w=600" alt="Page 79" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.79 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890fa6c6f3cc53c85b864%2F0118-full.jpg&w=600" alt="Page 118" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.118 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890fa6c6f3cc53c85b864%2F0158-full.jpg&w=600" alt="Page 158" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.158 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c890fa6c6f3cc53c85b864%2F0177-full.jpg&w=600" alt="Page 177" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.177 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c640d4b463eebe7caac78d" data-idx="888">
+        <div class="book-header">
+          <span class="book-num">#889</span>
+          <h3>Vitae quorundam eruditissimorum et illustrium virorum</h3>
+          <span class="page-count">251 pp</span>
+          <a href="https://sourcelibrary.org/book/69c640d4b463eebe7caac78d" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c640d4b463eebe7caac78d', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c640d4b463eebe7caac78d', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c640d4b463eebe7caac78d', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c640d4b463eebe7caac78d', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c640d4b463eebe7caac78d', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c640d4b463eebe7caac78d%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c640d4b463eebe7caac78d%2F0100-full.jpg&w=600" alt="Page 100" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.100 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c640d4b463eebe7caac78d%2F0151-full.jpg&w=600" alt="Page 151" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.151 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c640d4b463eebe7caac78d%2F0201-full.jpg&w=600" alt="Page 201" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.201 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c640d4b463eebe7caac78d%2F0226-full.jpg&w=600" alt="Page 226" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.226 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c730376a0f3d112faf724b" data-idx="889">
+        <div class="book-header">
+          <span class="book-num">#890</span>
+          <h3>Etwas zur richtigen Beurtheilung der Theosophie, Cabbala, Magie, und anderer geheimer übernatürlicher Wissenschaften</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c730376a0f3d112faf724b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c730376a0f3d112faf724b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c730376a0f3d112faf724b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c730376a0f3d112faf724b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c730376a0f3d112faf724b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c730376a0f3d112faf724b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c730376a0f3d112faf724b%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c730376a0f3d112faf724b%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c730376a0f3d112faf724b%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c730376a0f3d112faf724b%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c730376a0f3d112faf724b%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7bffd25ec2ba5ccd7fcae" data-idx="890">
+        <div class="book-header">
+          <span class="book-num">#891</span>
+          <h3>Historia critica philosophiae</h3>
+          <span class="page-count">709 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7bffd25ec2ba5ccd7fcae" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7bffd25ec2ba5ccd7fcae', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7bffd25ec2ba5ccd7fcae', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7bffd25ec2ba5ccd7fcae', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7bffd25ec2ba5ccd7fcae', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7bffd25ec2ba5ccd7fcae', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffd25ec2ba5ccd7fcae%2F0071-full.jpg&w=600" alt="Page 71" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.71 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffd25ec2ba5ccd7fcae%2F0284-full.jpg&w=600" alt="Page 284" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.284 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffd25ec2ba5ccd7fcae%2F0425-full.jpg&w=600" alt="Page 425" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.425 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffd25ec2ba5ccd7fcae%2F0567-full.jpg&w=600" alt="Page 567" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.567 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7bffd25ec2ba5ccd7fcae%2F0638-full.jpg&w=600" alt="Page 638" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.638 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c82e0d6c6f3cc53c84d53f" data-idx="891">
+        <div class="book-header">
+          <span class="book-num">#892</span>
+          <h3>Fragment aus dem dreissigjährigen Krieg, betreffend das Schicksal und die Einäscherung der Stadt Calw, geschehen den 10. Sept. 1634</h3>
+          <span class="page-count">63 pp</span>
+          <a href="https://sourcelibrary.org/book/69c82e0d6c6f3cc53c84d53f" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c82e0d6c6f3cc53c84d53f', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c82e0d6c6f3cc53c84d53f', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c82e0d6c6f3cc53c84d53f', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c82e0d6c6f3cc53c84d53f', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c82e0d6c6f3cc53c84d53f', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e0d6c6f3cc53c84d53f%2F0006-full.jpg&w=600" alt="Page 6" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.6 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e0d6c6f3cc53c84d53f%2F0025-full.jpg&w=600" alt="Page 25" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.25 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e0d6c6f3cc53c84d53f%2F0038-full.jpg&w=600" alt="Page 38" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.38 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e0d6c6f3cc53c84d53f%2F0050-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c82e0d6c6f3cc53c84d53f%2F0057-full.jpg&w=600" alt="Page 57" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.57 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c877496c6f3cc53c857ff5" data-idx="892">
+        <div class="book-header">
+          <span class="book-num">#893</span>
+          <h3>Figurae libri apocalypsis beati Joannis apostoli: figures du livre de l'apocalypse</h3>
+          <span class="page-count">84 pp</span>
+          <a href="https://sourcelibrary.org/book/69c877496c6f3cc53c857ff5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c877496c6f3cc53c857ff5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c877496c6f3cc53c857ff5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c877496c6f3cc53c857ff5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c877496c6f3cc53c857ff5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c877496c6f3cc53c857ff5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877496c6f3cc53c857ff5%2F0004-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877496c6f3cc53c857ff5%2F0017-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877496c6f3cc53c857ff5%2F0025-full.jpg&w=600" alt="Page 50" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.50 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877496c6f3cc53c857ff5%2F0034-full.jpg&w=600" alt="Page 67" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.67 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c877496c6f3cc53c857ff5%2F0038-full.jpg&w=600" alt="Page 76" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.76 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="6909cae5cf28baa1b4cafca7" data-idx="893">
+        <div class="book-header">
+          <span class="book-num">#894</span>
+          <h3>Versuch einer Geschichte des Arianismus</h3>
+          <span class="page-count">164 pp</span>
+          <a href="https://sourcelibrary.org/book/an-attempt-at-a-history-of-arianism-starck" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('6909cae5cf28baa1b4cafca7', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('6909cae5cf28baa1b4cafca7', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('6909cae5cf28baa1b4cafca7', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('6909cae5cf28baa1b4cafca7', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('6909cae5cf28baa1b4cafca7', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cae5cf28baa1b4cafca7%2F16.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cae5cf28baa1b4cafca7%2F66.jpg&w=600" alt="Page 66" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.66 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cae5cf28baa1b4cafca7%2F98.jpg&w=600" alt="Page 98" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.98 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cae5cf28baa1b4cafca7%2F131.jpg&w=600" alt="Page 131" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.131 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Farchived%2F6909cae5cf28baa1b4cafca7%2F148.jpg&w=600" alt="Page 148" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.148 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c72037da9771c716316bb6" data-idx="894">
+        <div class="book-header">
+          <span class="book-num">#895</span>
+          <h3>De geduurige blydtschap des geestes</h3>
+          <span class="page-count">269 pp</span>
+          <a href="https://sourcelibrary.org/book/69c72037da9771c716316bb6" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c72037da9771c716316bb6', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c72037da9771c716316bb6', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c72037da9771c716316bb6', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c72037da9771c716316bb6', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c72037da9771c716316bb6', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72037da9771c716316bb6%2F0027-full.jpg&w=600" alt="Page 27" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.27 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72037da9771c716316bb6%2F0108-full.jpg&w=600" alt="Page 108" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.108 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72037da9771c716316bb6%2F0161-full.jpg&w=600" alt="Page 161" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.161 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72037da9771c716316bb6%2F0215-full.jpg&w=600" alt="Page 215" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.215 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c72037da9771c716316bb6%2F0242-full.jpg&w=600" alt="Page 242" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.242 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c849216c6f3cc53c851dcf" data-idx="895">
+        <div class="book-header">
+          <span class="book-num">#896</span>
+          <h3>Die einzige wahre Religion, allgemein in ihren Grund-Sätzen, verwirret durch die Zankereyen der Schriftgelehrten, zertheilet in allerhand Secten, vereinigt in Christo</h3>
+          <span class="page-count">337 pp</span>
+          <a href="https://sourcelibrary.org/book/69c849216c6f3cc53c851dcf" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c849216c6f3cc53c851dcf', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c849216c6f3cc53c851dcf', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c849216c6f3cc53c851dcf', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c849216c6f3cc53c851dcf', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c849216c6f3cc53c851dcf', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849216c6f3cc53c851dcf%2F0034-full.jpg&w=600" alt="Page 34" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.34 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849216c6f3cc53c851dcf%2F0135-full.jpg&w=600" alt="Page 135" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.135 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849216c6f3cc53c851dcf%2F0202-full.jpg&w=600" alt="Page 202" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.202 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849216c6f3cc53c851dcf%2F0270-full.jpg&w=600" alt="Page 270" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.270 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c849216c6f3cc53c851dcf%2F0303-full.jpg&w=600" alt="Page 303" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.303 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c857136c6f3cc53c853f8b" data-idx="896">
+        <div class="book-header">
+          <span class="book-num">#897</span>
+          <h3>Cabala, Spiegel der Kunst und Natur: in Alchymia</h3>
+          <span class="page-count">20 pp</span>
+          <a href="https://sourcelibrary.org/book/69c857136c6f3cc53c853f8b" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c857136c6f3cc53c853f8b', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c857136c6f3cc53c853f8b', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c857136c6f3cc53c853f8b', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c857136c6f3cc53c853f8b', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c857136c6f3cc53c853f8b', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857136c6f3cc53c853f8b%2F0002-full.jpg&w=600" alt="Page 2" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.2 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857136c6f3cc53c853f8b%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857136c6f3cc53c853f8b%2F0012-full.jpg&w=600" alt="Page 12" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.12 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857136c6f3cc53c853f8b%2F0016-full.jpg&w=600" alt="Page 16" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.16 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c857136c6f3cc53c853f8b%2F0018-full.jpg&w=600" alt="Page 18" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.18 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7f5086c6f3cc53c841ae5" data-idx="897">
+        <div class="book-header">
+          <span class="book-num">#898</span>
+          <h3>Die Kunst der Chiromantzey</h3>
+          <span class="page-count">76 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7f5086c6f3cc53c841ae5" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7f5086c6f3cc53c841ae5', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7f5086c6f3cc53c841ae5', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7f5086c6f3cc53c841ae5', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7f5086c6f3cc53c841ae5', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7f5086c6f3cc53c841ae5', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5086c6f3cc53c841ae5%2F0008-full.jpg&w=600" alt="Page 8" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.8 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5086c6f3cc53c841ae5%2F0030-full.jpg&w=600" alt="Page 30" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.30 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5086c6f3cc53c841ae5%2F0046-full.jpg&w=600" alt="Page 46" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.46 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5086c6f3cc53c841ae5%2F0061-full.jpg&w=600" alt="Page 61" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.61 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7f5086c6f3cc53c841ae5%2F0068-full.jpg&w=600" alt="Page 68" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.68 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69c7ad8825ec2ba5ccd7f1fa" data-idx="898">
+        <div class="book-header">
+          <span class="book-num">#899</span>
+          <h3>[Hebrew: rashe tevot] Tractatus continens &amp; explicans abbreviaturas omnes</h3>
+          <span class="page-count">93 pp</span>
+          <a href="https://sourcelibrary.org/book/69c7ad8825ec2ba5ccd7f1fa" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fa', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fa', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fa', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fa', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69c7ad8825ec2ba5ccd7f1fa', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fa%2F0009-full.jpg&w=600" alt="Page 9" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.9 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fa%2F0037-full.jpg&w=600" alt="Page 37" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.37 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fa%2F0056-full.jpg&w=600" alt="Page 56" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.56 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fa%2F0074-full.jpg&w=600" alt="Page 74" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.74 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.sourcelibrary.org%2Fpages%2F69c7ad8825ec2ba5ccd7f1fa%2F0084-full.jpg&w=600" alt="Page 84" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.84 (90%)</div>
+        </div>
+        </div>
+      </div>
+
+      <div class="book-card" data-book-id="69b418ee2b0edf3eaa2de472" data-idx="899">
+        <div class="book-header">
+          <span class="book-num">#900</span>
+          <h3>Alchemical Texts — Hollandus, Llull, Ashmole, Ripley (PH435)</h3>
+          <span class="page-count">291 pp</span>
+          <a href="https://sourcelibrary.org/book/hollandus-llull-ashmole-ripley-english-alchemical-ms-18th-c-ripley" target="_blank" class="book-link">view</a>
+          <div class="flag-buttons">
+            <button class="flag-btn ok" onclick="flagBook('69b418ee2b0edf3eaa2de472', 'ok', this)" title="Looks good">OK</button>
+            <button class="flag-btn angled" onclick="flagBook('69b418ee2b0edf3eaa2de472', 'angled', this)" title="Angled/skewed scan">Angled</button>
+            <button class="flag-btn tight" onclick="flagBook('69b418ee2b0edf3eaa2de472', 'tight', this)" title="Tight gutter, text might clip">Tight</button>
+            <button class="flag-btn off-center" onclick="flagBook('69b418ee2b0edf3eaa2de472', 'off-center', this)" title="Split doesn't land on gutter">Off-center</button>
+            <button class="flag-btn other" onclick="flagBook('69b418ee2b0edf3eaa2de472', 'other', this)" title="Other issue">Other</button>
+          </div>
+        </div>
+        <div class="pages-row">
+          
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524638605131!PH435_0029.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 29" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.29 (10%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524638605131!PH435_0116.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 116" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.116 (40%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524638605131!PH435_0175.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 175" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.175 (60%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524638605131!PH435_0233.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 233" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.233 (80%)</div>
+        </div>
+
+        <div class="page-slot">
+          <div class="spread-container">
+            <img src="https://sourcelibrary.org/api/image?url=https%3A%2F%2Fimages.uba.uva.nl%2Fiiif%2F2%2Fdefault!1!3!1!9940524638605131!PH435_0262.jpg%2Ffull%2F1000%2C%2F0%2Fdefault.jpg&w=600" alt="Page 262" loading="lazy" />
+            <div class="split-line"></div>
+          </div>
+          <div class="page-label">p.262 (90%)</div>
+        </div>
+        </div>
+      </div>
+  <div class="pagination"><a href="split-review-1.html">Page 1</a> <a href="split-review-2.html">Page 2</a> <a href="split-review-3.html">Page 3</a> <a href="split-review-4.html">Page 4</a> <a href="split-review-5.html">Page 5</a> <a href="split-review-6.html">Page 6</a> <a href="split-review-7.html">Page 7</a> <a href="split-review-8.html">Page 8</a> <a href="split-review-9.html" class="active">Page 9</a> <a href="split-review-10.html">Page 10</a> <a href="split-review-11.html">Page 11</a></div>
+  <div class="export-bar">
+    <button onclick="exportFlags()">Export Flags (JSON)</button>
+    <button onclick="copyFlags()">Copy to Clipboard</button>
+    <div class="summary" id="export-summary"></div>
+  </div>
+
+<script>
+const flags = JSON.parse(localStorage.getItem('splitReviewFlags') || '{}');
+
+// Restore saved flags on load
+document.addEventListener('DOMContentLoaded', () => {
+  for (const [bookId, flag] of Object.entries(flags)) {
+    const card = document.querySelector('[data-book-id="' + bookId + '"]');
+    if (!card) continue;
+    card.className = 'book-card flagged-' + flag;
+    const btn = card.querySelector('.flag-btn.' + flag);
+    if (btn) btn.classList.add('selected');
+  }
+  updateStats();
+});
+
+function flagBook(bookId, flag, btn) {
+  const card = btn.closest('.book-card');
+  // Toggle off if already selected
+  if (flags[bookId] === flag) {
+    delete flags[bookId];
+    card.className = 'book-card';
+    btn.classList.remove('selected');
+  } else {
+    flags[bookId] = flag;
+    card.className = 'book-card flagged-' + flag;
+    card.querySelectorAll('.flag-btn').forEach(b => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  }
+  localStorage.setItem('splitReviewFlags', JSON.stringify(flags));
+  updateStats();
+}
+
+function updateStats() {
+  const counts = { ok: 0, angled: 0, tight: 0, 'off-center': 0, other: 0 };
+  for (const f of Object.values(flags)) counts[f] = (counts[f] || 0) + 1;
+  const total = document.querySelectorAll('.book-card').length;
+  const reviewed = Object.keys(flags).length;
+  document.getElementById('stat-ok').textContent = 'OK: ' + counts.ok;
+  document.getElementById('stat-angled').textContent = 'Angled: ' + counts.angled;
+  document.getElementById('stat-tight').textContent = 'Tight: ' + counts.tight;
+  document.getElementById('stat-off-center').textContent = 'Off-center: ' + counts['off-center'];
+  document.getElementById('stat-other').textContent = 'Other: ' + counts.other;
+  document.getElementById('stat-unreviewed').textContent = 'Unreviewed: ' + (total - reviewed);
+  document.getElementById('export-summary').textContent = reviewed + '/' + total + ' reviewed';
+}
+
+let currentFilter = 'all';
+function filterBooks(filter) {
+  currentFilter = filter;
+  document.querySelectorAll('.controls button').forEach(b => {
+    b.classList.toggle('active', b.dataset.filter === filter);
+  });
+  document.querySelectorAll('.book-card').forEach(card => {
+    const bookId = card.dataset.bookId;
+    const flag = flags[bookId];
+    let show = true;
+    if (filter === 'unreviewed') show = !flag;
+    else if (filter === 'ok') show = flag === 'ok';
+    else if (filter === 'flagged') show = flag && flag !== 'ok';
+    card.classList.toggle('hidden-by-filter', !show);
+  });
+}
+
+function exportFlags() {
+  const data = JSON.stringify(flags, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'split-review-flags.json'; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function copyFlags() {
+  navigator.clipboard.writeText(JSON.stringify(flags, null, 2)).then(() => {
+    document.getElementById('export-summary').textContent = 'Copied!';
+    setTimeout(updateStats, 1500);
+  });
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 11 static HTML pages for reviewing 1,089 BPH books that need page splitting
- Each book shows 5 sample pages (10%, 40%, 60%, 80%, 90%) with a red 50% split line overlay
- Reviewer can flag books as OK / Angled / Tight gutter / Off-center / Other
- Flags persist in localStorage, exportable as JSON for batch processing

## Context
We moved 1,131 BPH books out of warehouse and discovered 1,135 total need splitting. This review tool lets us visually QA the naive 50% split approach and identify books needing special handling (overlap crops, etc).

## Test plan
- [ ] Open /split-review-1.html and verify images load
- [ ] Flag a few books and confirm persistence across page refresh
- [ ] Export flags and verify JSON format

🤖 Generated with [Claude Code](https://claude.com/claude-code)