### PR TITLE
Mixed art+book collections

### DIFF
--- a/scripts/artwork-enrichment.mjs
+++ b/scripts/artwork-enrichment.mjs
@@ -234,17 +234,17 @@ async function main() {
           updated_at: new Date(),
         };
 
-        // Add to collection_slugs if collections assigned
-        if (enrichment.collections?.length > 0) {
-          const validSlugs = enrichment.collections.filter(s =>
-            ALL_COLLECTIONS.some(c => c.slug === s)
-          );
-          if (validSlugs.length > 0) {
-            updateFields.collection_slugs = validSlugs;
-          }
+        // Tag artwork into collections (same field books use)
+        const collectionSlugs = (enrichment.collections || []).filter(s =>
+          ALL_COLLECTIONS.some(c => c.slug === s)
+        );
+
+        const update = { $set: updateFields };
+        if (collectionSlugs.length > 0) {
+          update.$addToSet = { collections: { $each: collectionSlugs } };
         }
 
-        await books.updateOne({ _id: art._id }, { $set: updateFields });
+        await books.updateOne({ _id: art._id }, update);
       }
 
       // Rate limit: 2s between calls

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -37,17 +37,18 @@ export async function GET(
       return NextResponse.json({ error: 'Collection not found' }, { status: 404 });
     }
 
-    // Art collections bypass hidden/translation filters since artworks are hidden: true
-    // and have no translated pages
+    // Art-only collections filter by resource_type.
+    // Book collections include both books AND artworks (mixed content).
     const isArtCollection = collection.collection_type === 'visual_art';
 
     const filter: Record<string, unknown> = isArtCollection
       ? { collections: id, resource_type: { $exists: true } }
       : {
           collections: id,
-          visible: true,
-          pages_count: { $gt: 0 },
-          pages_translated: { $gt: 0 },
+          $or: [
+            { visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } },
+            { resource_type: { $exists: true } },
+          ],
         };
 
     // Manifest mode: return lightweight data for all books in one shot.
