### PR TITLE
Rank search results by publication date (oldest first)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -341,8 +341,8 @@ export async function GET(request: NextRequest) {
     if (sortBy === 'date_asc' || sortBy === 'date_desc') {
       const dir = sortBy === 'date_asc' ? 1 : -1;
       results.sort((a, b) => {
-        const aYear = parseInt(a.published?.match(/\d{4}/)?.[0] || '0');
-        const bYear = parseInt(b.published?.match(/\d{4}/)?.[0] || '0');
+        const aYear = parseInt(a.published?.match(/\d{3,4}/)?.[0] || '0');
+        const bYear = parseInt(b.published?.match(/\d{3,4}/)?.[0] || '0');
         return (aYear - bYear) * dir;
       });
     } else if (sortBy === 'title') {
@@ -381,8 +381,8 @@ export async function GET(request: NextRequest) {
         if (aOriginal !== bOriginal) return bOriginal - aOriginal;
 
         // 4. Older editions rank higher (earlier = closer to source)
-        const aYear = parseInt(a.published?.match(/\d{4}/)?.[0] || '9999');
-        const bYear = parseInt(b.published?.match(/\d{4}/)?.[0] || '9999');
+        const aYear = parseInt(a.published?.match(/\d{3,4}/)?.[0] || '9999');
+        const bYear = parseInt(b.published?.match(/\d{3,4}/)?.[0] || '9999');
         if (aYear !== bYear) return aYear - bYear;
 
         // 5. Quality score tie-breaker
@@ -454,8 +454,8 @@ export async function GET(request: NextRequest) {
 
         // Sort nearby by year distance from target
         nearby.sort((a, b) => {
-          const aYear = parseInt(a.published?.match(/\d{4}/)?.[0] || '0');
-          const bYear = parseInt(b.published?.match(/\d{4}/)?.[0] || '0');
+          const aYear = parseInt(a.published?.match(/\d{3,4}/)?.[0] || '0');
+          const bYear = parseInt(b.published?.match(/\d{3,4}/)?.[0] || '0');
           return Math.abs(aYear - yearNum) - Math.abs(bYear - yearNum);
         });
       }

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -6,6 +6,13 @@ import type { SearchResult } from '@/lib/api-client/types/search';
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';
 
+/** Parse year from published field — handles 3-digit years (e.g. "895") and 4-digit */
+function parsePublishedYear(published: string | undefined): number {
+  if (!published) return 9999;
+  const match = published.match(/\d{3,4}/);
+  return match ? parseInt(match[0]) : 9999;
+}
+
 export const preferredRegion = 'fra1';
 
 interface IndexResult {
@@ -202,6 +209,30 @@ async function searchBooks(
       }
     }
   }
+
+  // Canon-weighted reranking: older editions first, original language preferred
+  const queryLower = query.toLowerCase();
+  books.sort((a: any, b: any) => {
+    // 1. Title match (strongest signal)
+    const aTitle = (a.display_title || a.title || '').toLowerCase();
+    const bTitle = (b.display_title || b.title || '').toLowerCase();
+    const aTitleMatch = aTitle.includes(queryLower);
+    const bTitleMatch = bTitle.includes(queryLower);
+    if (aTitleMatch !== bTitleMatch) return aTitleMatch ? -1 : 1;
+
+    // 2. Original language beats English translations
+    const aOriginal = a.language !== 'English' ? 1 : 0;
+    const bOriginal = b.language !== 'English' ? 1 : 0;
+    if (aOriginal !== bOriginal) return bOriginal - aOriginal;
+
+    // 3. Older editions rank higher (earlier = closer to source)
+    const aYear = parsePublishedYear(a.published);
+    const bYear = parsePublishedYear(b.published);
+    if (aYear !== bYear) return aYear - bYear;
+
+    // 4. Quality score tie-breaker
+    return (b.quality_score || 0) - (a.quality_score || 0);
+  });
 
   const hasMore = books.length > limit;
   const truncated = hasMore ? books.slice(0, limit) : books;


### PR DESCRIPTION
## Summary
- The unified search (typeahead dropdown) returned results in Atlas Search relevance order only — a 1925 Loeb Plato ranked above an 1150 manuscript
- Added canon-weighted reranking: title match → original language → older publication date → quality score
- Fixed year parsing regex (`\d{4}` → `\d{3,4}`) so pre-1000 manuscripts like the Clarke Plato (895) rank correctly

## Test plan
- [ ] Search "plato" — 1150 Thirty-Two Dialogues and 895 Clarke Plato should appear before 1925 Loeb editions
- [ ] Search "ficino" — Latin originals should rank above English translations
- [ ] Search "hermes" — verify no regressions in result ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)