### PR TITLE
Update documentation: fix stale stats, add missing systems to system map

### DIFF
--- a/.claude/docs/batch-ocr-operations.md
+++ b/.claude/docs/batch-ocr-operations.md
@@ -4,10 +4,12 @@
 
 Batch OCR uses the Gemini Batch API to transcribe book page images at 50% lower cost than realtime API calls. The pipeline runs on Hetzner, not Vercel.
 
+**Model routing (since 2026-03-27):** BPH books use `gemini-3-flash-preview`, all others use `gemini-3.1-flash-lite-preview` (additional 50% savings). Routing via `getModelForBook()` in `src/lib/types/ai-models.ts`.
+
 **Key files:**
 - `scripts/workers/pipeline-orchestrator.mjs` — submits OCR jobs (Phase 2) and checks completion (Phase 3)
 - `scripts/workers/batch-collector.mjs` — collects results from Gemini and saves to MongoDB
-- Both run on Hetzner via crontab (every 10 minutes)
+- Both managed by unified scheduler (`scripts/workers/scheduler.mjs`)
 
 ## How It Works
 

--- a/.claude/docs/page-lifecycle.md
+++ b/.claude/docs/page-lifecycle.md
@@ -66,7 +66,7 @@ Extracts text from page images using Gemini vision models.
 | `POST /api/books/[id]/batch-ocr-multi` | Multi-batch | Large books |
 | `POST /api/pages/[id]/ask` | Single page | 1 page |
 
-**Model:** `gemini-3-flash-preview` (default). Language-specific prompts for Latin, German, Hebrew, Arabic, etc.
+**Model:** `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite-preview` for all others (50% cheaper). Routing via `getModelForBook()` in `src/lib/types/ai-models.ts`. ALWAYS use Standard OCR v6 prompt — do NOT use language-specific prompts.
 
 **Image fallback chain:** `cropped_photo` → `archived_photo` → `photo` → `photo_original`
 

--- a/.claude/docs/pipeline-architecture.md
+++ b/.claude/docs/pipeline-architecture.md
@@ -1,6 +1,6 @@
 # Source Library Pipeline Architecture
 
-> Authoritative reference as of March 18, 2026. Detailed enough for any developer (human or AI) to operate, debug, or migrate the pipeline.
+> Authoritative reference as of April 2, 2026. Detailed enough for any developer (human or AI) to operate, debug, or migrate the pipeline.
 >
 > **See also:** `pipeline.md` for the full processing pipeline (states, crons, prompts, costs).
 
