### PR TITLE
Add site navigation menu + fix sparse collection hero banners

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -561,7 +561,12 @@ export default async function CollectionDetailPage({ params }: Props) {
       {/* Hero Section */}
       <div className="relative bg-dark overflow-hidden">
         {heroImages.length > 0 ? (
-          <div className="absolute inset-0 grid grid-cols-3 sm:grid-cols-6 opacity-30">
+          <div className={`absolute inset-0 grid opacity-30 ${
+            heroImages.length <= 2 ? 'grid-cols-2' :
+            heroImages.length <= 3 ? 'grid-cols-3' :
+            heroImages.length <= 4 ? 'grid-cols-2 sm:grid-cols-4' :
+            'grid-cols-3 sm:grid-cols-6'
+          }`}>
             {heroImages.map((img: { pageId?: string; page_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string }) => {
               const src = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
               const key = `${img.pageId || img.page_id}-${img.detectionIndex ?? img.detection_index}`;

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,8 +1,19 @@
 'use client';
 
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import Logo from './Logo';
 import UserMenu from './UserMenu';
+
+const NAV_LINKS = [
+  { label: 'Collections', href: '/collections' },
+  { label: 'Gallery', href: '/gallery' },
+  { label: 'Browse', href: '/browse' },
+  { label: 'Timeline', href: '/timeline' },
+  { label: 'Libraries', href: '/libraries' },
+  { label: 'The Embassy', href: '/embassy' },
+];
 
 interface Breadcrumb {
   label: string;
@@ -22,12 +33,38 @@ interface SiteHeaderProps {
 
 export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, className = '' }: SiteHeaderProps) {
   const isWhiteText = variant === 'transparent' || variant === 'dark';
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  // Close menu on route change
+  useEffect(() => { setMenuOpen(false); }, [pathname]);
+
+  // Close menu on click outside
+  useEffect(() => {
+    if (!menuOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [menuOpen]);
 
   const variantClasses = {
     transparent: 'relative z-50 py-4',
     light: 'bg-cream border-b border-border-light py-3',
     dark: 'bg-stone-900 text-white py-3',
   }[variant];
+
+  const linkClass = isWhiteText
+    ? 'text-white/70 hover:text-white'
+    : 'text-secondary hover:text-primary';
+
+  const activeLinkClass = isWhiteText
+    ? 'text-white'
+    : 'text-primary font-medium';
 
   return (
     <header
@@ -51,16 +88,74 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
           ))}
         </div>
         <div className="flex items-center gap-6">
-          <Link
-            href="/embassy"
-            className={`text-sm font-sans tracking-wide hidden sm:block ${
-              isWhiteText
-                ? 'text-white/70 hover:text-white'
-                : 'text-secondary hover:text-primary'
-            } transition-colors`}
-          >
-            The Embassy
-          </Link>
+          {/* Desktop nav links */}
+          <nav className="hidden lg:flex items-center gap-5">
+            {NAV_LINKS.map((link) => {
+              const isActive = pathname === link.href || pathname?.startsWith(link.href + '/');
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={`text-sm font-sans tracking-wide transition-colors ${
+                    isActive ? activeLinkClass : linkClass
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          {/* Mobile hamburger */}
+          <div className="relative lg:hidden" ref={menuRef}>
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className={`p-1.5 rounded transition-colors ${
+                isWhiteText ? 'text-white/70 hover:text-white' : 'text-secondary hover:text-primary'
+              }`}
+              aria-label="Navigation menu"
+              aria-expanded={menuOpen}
+            >
+              {menuOpen ? (
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
+
+            {menuOpen && (
+              <div className="absolute right-0 top-full mt-2 w-52 bg-white rounded-lg shadow-lg border border-border-light py-2 z-50">
+                {NAV_LINKS.map((link) => {
+                  const isActive = pathname === link.href || pathname?.startsWith(link.href + '/');
+                  return (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className={`block px-4 py-2.5 text-sm transition-colors ${
+                        isActive
+                          ? 'text-primary font-medium bg-warm'
+                          : 'text-secondary hover:text-primary hover:bg-warm/50'
+                      }`}
+                    >
+                      {link.label}
+                    </Link>
+                  );
+                })}
+                <div className="border-t border-border-light my-1.5" />
+                <Link
+                  href="/search"
+                  className="block px-4 py-2.5 text-sm text-secondary hover:text-primary hover:bg-warm/50 transition-colors"
+                >
+                  Search
+                </Link>
+              </div>
+            )}
+          </div>
+
           <UserMenu variant={isWhiteText ? 'hero' : 'default'} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Navigation menu**: SiteHeader now has full nav links (Collections, Gallery, Browse, Timeline, Libraries, The Embassy) visible on desktop (lg+). On mobile/tablet, a hamburger dropdown with active state highlighting, click-outside dismiss, and route-change auto-close.
- **Hero banner fix**: Collection detail hero adapts grid columns to actual image count (grid-cols-2/3/4/6) instead of always grid-cols-6. Fixes the half-blank banner on collections with fewer gallery images (e.g. Syriac Tradition with 3 images).

## Test plan
- [ ] Desktop: nav links visible in header, active state on current page
- [ ] Mobile: hamburger opens dropdown, clicking link navigates and closes menu
- [ ] /collections/syriac-tradition — hero banner fills full width with 3 images
- [ ] /collections/alchemy — hero banner unchanged (6 images, full width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)