### PR TITLE
Fix NaN stats + prioritize batch-able books in pool

### DIFF
--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -341,7 +341,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
       { $set: { 'pipeline_auto.status': 'translate_complete', updated_at: new Date() }, $unset: { job: '' } },
     );
     console.log(`  [${label}] Already complete`);
-    return { translated: 0, failed: 0 };
+    return { translated: 0, failed: 0, completed: 1, inputTokens: 0, outputTokens: 0 };
   }
 
   const batchMode = effectiveBatchSize(pages, BATCH_SIZE) > 1 ? `batch-${BATCH_SIZE}` : 'single';
@@ -997,8 +997,9 @@ async function main() {
 
   console.log(`[TRANSLATE] Starting pool (concurrency: ${CONCURRENCY}, deadline: ${Math.round(RUN_DEADLINE_MS/60000)}min, ${batchLabel})`);
 
-  // Seed the queue with initial books
-  const queue = [...books];
+  // Seed the queue with initial books, sorted by speed tier (fast/batch-able first)
+  // This ensures Latin-script books (batch-5, ~5x faster) fill slots before manuscripts
+  const queue = [...books].sort((a, b) => langSpeedTier(a.language) - langSpeedTier(b.language));
   books.forEach(b => processedIds.add(b.id));
   let activeSlots = 0;
 
@@ -1024,6 +1025,8 @@ async function main() {
           if (queue.length < 3 && Date.now() < deadline && globalCounter.count < PAGES_PER_RUN) {
             fetchMoreBooks(CONCURRENCY).then(more => {
               const newBooks = more.filter(b => !processedIds.has(b.id));
+              // Sort fast books first so they fill freed slots before slow manuscripts
+              newBooks.sort((a, b) => langSpeedTier(a.language) - langSpeedTier(b.language));
               newBooks.forEach(b => { processedIds.add(b.id); queue.push(b); });
               if (newBooks.length > 0) console.log(`[TRANSLATE] Backfilled ${newBooks.length} books (queue: ${queue.length})`);
               tryStartNext();


### PR DESCRIPTION
## Summary
1. **Fix NaN:** processBook's 'already complete' return was missing fields, causing NaN in cost/completed stats.
2. **Speed tier sorting:** Queue now sorts Latin-script books (batch-5, ~5x faster) before non-Latin manuscripts (single-page). Prevents slow Syriac/Hebrew/Armenian books from filling all 15 slots while doing only 15-25 pages each.

Current problem: rate dropped from 17K to 8K/hr because manuscripts (single-page mode, 15p per 15min) are mixed in equally with Latin books (batch-5, 200p per 15min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)