@@ -48,19 +48,14 @@ Note: `enrich-books` cron code exists in the codebase but is NOT in `vercel.json
 
 #### Hetzner Cron Schedule
 
-**Pipeline core (high frequency):**
+> **Since late March 2026:** All Hetzner crons are managed by a **unified scheduler** (`scripts/workers/scheduler.mjs`, PRs #647/#649). The scheduler is the single crontab entry that spawns all workers below. It enforces a global ~60-connection budget, probes DB health before spawning, and respects `processing_control.paused`. Individual phase crons no longer run independently.
 
-| Cron | Interval | Lock file | Purpose |
-|------|----------|-----------|---------|
+**Pipeline core (high frequency, managed by scheduler):**
+
+| Worker | Interval | Lock file | Purpose |
+|--------|----------|-----------|---------|
 | `pipeline-orchestrator.mjs` (main) | */2 min | `sl-pipeline.lock` | All phases (fallback orchestrator) |
 | `translate-worker.mjs` | */2 min | `sl-translate.lock` | Inline translation via Gemini (no Lambda) |
-| `--phase 1.5` (preview OCR) | */2 min | `sl-preview-ocr.lock` | First 25 pages via Lambda for fast preview |
-| `--phase 4` (translate dispatch) | */2 min | `sl-translate-dispatch.lock` | Dispatch books to translate-worker |
-| `--phase 5` (translate complete) | */5 min | `sl-translate-complete.lock` | Translation completion check |
-| `--phase 0` (enrollment) | */10 min | `sl-enroll.lock` | New books -> queued |
-| `--phase 1` (archive check) | */10 min | `sl-archive-check.lock` | queued -> archive_complete |
-| `--phase 2` (OCR submit) | */10 min | `sl-ocr-submit.lock` | Submit to Gemini Batch API |
-| `--phase 3` (OCR complete) | */10 min | `sl-ocr-complete.lock` | Batch results -> pages |
 | `batch-collector.mjs` | */10 min | `sl-collector.lock` | Poll Gemini Batch API |
 | `archive-bulk.mjs` | */10 min | `sl-archive-bulk.lock` | IA bulk JP2 zip download -> R2 |
 
@@ -120,8 +115,8 @@ npm run lambda:prepare && secret-lover run -- bash -c \
 
 ### MongoDB Atlas (db: bookstore)
 
-- 28,625 books, 4.22M `gemini_usage` records
-- Key collections: `books`, `pages`, `jobs`, `batch_jobs`, `gemini_usage`, `cron_runs`, `system_config`, `page_revisions`
+- ~17K live books + ~24.5K warehouse books, ~3.1M live pages + ~6.4M warehouse pages (as of 2026-04-01)
+- Key collections: `books`, `books_warehouse`, `pages`, `pages_warehouse`, `jobs`, `batch_jobs`, `gemini_usage`, `cron_runs`, `system_config`, `page_revisions`
 - **Saturates at ~40 concurrent Lambda jobs** -- adaptive limits prevent this
 
 ---
@@ -236,7 +231,7 @@ $0.0017/page (measured from `gemini_usage`: $354 / 211K pages over 7 days)
 4. Calls Gemini directly -- model: `gemini-3-flash-preview` (BPH) or `gemini-3.1-flash-lite-preview` (others)
 5. Writes translation directly to `pages` collection
 6. Rotates API keys on rate limits (up to 11 keys)
-7. Concurrency: 40 books simultaneously, 8,000 page cap per run
+7. Concurrency: 15 books simultaneously (tuned for 60-connection budget), 8,000 page cap per run
 
 ### Legacy Lambda Path (Fallback)
 

--- a/.claude/docs/pipeline.md
+++ b/.claude/docs/pipeline.md
@@ -29,9 +29,15 @@ Every step is independent and idempotent. Books can enter at any stage and be re
 
 ## Auto Pipeline State Machine
 
-The pipeline is orchestrated from **Hetzner** (`scripts/workers/pipeline-orchestrator.mjs`, every 2 min). Translation runs on a separate Hetzner worker (`translate-worker.mjs`, every 2 min). Batch OCR results are collected by `batch-collector.mjs` (every 10 min). See `pipeline-architecture.md` for the full cron schedule and infrastructure map.
+**Current (2026-03-28+):** All Hetzner crons consolidated into a **unified scheduler** (`scripts/workers/scheduler.mjs`). Replaces 15+ independent crons with a single entry point that enforces connection budget (~60), health checks, and pause respect. See PRs #647/#649.
 
-**Legacy:** The Vercel crons (`post-import-pipeline`, `enrich-books`) still exist in `_archived/` but are no longer active. The Hetzner orchestrator (`pipeline-orchestrator.mjs`) handles phases 0-5 and 8+. A separate Hetzner worker (`enrich-worker.mjs`, every 5 min) handles phases 6-7 (summary+index, chapters) with direct Gemini calls. The `cron_runs` collection logs from both — orchestrator runs log as `archive-bulk`, enrich runs have their own entries.
+The scheduler runs the orchestrator, translate-worker, batch-collector, enrich-worker, and other tasks on configurable intervals. Translation runs inline on Hetzner (`translate-worker.mjs`). Batch OCR results are collected by `batch-collector.mjs`.
+
+**Legacy:** The Vercel crons (`post-import-pipeline`, `enrich-books`) still exist in `_archived/` but are no longer active. The `cron_runs` collection logs all runs.
+
+**Operational lessons:**
+- **NEVER comment out crons with `#PAUSED#`** — bypasses all in-code auto-resume. Use `processing_control` only. Caused 7h stall on 2026-03-30.
+- **Always check `git diff` on Hetzner before AND after deploying** — `git stash/pop` silently reverts local fixes. Caused 3x throughput regression on 2026-03-30.
 
 Each book has a `pipeline_auto` object tracking its state.
 

