### PR TITLE
Fix inscription translation save + --needs-translation flag

### DIFF
--- a/scripts/artwork-enrichment.mjs
+++ b/scripts/artwork-enrichment.mjs
@@ -15,6 +15,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const FORCE = process.argv.includes('--force');
+const NEEDS_TRANSLATION = process.argv.includes('--needs-translation');
 const LIMIT = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--limit') || '10');
 const ARTIST_FILTER = process.argv.find((_, i, a) => a[i - 1] === '--artist') || null;
 const PROVIDER_FILTER = process.argv.find((_, i, a) => a[i - 1] === '--provider') || null;
@@ -158,7 +159,13 @@ async function main() {
 
   // Build query — resource_type_sparse index makes this fast
   const query = { resource_type: { $exists: true } };
-  if (!FORCE) query.enrichment = { $exists: false };
+  if (NEEDS_TRANSLATION) {
+    // Target artworks with readable text but no translation yet
+    query['enrichment.has_readable_text'] = true;
+    query['enrichment.inscriptions_translation'] = { $exists: false };
+  } else if (!FORCE) {
+    query.enrichment = { $exists: false };
+  }
   if (ARTIST_FILTER) query.author = ARTIST_FILTER;
   if (PROVIDER_FILTER) query['image_source.provider'] = PROVIDER_FILTER;
 
@@ -231,6 +238,8 @@ async function main() {
             genre: enrichment.genre,
             cross_references: enrichment.cross_references || [],
             inscriptions: enrichment.inscriptions || null,
+            inscriptions_translation: enrichment.inscriptions_translation || null,
+            inscriptions_language: enrichment.inscriptions_language || null,
             has_readable_text: !!enrichment.has_readable_text,
             figures_depicted: enrichment.figures_depicted || [],
             symbols: enrichment.symbols || [],


### PR DESCRIPTION
## Summary
- **Bug fix**: enrichment save code explicitly mapped fields but was missing `inscriptions_translation` and `inscriptions_language` — Gemini produced translations but they were silently dropped on write
- **New flag**: `--needs-translation` targets artworks with `has_readable_text: true` but no `inscriptions_translation` field

## Context
3,755 artworks with readable text (Latin inscriptions on Goltzius, Dürer, Rembrandt prints, etc.) are being re-enriched with the fixed code. ~16h run in progress (PID 40524, log at `/tmp/artwork-enrichment-translations.log`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)