### PR TITLE
Security hardening: regex injection, OIDC tokens, fail-closed auth

### DIFF
--- a/src/app/api/auth/oidc/authorize/route.ts
+++ b/src/app/api/auth/oidc/authorize/route.ts
@@ -23,6 +23,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'invalid_client' }, { status: 400 });
   }
 
+  // Validate redirect_uri against allowed origins
+  try {
+    const redirectHost = new URL(redirectUri).hostname;
+    const allowedHosts = (process.env.OIDC_ALLOWED_REDIRECT_HOSTS || 'chat.embassyofthefreemind.com').split(',');
+    if (!allowedHosts.some(h => redirectHost === h.trim() || redirectHost.endsWith('.' + h.trim()))) {
+      return NextResponse.json({ error: 'invalid_redirect_uri' }, { status: 400 });
+    }
+  } catch {
+    return NextResponse.json({ error: 'invalid_redirect_uri' }, { status: 400 });
+  }
+
   // Check if user is signed in to Source Library
   const session = await auth();
 

--- a/src/app/api/auth/oidc/debug/route.ts
+++ b/src/app/api/auth/oidc/debug/route.ts
@@ -1,14 +1,15 @@
 import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export const GET = withAdminAuth(async () => {
   const db = await getDb();
   const count = await db.collection('oidc_auth_codes').countDocuments();
-  return NextResponse.json({ 
+  return NextResponse.json({
     version: 'mongodb-v3',
     codesInDb: count,
     timestamp: new Date().toISOString(),
   });
-}
+});

--- a/src/app/api/entities/[id]/route.ts
+++ b/src/app/api/entities/[id]/route.ts
@@ -4,6 +4,10 @@ import { ObjectId } from 'mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 import { buildEntityJsonLd } from '@/lib/jsonld';
 
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * GET /api/entities/[id]
  *
@@ -28,7 +32,7 @@ export async function GET(
     if (!entity) {
       const decodedName = decodeURIComponent(id);
       entity = await db.collection('entities').findOne(
-        { name: { $regex: `^${decodedName}$`, $options: 'i' } },
+        { name: { $regex: `^${escapeRegex(decodedName)}$`, $options: 'i' } },
         { sort: { book_count: -1 } }
       );
     }

--- a/src/lib/cron-auth.ts
+++ b/src/lib/cron-auth.ts
@@ -11,7 +11,10 @@ import { NextRequest, NextResponse } from 'next/server';
 export function verifyCronAuth(request: NextRequest): NextResponse | null {
   const secret = process.env.CRON_SECRET;
   if (!secret) {
-    // If CRON_SECRET isn't configured, allow (development mode)
+    if (process.env.NODE_ENV === 'production') {
+      return NextResponse.json({ error: 'CRON_SECRET not configured' }, { status: 500 });
+    }
+    // Development mode — allow without secret
     return null;
   }
 

--- a/src/lib/oidc/provider.ts
+++ b/src/lib/oidc/provider.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHash, createSign, createPrivateKey, createPublicKey } from 'crypto';
+import { randomBytes, createHash, createHmac, createSign, createPrivateKey, createPublicKey } from 'crypto';
 import { ObjectId } from 'mongodb';
 import { getDb } from '@/lib/mongodb';
 
@@ -8,7 +8,10 @@ import { getDb } from '@/lib/mongodb';
  */
 
 const OIDC_CLIENT_ID = 'synapse-embassy';
-const OIDC_CLIENT_SECRET = process.env.OIDC_CLIENT_SECRET || 'embassy-oidc-secret-2026';
+const OIDC_CLIENT_SECRET = process.env.OIDC_CLIENT_SECRET;
+if (!OIDC_CLIENT_SECRET && process.env.NODE_ENV === 'production') {
+  throw new Error('OIDC_CLIENT_SECRET must be set in production');
+}
 
 // RSA key for signing JWTs — persisted in MongoDB for consistency across cold starts
 let _rsaKeys: { privateKey: string; publicKey: string; keyId: string } | null = null;
@@ -50,7 +53,10 @@ async function getOrCreateKeys() {
 
 export function validateClient(clientId: string, clientSecret?: string): boolean {
   if (clientId !== OIDC_CLIENT_ID) return false;
-  if (clientSecret && clientSecret !== OIDC_CLIENT_SECRET) return false;
+  if (clientSecret) {
+    // In production, OIDC_CLIENT_SECRET must be set (enforced at module load)
+    if (!OIDC_CLIENT_SECRET || clientSecret !== OIDC_CLIENT_SECRET) return false;
+  }
   return true;
 }
 
@@ -126,13 +132,24 @@ export async function createIdToken(userId: string, email: string, name: string)
   return `${signingInput}.${signature}`;
 }
 
+function getTokenSecret(): string {
+  return process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET || 'dev-only-secret';
+}
+
 export function createAccessToken(userId: string): string {
-  return Buffer.from(JSON.stringify({ sub: userId, exp: Date.now() + 3600000 })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ sub: userId, exp: Date.now() + 3600000 })).toString('base64url');
+  const sig = createHmac('sha256', getTokenSecret()).update(payload).digest('base64url');
+  return `${payload}.${sig}`;
 }
 
 export function decodeAccessToken(token: string): { sub: string } | null {
   try {
-    const data = JSON.parse(Buffer.from(token, 'base64url').toString());
+    const [payload, sig] = token.split('.');
+    if (!payload || !sig) return null;
+    // Verify HMAC signature
+    const expected = createHmac('sha256', getTokenSecret()).update(payload).digest('base64url');
+    if (sig !== expected) return null;
+    const data = JSON.parse(Buffer.from(payload, 'base64url').toString());
     if (data.exp < Date.now()) return null;
     return { sub: data.sub };
   } catch {


### PR DESCRIPTION
## Summary
- **Fix regex injection** in `/api/entities/[id]` — user input was interpolated into `$regex` without escaping
- **HMAC-sign OIDC access tokens** — were unsigned base64 (forgeable by anyone who knew the format)
- **Fail-closed auth** — `OIDC_CLIENT_SECRET` and `CRON_SECRET` now required in production (were silently permissive if unset)
- **Protect OIDC debug endpoint** with `withAdminAuth` (was unauthenticated)
- **Validate redirect_uri** in OIDC authorize against allowed hosts (was open redirect)

Closes #716

## Files changed
- `src/app/api/entities/[id]/route.ts` — add `escapeRegex()` to name lookup
- `src/lib/oidc/provider.ts` — HMAC-signed access tokens, fail-closed secret
- `src/lib/cron-auth.ts` — fail-closed in production
- `src/app/api/auth/oidc/debug/route.ts` — require admin auth
- `src/app/api/auth/oidc/authorize/route.ts` — redirect_uri host validation

## Test plan
- [ ] Verify entity lookup still works: `sourcelibrary.org/api/entities/Paracelsus`
- [ ] Verify OIDC flow with Matrix Synapse still works (access token format changed)
- [ ] Verify cron jobs still authenticate in production
- [ ] Confirm `OIDC_CLIENT_SECRET` is set in Vercel env vars
- [ ] Confirm `OIDC_ALLOWED_REDIRECT_HOSTS` is set (defaults to `chat.embassyofthefreemind.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)