--- a/.claude/docs/system-map.md
+++ b/.claude/docs/system-map.md
@@ -1,24 +1,28 @@
 # Source Library System Map
 
-> Last audited: 2026-03-25. Use this as the primary navigation reference.
+> Last audited: 2026-04-01. Use this as the primary navigation reference.
 
 ## Architecture Overview
 
 ```
 Users ──> Vercel (Next.js 16) ──> MongoDB Atlas (bookstore)
                 │                        ▲
-                ├──> Cloudflare R2       │ write-processor
+                ├──> Supabase Postgres   │ write-processor
+                │    (analytics, browse, catalog, search)
+                │                        │
+                ├──> Cloudflare R2       │
                 │    (images.sourcelibrary.org)  │
                 │                        │
                 ├──> SQS Queues ──> Lambda Workers ──> Gemini AI
                 │    (eu-central-1)   (OCR, Translation, Images)
                 │
                 ├──> Hetzner (46.224.122.120)
-                │    (pipeline orchestration crons)
+                │    (pipeline orchestration, translate-worker, embedding server)
                 │
                 ├──> Stripe (Ficino Society payments)
                 ├──> Twitter/X API (@SourceLibrary_)
                 ├──> Zenodo (DOI minting)
+                ├──> Museum APIs (Met, Cleveland, Rijksmuseum, AIC)
                 └──> IIIF Sources (IA, Gallica, Wellcome, etc.)
 ```
 
@@ -26,13 +30,14 @@ Users ──> Vercel (Next.js 16) ──> MongoDB Atlas (bookstore)
 
 | Service | Purpose | Key Config |
 |---------|---------|------------|
-| **Vercel** | Next.js hosting, 4 crons | Project: `sourcelibrary-v2` |
-| **MongoDB Atlas** | Primary database | DB: `bookstore`, ~38,195 books |
-| **AWS Lambda** (eu-central-1) | AI processing workers | 3 functions, SQS-triggered |
+| **Vercel** | Next.js hosting, 5 crons | Project: `sourcelibrary-v2` |
+| **MongoDB Atlas** | Primary database | DB: `bookstore`, ~17K live + ~24.5K warehouse books |
+| **Supabase Postgres** | Analytics, browse cache, catalog, search | pgvector, pg_trgm, pg_cron |
+| **AWS Lambda** (eu-central-1) | AI processing workers | 4 functions, SQS-triggered |
 | **AWS SQS** (eu-central-1) | Job queues (FIFO) | 4 queues: OCR, translation, images, write |
 | **Cloudflare R2** | Image/page storage | `images.sourcelibrary.org` |
-| **Hetzner** (cax31) | Pipeline orchestration | `root@46.224.122.120`, crons not in git |
-| **Gemini AI** | OCR, translation, enrichment | 10-key rotation, model: `gemini-3-flash-preview` |
+| **Hetzner** (cax31) | Pipeline orchestration, translation, embeddings | `root@46.224.122.120`, unified scheduler |
+| **Gemini AI** | OCR, translation, enrichment | 10-key rotation. BPH: `gemini-3-flash-preview`, others: `gemini-3.1-flash-lite-preview` |
 | **Stripe** | Payments | Ficino Society membership |
 | **Zenodo** | DOI publishing | Scholarly editions |
 | **Twitter/X** | Social automation | 3h posting cron |
