### PR TITLE
Fix search thumbnails, Libraries counter, gallery lazy-loading

### DIFF
--- a/src/app/gallery/collections/[slug]/CollectionImageCard.tsx
+++ b/src/app/gallery/collections/[slug]/CollectionImageCard.tsx
@@ -18,7 +18,7 @@ export interface CollectionImageProps {
   likeCount?: number;
 }
 
-export default function CollectionImageCard({ item }: { item: CollectionImageProps }) {
+export default function CollectionImageCard({ item, priority = false }: { item: CollectionImageProps; priority?: boolean }) {
   const [imageError, setImageError] = useState(false);
   const displayUrl = item.thumbnailUrl || item.extractedUrl || item.imageUrl;
 
@@ -35,6 +35,8 @@ export default function CollectionImageCard({ item }: { item: CollectionImagePro
               sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 16vw"
               onError={() => setImageError(true)}
               unoptimized
+              priority={priority}
+              loading={priority ? 'eager' : 'lazy'}
             />
           ) : (
             <div className="absolute inset-0 flex items-center justify-center text-stone-300">

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -121,8 +121,8 @@ export default async function CollectionDetailPage({ params }: PageProps) {
           </div>
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-            {data.items.map((item) => (
-              <CollectionImageCard key={item.id} item={item} />
+            {data.items.map((item, i) => (
+              <CollectionImageCard key={item.id} item={item} priority={i < 10} />
             ))}
           </div>
         )}

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -75,7 +75,6 @@ async function fetchContributingLibraries(): Promise<ContributingLibrary[]> {
     .select('contributing_library')
     .eq('visible', true)
     .gt('pages_count', 0)
-    .gt('pages_translated', 0)
     .not('contributing_library', 'is', null);
 
   if (error) throw new Error(`Contributing libraries query failed: ${error.message}`);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1155,6 +1155,7 @@ export default function SearchPage() {
 function BookResultCard({ result, query }: { result: SearchResult; query: string }) {
   const cover = result.thumbnail || (result as any).thumbnail_blob;
   const text = result.snippet || result.summary;
+  const [imgError, setImgError] = useState(false);
 
   return (
     <Link
@@ -1162,13 +1163,15 @@ function BookResultCard({ result, query }: { result: SearchResult; query: string
       className="block bg-white rounded-xl border border-border-light p-4 hover:border-accent-rust/30 hover:shadow-md transition-all"
     >
       <div className="flex items-start gap-4">
-        {cover ? (
+        {cover && !imgError ? (
           <Image
             src={cover}
             alt=""
             width={60}
             height={84}
             className="rounded shadow-sm flex-shrink-0 object-cover"
+            onError={() => setImgError(true)}
+            unoptimized
           />
         ) : (
           <div className="w-[60px] h-[84px] rounded bg-warm flex items-center justify-center flex-shrink-0">

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -600,7 +600,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
             )}
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               {allItems.map((item, idx) => (
-                <GalleryCard key={`${item.pageId}-${item.detectionIndex}-${idx}`} item={item} />
+                <GalleryCard key={`${item.pageId}-${item.detectionIndex}-${idx}`} item={item} priority={idx < 12} />
               ))}
             </div>
 
@@ -630,7 +630,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   );
 }
 
-function GalleryCard({ item }: { item: GalleryItem }) {
+function GalleryCard({ item, priority = false }: { item: GalleryItem; priority?: boolean }) {
   const [imageError, setImageError] = useState(false);
   const [useCropFallback, setUseCropFallback] = useState(false);
 
@@ -672,6 +672,8 @@ function GalleryCard({ item }: { item: GalleryItem }) {
               }
             }}
             unoptimized={!isPreGenerated && !!item.bbox}
+            priority={priority}
+            loading={priority ? 'eager' : 'lazy'}
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center text-stone-300">


### PR DESCRIPTION
## Summary
- **Search thumbnails:** `BookResultCard` now gracefully falls back to a book icon when thumbnail URLs fail to load (was showing broken image placeholders)
- **Libraries "0 institutions":** Removed `pages_translated > 0` filter from contributing institutions query — many books have `contributing_library` set but aren't translated yet, causing the counter to undercount or show 0
- **Gallery above-the-fold:** Added `priority` prop to `GalleryCard` and `CollectionImageCard` — first 10-12 images now load eagerly instead of all lazy, eliminating the blank gray cards on initial page load

## Test plan
- [ ] Search for "Paracelsus" — verify all result thumbnails show either an image or a book icon, no broken placeholders
- [ ] Visit /libraries — verify "contributing institutions" count is > 0 in the header
- [ ] Visit /gallery — verify first screen of images loads immediately without blank gray cards
- [ ] Visit /gallery/collections/[any-slug] — verify same immediate loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)