### PR TITLE
Use display_title in CollectionBookCard and BookMap

### DIFF
--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -42,7 +42,7 @@ async function fetchMapData() {
     .find(
       { visible: true, 'locations.0': { $exists: true } },
       {
-        projection: { id: 1, title: 1, author: 1, year: 1, slug: 1, locations: 1 },
+        projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1, locations: 1 },
         maxTimeMS: 45000,
       },
     )
@@ -74,6 +74,7 @@ async function fetchMapData() {
         group.books.push({
           id: book.id as string,
           title: (book.title as string) || 'Untitled',
+          display_title: (book.display_title as string) || undefined,
           author: (book.author as string) || 'Unknown',
           year: (book.year as number) || null,
           slug: (book.slug as string) || '',

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -13,6 +13,7 @@ interface CollectionBook {
   id?: string;
   slug?: string;
   title: string;
+  display_title?: string | null;
   author: string;
   year: number;
   pages?: number;
@@ -60,7 +61,7 @@ export default function CollectionBookCard({ book, priority = false }: Collectio
           {thumbnailUrl && !imageError ? (
             <Image
               src={thumbnailUrl}
-              alt={book.title}
+              alt={book.display_title || book.title}
               fill
               quality={85}
               className={cn(
@@ -108,7 +109,7 @@ export default function CollectionBookCard({ book, priority = false }: Collectio
             className="text-base font-bold text-primary group-hover:text-accent-rust transition-colors mb-2 leading-tight line-clamp-2"
             style={{ fontFamily: 'var(--font-serif)' }}
           >
-            {book.title}
+            {book.display_title || book.title}
           </h3>
           <p className="text-sm text-secondary mb-3 line-clamp-1"><AuthorName author={book.author} /></p>
 

--- a/src/components/explore/BookMap.tsx
+++ b/src/components/explore/BookMap.tsx
@@ -13,6 +13,7 @@ export interface BookLocation {
   books: Array<{
     id: string;
     title: string;
+    display_title?: string;
     author: string;
     year: number | null;
     slug: string;
@@ -331,7 +332,7 @@ export default function BookMap({ locations, stats }: BookMapProps) {
                     className="text-[13px] leading-snug font-medium"
                     style={{ color: 'var(--text-primary)' }}
                   >
-                    {book.title.length > 65 ? book.title.substring(0, 65) + '\u2026' : book.title}
+                    {(() => { const t = book.display_title || book.title; return t.length > 65 ? t.substring(0, 65) + '\u2026' : t; })()}
                   </div>
                   <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
                     {book.author.length > 40 ? book.author.substring(0, 40) + '\u2026' : book.author}


### PR DESCRIPTION
## Summary
- **CollectionBookCard** was rendering raw `book.title` (shelfmarks like "Bodleian Library MS. Barocci 43") instead of enriched `display_title`
- **BookMap** same issue — map popups showed shelfmarks instead of English titles
- Added `display_title` to both component interfaces and the map data fallback query
- Also re-ran the display_title enrichment script on 32 books that still had shelfmarks as their `display_title`

## Test plan
- [ ] Visit a collection page with Bodleian manuscripts — titles should show English names
- [ ] Visit /explore/map — click a location with Bodleian books, verify English titles in popup
- [ ] Verify no type errors (`npx tsc --noEmit` passes clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)