### PR TITLE
Add warehouse + visibility breakdown to admin dashboard

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,14 @@
 
 import { useState, useEffect } from 'react';
 
+interface CollectionStats {
+  total_books: number;
+  total_pages: number;
+  pages_ocr: number;
+  pages_translated: number;
+  first_translations: number;
+}
+
 interface DashboardData {
   canon: {
     total_books: number;
@@ -32,6 +40,8 @@ interface DashboardData {
     total_cost_30d: number;
     pages_translated_30d: number;
   };
+  invisible?: CollectionStats;
+  warehouse?: CollectionStats;
   _snapshot?: {
     updated_at: string;
     stale: boolean;
@@ -228,7 +238,7 @@ export default function AdminDashboard() {
       </div>
 
       {/* Row 4: Pipeline + Economics */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 28 }}>
         <div style={{
           background: '#0d1117', border: '1px solid #30363d', borderRadius: 10,
           padding: '16px 20px',
@@ -280,6 +290,80 @@ export default function AdminDashboard() {
           </div>
         </div>
       </div>
+
+      {/* Row 5: Full Library Breakdown */}
+      {(data.invisible || data.warehouse) && (
+        <div style={{ marginBottom: 28 }}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 1, color: '#8b949e', marginBottom: 10 }}>
+            Full Library
+          </div>
+          <div style={{
+            background: '#0d1117', border: '1px solid #30363d', borderRadius: 10,
+            padding: '16px 20px',
+          }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+              <thead>
+                <tr style={{ color: '#8b949e', textAlign: 'left' }}>
+                  <th style={{ padding: '6px 12px 6px 0', fontWeight: 500 }}>Collection</th>
+                  <th style={{ padding: '6px 12px', fontWeight: 500, textAlign: 'right' }}>Books</th>
+                  <th style={{ padding: '6px 12px', fontWeight: 500, textAlign: 'right' }}>Pages</th>
+                  <th style={{ padding: '6px 12px', fontWeight: 500, textAlign: 'right' }}>OCR</th>
+                  <th style={{ padding: '6px 12px', fontWeight: 500, textAlign: 'right' }}>Translated</th>
+                  <th style={{ padding: '6px 12px', fontWeight: 500, textAlign: 'right' }}>First Trans.</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr style={{ color: '#3fb950' }}>
+                  <td style={{ padding: '6px 12px 6px 0' }}>Visible</td>
+                  <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(canon.total_books)}</td>
+                  <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(canon.total_pages)}</td>
+                  <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(coverage.ocr_pages)}</td>
+                  <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(coverage.translated_pages)}</td>
+                  <td style={{ padding: '6px 12px', textAlign: 'right' }}>{canon.first_translations}</td>
+                </tr>
+                {data.invisible && (
+                  <tr style={{ color: '#d29922' }}>
+                    <td style={{ padding: '6px 12px 6px 0' }}>Invisible</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.invisible.total_books)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.invisible.total_pages)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.invisible.pages_ocr)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.invisible.pages_translated)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{data.invisible.first_translations}</td>
+                  </tr>
+                )}
+                {data.warehouse && (
+                  <tr style={{ color: '#8b949e' }}>
+                    <td style={{ padding: '6px 12px 6px 0' }}>Warehouse</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.warehouse.total_books)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.warehouse.total_pages)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.warehouse.pages_ocr)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{fmt(data.warehouse.pages_translated)}</td>
+                    <td style={{ padding: '6px 12px', textAlign: 'right' }}>{data.warehouse.first_translations}</td>
+                  </tr>
+                )}
+                <tr style={{ color: '#f0f6fc', borderTop: '1px solid #30363d', fontWeight: 600 }}>
+                  <td style={{ padding: '8px 12px 6px 0' }}>Total</td>
+                  <td style={{ padding: '8px 12px', textAlign: 'right' }}>
+                    {fmt(canon.total_books + (data.invisible?.total_books || 0) + (data.warehouse?.total_books || 0))}
+                  </td>
+                  <td style={{ padding: '8px 12px', textAlign: 'right' }}>
+                    {fmt(canon.total_pages + (data.invisible?.total_pages || 0) + (data.warehouse?.total_pages || 0))}
+                  </td>
+                  <td style={{ padding: '8px 12px', textAlign: 'right' }}>
+                    {fmt(coverage.ocr_pages + (data.invisible?.pages_ocr || 0) + (data.warehouse?.pages_ocr || 0))}
+                  </td>
+                  <td style={{ padding: '8px 12px', textAlign: 'right' }}>
+                    {fmt(coverage.translated_pages + (data.invisible?.pages_translated || 0) + (data.warehouse?.pages_translated || 0))}
+                  </td>
+                  <td style={{ padding: '8px 12px', textAlign: 'right' }}>
+                    {canon.first_translations + (data.invisible?.first_translations || 0) + (data.warehouse?.first_translations || 0)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -87,6 +87,29 @@ async function computeSnapshot(db: any) {
 
   const jobMap = Object.fromEntries(jobsActive.map((j: any) => [j._id, j.count]));
 
+  // Invisible books (main collection, not visible) + warehouse counts
+  const invisible = { visible: { $ne: true } };
+  const warehouse = db.collection('books_warehouse');
+
+  const [invisibleCount, invisibleTotals, warehouseCount, warehouseTotals,
+    invisibleFirstTranslations, warehouseFirstTranslations,
+  ] = await Promise.all([
+    books.countDocuments(invisible),
+    books.aggregate([
+      { $match: invisible },
+      { $group: { _id: null, pages: { $sum: { $ifNull: ['$pages_count', 0] } }, pages_ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } }, pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } } } },
+    ], { maxTimeMS: 15000 }).toArray(),
+    warehouse.countDocuments({}),
+    warehouse.aggregate([
+      { $group: { _id: null, pages: { $sum: { $ifNull: ['$pages_count', 0] } }, pages_ocr: { $sum: { $ifNull: ['$pages_ocr', 0] } }, pages_translated: { $sum: { $ifNull: ['$pages_translated', 0] } } } },
+    ], { maxTimeMS: 15000 }).toArray(),
+    books.countDocuments({ ...invisible, is_first_translation: true }),
+    warehouse.countDocuments({ is_first_translation: true }),
+  ]);
+
+  const it = invisibleTotals[0] || { pages: 0, pages_ocr: 0, pages_translated: 0 };
+  const wt = warehouseTotals[0] || { pages: 0, pages_ocr: 0, pages_translated: 0 };
+
   return {
     canon: {
       total_books: totalBooks,
@@ -113,6 +136,20 @@ async function computeSnapshot(db: any) {
       queued: jobMap.queued || 0,
     },
     economics,
+    invisible: {
+      total_books: invisibleCount,
+      total_pages: it.pages,
+      pages_ocr: it.pages_ocr,
+      pages_translated: it.pages_translated,
+      first_translations: invisibleFirstTranslations,
+    },
+    warehouse: {
+      total_books: warehouseCount,
+      total_pages: wt.pages,
+      pages_ocr: wt.pages_ocr,
+      pages_translated: wt.pages_translated,
+      first_translations: warehouseFirstTranslations,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- Admin dashboard API now computes invisible (main collection, not visible) and warehouse (`books_warehouse`) counts alongside visible books
- New "Full Library" table on the dashboard shows three tiers: Visible (green), Invisible (yellow), Warehouse (gray) with totals
- Each tier shows: books, pages, OCR pages, translated pages, first translations
- Closes remaining work from #665

## Test plan
- [ ] POST `/api/admin/dashboard` returns `invisible` and `warehouse` objects
- [ ] Admin dashboard renders the Full Library table
- [ ] Totals row sums correctly across all three tiers
- [ ] Backwards-compatible: old snapshots without these fields still render (conditional rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)