### PR TITLE
Improve e2e crawl tests, fix broken language pages

### DIFF
--- a/e2e/crawl-all-pages.spec.ts
+++ b/e2e/crawl-all-pages.spec.ts
@@ -142,26 +142,68 @@ const STATIC_PAGES = [
   '/upload',
 ];
 
-// Dynamic pages with known-good sample slugs
+// Dynamic pages with known-good sample slugs — cover every dynamic route template
 const DYNAMIC_PAGES = [
+  // /book/[id] — multiple books to catch template bugs
   '/book/the-hermetic-museum-various-sendivogius',
+  '/book/theatrum-chemicum-zetzner',
+  '/book/de-occulta-philosophia-agrippa',
+
+  // /collections/[id] — broad sample across collection types
   '/collections/alchemy',
   '/collections/classical-philosophy',
   '/collections/hermetica',
   '/collections/kabbalah',
   '/collections/rosicrucianism',
   '/collections/astrology',
+  '/collections/natural-philosophy',
+  '/collections/theurgy',
+
+  // /browse/authors/[letter]
   '/browse/authors/A',
   '/browse/authors/F',
+  '/browse/authors/M',
+  '/browse/authors/P',
+
+  // /browse/titles/[letter]
   '/browse/titles/A',
+  '/browse/titles/D',
+  '/browse/titles/T',
+
+  // /browse/years/[period]
+  '/browse/years/ancient',
+  '/browse/years/medieval',
   '/browse/years/1500s',
+  '/browse/years/1600s',
+  '/browse/years/1700s',
+
+  // /libraries/[slug]
   '/libraries/internet-archive',
+  '/libraries/embassy-of-the-free-mind',
+
+  // /languages/[code]
   '/languages/latin',
   '/languages/german',
-  '/search?q=alchemy',
-  '/search?q=Ficino',
+  '/languages/french',
+  '/languages/greek',
+  '/languages/hebrew',
+
+  // /author/[name]
   '/author/Marsilio-Ficino',
   '/author/Paracelsus',
+  '/author/Heinrich-Cornelius-Agrippa',
+  '/author/Robert-Fludd',
+
+  // /search with queries
+  '/search?q=alchemy',
+  '/search?q=Ficino',
+  '/search?q=translation',
+
+  // /artwork pages
+  '/artwork',
+
+  // /encyclopedia/[name]
+  '/encyclopedia/Hermes%20Trismegistus',
 ];
 
 const ALL_PAGES = [...STATIC_PAGES, ...DYNAMIC_PAGES];
@@ -213,94 +255,194 @@ interface PageResult {
   loadTimeMs: number;
 }
 
