### PR TITLE
Bump IIIF import resolution to 2000px for all providers

### DIFF
--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -207,12 +207,12 @@ export const POST = withAuth(async (request, session) => {
       const canvas = canvases[index];
       const serviceId = canvas?.images?.[0]?.resource?.service?.['@id'];
       if (serviceId) {
-        return `${serviceId}/full/1000,/0/default.jpg`;
+        return `${serviceId}/full/2000,/0/default.jpg`;
       }
       // Fallback to webcache
       const canvasId = canvas?.['@id']?.split('/').pop();
       if (canvasId) {
-        return `https://www.e-rara.ch/download/webcache/1000/${canvasId}`;
+        return `https://www.e-rara.ch/download/webcache/2000/${canvasId}`;
       }
       return null;
     };

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -283,7 +283,7 @@ export const POST = withAuth(async (request, session) => {
         const imageService = service?.id || service?.['@id'];
 
         if (imageService) {
-          imageUrl = `${imageService}/full/1000,/0/default.jpg`;
+          imageUrl = `${imageService}/full/2000,/0/default.jpg`;
         }
 
         let thumbnailUrl = canvas.thumbnail?.[0]?.id || '';
@@ -304,7 +304,7 @@ export const POST = withAuth(async (request, session) => {
         const imageService = imageResource?.service?.['@id'];
 
         if (imageService) {
-          imageUrl = `${imageService}/full/1000,/0/default.jpg`;
+          imageUrl = `${imageService}/full/2000,/0/default.jpg`;
         }
 
         let thumbnailUrl = imageUrl;

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -80,7 +80,7 @@ function pickBestImage(variants: LOCFileVariant[]): { photo: string; thumbnail: 
   if (jp2?.info) {
     // IIIF Image API — construct from info endpoint base
     const iiifBase = jp2.info.replace(/\/info\.json$/, '');
-    photo = `${iiifBase}/full/1000,/0/default.jpg`;
+    photo = `${iiifBase}/full/2000,/0/default.jpg`;
     thumbnail = `${iiifBase}/full/200,/0/default.jpg`;
   }
 

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -154,7 +154,7 @@ export const POST = withAuth(async (request, session) => {
     // Format: bsb_id_pagenum (padded to 5 digits)
     const getPageImageUrl = (pageNum: number) => {
       const paddedPage = String(pageNum + 1).padStart(5, '0');
-      return `https://api.digitale-sammlungen.de/iiif/image/v2/${normalizedId}_${paddedPage}/full/1000,/0/default.jpg`;
+      return `https://api.digitale-sammlungen.de/iiif/image/v2/${normalizedId}_${paddedPage}/full/2000,/0/default.jpg`;
     };
 
     const getThumbnailUrl = (pageNum: number) => {

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -198,7 +198,7 @@ export const POST = withAuth(async (request, session) => {
                        canvas?.images?.[0]?.resource?.['@id'];
       if (imageUrl) {
         // Use IIIF Image API for consistent sizing
-        return `${imageUrl}/full/1000,/0/default.jpg`;
+        return `${imageUrl}/full/2000,/0/default.jpg`;
       }
       return null;
     };


### PR DESCRIPTION
## Summary
- Same fix as #740 (Gallica) applied to the remaining 5 IIIF import routes
- MDZ, Library of Congress, Wellcome, e-rara, and generic IIIF all had `/full/1000,/` hardcoded
- Now all use `/full/2000,/` — 2x resolution for new imports, reasonable file sizes
- e-rara webcache fallback also bumped from 1000 to 2000

## Changed files
- `src/app/api/import/mdz/route.ts`
- `src/app/api/import/loc/route.ts`
- `src/app/api/import/wellcome/route.ts`
- `src/app/api/import/e-rara/route.ts`
- `src/app/api/import/iiif/route.ts`

## Test plan
- [ ] Import a test book from MDZ and verify 2000px source URLs in page records
- [ ] Existing books unaffected (only new imports get higher res)

🤖 Generated with [Claude Code](https://claude.com/claude-code)