@@ -44,7 +49,7 @@ The system has **one unified pipeline** with three parallel processing phases sh
 ```
 Import (IA/Gallica/IIIF)
   └─> books + pages collections created
-       └─> Hetzner cron (post-import-pipeline, every 10min)
+       └─> Hetzner unified scheduler (scheduler.mjs, every 10min)
             ├─ Phase 1: OCR (parallel, batch-friendly)
             │  SQS pageOcr ──> Lambda ocr-processor (×10) ──> Gemini ──> writeResults
             │
@@ -61,16 +66,59 @@ Import (IA/Gallica/IIIF)
 
 Phases run concurrently with independent concurrency limits. Backpressure: `system_config.paused_phases` array.
 
+## Supabase Layer (added 2026-03-27+)
+
+Supabase serves derived reads for performance-critical paths. MongoDB remains source of truth.
+
+| Table/View | Purpose | Source |
+|------------|---------|--------|
+| `books_catalog` | Browse cache (11s→0.6s) | Synced from MongoDB `books` |
+| `page_translations` | Semantic search embeddings | pgvector, e5-base model |
+| `gemini_usage` | AI cost analytics | Synced from MongoDB |
+| `pipeline_snapshots` | Pipeline velocity charts | Synced from MongoDB |
+| `cron_runs` | Cron execution logs | Synced from MongoDB |
+| `ustc_editions` / `ustc_enrichments` | USTC catalog | Direct import |
+| `contributing_library` | Library pages (was 5s timeout) | Materialized view |
+
+Key: `src/lib/supabase.ts` (client), `.claude/docs/supabase.md` (full reference)
+
+## Author Pages (added 2026-03-30+)
+
+Entity-driven author system with normalized names, Wikipedia enrichment, aliases.
+
+| Route | Purpose |
+|-------|---------|
+| `/author/[name]` | Author detail — catalog table, title page gallery, publisher column |
+| `/browse/authors` | Author listing/browse |
+| `/api/admin/revalidate-authors` | ISR revalidation endpoint |
+
+Key: `src/app/author/`, `src/app/browse/authors/`, author normalization in `src/lib/`
+
+## Visual Art Wing (added 2026-03-30+)
+
+Museum artwork imports alongside historical texts. Mixed collections show both.
+
+| Source | Script | Status |
+|--------|--------|--------|
+| Met Museum | `scripts/import-met-artworks.mjs` | Active, `--object-ids` flag |
+| Cleveland Museum | `scripts/import-cleveland-artworks.mjs` | Active |
+| Rijksmuseum | Planned | — |
+
+Collections support `collection_type` field. Low-res artwork filtering and upgrade pipeline in place.
+
 ## MongoDB Collections (73)
 
 ### Core Data
 | Collection | Purpose | Key Fields |
 |------------|---------|------------|
-| `books` | Book metadata | `id`, `title`, `author`, `slug`, `pages_count`, `pages_ocr`, `pages_translated` |
-| `pages` | Individual pages | `book_id`, `ocr.data`, `translation.data`, `detected_images`, `page_type` |
+| `books` | Book metadata (~17K live) | `id`, `title`, `author`, `slug`, `pages_count`, `pages_ocr`, `pages_translated` |
+| `books_warehouse` | Archived books (~24.5K) | Same schema, moved for Atlas perf |
+| `pages` | Individual pages (~3.1M live) | `book_id`, `ocr.data`, `translation.data`, `detected_images`, `page_type` |
+| `pages_warehouse` | Archived pages (~6.4M) | Same schema |
 | `deleted_books` | Soft-deleted books | Same as books, recoverable |
-| `collections` | Book groupings | `slug`, `name`, `hidden` |
+| `collections` | Book groupings | `slug`, `name`, `hidden`, `collection_type` |
 | `entities` | Encyclopedia entries | People, places, concepts |
+| `authors` | Normalized author entities | Aliases, Wikipedia, enrichment |
 
 ### Processing
 | Collection | Purpose |
@@ -102,9 +150,9 @@ Phases run concurrently with independent concurrency limits. Backpressure: `syst
 ### Analytics & Monitoring
 | Collection | Purpose |
 |------------|---------|
-| `analytics_events`, `analytics_pageviews` | User behavior |
-| `pipeline_snapshots`, `pipeline_health_daily` | Pipeline metrics |
-| `cron_runs` | Cron execution logs |
+| `analytics_events`, `analytics_pageviews` | User behavior (migrating to Supabase) |
+| `pipeline_snapshots`, `pipeline_health_daily` | Pipeline metrics (mirrored to Supabase) |
+| `cron_runs` | Cron execution logs (mirrored to Supabase) |
 | `audit_log` | Admin action trail |
 | `application_errors` | Error logging |
 
@@ -131,8 +179,10 @@ src/
 │   │   ├── stripe/         # 4 payment endpoints
 │   │   ├── dataset/v1/     # Public API (keyed access)
 │   │   └── ...             # experiments, analytics, ficino, etc.
+│   ├── author/[name]/      # Author detail page (catalog, gallery strip)
 │   ├── book/[id]/          # Reader pages (guide, summary, QA, pipeline, editions)
