### PR TITLE
Migrate /catalog to Supabase server-side pagination

### DIFF
--- a/src/app/api/catalog/browse/route.ts
+++ b/src/app/api/catalog/browse/route.ts
@@ -1,120 +1,48 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { browseBooks, getLanguageCounts, type SortOption } from '@/lib/books-catalog';
 
-export const maxDuration = 30;
+export const maxDuration = 15;
+
+const VALID_SORTS = new Set<SortOption>([
+  'popular', 'recent', 'last_translated', 'title', 'author', 'year_asc', 'year_desc',
+]);
 
 /**
  * GET /api/catalog/browse
  *
- * Returns lightweight manifest of all visible, translated books for
- * the full-library catalog view. Client-side filter/sort/paginate.
+ * Server-side paginated catalog browse powered by Supabase books_catalog.
+ * Replaces the old MongoDB snapshot approach.
  *
- * Uses a cached snapshot in system_config (refreshed by ?refresh=1 or
- * when stale >6h). Direct query takes ~15s on Atlas — too slow for
- * every page load.
+ * Query params: sort, language, q, page, limit
  */
 export async function GET(request: Request) {
   try {
-    const db = await getDb();
     const { searchParams } = new URL(request.url);
-    const forceRefresh = searchParams.get('refresh') === '1';
+    const sortRaw = searchParams.get('sort') || 'popular';
+    const sort: SortOption = VALID_SORTS.has(sortRaw as SortOption) ? (sortRaw as SortOption) : 'popular';
+    const language = searchParams.get('language') || undefined;
+    const search = searchParams.get('q') || undefined;
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const limit = Math.min(120, Math.max(1, parseInt(searchParams.get('limit') || '60', 10)));
+    const offset = (page - 1) * limit;
+    const includeLangs = searchParams.get('langs') === '1';
 
-    // Try cached snapshot first
-    if (!forceRefresh) {
-      const cached = await db.collection('system_config').findOne(
-        { _id: 'catalog_browse_snapshot' } as any,
-        { maxTimeMS: 3000 },
-      );
-      if (cached?.books && cached?.updated_at) {
-        const age = Date.now() - new Date(cached.updated_at).getTime();
-        // Serve cache if <6h old
-        if (age < 6 * 60 * 60 * 1000) {
-          return NextResponse.json(
-            { books: cached.books, languages: cached.languages, total: cached.books.length },
-            { headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=60' } },
-          );
-        }
-      }
-    }
+    const promises: [Promise<{ books: unknown[]; total: number }>, Promise<{ lang: string; count: number }[]> | null] = [
+      browseBooks({ hasTranslation: true, language, search, sort, offset, limit }),
+      includeLangs ? getLanguageCounts({}) : null,
+    ];
 
-    // Cache miss or stale — rebuild from books collection
-    const filter = {
-      visible: true,
-      pages_count: { $gt: 0 },
-      pages_translated: { $gt: 0 },
-    };
+    const [result, languages] = await Promise.all([
+      promises[0],
+      promises[1] || Promise.resolve(null),
+    ]);
 
-    const projection = {
-      _id: 0,
-      id: 1,
-      slug: 1,
-      title: 1,
-      display_title: 1,
-      author: 1,
-      year: 1,
-      language: 1,
-      pages_count: 1,
-      pages_ocr: 1,
-      pages_translated: 1,
-      pages_blank: 1,
-      published: 1,
-      read_count: 1,
-      thumbnail: 1,
-      thumbnail_blob: 1,
-      is_first_translation: 1,
-      ft_disposition: 1,
-      created_at: 1,
-      last_translation_at: 1,
-    };
-
-    const books = await db
-      .collection('books')
-      .find(filter, { projection })
-      .hint('books_visible_created_idx')
-      .maxTimeMS(25000)
-      .toArray();
-
-    // Language facet
-    const langMap = new Map<string, number>();
-    for (const b of books) {
-      if (b.language) {
-        langMap.set(b.language, (langMap.get(b.language) || 0) + 1);
-      }
-    }
-    const languages = [...langMap.entries()]
-      .map(([lang, count]) => ({ lang, count }))
-      .sort((a, b) => b.count - a.count);
-
-    // Write snapshot to system_config (fire-and-forget)
-    db.collection('system_config').updateOne(
-      { _id: 'catalog_browse_snapshot' } as any,
-      { $set: { books, languages, updated_at: new Date().toISOString() } },
-      { upsert: true },
-    ).catch(() => {});
-
-    return NextResponse.json({ books, languages, total: books.length }, {
-      headers: {
-        'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=60',
-      },
-    });
+    return NextResponse.json(
+      { books: result.books, total: result.total, ...(languages ? { languages } : {}) },
+      { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30' } },
+    );
   } catch (err) {
     console.error('Catalog browse error:', err);
-
-    // Last resort: try serving stale cache
-    try {
-      const db = await getDb();
-      const cached = await db.collection('system_config').findOne(
-        { _id: 'catalog_browse_snapshot' } as any,
-        { maxTimeMS: 3000 },
-      );
-      if (cached?.books) {
-        return NextResponse.json(
-          { books: cached.books, languages: cached.languages, total: cached.books.length },
-          { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30' } },
-        );
-      }
-    } catch { /* ignore */ }
-
     return NextResponse.json({ error: 'Failed to load catalog' }, { status: 500 });
   }
 }

--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -1,6 +1,9 @@
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
 import CatalogBrowser from '@/components/catalog/CatalogBrowser';
+import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
+
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: 'Catalog - Source Library',
@@ -8,7 +11,12 @@ export const metadata: Metadata = {
   alternates: { canonical: '/catalog' },
 };
 
-export default function CatalogPage() {
+export default async function CatalogPage() {
+  const [{ books, total }, languages] = await Promise.all([
+    browseBooks({ hasTranslation: true, sort: 'popular', limit: 60 }),
+    getLanguageCounts({}),
+  ]);
+
   return (
     <>
       <SiteHeader variant="light" />
@@ -20,7 +28,11 @@ export default function CatalogPage() {
           Every translated book in the library.
         </p>
 
-        <CatalogBrowser />
+        <CatalogBrowser
+          initialBooks={books}
+          initialTotal={total}
+          languages={languages}
+        />
       </div>
     </>
   );

--- a/src/components/catalog/CatalogBrowser.tsx
+++ b/src/components/catalog/CatalogBrowser.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { Search, X, LayoutGrid, List } from 'lucide-react';
 import CollectionBookCard from '@/components/CollectionBookCard';
 import CollectionListView from '@/components/collections/CollectionListView';
@@ -10,25 +10,23 @@ const PER_PAGE = 60;
 
 interface BookItem {
   id: string;
-  slug?: string;
+  slug?: string | null;
   title: string;
-  display_title?: string;
-  author?: string;
-  year?: number;
-  language?: string;
+  display_title?: string | null;
+  author?: string | null;
+  year?: number | null;
+  language?: string | null;
   pages_count?: number;
   pages_ocr?: number;
   pages_translated?: number;
   pages_blank?: number;
-  photo?: string;
-  thumbnail?: string;
-  thumbnail_blob?: string;
-  published?: string;
+  photo?: string | null;
+  thumbnail?: string | null;
+  thumbnail_blob?: string | null;
+  published?: string | null;
   read_count?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
-  created_at?: string;
-  last_translation_at?: string;
 }
 
 type ViewMode = 'grid' | 'list';
@@ -38,48 +36,16 @@ function getStoredView(): ViewMode | null {
   return localStorage.getItem('sl-catalog-view') as ViewMode | null;
 }
 
-function sortBooks(books: BookItem[], sort: string): BookItem[] {
-  const sorted = [...books];
-  switch (sort) {
-    case 'year_asc':
-      return sorted.sort((a, b) => (a.year || 9999) - (b.year || 9999) || (a.title || '').localeCompare(b.title || ''));
-    case 'year_desc':
-      return sorted.sort((a, b) => (b.year || 0) - (a.year || 0) || (a.title || '').localeCompare(b.title || ''));
-    case 'title':
-      return sorted.sort((a, b) => (a.display_title || a.title || '').localeCompare(b.display_title || b.title || ''));
-    case 'author':
-      return sorted.sort((a, b) => (a.author || 'zzz').localeCompare(b.author || 'zzz') || (a.title || '').localeCompare(b.title || ''));
-    case 'recent':
-      return sorted.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
-    case 'last_translated':
-      return sorted.sort((a, b) => (b.last_translation_at || '').localeCompare(a.last_translation_at || ''));
-    case 'popular':
-      return sorted.sort((a, b) => (b.read_count || 0) - (a.read_count || 0) || (a.title || '').localeCompare(b.title || ''));
-    default:
-      return sorted.sort((a, b) => (b.read_count || 0) - (a.read_count || 0));
-  }
+interface CatalogBrowserProps {
+  initialBooks: BookItem[];
+  initialTotal: number;
+  languages: { lang: string; count: number }[];
 }
 
-function filterBooks(books: BookItem[], query: string, language: string): BookItem[] {
-  let result = books;
-  if (language) {
-    result = result.filter(b => b.language === language);
-  }
-  if (query) {
-    const q = query.toLowerCase();
-    result = result.filter(b =>
-      (b.title || '').toLowerCase().includes(q) ||
-      (b.display_title || '').toLowerCase().includes(q) ||
-      (b.author || '').toLowerCase().includes(q)
-    );
-  }
-  return result;
-}
-
-export default function CatalogBrowser() {
-  const [allBooks, setAllBooks] = useState<BookItem[]>([]);
-  const [languages, setLanguages] = useState<{ lang: string; count: number }[]>([]);
-  const [loading, setLoading] = useState(true);
+export default function CatalogBrowser({ initialBooks, initialTotal, languages }: CatalogBrowserProps) {
+  const [books, setBooks] = useState<BookItem[]>(initialBooks);
+  const [total, setTotal] = useState(initialTotal);
+  const [loading, setLoading] = useState(false);
   const [sort, setSort] = useState('popular');
   const [language, setLanguage] = useState('');
   const [query, setQuery] = useState('');
@@ -87,46 +53,68 @@ export default function CatalogBrowser() {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const searchRef = useRef<HTMLInputElement>(null);
   const initializedRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
-  // Fetch manifest on mount
+  const totalPages = Math.ceil(total / PER_PAGE);
+
+  // Fetch from API with current filters
+  const fetchBooks = useCallback(async (params: {
+    sort: string; language: string; query: string; page: number;
+  }) => {
+    // Cancel any in-flight request
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams();
+      if (params.sort !== 'popular') qs.set('sort', params.sort);
+      if (params.language) qs.set('language', params.language);
+      if (params.query) qs.set('q', params.query);
+      if (params.page > 1) qs.set('page', String(params.page));
+
+      const res = await fetch(`/api/catalog/browse?${qs.toString()}`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error('fetch failed');
+      const data = await res.json();
+      setBooks(data.books || []);
+      setTotal(data.total || 0);
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+      // Keep current state on error
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  // Initialize from URL params on mount
   useEffect(() => {
     if (initializedRef.current) return;
     initializedRef.current = true;
 
-    // Read URL state
     const params = new URLSearchParams(window.location.search);
-    const urlSort = params.get('sort');
-    const urlLang = params.get('language');
-    const urlQ = params.get('q');
-    const urlPage = params.get('page');
+    const urlSort = params.get('sort') || 'popular';
+    const urlLang = params.get('language') || '';
+    const urlQ = params.get('q') || '';
+    const urlPage = parseInt(params.get('page') || '1', 10);
     const urlView = params.get('view') as ViewMode | null;
     const storedView = getStoredView();
 
-    if (urlSort) setSort(urlSort);
-    if (urlLang) setLanguage(urlLang);
-    if (urlQ) setQuery(urlQ);
-    if (urlPage) setCurrentPage(parseInt(urlPage));
+    setSort(urlSort);
+    setLanguage(urlLang);
+    setQuery(urlQ);
+    setCurrentPage(urlPage);
     setViewMode(urlView || storedView || 'list');
 
-    fetch('/api/catalog/browse')
-      .then(res => res.json())
-      .then(data => {
-        setAllBooks(data.books || []);
-        setLanguages(data.languages || []);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, []);
-
-  // Client-side filter → sort → paginate
-  const filtered = useMemo(() => filterBooks(allBooks, query, language), [allBooks, query, language]);
-  const sorted = useMemo(() => sortBooks(filtered, sort), [filtered, sort]);
-  const totalPages = Math.ceil(sorted.length / PER_PAGE);
-  const safePage = Math.min(currentPage, Math.max(1, totalPages));
-  const pageBooks = useMemo(
-    () => sorted.slice((safePage - 1) * PER_PAGE, safePage * PER_PAGE),
-    [sorted, safePage],
-  );
+    // If URL has non-default params, fetch that specific page
+    const isDefault = urlSort === 'popular' && !urlLang && !urlQ && urlPage === 1;
+    if (!isDefault) {
+      fetchBooks({ sort: urlSort, language: urlLang, query: urlQ, page: urlPage });
+    }
+  }, [fetchBooks]);
 
   const updateUrl = useCallback((s: string, lang: string, page: number, q: string, view: ViewMode) => {
     const params = new URLSearchParams();
@@ -143,24 +131,33 @@ export default function CatalogBrowser() {
     setSort(newSort);
     setCurrentPage(1);
     updateUrl(newSort, language, 1, query, viewMode);
-  }, [language, query, updateUrl, viewMode]);
+    fetchBooks({ sort: newSort, language, query, page: 1 });
+  }, [language, query, viewMode, updateUrl, fetchBooks]);
 
   const handleLanguage = useCallback((newLang: string) => {
     setLanguage(newLang);
     setCurrentPage(1);
     updateUrl(sort, newLang, 1, query, viewMode);
-  }, [sort, query, updateUrl, viewMode]);
+    fetchBooks({ sort, language: newLang, query, page: 1 });
+  }, [sort, query, viewMode, updateUrl, fetchBooks]);
 
   const handleSearch = useCallback((value: string) => {
     setQuery(value);
     setCurrentPage(1);
-  }, []);
+    // Debounce API call
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      updateUrl(sort, language, 1, value, viewMode);
+      fetchBooks({ sort, language, query: value, page: 1 });
+    }, 300);
+  }, [sort, language, viewMode, updateUrl, fetchBooks]);
 
   const handlePage = useCallback((page: number) => {
     setCurrentPage(page);
     updateUrl(sort, language, page, query, viewMode);
+    fetchBooks({ sort, language, query, page });
     window.scrollTo({ top: 0, behavior: 'smooth' });
-  }, [sort, language, query, updateUrl, viewMode]);
+  }, [sort, language, query, viewMode, updateUrl, fetchBooks]);
 
   const handleViewToggle = useCallback((mode: ViewMode) => {
     setViewMode(mode);
@@ -174,12 +171,10 @@ export default function CatalogBrowser() {
       <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
         <div>
           <p className="text-sm text-muted">
-            {loading ? (
-              'Loading catalog...'
-            ) : query || language ? (
-              `${sorted.length.toLocaleString()} of ${allBooks.length.toLocaleString()} books`
+            {query || language ? (
+              `${total.toLocaleString()} of ${initialTotal.toLocaleString()} books`
             ) : (
-              `${allBooks.length.toLocaleString()} books`
+              `${total.toLocaleString()} books`
             )}
           </p>
         </div>
@@ -222,8 +217,8 @@ export default function CatalogBrowser() {
             <option value="popular">Most read</option>
             <option value="recent">Recently added</option>
             <option value="last_translated">Recently translated</option>
-            <option value="title">Title A–Z</option>
-            <option value="author">Author A–Z</option>
+            <option value="title">Title A-Z</option>
+            <option value="author">Author A-Z</option>
             <option value="year_asc">Year (oldest)</option>
             <option value="year_desc">Year (newest)</option>
           </select>
@@ -255,7 +250,14 @@ export default function CatalogBrowser() {
             />
             {query && (
               <button
-                onClick={() => { setQuery(''); searchRef.current?.focus(); }}
+                onClick={() => {
+                  setQuery('');
+                  setCurrentPage(1);
+                  if (debounceRef.current) clearTimeout(debounceRef.current);
+                  updateUrl(sort, language, 1, '', viewMode);
+                  fetchBooks({ sort, language, query: '', page: 1 });
+                  searchRef.current?.focus();
+                }}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-primary cursor-pointer"
               >
                 <X className="w-3.5 h-3.5" />
@@ -266,40 +268,45 @@ export default function CatalogBrowser() {
       </div>
 
       {/* Book list/grid */}
-      {loading ? (
-        <div className="py-20 text-center text-muted">Loading...</div>
-      ) : sorted.length === 0 ? (
-        <div className="py-20 text-center text-muted">
-          No books match your filters.
-        </div>
-      ) : viewMode === 'list' ? (
-        <CollectionListView
-          books={pageBooks}
-          sort={sort}
-          onSort={handleSort}
-          loading={loading}
-        />
-      ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 md:gap-5">
-          {pageBooks.map(book => (
-            <CollectionBookCard
-              key={book.id}
-              book={{
-                ...book,
-                bookId: book.id,
-                author: book.author || 'Unknown',
-                year: book.year || 0,
-                pages_count: book.pages_count || 0,
-                pages_translated: book.pages_translated || 0,
-                pages_ocr: book.pages_ocr || 0,
-              }}
-            />
-          ))}
-        </div>
-      )}
+      <div className={loading ? 'opacity-60 pointer-events-none transition-opacity' : 'transition-opacity'}>
+        {books.length === 0 && !loading ? (
+          <div className="py-20 text-center text-muted">
+            No books match your filters.
+          </div>
+        ) : viewMode === 'list' ? (
+          <CollectionListView
+            books={books as any}
+            sort={sort}
+            onSort={handleSort}
+            loading={loading}
+          />
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 md:gap-5">
+            {books.map(book => (
+              <CollectionBookCard
+                key={book.id}
+                book={{
+                  ...book,
+                  bookId: book.id,
+                  slug: book.slug || undefined,
+                  author: book.author || 'Unknown',
+                  year: book.year || 0,
+                  pages_count: book.pages_count || 0,
+                  pages_translated: book.pages_translated || 0,
+                  pages_ocr: book.pages_ocr || 0,
+                  thumbnail: book.thumbnail || undefined,
+                  thumbnail_blob: book.thumbnail_blob || undefined,
+                  language: book.language || undefined,
+                  published: book.published || undefined,
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
 
       <CatalogPagination
-        currentPage={safePage}
+        currentPage={currentPage}
         totalPages={totalPages}
         onPageChange={handlePage}
       />

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -36,7 +36,7 @@ export interface CatalogBook {
 
 const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections';
 
-export type SortOption = 'popular' | 'title' | 'year_asc' | 'year_desc' | 'recent' | 'quality';
+export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function applySort(query: any, sort: SortOption) {
@@ -44,7 +44,9 @@ function applySort(query: any, sort: SortOption) {
     case 'title': return query.order('sort_title', { ascending: true });
     case 'year_asc': return query.order('year', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
     case 'year_desc': return query.order('year', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
+    case 'author': return query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
     case 'recent': return query.order('created_at', { ascending: false });
+    case 'last_translated': return query.order('last_translation_at', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
     case 'quality': return query.order('quality_score', { ascending: false }).order('title', { ascending: true });
     case 'popular':
     default: return query.order('read_count', { ascending: false, nullsFirst: false }).order('title', { ascending: true });


### PR DESCRIPTION
## Summary
- Replaces the MongoDB snapshot approach (fetching all ~17K books as JSON, filtering client-side) with Supabase `browseBooks()` server-side pagination
- Initial page data loaded server-side (ISR, revalidate=600), subsequent interactions fetch paginated results from `/api/catalog/browse`
- Adds `author` and `last_translated` sort options to `books-catalog.ts`
- Same visual UI and UX preserved: grid/list toggle, all sort options, language filter, search with 300ms debounce, URL params for shareability

## Changes
- `src/app/catalog/page.tsx` — server component, fetches initial 60 books + language counts
- `src/components/catalog/CatalogBrowser.tsx` — accepts server-rendered initial data, fetches from API on interaction
- `src/app/api/catalog/browse/route.ts` — thin Supabase wrapper replacing MongoDB snapshot
- `src/lib/books-catalog.ts` — added `author` and `last_translated` sort options

## What's NOT changed
- `/api/catalog/route.ts` (machine-readable export) untouched
- `/api/catalog/search` and `/api/catalog/coverage` untouched
- `catalog_browse_snapshot` in system_config left in place (cleanup separate)

## Test plan
- [ ] Visit /catalog — should load instantly with server-rendered first page
- [ ] Change sort (all 7 options), verify results update
- [ ] Filter by language, verify count updates
- [ ] Search by title/author, verify debounced results
- [ ] Paginate through results
- [ ] Toggle grid/list view
- [ ] Verify URL params persist on reload
- [ ] Check network tab — no more 2MB+ JSON payload on initial load

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)