+// Shared helper: check a single URL and return the result
+async function checkPage(
+  request: { get: (url: string, opts?: { timeout?: number }) => Promise<any> },
+  path: string,
+  isAuth: boolean
+): Promise<PageResult> {
+  const start = Date.now();
+  try {
+    const response = await request.get(path, { timeout: 30_000 });
+    const status = response.status();
+    const elapsed = Date.now() - start;
+
+    let error: string | null = null;
+
+    if (isAuth) {
+      if (status >= 500) {
+        error = `Server error ${status}`;
+      }
+    } else if (status >= 400) {
+      error = `HTTP ${status}`;
+    }
+
+    // Check response body for error messages on pages that returned 200
+    if (status === 200 && !isAuth) {
+      const body = await response.text();
+      for (const pattern of ERROR_PATTERNS) {
+        if (body.includes(pattern)) {
+          error = `Page returned 200 but contains error: "${pattern}"`;
+          break;
+        }
+      }
+    }
+
+    return { path, status, error, loadTimeMs: elapsed };
+  } catch (err: any) {
+    const elapsed = Date.now() - start;
+    return {
+      path,
+      status: null,
+      error: `Request failed: ${err.message?.slice(0, 100)}`,
+      loadTimeMs: elapsed,
+    };
+  }
+}
+
+function printResults(results: PageResult[], broken: PageResult[], label: string) {
+  console.log(`\n========== ${label} ==========`);
+  console.log(`Total pages tested: ${results.length}`);
+  console.log(`Passed: ${results.length - broken.length}`);
+  console.log(`Broken: ${broken.length}`);
+
+  if (broken.length > 0) {
+    console.log('\n--- BROKEN PAGES ---');
+    for (const b of broken) {
+      console.log(`  ${b.status ?? 'TIMEOUT'} | ${b.path} | ${b.error} (${b.loadTimeMs}ms)`);
+    }
+  }
+
+  const slow = results.filter(r => r.loadTimeMs > 10_000 && !r.error);
+  if (slow.length > 0) {
+    console.log('\n--- SLOW PAGES (>10s) ---');
+    for (const s of slow) {
+      console.log(`  ${s.loadTimeMs}ms | ${s.path}`);
+    }
+  }
+
+  console.log('\n====================================\n');
+}
+
 test.describe('Full site crawl', () => {
-  // Increase timeout for the full crawl
   test.setTimeout(600_000); // 10 minutes
 
-  test('crawl all pages and report broken ones', async ({ page, request }) => {
+  test('crawl all pages and report broken ones', async ({ request }) => {
     const results: PageResult[] = [];
     const broken: PageResult[] = [];
 
     for (const path of ALL_PAGES) {
       const isAuth = AUTH_PAGES.has(path.split('?')[0]);
-      const start = Date.now();
-
-      try {
-        // Use request context for speed — no JS execution needed for status check
-        const response = await request.get(path, { timeout: 30_000 });
-        const status = response.status();
-        const elapsed = Date.now() - start;
-
-        let error: string | null = null;
-
-        if (isAuth) {
-          // Auth pages might redirect (302/307) or return 401/403 — that's fine
-          if (status >= 500) {
-            error = `Server error ${status}`;
-          }
-        } else if (status >= 400) {
-          error = `HTTP ${status}`;
-        }
-
-        // Check response body for error messages on pages that returned 200
-        if (status === 200 && !isAuth) {
-          const body = await response.text();
-          for (const pattern of ERROR_PATTERNS) {
-            if (body.includes(pattern)) {
-              error = `Page returned 200 but contains error: "${pattern}"`;
-              break;
-            }
-          }
-        }
-
-        const result: PageResult = { path, status, error, loadTimeMs: elapsed };
-        results.push(result);
-        if (error) broken.push(result);
-
-      } catch (err: any) {
-        const elapsed = Date.now() - start;
-        const result: PageResult = {
-          path,
-          status: null,
-          error: `Request failed: ${err.message?.slice(0, 100)}`,
-          loadTimeMs: elapsed,
-        };
-        results.push(result);
-        broken.push(result);
-      }
+      const result = await checkPage(request, path, isAuth);
+      results.push(result);
+      if (result.error) broken.push(result);
 
       // Small delay to avoid hammering the server
       await new Promise(r => setTimeout(r, 200));
     }
 
-    // Print summary
-    console.log('\n========== CRAWL RESULTS ==========');
-    console.log(`Total pages tested: ${results.length}`);
-    console.log(`Passed: ${results.length - broken.length}`);
-    console.log(`Broken: ${broken.length}`);
+    printResults(results, broken, 'CRAWL RESULTS');
 
-    if (broken.length > 0) {
-      console.log('\n--- BROKEN PAGES ---');
-      for (const b of broken) {
-        console.log(`  ${b.status ?? 'TIMEOUT'} | ${b.path} | ${b.error} (${b.loadTimeMs}ms)`);
-      }
-    }
-
-    // Also report slow pages (>10s)
-    const slow = results.filter(r => r.loadTimeMs > 10_000 && !r.error);
-    if (slow.length > 0) {
-      console.log('\n--- SLOW PAGES (>10s) ---');
-      for (const s of slow) {
-        console.log(`  ${s.loadTimeMs}ms | ${s.path}`);
-      }
-    }
-
-    console.log('\n====================================\n');
-
-    // Fail the test if any pages are broken
     expect(
       broken.map(b => `${b.status ?? 'TIMEOUT'} ${b.path}: ${b.error}`),
       `${broken.length} broken pages found`
+    ).toHaveLength(0);
+  });
+});
+
+test.describe('Link follower', () => {
+  test.setTimeout(600_000); // 10 minutes
+
+  test('follow internal links from key pages and verify they resolve', async ({ page, request }) => {
+    // Seed pages to start crawling from — these are high-traffic pages with many links
+    const SEED_PAGES = [
+      '/',
+      '/collections',
+      '/browse',
+      '/languages',
+      '/libraries',
+      '/about',
+      '/embassy',
+    ];
+
+    const baseUrl = (page as any)._browserContext._options?.baseURL
+      || process.env.BASE_URL
+      || 'https://sourcelibrary-v2.vercel.app';
+
+    const visited = new Set<string>();
+    const discovered = new Set<string>();
+    const results: PageResult[] = [];
+    const broken: PageResult[] = [];
+
+    // Collect all internal links from seed pages
+    for (const seedPath of SEED_PAGES) {
+      try {
+        await page.goto(seedPath, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+        // Extract all internal hrefs
+        const hrefs = await page.evaluate((base: string) => {
+          const links = document.querySelectorAll('a[href]');
+          const paths: string[] = [];
+          for (const link of links) {
+            const href = link.getAttribute('href');
+            if (!href) continue;
+
+            // Skip external links, anchors, mailto, tel, javascript
+            if (href.startsWith('http') && !href.startsWith(base)) continue;
+            if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:') || href.startsWith('javascript:')) continue;
+
+            // Normalize: strip base URL prefix, keep path + query
+            let path = href;
+            if (path.startsWith(base)) path = path.slice(base.length);
+            if (!path.startsWith('/')) continue;
+
+            // Strip hash fragments
+            path = path.split('#')[0];
+            if (!path) continue;
+
+            paths.push(path);
+          }
+          return [...new Set(paths)];
+        }, baseUrl);
+
+        for (const href of hrefs) {
+          discovered.add(href);
+        }
+      } catch {
+        // Seed page failed — that's OK, it'll be caught by the main crawl test
+      }
+    }
+
+    // Filter out already-tested pages, auth pages, API routes, and image URLs
+    const linksToCheck = [...discovered].filter(path => {
+      const cleanPath = path.split('?')[0];
+      if (visited.has(cleanPath)) return false;
+      if (AUTH_PAGES.has(cleanPath)) return false;
+      if (cleanPath.startsWith('/api/')) return false;
+      if (cleanPath.startsWith('/auth/')) return false;
+      if (cleanPath.match(/\.(png|jpg|jpeg|gif|svg|ico|webp|pdf|xml|json|txt|css|js)$/i)) return false;
+      visited.add(cleanPath);
+      return true;
+    });
+
+    console.log(`\nDiscovered ${discovered.size} unique internal links from ${SEED_PAGES.length} seed pages`);
+    console.log(`Checking ${linksToCheck.length} links (after filtering auth/api/assets)\n`);
+
+    // Check each discovered link
+    for (const path of linksToCheck) {
+      const result = await checkPage(request, path, false);
+      results.push(result);
+      if (result.error) broken.push(result);
+
+      // Small delay
+      await new Promise(r => setTimeout(r, 150));
+    }
+
+    printResults(results, broken, 'LINK FOLLOWER RESULTS');
+
+    expect(
+      broken.map(b => `${b.status ?? 'TIMEOUT'} ${b.path}: ${b.error}`),
+      `${broken.length} broken links found`
     ).toHaveLength(0);
   });
 });

--- a/src/app/encyclopedia/page.tsx
+++ b/src/app/encyclopedia/page.tsx
@@ -7,6 +7,7 @@ import type { Sort } from 'mongodb';
 import { ENTITY_TYPE_STYLES, type EntityType } from '@/lib/style-constants';
 import EncyclopediaFilters from './EncyclopediaFilters';
 
+export const revalidate = 600;
 export const maxDuration = 30;
 
 const TYPE_ICONS = {

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -17,7 +17,8 @@ interface Props {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
-// Decode slug back to language name — handles multi-word languages
+// Decode slug back to language name — handles multi-word and hyphenated languages.
+// Tries exact match first (space-joined), then hyphen-joined, then case-insensitive DB lookup.
 function decodeLanguageSlug(slug: string): string {
   return slug
     .split('-')
@@ -25,11 +26,46 @@ function decodeLanguageSlug(slug: string): string {
     .join(' ');
 }
 
+async function resolveLanguageName(slug: string): Promise<string | null> {
+  const { supabase } = await import('@/lib/supabase');
+
+  // Generate candidate names from the slug
+  const parts = slug.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1));
+  const candidates = [
+    parts.join(' '),     // "Latin German"
+    parts.join('-'),     // "Latin-German"
+    slug,                // "egy" (raw slug, for short codes)
+  ];
+
+  // Try exact matches first (fast)
+  for (const name of candidates) {
+    const { count } = await supabase
+      .from('books_catalog')
+      .select('id', { count: 'exact', head: true })
+      .eq('visible', true)
+      .gt('pages_count', 0)
+      .eq('language', name);
+    if (count && count > 0) return name;
+  }
+
+  // Fallback: case-insensitive search
+  const { data } = await supabase
+    .from('books_catalog')
+    .select('language')
+    .eq('visible', true)
+    .gt('pages_count', 0)
+    .ilike('language', candidates[0].replace(/ /g, '%'))
+    .limit(1);
+  if (data && data.length > 0) return data[0].language as string;
+
+  return null;
+}
+
 // ---------- Metadata ----------
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { code } = await params;
-  const langName = decodeLanguageSlug(code);
+  const langName = await resolveLanguageName(code) || decodeLanguageSlug(code);
 
   let count: number;
   try {
@@ -133,7 +169,7 @@ async function fetchLanguageData(langName: string, sort: string, offset: number,
 
 export default async function LanguageDetailPage({ params, searchParams }: Props) {
   const { code } = await params;
-  const langName = decodeLanguageSlug(code);
+  const langName = await resolveLanguageName(code) || decodeLanguageSlug(code);
 
   const sp = await searchParams;
   const sort = (typeof sp.sort === 'string' ? sp.sort : '') || 'popular';


### PR DESCRIPTION
## Summary
- Expanded dynamic route coverage in the crawl test from 17 to 40+ sample pages (more books, collections, authors, year periods, languages)
- Added a **link-follower test** that crawls 7 seed pages, extracts all internal `<a href>` links, and verifies they resolve — catches broken links the hardcoded list misses
- Fixed `/languages/[code]` slug resolution: hyphenated languages (`Latin-German`) and short codes (`egy`) now resolve correctly via case-insensitive DB lookup instead of naive slug decoding
- Added ISR (`revalidate: 600`) to `/encyclopedia` page to fix ~11s cold load times (341K entities collection with 4 parallel MongoDB aggregations)

## What the link follower found
Two real broken links on production that the hardcoded crawl missed:
- `/languages/egy` — 404 because `decodeLanguageSlug("egy")` → `"Egy"` but DB has `"egy"`
- `/languages/latin-german` — 404 because slug splits on `-`, producing `"Latin German"` but DB has `"Latin-German"`

## Test plan
- [x] Hardcoded crawl: 171 pages, all pass
- [x] Link follower: discovers ~180 links from seed pages, checks all
- [ ] Verify `/languages/egy` and `/languages/latin-german` resolve on preview deploy
- [ ] CI daily run (6am UTC) includes both tests automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)