### PR TITLE
Fix low-res gallery images and Gallica import resolution

### DIFF
--- a/src/app/api/crop-image/route.ts
+++ b/src/app/api/crop-image/route.ts
@@ -62,6 +62,20 @@ export async function GET(request: NextRequest) {
     if (rotation && [90, 180, 270].includes(rotation)) {
       pipeline = pipeline.rotate(rotation);
     }
+
+    // Ensure minimum display size — small crops from low-res sources look terrible
+    const MIN_CROP_DIM = 800;
+    // After rotation, width/height may swap
+    const croppedW = (rotation === 90 || rotation === 270) ? height : width;
+    const croppedH = (rotation === 90 || rotation === 270) ? width : height;
+    if (Math.max(croppedW, croppedH) < MIN_CROP_DIM) {
+      pipeline = pipeline.resize(MIN_CROP_DIM, MIN_CROP_DIM, {
+        fit: 'inside',
+        withoutEnlargement: false,
+        kernel: 'lanczos3',
+      });
+    }
+
     const croppedBuffer = await pipeline
       .jpeg({ quality: 85 })
       .toBuffer();

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -126,10 +126,10 @@ export const POST = withAuth(async (request, session) => {
     const bookIdStr = bookId.toHexString();
 
     // Gallica IIIF image URL pattern
-    // Full quality: /full/full/0/native.jpg
-    // Reduced for display: /full/1000,/0/default.jpg
+    // Full quality: /full/full/0/default.jpg (native resolution, typically 3000-5000px)
+    // Display: /full/2000,/0/default.jpg (capped at 2000px wide for reasonable file sizes)
     const getPageImageUrl = (pageNum: number) =>
-      `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/f${pageNum + 1}/full/1000,/0/default.jpg`;
+      `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/f${pageNum + 1}/full/2000,/0/default.jpg`;
 
     const getThumbnailUrl = (pageNum: number) =>
       `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/f${pageNum + 1}/full/200,/0/default.jpg`;

--- a/src/lib/gallery-image-gen.ts
+++ b/src/lib/gallery-image-gen.ts
@@ -99,9 +99,27 @@ export async function generateGalleryImages(
   }
 
   // Generate full-size extracted image (JPEG 85)
-  const extractedBuffer = await pipeline
-    .jpeg({ quality: 85, progressive: true })
-    .toBuffer();
+  // Ensure a minimum display size of 800px on the longest side — if the source is
+  // low-res and the crop region is small, the extracted image can be tiny (e.g. 300px).
+  // Upscaling with Lanczos produces acceptable results and prevents blurry gallery cards.
+  const MIN_GALLERY_DIM = 800;
+  const croppedBuffer = await pipeline.toBuffer();
+  const croppedMeta = await sharp(croppedBuffer).metadata();
+  const croppedW = croppedMeta.width || 1;
+  const croppedH = croppedMeta.height || 1;
+
+  let extractedBuffer: Buffer;
+  if (Math.max(croppedW, croppedH) < MIN_GALLERY_DIM) {
+    // Upscale so longest side hits MIN_GALLERY_DIM
+    extractedBuffer = await sharp(croppedBuffer)
+      .resize(MIN_GALLERY_DIM, MIN_GALLERY_DIM, { fit: 'inside', withoutEnlargement: false, kernel: 'lanczos3' })
+      .jpeg({ quality: 85, progressive: true })
+      .toBuffer();
+  } else {
+    extractedBuffer = await sharp(croppedBuffer)
+      .jpeg({ quality: 85, progressive: true })
+      .toBuffer();
+  }
 
   // Get pixel dimensions of the extracted crop
   const extractedMeta = await sharp(extractedBuffer).metadata();


### PR DESCRIPTION
## Summary
- Gallery image crops from low-res sources (e.g. Gallica 1000px pages) were ending up tiny (~300px). Now both pre-generated and on-the-fly crops upscale to 800px minimum using Lanczos3 interpolation.
- Gallica import bumped from 1000px to 2000px source images for new imports.
- Existing 171 Gallica books need a DB migration to update URLs (separate script).

## Changed files
- `src/lib/gallery-image-gen.ts` — min 800px upscale for pre-generated gallery images
- `src/app/api/crop-image/route.ts` — min 800px upscale for on-the-fly crops
- `src/app/api/import/gallica/route.ts` — 1000px → 2000px for new imports

## Test plan
- [ ] Verify gallery image at https://sourcelibrary.org/gallery/image/69504445618fd88f7039b9da-0 renders at reasonable size after deploy
- [ ] Import a new Gallica book and verify 2000px source URLs
- [ ] Check that large crops (>800px) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)