@@ -59,6 +60,7 @@ export async function GET(
         published: 1, read_count: 1, thumbnail: 1, thumbnail_blob: 1,
         is_first_translation: 1, ft_disposition: 1,
         created_at: 1, last_translation_at: 1,
+        resource_type: 1, medium: 1, enrichment: 1,
       };
       // Include relevance score for this collection
       const manifestProjectionWithScore = {
@@ -109,7 +111,8 @@ export async function GET(
       _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1,
       language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_blank: 1,
       photo: 1, categories: 1, thumbnail: 1, thumbnail_blob: 1, published: 1, read_count: 1,
-      resource_type: 1, is_first_translation: 1, ft_disposition: 1,
+      resource_type: 1, medium: 1, 'enrichment.subject': 1, 'enrichment.genre': 1,
+      is_first_translation: 1, ft_disposition: 1,
     };
 
     const highlightProjection = {
@@ -130,12 +133,12 @@ export async function GET(
         .skip(offset)
         .limit(limit)
         .toArray(),
-      // Top 5: art collections use main filter; book collections prefer translated
+      // Top 5: art collections use main filter; book collections prefer translated books (not artworks)
       db.collection('books')
         .find(
           isArtCollection
             ? { collections: id, resource_type: { $exists: true } }
-            : { collections: id, visible: true, pages_translated: { $gt: 0 } },
+            : { collections: id, visible: true, pages_translated: { $gt: 0 }, resource_type: { $exists: false } },
           { projection: highlightProjection },
         )
         .sort(isArtCollection ? { title: 1 } : { quality_score: -1, read_count: -1, pages_translated: -1 })

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -88,6 +88,7 @@ interface BookItem {
   read_count?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  resource_type?: string;
 }
 
 interface CuratedHighlight {
@@ -207,9 +208,10 @@ async function fetchCollectionData(id: string) {
     ? { collections: id, resource_type: { $exists: true } }
     : {
         collections: id,
-        visible: true,
-        pages_count: { $gt: 0 },
-        pages_translated: { $gt: 0 },
+        $or: [
+          { visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } },
+          { resource_type: { $exists: true } },
+        ],
       };
 
   const projection = {
@@ -237,6 +239,29 @@ async function fetchCollectionData(id: string) {
 
   // All queries run in parallel with timeouts. Cold MongoDB connections from
   // Mumbai→Virginia can take 15-20s, so even "critical" queries need protection.
+  // Fetch artworks for mixed collections (book collections that also contain artworks)
+  const artworksPromise = !isArtCollection
+    ? withTimeout(
+        db.collection('books')
+          .find(
+            { collections: id, resource_type: { $exists: true } },
+            {
+              projection: {
+                _id: 0, id: 1, slug: 1, title: 1, author: 1, published: 1,
+                resource_type: 1, medium: 1, thumbnail: 1, thumbnail_blob: 1,
+                'enrichment.subject': 1, 'enrichment.genre': 1,
+                commons_width: 1, commons_height: 1,
+              },
+              maxTimeMS: 8000,
+            },
+          )
+          .sort({ author: 1, title: 1 })
+          .limit(60)
+          .toArray(),
+        8000, [],
+      )
+    : Promise.resolve([]);
+
   const [books, highlights, galleryImages, mentionedBooks] = await Promise.all([
     withTimeout(
       db.collection('books')
@@ -311,6 +336,8 @@ async function fetchCollectionData(id: string) {
         )
       : Promise.resolve([]),
   ]);
+
+  const artworks = await artworksPromise;
 
   // Fetch parent collection if this is a subcollection
   let parentCollection: { slug: string; name: string } | null = null;
@@ -430,6 +457,8 @@ async function fetchCollectionData(id: string) {
     exhibition: curationDraft?.curation || null,
     exhibitionBooks,
     childCollections: childCollections.map(({ _id, ...rest }) => rest) as { slug: string; name: string; subtitle?: string; book_count?: number; featured_images?: { extracted_url?: string; image_url?: string; thumbnail_url?: string }[] }[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    artworks: artworks as any[],
   };
 }
 
@@ -449,7 +478,7 @@ export default async function CollectionDetailPage({ params }: Props) {
   }
   if (!data) notFound();
 
-  const { collection, books, highlights: curatedHighlightsData, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, exhibition, exhibitionBooks, childCollections } = data;
+  const { collection, books, highlights: curatedHighlightsData, galleryImages, total, mentionedBooks, parentCollection, galleryCollectionSlug, exhibition, exhibitionBooks, childCollections, artworks } = data;
   const languages = (collection.languages || []).filter((l: { count: number }) => l.count > 2);
   const isArtCollection = collection.collection_type === 'visual_art';
   const itemLabel = isArtCollection ? 'works' : 'books';
@@ -758,6 +787,88 @@ export default async function CollectionDetailPage({ params }: Props) {
         </div>
       )}
 
+      {/* Visual Art — artworks tagged to this collection */}
+      {artworks.length > 0 && (
+        <div className="bg-warm border-b border-border-light">
+          <div className="max-w-7xl mx-auto px-6 py-8">
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-2xl sm:text-3xl text-primary font-display">
+                Visual Art
+              </h2>
+              <Link
+                href="/artwork"
+                className="text-sm text-muted hover:text-accent-rust transition-colors"
+              >
+                Browse all art &rarr;
+              </Link>
+            </div>
+            <p className="text-sm text-muted mb-5">
+              {artworks.length} {artworks.length === 1 ? 'work' : 'works'} of visual art in this collection
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {artworks.slice(0, 15).map((art: { id: string; slug?: string; title: string; author?: string; published?: string; resource_type?: string; medium?: string; thumbnail?: string; thumbnail_blob?: string; enrichment?: { subject?: string; genre?: string }; commons_width?: number; commons_height?: number }) => {
+                const thumb = sanitizeThumbnail(art.thumbnail_blob || art.thumbnail || '');
+                const isPortrait = (art.commons_height || 0) > (art.commons_width || 0);
+                return (
+                  <Link
+                    key={art.id}
+                    href={`/artwork/${art.slug || art.id}`}
+                    className="group block"
+                  >
+                    <div className="rounded-lg border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">
+                      <div className={`relative ${isPortrait ? 'aspect-[3/4]' : 'aspect-[4/3]'} bg-stone-100 overflow-hidden`}>
+                        {thumb ? (
+                          /* eslint-disable-next-line @next/next/no-img-element */
+                          <img
+                            src={thumb}
+                            alt={art.title}
+                            className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div className="absolute inset-0 flex items-center justify-center">
+                            <Images className="w-8 h-8 text-muted" />
+                          </div>
+                        )}
+                        {art.resource_type && art.resource_type !== 'printed_book' && (
+                          <span className="absolute top-2 left-2 text-[10px] bg-dark/70 text-white px-1.5 py-0.5 rounded capitalize">
+                            {art.resource_type}
+                          </span>
+                        )}
+                      </div>
+                      <div className="p-3">
+                        <h3
+                          className="text-sm font-semibold text-primary group-hover:text-accent-rust transition-colors leading-tight line-clamp-2 mb-1"
+                          style={{ fontFamily: 'var(--font-serif)' }}
+                        >
+                          {art.title}
+                        </h3>
+                        {art.author && (
+                          <p className="text-xs text-muted line-clamp-1">{art.author}</p>
+                        )}
+                        {art.enrichment?.subject && (
+                          <p className="text-xs text-secondary mt-1 line-clamp-2 leading-relaxed">
+                            {art.enrichment.subject}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+              {artworks.length > 15 && (
+                <Link
+                  href={`/artwork`}
+                  className="flex items-center justify-center rounded-lg border border-dashed border-border-light hover:border-accent-rust/40 hover:bg-warm transition-all aspect-[4/3] text-sm text-muted hover:text-accent-rust"
+                >
+                  +{artworks.length - 15} more works
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Overview description */}
       {!exhibition?.layout && (collection.expanded_description || collection.description) && (
         <div className="bg-warm border-b border-border-light">
@@ -953,7 +1064,7 @@ export default async function CollectionDetailPage({ params }: Props) {
         {/* All Books — client component handles compact → expanded transition */}
         <CollectionAllBooks
           collectionId={id}
-          compactBooks={books}
+          compactBooks={books.filter(b => !b.resource_type)}
           total={total}
           languages={languages}
           collectionType={collection.collection_type}

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -117,7 +117,9 @@ export default function CollectionAllBooks({
       const res = await fetch(`/api/collections/${collectionId}?mode=manifest`);
       if (!res.ok) throw new Error('Failed to fetch');
       const data = await res.json();
-      setAllBooks(data.books || []);
+      // Filter out artworks — they have their own section on the collection page
+      const booksOnly = (data.books || []).filter((b: BookItem & { resource_type?: string }) => !b.resource_type);
+      setAllBooks(booksOnly);
     } catch {
       // Keep existing state on error
     } finally {


### PR DESCRIPTION
## Summary
- Collections can now contain both books AND artworks. The Alchemy collection shows alchemical texts alongside alchemical art, the Hermetica collection shows Hermetic texts alongside Hermetic paintings, etc.
- Artworks render in a "Visual Art" section with thumbnails, resource type badges, and enrichment subjects
- Fixed `artwork-enrichment.mjs` to write to the `collections` array (which the system actually uses) instead of the dead `collection_slugs` field
- Enrichment running now on all ~2,700 artworks — will tag them into topical collections like alchemy, hermetica, kabbalah, etc.

## Changes
- **API** (`/api/collections/[id]`): OR filter includes `resource_type` items alongside visible translated books
- **Collection page**: New "Visual Art" section between gallery/description, separate from "All Books"
- **CollectionAllBooks**: Filters out artworks from the book listing to avoid duplicates
- **artwork-enrichment.mjs**: Uses `$addToSet` on `collections` instead of `$set` on `collection_slugs`

## Test plan
- [ ] Visit a collection that has artworks tagged (e.g., alchemy after enrichment completes)
- [ ] Verify artworks appear in the Visual Art section with correct thumbnails
- [ ] Verify artwork cards link to `/artwork/slug`
- [ ] Verify books-only collections render normally (no empty Visual Art section)
- [ ] Verify pure art collections (`collection_type: 'visual_art'`) still work in `/artwork`

🤖 Generated with [Claude Code](https://claude.com/claude-code)