-│   ├── collections/        # Collection browse & detail
+│   ├── browse/authors/     # Author listing
+│   ├── collections/        # Collection browse & detail (supports mixed art+book)
 │   ├── gallery/            # Image gallery
 │   ├── admin/              # Admin dashboard pages
 │   ├── blog/               # 31 blog posts (hardcoded JSX, no CMS)
@@ -157,6 +207,7 @@ src/
 │
 ├── lib/                    # 200 utility modules
 │   ├── mongodb.ts          # DB connection (singleton, pool management)
+│   ├── supabase.ts         # Supabase client (analytics, browse, search)
 │   ├── ai.ts               # Core Gemini operations
 │   ├── gemini-client.ts    # API key rotation (10 keys)
 │   ├── gemini-batch.ts     # Batch API orchestration
@@ -188,7 +239,7 @@ scripts/                    # 308 operational scripts
 ├── import/                 # ~17 bulk import scripts
 ├── one-off/                # ~7 exploratory scripts
 ├── aws-lambda/             # Lambda build/deploy
-├── workers/                # sync-worker.mjs (Hetzner cron replacement)
+├── workers/                # scheduler.mjs (unified), translate-worker, pipeline-orchestrator, etc.
 └── lib/                    # Shared script utilities
 ```
 
@@ -196,7 +247,7 @@ scripts/                    # 308 operational scripts
 
 | Category | Count | Content Source | Examples |
 |----------|-------|---------------|----------|
-| Core library (dynamic) | ~40 | MongoDB + APIs | Book reader, search, collections, author pages |
+| Core library (dynamic) | ~45 | MongoDB + APIs | Book reader, search, collections, author pages, browse/authors, artworks |
 | Admin/ops dashboards | ~15 | MongoDB + APIs | Pipeline control, jobs, analytics, email, KDP |
 | Research/experiments | ~20 | MongoDB + APIs | OCR quality, concept diffusion, image atlas |
 | Blog posts | 31 | Hardcoded JSX (no CMS) | origin-story, progress-studies, hidden-engineers |
@@ -220,16 +271,17 @@ scripts/                    # 308 operational scripts
 4. **Page revisions before writes** — Any script modifying `ocr.data` or `translation.data` MUST call `createRevision()` first.
 5. **Admin via whitelist** — `admin_users` collection, no RBAC. `withAdminAuth()` wrapper.
 6. **Key rotation for Gemini** — 10 API keys with cooldown. `gemini-client.ts` handles rotation.
-7. **Hetzner for heavy crons** — Pipeline orchestration moved off Vercel to reduce costs/timeouts.
+7. **Hetzner for heavy crons** — Pipeline orchestration moved off Vercel to reduce costs/timeouts. Unified scheduler manages all workers.
+8. **Supabase for read-heavy paths** — Browse, analytics, search, and libraries queries hit Supabase for speed. MongoDB remains source of truth; Supabase mirrors derived data via sync crons.
+9. **Model routing by source** — BPH books get `gemini-3-flash-preview` (premium), all others get `gemini-3.1-flash-lite-preview` (50% cheaper). See `src/lib/types/ai-models.ts`.
 
 ## Known Dead Code & Duplicates
 
-### Unused Components (29 remaining — safe to delete)
-6 deleted since last audit: BetaGateModal, useBetaGate, QualityBadge, ReadingSidebar, PageThumbnail, Skeleton.
+### Confirmed Dead Components (verified 2026-04-01, zero imports)
+Issue #258 closed. These remain with no imports anywhere:
 
 | Component | Path | Notes |
 |-----------|------|-------|
-| `Footer.tsx` | `components/layout/` | Superseded by `GlobalFooter.tsx` |
 | `BookEditModal.tsx` | `components/book/` | Orphaned |
 | `BookPagesActions.tsx` | `components/book/` | Orphaned |
 | `BookPagesStats.tsx` | `components/book/` | Orphaned |
@@ -237,19 +289,21 @@ scripts/                    # 308 operational scripts
 | `PagesGrid.tsx` | `components/book/` | Orphaned |
 | `ProcessingPanel.tsx` | `components/book/` | Orphaned |
 | `ReorderModePanel.tsx` | `components/book/` | Orphaned |
-| Camera components (6) | `components/camera/` | Mobile scanning feature — verify if still wanted |
-| Rithmomachia components (12) | `components/rithmomachia/` | Game feature — verify if still wanted |
-| `EntityMap.tsx` | `components/explore/` | Internal only |
-| `MapSidebar.tsx` | `components/explore/` | Internal only |
+| `EntityMap.tsx` | `components/explore/` | Orphaned |
+| `MapSidebar.tsx` | `components/explore/` | Orphaned |
 | `PipelineStageCard.tsx` | `components/pipeline/` | Orphaned |
-| `PageTracker.tsx` | `components/reader/` | Imported but unused |
+| `PageTracker.tsx` | `components/reader/` | Orphaned |
 | `SessionCard.tsx` | `components/research/` | Orphaned |
+| Camera components (6) | `components/camera/` | Mobile scanning — unused, ask before deleting |
+| Rithmomachia components (14) | `components/rithmomachia/` | Game — unused, ask before deleting |
+
+`Footer.tsx` was previously listed but no longer exists (already deleted).
 
 ### Duplicate Functions
 | Function | Location A | Location B | Action |
 |----------|-----------|-----------|--------|
-| `withTimeout()` | `lib/collections-utils.ts` | `app/page.tsx` (local) | Consolidate to lib |
-| `sortCollections()` | `lib/collections-utils.ts` | `app/page.tsx` (local) | Consolidate to lib |
+| `withTimeout()` | `lib/collections-utils.ts` | `api/books/search/route.ts` (local, different signature) | Different impls, both used |
+| `sortCollections()` | `lib/collections-utils.ts` | `api/books/search/route.ts` (local) | Consolidate to lib |
 
 ### Disabled Cron Routes
 7 cron API routes still exist in code but are removed from `vercel.json` (moved to Hetzner):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,17 +41,17 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 
 ## Stack
 - Next.js 16, MongoDB Atlas, Gemini AI, Vercel deployment
-- Production database: `bookstore` (5,355 books), NOT `sourcelibrary_research`
+- Production database: `bookstore` (~17K live books, ~24.5K warehouse), NOT `sourcelibrary_research`
 
 ## AI Models — IMPORTANT
 - Summary/Index generation: ALWAYS use `gemini-3-flash-preview`. This was a recurring issue — do not use older models.
-- OCR/Translation: check batch-ocr and translate routes for current models
+- OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite-preview` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 
 ## System Map
 - **Interactive diagram:** https://sourcelibrary.org/admin/system-map — click any node for details, key files, collections, gotchas
 - **Markdown reference:** `.claude/docs/system-map.md` — full text version with file layout, collection inventory, dead code list
