### PR TITLE
Author page: bibliography table with rich metadata

### DIFF
--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -4,6 +4,7 @@ import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { notFound, redirect } from 'next/navigation';
 import { bookUrl, authorSlug } from '@/lib/slugify';
+import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { ObjectId } from 'mongodb';
 
 interface Book {
@@ -14,11 +15,17 @@ interface Book {
   author: string;
   language: string;
   published: string;
+  year?: number;
   thumbnail?: string;
   pages_count?: number;
+  pages_ocr?: number;
   pages_translated?: number;
+  pages_blank?: number;
   translation_percent?: number;
   summary?: { data: string } | string;
+  is_first_translation?: boolean;
+  ft_disposition?: string;
+  image_source?: { contributing_library?: string; provider_name?: string };
 }
 
 interface AuthorEntity {
@@ -55,9 +62,10 @@ interface AuthorPageProps {
  */
 const BOOK_PROJECTION = {
   _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
-  author_entity_id: 1, language: 1, published: 1, thumbnail: 1,
+  author_entity_id: 1, language: 1, published: 1,
   pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_blank: 1, year: 1,
-  summary: 1,
+  summary: 1, is_first_translation: 1, ft_disposition: 1,
+  'image_source.contributing_library': 1, 'image_source.provider_name': 1,
 };
 
 function computeBooks(raw: any[]): Book[] {
@@ -334,48 +342,80 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         </div>
       </div>
 
-      {/* Content — catalog list */}
-      <main className="max-w-4xl mx-auto px-6 md:px-12 py-8 md:py-12">
-        <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
-          {books.map(book => {
-            const summaryText = typeof book.summary === 'string'
-              ? book.summary
-              : book.summary?.data;
-            const pct = book.translation_percent ?? 0;
+      {/* Content — bibliography table */}
+      <main className="max-w-6xl mx-auto px-6 md:px-12 py-8 md:py-12">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b text-xs uppercase tracking-wide" style={{ borderColor: 'var(--border-medium)', color: 'var(--text-muted)' }}>
+                <th className="pb-3 pr-4 font-medium">Title</th>
+                <th className="pb-3 pr-4 font-medium w-16">Year</th>
+                <th className="pb-3 pr-4 font-medium hidden md:table-cell w-24">Language</th>
+                <th className="pb-3 pr-4 font-medium hidden lg:table-cell">Source</th>
+                <th className="pb-3 font-medium hidden sm:table-cell w-20 text-right">Pages</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+              {books.map(book => {
+                const pct = book.translation_percent ?? 0;
+                const hasOriginalTitle = book.display_title && book.title !== book.display_title;
+                const source = book.image_source?.contributing_library || book.image_source?.provider_name;
 
-            return (
-              <Link
-                key={book.id}
-                href={bookUrl(book)}
-                className="flex items-start gap-4 py-4 hover:opacity-70 transition-opacity"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
-                    {book.display_title || book.title}
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                    {book.published || ''}
-                    {book.language ? ` · ${book.language}` : ''}
-                    {book.pages_count ? ` · ${book.pages_count} pp.` : ''}
-                  </p>
-                  {summaryText && (
-                    <p className="text-xs mt-1 line-clamp-1" style={{ color: 'var(--text-faint)' }}>
-                      {summaryText}
-                    </p>
-                  )}
-                </div>
-                <span className={`shrink-0 px-2 py-0.5 rounded text-xs font-medium ${
-                  pct >= 95
-                    ? 'bg-status-success/10 text-status-success'
-                    : pct > 0
-                      ? 'bg-accent-gold/10 text-accent-gold'
-                      : 'bg-stone-100 text-stone-400'
-                }`}>
-                  {pct >= 95 ? 'Translated' : `${pct}%`}
-                </span>
-              </Link>
-            );
-          })}
+                return (
+                  <tr key={book.id} className="group" style={{ transition: 'background 150ms' }}>
+                    <td className="py-3 pr-4">
+                      <Link href={bookUrl(book)} className="block">
+                        <span
+                          className="text-sm font-medium line-clamp-1"
+                          style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-serif)' }}
+                        >
+                          {book.display_title || book.title}
+                        </span>
+                        {book.is_first_translation && (
+                          <span className="inline-block ml-2 bg-accent-gold/15 text-[10px] px-1.5 py-0.5 rounded-full font-medium align-middle" style={{ color: 'var(--accent-gold-dark)' }}>
+                            {firstTranslationBadge(book.ft_disposition, book.language)}
+                          </span>
+                        )}
+                        {hasOriginalTitle && (
+                          <span className="block text-xs mt-0.5 line-clamp-1 italic" style={{ color: 'var(--text-faint)' }}>
+                            {book.title}
+                          </span>
+                        )}
+                      </Link>
+                    </td>
+                    <td className="py-3 pr-4 text-sm tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                      <Link href={bookUrl(book)} className="block">
+                        {book.year || book.published || '—'}
+                      </Link>
+                    </td>
+                    <td className="py-3 pr-4 hidden md:table-cell">
+                      <Link href={bookUrl(book)} className="block">
+                        <span className="text-xs px-2 py-0.5 rounded" style={{ color: 'var(--text-muted)', background: 'var(--bg-warm)' }}>
+                          {book.language || '—'}
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="py-3 pr-4 hidden lg:table-cell">
+                      <Link href={bookUrl(book)} className="block text-xs line-clamp-1" style={{ color: 'var(--text-faint)' }}>
+                        {source || '—'}
+                      </Link>
+                    </td>
+                    <td className="py-3 hidden sm:table-cell text-right">
+                      <Link href={bookUrl(book)} className="block text-sm tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                        {book.pages_count || '—'}
+                        {pct > 0 && pct < 95 && (
+                          <span className="text-[10px] ml-1" style={{ color: 'var(--accent-gold-dark)' }}>{pct}%</span>
+                        )}
+                        {pct >= 95 && (
+                          <span className="text-[10px] ml-1" style={{ color: 'var(--status-success)' }}>done</span>
+                        )}
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
Replace author page content with a proper bibliography table matching the /catalog style. Since all books share the same author, the Author column is replaced with more useful metadata.

**Columns:** Title (+ original title in italics) | Year | Language | Source (contributing library) | Pages + translation %

**Also shows:** First-translation badges, original Latin/Greek titles under the English display title.

## Test plan
- [ ] Visit https://sourcelibrary.org/author/marsilio-ficino — should show table with original titles
- [ ] Compare layout with https://sourcelibrary.org/catalog — same visual language
- [ ] Check mobile — Title + Year columns always visible, Language/Source/Pages responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)