### PR TITLE
Fix site audit: image loading, contributing institutions, collection thumbnails

### DIFF
--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -102,7 +102,7 @@ async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total:
   }
 }
 
-function CollectionCard({ col }: { col: CollectionDoc }) {
+function CollectionCard({ col, priority = false }: { col: CollectionDoc; priority?: boolean }) {
   const hero = col.featured_images?.find(
     img => img.extracted_url || img.image_url || img.thumbnail_url
   );
@@ -122,6 +122,7 @@ function CollectionCard({ col }: { col: CollectionDoc }) {
           sizes="(max-width: 640px) 50vw, 25vw"
           className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
           unoptimized
+          {...(priority ? { priority: true } : { loading: 'lazy' as const })}
         />
       ) : (
         <div className="absolute inset-0 bg-warm" />
@@ -172,8 +173,8 @@ export default async function CollectionsPage() {
 
       {/* Category collections */}
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
-        {categories.map((col) => (
-          <CollectionCard key={col.slug} col={col} />
+        {categories.map((col, i) => (
+          <CollectionCard key={col.slug} col={col} priority={i < 8} />
         ))}
       </div>
 

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -63,7 +63,7 @@ async function fetchCuratedCollections() {
   return { published, upcoming };
 }
 
-function PublishedCard({ col }: { col: CuratedCollection }) {
+function PublishedCard({ col, priority = false }: { col: CuratedCollection; priority?: boolean }) {
   const heroUrl = getHeroImage(col);
 
   return (
@@ -79,6 +79,7 @@ function PublishedCard({ col }: { col: CuratedCollection }) {
           sizes="(max-width: 640px) 100vw, 50vw"
           className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
           unoptimized
+          {...(priority ? { priority: true } : { loading: 'lazy' as const })}
         />
       ) : (
         <div className="absolute inset-0 bg-warm" />
@@ -148,8 +149,8 @@ export default async function CuratedCollectionsPage() {
         {published.length > 0 && (
           <div className="mb-14">
             <div className="grid gap-6 grid-cols-1 sm:grid-cols-2">
-              {published.map((col) => (
-                <PublishedCard key={col.slug} col={col} />
+              {published.map((col, i) => (
+                <PublishedCard key={col.slug} col={col} priority={i < 4} />
               ))}
             </div>
           </div>

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -70,10 +70,26 @@ async function fetchProviderStats(): Promise<ProviderStats[]> {
 }
 
 async function fetchContributingLibraries(): Promise<ContributingLibrary[]> {
-  // contributing_library is not in books_catalog, so use a simple
-  // fallback — return empty until we add the field to the catalog.
-  // The libraries index page still renders the Digital Sources section.
-  return [];
+  const { data, error } = await supabase
+    .from('books_catalog')
+    .select('contributing_library')
+    .eq('visible', true)
+    .gt('pages_count', 0)
+    .gt('pages_translated', 0)
+    .not('contributing_library', 'is', null);
+
+  if (error) throw new Error(`Contributing libraries query failed: ${error.message}`);
+
+  const counts = new Map<string, number>();
+  for (const row of (data || [])) {
+    const name = (row.contributing_library as string || '').trim();
+    if (!name) continue;
+    counts.set(name, (counts.get(name) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count);
 }
 
 export default async function LibrariesPage() {
@@ -97,7 +113,7 @@ export default async function LibrariesPage() {
     <ContentPageLayout>
       <ContentHeader
         title="Libraries"
-        subtitle={`${totalBooks.toLocaleString()} books sourced from ${partners.length} digital platforms and ${totalInstitutions} contributing institutions worldwide.`}
+        subtitle={`${totalBooks.toLocaleString()} books sourced from ${partners.length} digital platforms${totalInstitutions > 0 ? ` and ${totalInstitutions} contributing institutions` : ''} worldwide.`}
       />
 
       {/* Digital Sources */}
@@ -107,7 +123,7 @@ export default async function LibrariesPage() {
       </p>
 
       <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 mb-16">
-        {partners.map((partner) => {
+        {partners.map((partner, i) => {
           const topLangs = partner.languages.slice(0, 3).map(l => l).join(', ');
 
           return (
@@ -125,6 +141,7 @@ export default async function LibrariesPage() {
                   sizes="(max-width: 640px) 100vw, 50vw"
                   className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
                   unoptimized
+                  {...(i < 4 ? { priority: true } : { loading: 'lazy' as const })}
                 />
               ) : (
                 <div className="absolute inset-0 bg-warm" />

--- a/src/components/gallery/FeaturedCollections.tsx
+++ b/src/components/gallery/FeaturedCollections.tsx
@@ -47,7 +47,7 @@ export default function FeaturedCollections({ initialCollections }: FeaturedColl
       <p className="text-stone-500 text-base mb-5">Curated selections of illustrations from rare alchemical, Hermetic, and philosophical manuscripts.</p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {shown.map((collection) => (
+        {shown.map((collection, i) => (
           <Link
             key={collection.id}
             href={`/gallery/collections/${collection.slug}`}
@@ -61,6 +61,7 @@ export default function FeaturedCollections({ initialCollections }: FeaturedColl
                 className="object-cover group-hover:scale-105 transition-transform duration-300"
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                 unoptimized
+                {...(i < 6 ? { priority: true } : { loading: 'lazy' as const })}
               />
             ) : (
               <div className="absolute inset-0 bg-stone-200 flex items-center justify-center text-stone-400">


### PR DESCRIPTION
## Summary
- **Image loading**: Add `priority` loading for above-the-fold images on /collections (first 8), /curated (first 4), /libraries (first 4), and /gallery FeaturedCollections (first 6). Eliminates gray placeholder flash on first page load.
- **Contributing institutions**: Fix "0 contributing institutions" on /libraries page — now queries Supabase `books_catalog.contributing_library` instead of returning empty array. Only shows count when > 0.
- **Collection thumbnails**: Backfilled `featured_images` in DB for 5 collections that had zero images (Gnostic Texts, Islamic Philosophy, Syriac Tradition, Slavic & Russian Tradition, Miscellany) plus refreshed Psychology (had only 1 image, now has 6).

## Test plan
- [ ] /collections — all cards should show images, first 2 rows load instantly
- [ ] /curated — first 4 cards load without gray flash
- [ ] /libraries — subtitle shows institution count, cards load eagerly
- [ ] /gallery — FeaturedCollections section loads images immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)