-- **Dead code cleanup:** GitHub issue #258 — 35 unused components, 2 duplicate functions, disabled cron routes
+- **Dead code cleanup:** GitHub issue #258 (closed) — most cleaned up, some camera/rithmomachia components may remain
 
 ## Domain Context
 Detect the work domain from the user's prompt and load the right context automatically:


### PR DESCRIPTION
## Summary
- Fix book/page counts across all docs (were 3x stale after warehouse migration growth)
- Add Supabase, author pages, and visual art wing to system-map.md (all missing)
- Update pipeline docs: unified scheduler replaces individual crons, concurrency 40→15
- Add model routing documentation (BPH: flash, others: flash-lite)
- Re-verify dead code list: remove false positives, confirm 12 orphaned + 20 feature components
- Update CLAUDE.md project instructions with current stats and model guidance

## Files changed
- `CLAUDE.md` — book count, model routing, dead code issue status
- `.claude/docs/system-map.md` — Supabase, authors, art, warehouse, crons, architecture patterns
- `.claude/docs/pipeline-architecture.md` — unified scheduler, warehouse, concurrency fix
- `.claude/docs/pipeline.md` — unified scheduler, operational lessons
- `.claude/docs/page-lifecycle.md` — model routing
- `.claude/docs/batch-ocr-operations.md` — model routing, scheduler reference

## Test plan
- [ ] Docs are internal (.claude/), no runtime impact
- [ ] Verify no sensitive information in diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)