### PR TITLE
Fix zombie job accumulation: signal handlers + robust reaper

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2610,21 +2610,23 @@ async function run() {
     if (shouldRun(4)) {
       console.log('\n--- Phase 4: Dispatch translation to Lambda (SQS FIFO) ---');
 
-      // Zombie job reaper: cancel ANY jobs stuck in processing with 0 progress for >2h.
-      // These are dead Lambda workers that will never complete, blocking the in-flight cap.
+      // Zombie job reaper: cancel ANY job stuck in processing with no update for >1h.
+      // Workers crash, get OOM-killed, or stall — their jobs rot forever, blocking the in-flight cap.
       if (!DRY_RUN) {
-        const zombieThreshold = new Date(Date.now() - 2 * 60 * 60 * 1000);
+        const zombieThreshold = new Date(Date.now() - 1 * 60 * 60 * 1000);
         const zombieJobs = await db.collection('jobs').find({
           status: 'processing',
-          'progress.completed': 0,
-          created_at: { $lt: zombieThreshold },
+          $or: [
+            { updated_at: { $lt: zombieThreshold } },
+            { updated_at: { $exists: false }, created_at: { $lt: zombieThreshold } },
+          ],
         }).project({ _id: 1, book_id: 1, book_title: 1, type: 1 }).toArray();
 
         if (zombieJobs.length > 0) {
           const zombieBookIds = zombieJobs.map(j => j.book_id);
           await db.collection('jobs').updateMany(
             { _id: { $in: zombieJobs.map(j => j._id) } },
-            { $set: { status: 'failed', error: 'Auto-cancelled: stuck >2h with 0 progress', updated_at: new Date() } },
+            { $set: { status: 'failed', error: 'Auto-cancelled: stuck >1h with no update', updated_at: new Date() } },
           );
           // Reset affected books so they can be re-dispatched
           const rollbackMap = {

--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -304,24 +304,42 @@ async function main() {
     //     Workers crash, get OOM-killed, or time out — their jobs rot forever.
     const ZOMBIE_THRESHOLD_MS = 30 * 60 * 1000;
     const zombieCutoff = new Date(Date.now() - ZOMBIE_THRESHOLD_MS);
-    const reaped = await db.collection('jobs').updateMany(
-      {
-        status: 'processing',
-        $or: [
-          { updated_at: { $lt: zombieCutoff } },
-          { updated_at: { $exists: false }, started_at: { $lt: zombieCutoff } },
-        ],
-      },
-      {
-        $set: {
-          status: 'cancelled',
-          cancelled_at: new Date(),
-          cancel_reason: 'scheduler: zombie reaper (no heartbeat for >30min)',
-        },
+    // First find zombie jobs so we can clean up their book locks too
+    const zombieJobs = await db.collection('jobs').find({
+      status: 'processing',
+      $or: [
+        { updated_at: { $lt: zombieCutoff } },
+        { updated_at: { $exists: false }, started_at: { $lt: zombieCutoff } },
+      ],
+    }).project({ _id: 1, book_id: 1 }).toArray().catch(err => {
+      console.log(`[scheduler] zombie find failed: ${err.message}`);
+      return [];
+    });
+
+    if (zombieJobs.length > 0) {
+      // Cancel the zombie jobs
+      await db.collection('jobs').updateMany(
+        { _id: { $in: zombieJobs.map(j => j._id) } },
+        {
+          $set: {
+            status: 'cancelled',
+            cancelled_at: new Date(),
+            cancel_reason: 'scheduler: zombie reaper (no heartbeat for >30min)',
+          },
+        }
+      ).catch(err => { console.log(`[scheduler] zombie cancel failed: ${err.message}`); });
+
+      // Unset book.job on affected books so they can be re-dispatched
+      const zombieBookIds = zombieJobs.map(j => j.book_id).filter(Boolean);
+      if (zombieBookIds.length > 0) {
+        const bookCleanup = await db.collection('books').updateMany(
+          { id: { $in: zombieBookIds }, 'job': { $exists: true } },
+          { $unset: { job: '' }, $set: { updated_at: new Date() } },
+        ).catch(err => { console.log(`[scheduler] zombie book cleanup failed: ${err.message}`); return { modifiedCount: 0 }; });
+        console.log(`[scheduler] REAPED ${zombieJobs.length} zombie jobs, unset book.job on ${bookCleanup.modifiedCount} books`);
+      } else {
+        console.log(`[scheduler] REAPED ${zombieJobs.length} zombie jobs (no book_ids to clean)`);
       }
-    ).catch(err => { console.log(`[scheduler] zombie reap failed: ${err.message}`); return { modifiedCount: 0 }; });
-    if (reaped.modifiedCount > 0) {
-      console.log(`[scheduler] REAPED ${reaped.modifiedCount} zombie jobs`);
     }
 
     // 3. Survey running workers and compute used connection budget

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -97,6 +97,46 @@ const SKIP_PAGE_TYPES = ['blank', 'digitizer-notice', 'illustration', 'map', 'di
 // Short pages in batches cause the model to produce minimal responses without XML tags.
 const MIN_OCR_CHARS_FOR_BATCH = 200;
 
+// ── Graceful shutdown tracking ──
+// Track in-flight books so signal handlers can clean up zombie locks
+const activeBooks = new Map(); // bookId → jobId
+
+async function cleanupAndExit(reason) {
+  if (activeBooks.size === 0) {
+    console.log(`[TRANSLATE] ${reason} — no active books, exiting cleanly`);
+    process.exit(0);
+  }
+  console.log(`[TRANSLATE] ${reason} — cleaning up ${activeBooks.size} active book(s)`);
+  try {
+    const cleanupClient = new MongoClient(process.env.MONGODB_URI, {
+      serverSelectionTimeoutMS: 5000,
+      maxPoolSize: 1,
+    });
+    await cleanupClient.connect();
+    const db = cleanupClient.db('bookstore');
+    for (const [bookId, jobId] of activeBooks) {
+      await db.collection('books').updateOne(
+        { id: bookId },
+        { $unset: { job: '' }, $set: { updated_at: new Date() } },
+      );
+      if (jobId) {
+        await db.collection('jobs').updateOne(
+          { id: jobId, status: 'processing' },
+          { $set: { status: 'cancelled', cancelled_at: new Date(), cancel_reason: 'worker_shutdown' } },
+        );
+      }
+      console.log(`[TRANSLATE] Cleaned up book ${bookId} (job ${jobId})`);
+    }
+    await cleanupClient.close();
+  } catch (err) {
+    console.error(`[TRANSLATE] Cleanup failed: ${err.message}`);
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => cleanupAndExit('SIGTERM received'));
+process.on('SIGINT', () => cleanupAndExit('SIGINT received'));
+
 // ── MongoDB ──
 const client = new MongoClient(process.env.MONGODB_URI, {
   serverSelectionTimeoutMS: 10000,
@@ -967,6 +1007,8 @@ async function main() {
   async function processWithJob(book) {
     const zero = { translated: 0, failed: 0, completed: 0, inputTokens: 0, outputTokens: 0 };
     let jobId = book.job?.job_id;
+    // Track for graceful shutdown cleanup
+    activeBooks.set(book.id, jobId || null);
     if (!jobId) {
       const orphanJob = await db.collection('jobs').findOne(
         { book_id: book.id, type: 'translation', status: { $in: ['pending', 'processing'] } },
@@ -1059,6 +1101,7 @@ async function main() {
 
         processWithJob(book).then(result => {
           activeSlots--;
+          activeBooks.delete(book.id);
           results.push(result);
 
           // If queue is getting low, fetch more
@@ -1076,6 +1119,7 @@ async function main() {
           }
         }).catch(err => {
           activeSlots--;
+          activeBooks.delete(book.id);
           console.error(`[TRANSLATE] processWithJob error: ${err.message}`);
           results.push({ translated: 0, failed: 0, completed: 0, inputTokens: 0, outputTokens: 0 });
           tryStartNext();
@@ -1150,7 +1194,7 @@ async function main() {
   await client.close();
 }
 
-main().catch((err) => {
+main().catch(async (err) => {
   console.error('[TRANSLATE] Fatal:', err);
-  process.exit(1);
+  await cleanupAndExit(`Fatal error: ${err.message}`);
 });


### PR DESCRIPTION
## Summary
- **translate-worker.mjs:** Add SIGTERM/SIGINT handlers that track active books in a `Map` and clean up on shutdown (unset `book.job`, cancel active jobs). Fatal errors also trigger cleanup instead of leaving zombies.
- **pipeline-orchestrator.mjs:** Remove the `progress.completed: 0` filter from the zombie reaper — now catches ANY translation job stuck >1h with no `updated_at` heartbeat (was >2h with zero progress only).
- **scheduler.mjs:** After cancelling zombie jobs, also `$unset book.job` on affected books so they can be re-dispatched instead of stuck forever.

## Test plan
- [ ] Deploy to Hetzner and verify translate-worker starts cleanly
- [ ] Send SIGTERM to translate-worker mid-run, confirm books get unlocked
- [ ] Monitor orchestrator logs for zombie reaper activity over 24h
- [ ] Verify no books remain stuck in `translate_submitted` with stale `book.job` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)