### PR TITLE
BPH catalog browse view with shelfmarks

### DIFF
--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+const PER_PAGE = 50;
+
+export async function GET(req: NextRequest) {
+  const sp = req.nextUrl.searchParams;
+  const q = sp.get('q') || '';
+  const keyword = sp.get('keyword') || '';
+  const sort = sp.get('sort') || 'title';
+  const offset = Math.max(0, parseInt(sp.get('offset') || '0') || 0);
+  const digitized = sp.get('digitized'); // 'true' | 'false' | null
+
+  let query = supabase
+    .from('bph_works')
+    .select('ubn, title, author, year, shelf_mark, keywords, ia_identifier, ustc_sn, place, publisher, printer', { count: 'exact' });
+
+  // Text search
+  if (q.length >= 2) {
+    query = query.or(`title.ilike.%${q}%,author.ilike.%${q}%,shelf_mark.ilike.%${q}%`);
+  }
+
+  // Keyword filter
+  if (keyword) {
+    query = query.eq('keywords', keyword);
+  }
+
+  // Digitized filter
+  if (digitized === 'true') {
+    query = query.not('ia_identifier', 'is', null);
+  } else if (digitized === 'false') {
+    query = query.is('ia_identifier', null);
+  }
+
+  // Sort
+  switch (sort) {
+    case 'year_asc':
+      query = query.order('year', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    case 'year_desc':
+      query = query.order('year', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    case 'author':
+      query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    case 'shelfmark':
+      query = query.order('shelf_mark', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    default:
+      query = query.order('title', { ascending: true });
+  }
+
+  query = query.range(offset, offset + PER_PAGE - 1);
+
+  const { data, count, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ works: data || [], total: count || 0 });
+}

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -11,6 +11,8 @@ import { getPartnerBySlug, getAllPartnerSlugs } from '@/lib/library-partners';
 import CollectionBookCard from '@/components/CollectionBookCard';
 import CollectionFilters from '@/components/collections/CollectionFilters';
 import { bookTitle } from '@/lib/collections-utils';
+import LibraryViewTabs from '@/components/libraries/LibraryViewTabs';
+import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
 
 const PER_PAGE = 60;
 
@@ -149,6 +151,36 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
   };
 }
 
+/** Build a UBN → { id, slug } map for BPH books on Source Library */
+async function fetchBphDigitizedMap(): Promise<Record<string, { id: string; slug: string }>> {
+  try {
+    const db = await getDb();
+    const bphBooks = await db.collection('books').find(
+      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true } },
+      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 } }
+    ).toArray();
+
+    const map: Record<string, { id: string; slug: string }> = {};
+    for (const b of bphBooks) {
+      const ubn = b.dublin_core?.dc_identifier;
+      if (ubn) {
+        map[ubn] = { id: b.id, slug: b.slug || b.id };
+      }
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+/** Get total count of BPH catalog works */
+async function fetchBphCatalogTotal(): Promise<number> {
+  const { count } = await supabase
+    .from('bph_works')
+    .select('*', { count: 'exact', head: true });
+  return count || 0;
+}
+
 // ---------- Page ----------
 
 export default async function LibraryDetailPage({ params, searchParams }: Props) {
@@ -161,10 +193,18 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
   const language = typeof sp.language === 'string' ? sp.language : '';
   const q = typeof sp.q === 'string' ? sp.q : '';
   const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0') || 0;
+  const view = typeof sp.view === 'string' ? sp.view : 'books';
 
-  const { books, total, languages, galleryImages, contributingLibraries } = await fetchLibraryData(
-    partner.providerKey, sort, language, offset, q || undefined
-  );
+  const isBph = partner.providerKey === 'bph';
+
+  // Fetch data — catalog data only for BPH
+  const [libraryData, digitizedUbns, catalogTotal] = await Promise.all([
+    fetchLibraryData(partner.providerKey, sort, language, offset, q || undefined),
+    isBph ? fetchBphDigitizedMap() : Promise.resolve({}),
+    isBph ? fetchBphCatalogTotal() : Promise.resolve(0),
+  ]);
+
+  const { books, total, languages, galleryImages, contributingLibraries } = libraryData;
 
   const totalPages = Math.ceil(total / PER_PAGE);
   const currentPage = Math.floor(offset / PER_PAGE) + 1;
@@ -190,7 +230,13 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
           </p>
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-            <span>{total.toLocaleString()} books</span>
+            <span>{total.toLocaleString()} translated books</span>
+            {isBph && catalogTotal > 0 && (
+              <>
+                <span className="w-px h-4 bg-white/20" />
+                <span>{catalogTotal.toLocaleString()} works in catalog</span>
+              </>
+            )}
             {languages.length > 0 && (
               <>
                 <span className="w-px h-4 bg-white/20" />
@@ -290,100 +336,130 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
       )}
 
       <div className="max-w-7xl mx-auto px-6 py-10">
-        {/* All Books Header */}
-        <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
-          <div>
-            <h2
-              className="text-2xl sm:text-3xl text-primary font-display"
-            >
-              All Books
-            </h2>
-            <p className="text-sm text-muted mt-1">
-              {total.toLocaleString()} books from {partner.name}
-            </p>
-          </div>
-
-          <CollectionFilters
-            collectionId={slug}
-            languages={filteredLanguages}
+        {/* View tabs (BPH only) */}
+        {isBph && (
+          <LibraryViewTabs
             basePath={basePath}
-            showSearch
+            catalogTotal={catalogTotal}
+            booksTotal={total}
           />
-        </div>
-
-        {/* Books Grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-          {books.map((book, i) => (
-            <CollectionBookCard
-              key={book.id}
-              book={{
-                bookId: book.id,
-                id: book.id,
-                slug: book.slug,
-                title: bookTitle(book),
-                author: book.author || '',
-                year: book.year || 0,
-                pages_count: book.pages_count,
-                pages_ocr: book.pages_ocr,
-                pages_translated: book.pages_translated,
-                thumbnail: book.thumbnail || book.thumbnail_blob || book.photo,
-                thumbnail_blob: book.thumbnail_blob,
-                language: book.language,
-                published: book.published,
-                translation_percent: book.pages_ocr && book.pages_translated
-                  ? Math.round((book.pages_translated / Math.max((book.pages_ocr || 0) - (book.pages_blank || 0), 1)) * 100)
-                  : 0,
-              }}
-              priority={i < 10}
-            />
-          ))}
-        </div>
-
-        {/* Empty state */}
-        {books.length === 0 && (
-          <div className="text-center py-16">
-            <BookOpen className="w-12 h-12 text-muted mx-auto mb-4" />
-            <p className="text-lg text-secondary">No books found matching your filters.</p>
-            <Link
-              href={basePath}
-              className="text-sm text-accent-rust hover:underline mt-2 inline-block"
-            >
-              Clear filters
-            </Link>
-          </div>
         )}
 
-        {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-4 mt-10 text-sm">
-            {offset > 0 ? (
-              <Link
-                href={`${basePath}?sort=${sort}${language ? `&language=${language}` : ''}&offset=${Math.max(0, offset - PER_PAGE)}`}
-                className="px-4 py-2 rounded-lg border border-border-light hover:bg-warm transition-colors"
-              >
-                Previous
-              </Link>
-            ) : (
-              <span className="px-4 py-2 rounded-lg border border-border-light opacity-30">
-                Previous
-              </span>
-            )}
-            <span className="text-muted">
-              Page {currentPage} of {totalPages}
-            </span>
-            {currentPage < totalPages ? (
-              <Link
-                href={`${basePath}?sort=${sort}${language ? `&language=${language}` : ''}&offset=${offset + PER_PAGE}`}
-                className="px-4 py-2 rounded-lg border border-border-light hover:bg-warm transition-colors"
-              >
-                Next
-              </Link>
-            ) : (
-              <span className="px-4 py-2 rounded-lg border border-border-light opacity-30">
-                Next
-              </span>
-            )}
+        {/* Catalog View */}
+        {isBph && view === 'catalog' ? (
+          <div>
+            <div className="mb-6">
+              <h2 className="text-2xl sm:text-3xl text-primary font-display">
+                Library Catalog
+              </h2>
+              <p className="text-sm text-muted mt-1">
+                Complete catalog of the Bibliotheca Philosophica Hermetica — {catalogTotal.toLocaleString()} works in the collection.
+                Works available on Source Library are marked with a book icon.
+              </p>
+            </div>
+            <BphCatalogBrowser
+              basePath={basePath}
+              digitizedUbns={digitizedUbns}
+            />
           </div>
+        ) : (
+          <>
+            {/* All Books Header */}
+            <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
+              <div>
+                <h2
+                  className="text-2xl sm:text-3xl text-primary font-display"
+                >
+                  {isBph ? 'Translated Books' : 'All Books'}
+                </h2>
+                <p className="text-sm text-muted mt-1">
+                  {total.toLocaleString()} books from {partner.name}
+                </p>
+              </div>
+
+              <CollectionFilters
+                collectionId={slug}
+                languages={filteredLanguages}
+                basePath={basePath}
+                showSearch
+              />
+            </div>
+
+            {/* Books Grid */}
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              {books.map((book, i) => (
+                <CollectionBookCard
+                  key={book.id}
+                  book={{
+                    bookId: book.id,
+                    id: book.id,
+                    slug: book.slug,
+                    title: bookTitle(book),
+                    author: book.author || '',
+                    year: book.year || 0,
+                    pages_count: book.pages_count,
+                    pages_ocr: book.pages_ocr,
+                    pages_translated: book.pages_translated,
+                    thumbnail: book.thumbnail || book.thumbnail_blob || book.photo,
+                    thumbnail_blob: book.thumbnail_blob,
+                    language: book.language,
+                    published: book.published,
+                    translation_percent: book.pages_ocr && book.pages_translated
+                      ? Math.round((book.pages_translated / Math.max((book.pages_ocr || 0) - (book.pages_blank || 0), 1)) * 100)
+                      : 0,
+                  }}
+                  priority={i < 10}
+                />
+              ))}
+            </div>
+
+            {/* Empty state */}
+            {books.length === 0 && (
+              <div className="text-center py-16">
+                <BookOpen className="w-12 h-12 text-muted mx-auto mb-4" />
+                <p className="text-lg text-secondary">No books found matching your filters.</p>
+                <Link
+                  href={basePath}
+                  className="text-sm text-accent-rust hover:underline mt-2 inline-block"
+                >
+                  Clear filters
+                </Link>
+              </div>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-4 mt-10 text-sm">
+                {offset > 0 ? (
+                  <Link
+                    href={`${basePath}?sort=${sort}${language ? `&language=${language}` : ''}&offset=${Math.max(0, offset - PER_PAGE)}`}
+                    className="px-4 py-2 rounded-lg border border-border-light hover:bg-warm transition-colors"
+                  >
+                    Previous
+                  </Link>
+                ) : (
+                  <span className="px-4 py-2 rounded-lg border border-border-light opacity-30">
+                    Previous
+                  </span>
+                )}
+                <span className="text-muted">
+                  Page {currentPage} of {totalPages}
+                </span>
+                {currentPage < totalPages ? (
+                  <Link
+                    href={`${basePath}?sort=${sort}${language ? `&language=${language}` : ''}&offset=${offset + PER_PAGE}`}
+                    className="px-4 py-2 rounded-lg border border-border-light hover:bg-warm transition-colors"
+                  >
+                    Next
+                  </Link>
+                ) : (
+                  <span className="px-4 py-2 rounded-lg border border-border-light opacity-30">
+                    Next
+                  </span>
+                )}
+              </div>
+            )}
+          </>
         )}
 
         {/* Attribution */}

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useDebouncedCallback } from 'use-debounce';
+import { Search, X, ChevronLeft, ChevronRight, BookMarked } from 'lucide-react';
+
+interface BphWork {
+  ubn: string;
+  title: string;
+  author: string | null;
+  year: number | null;
+  shelf_mark: string | null;
+  keywords: string | null;
+  place: string | null;
+  publisher: string | null;
+  printer: string | null;
+  ia_identifier: string | null;
+  ustc_sn: string | null;
+}
+
+const PER_PAGE = 50;
+
+const SORT_OPTIONS = [
+  { value: 'title', label: 'Title A-Z' },
+  { value: 'author', label: 'Author A-Z' },
+  { value: 'year_asc', label: 'Oldest first' },
+  { value: 'year_desc', label: 'Newest first' },
+  { value: 'shelfmark', label: 'Shelfmark' },
+];
+
+const KEYWORD_OPTIONS = [
+  { value: '', label: 'All subjects' },
+  { value: 'hermetica', label: 'Hermetica' },
+  { value: 'alchemy', label: 'Alchemy' },
+  { value: 'mysticism', label: 'Mysticism' },
+  { value: 'esotericism', label: 'Esotericism' },
+  { value: 'rosicrucianism', label: 'Rosicrucianism' },
+  { value: 'Kabbalah', label: 'Kabbalah' },
+  { value: 'freemasonry', label: 'Freemasonry' },
+  { value: 'theosophy', label: 'Theosophy' },
+  { value: 'anthroposophy', label: 'Anthroposophy' },
+  { value: 'gnosis', label: 'Gnosis' },
+  { value: 'magic', label: 'Magic' },
+  { value: 'astrology', label: 'Astrology' },
+  { value: 'Sufism', label: 'Sufism' },
+  { value: 'Buddhism', label: 'Buddhism' },
+  { value: 'Judaica', label: 'Judaica' },
+  { value: 'grail', label: 'Grail' },
+  { value: 'catharism', label: 'Catharism' },
+  { value: 'tarot', label: 'Tarot' },
+  { value: 'reference', label: 'Reference' },
+  { value: 'history of religion', label: 'History of Religion' },
+];
+
+interface Props {
+  basePath: string;
+  /** Map of UBN → { id, slug } for BPH books that exist on Source Library */
+  digitizedUbns: Record<string, { id: string; slug: string }>;
+}
+
+export default function BphCatalogBrowser({ basePath, digitizedUbns }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const initialQ = searchParams.get('cq') || '';
+  const initialSort = searchParams.get('csort') || 'title';
+  const initialKeyword = searchParams.get('ckeyword') || '';
+  const initialOffset = parseInt(searchParams.get('coffset') || '0') || 0;
+
+  const [works, setWorks] = useState<BphWork[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState(initialQ);
+  const [sort, setSort] = useState(initialSort);
+  const [keyword, setKeyword] = useState(initialKeyword);
+  const [offset, setOffset] = useState(initialOffset);
+
+  const fetchWorks = useCallback(async (q: string, s: string, kw: string, off: number) => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (q) params.set('q', q);
+      if (s) params.set('sort', s);
+      if (kw) params.set('keyword', kw);
+      if (off) params.set('offset', String(off));
+      const res = await fetch(`/api/catalog/bph?${params}`);
+      const data = await res.json();
+      setWorks(data.works || []);
+      setTotal(data.total || 0);
+    } catch {
+      setWorks([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Sync URL params
+  const updateUrl = useCallback((q: string, s: string, kw: string, off: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    // Preserve existing params (view tab, etc.)
+    if (q) params.set('cq', q); else params.delete('cq');
+    if (s && s !== 'title') params.set('csort', s); else params.delete('csort');
+    if (kw) params.set('ckeyword', kw); else params.delete('ckeyword');
+    if (off) params.set('coffset', String(off)); else params.delete('coffset');
+    params.set('view', 'catalog');
+    router.replace(`${basePath}?${params}`, { scroll: false });
+  }, [searchParams, router, basePath]);
+
+  useEffect(() => {
+    fetchWorks(initialQ, initialSort, initialKeyword, initialOffset);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const debouncedSearch = useDebouncedCallback((value: string) => {
+    setOffset(0);
+    fetchWorks(value, sort, keyword, 0);
+    updateUrl(value, sort, keyword, 0);
+  }, 300);
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    debouncedSearch(value);
+  };
+
+  const handleSortChange = (newSort: string) => {
+    setSort(newSort);
+    setOffset(0);
+    fetchWorks(searchQuery, newSort, keyword, 0);
+    updateUrl(searchQuery, newSort, keyword, 0);
+  };
+
+  const handleKeywordChange = (newKw: string) => {
+    setKeyword(newKw);
+    setOffset(0);
+    fetchWorks(searchQuery, sort, newKw, 0);
+    updateUrl(searchQuery, sort, newKw, 0);
+  };
+
+  const handlePage = (newOffset: number) => {
+    setOffset(newOffset);
+    fetchWorks(searchQuery, sort, keyword, newOffset);
+    updateUrl(searchQuery, sort, keyword, newOffset);
+  };
+
+  const currentPage = Math.floor(offset / PER_PAGE) + 1;
+  const totalPages = Math.ceil(total / PER_PAGE);
+
+  return (
+    <div>
+      {/* Filters row */}
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="Search catalog..."
+            className="text-sm border border-border-light rounded-md pl-8 pr-8 py-1.5 bg-white text-primary w-56 focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => handleSearchChange('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-primary"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        <select
+          value={keyword}
+          onChange={(e) => handleKeywordChange(e.target.value)}
+          className="text-sm border border-border-light rounded-md px-3 py-1.5 bg-white text-primary"
+        >
+          {KEYWORD_OPTIONS.map(o => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+
+        <select
+          value={sort}
+          onChange={(e) => handleSortChange(e.target.value)}
+          className="text-sm border border-border-light rounded-md px-3 py-1.5 bg-white text-primary"
+        >
+          {SORT_OPTIONS.map(o => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+
+        <span className="text-sm text-muted ml-auto">
+          {total.toLocaleString()} works
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="border border-border-light rounded-lg overflow-hidden bg-white">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border-light bg-warm">
+                <th className="text-left px-3 py-2.5 font-medium text-secondary">Title</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden sm:table-cell">Author</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary w-16">Year</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Shelfmark</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden lg:table-cell">Subject</th>
+                <th className="text-center px-3 py-2.5 font-medium text-secondary w-10" title="On Source Library">SL</th>
+              </tr>
+            </thead>
+            <tbody className={loading ? 'opacity-50' : ''}>
+              {works.map((w) => {
+                const digitized = digitizedUbns[w.ubn];
+                return (
+                  <tr
+                    key={w.ubn}
+                    className="border-b border-border-light last:border-0 hover:bg-cream/50 transition-colors"
+                  >
+                    <td className="px-3 py-2">
+                      <div className="font-medium text-primary leading-snug">
+                        {digitized ? (
+                          <a
+                            href={`/book/${digitized.slug || digitized.id}`}
+                            className="hover:text-accent-rust transition-colors"
+                          >
+                            {w.title}
+                          </a>
+                        ) : (
+                          w.title
+                        )}
+                      </div>
+                      {/* Mobile: show author + place inline */}
+                      <div className="text-xs text-muted sm:hidden mt-0.5">
+                        {w.author}{w.place ? ` · ${w.place}` : ''}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-secondary hidden sm:table-cell">
+                      {w.author || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 text-secondary tabular-nums">
+                      {w.year || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 text-secondary font-mono text-xs hidden md:table-cell">
+                      {w.shelf_mark || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 hidden lg:table-cell">
+                      {w.keywords ? (
+                        <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-cream border border-border-light text-secondary capitalize">
+                          {w.keywords}
+                        </span>
+                      ) : (
+                        <span className="text-muted">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      {digitized ? (
+                        <a
+                          href={`/book/${digitized.slug || digitized.id}`}
+                          title="Read on Source Library"
+                        >
+                          <BookMarked className="w-4 h-4 text-accent-rust inline-block" />
+                        </a>
+                      ) : (
+                        <span className="text-muted/30">·</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+              {!loading && works.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-12 text-center text-muted">
+                    No works found matching your search.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <button
+            onClick={() => handlePage(Math.max(0, offset - PER_PAGE))}
+            disabled={offset === 0}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm border border-border-light rounded-md hover:bg-warm transition-colors disabled:opacity-30 disabled:cursor-default"
+          >
+            <ChevronLeft className="w-4 h-4" /> Previous
+          </button>
+          <span className="text-sm text-muted">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            onClick={() => handlePage(offset + PER_PAGE)}
+            disabled={currentPage >= totalPages}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm border border-border-light rounded-md hover:bg-warm transition-colors disabled:opacity-30 disabled:cursor-default"
+          >
+            Next <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/libraries/LibraryViewTabs.tsx
+++ b/src/components/libraries/LibraryViewTabs.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { BookOpen, TableProperties } from 'lucide-react';
+
+interface Props {
+  basePath: string;
+  catalogTotal: number;
+  booksTotal: number;
+}
+
+export default function LibraryViewTabs({ basePath, catalogTotal, booksTotal }: Props) {
+  const searchParams = useSearchParams();
+  const view = searchParams.get('view') || 'books';
+
+  return (
+    <div className="flex gap-1 border-b border-border-light mb-6">
+      <Link
+        href={basePath}
+        className={`inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px ${
+          view !== 'catalog'
+            ? 'border-accent-rust text-primary'
+            : 'border-transparent text-muted hover:text-secondary'
+        }`}
+      >
+        <BookOpen className="w-4 h-4" />
+        Translated Books
+        <span className="text-xs text-muted">({booksTotal.toLocaleString()})</span>
+      </Link>
+      <Link
+        href={`${basePath}?view=catalog`}
+        className={`inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px ${
+          view === 'catalog'
+            ? 'border-accent-rust text-primary'
+            : 'border-transparent text-muted hover:text-secondary'
+        }`}
+      >
+        <TableProperties className="w-4 h-4" />
+        Full Catalog
+        <span className="text-xs text-muted">({catalogTotal.toLocaleString()})</span>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **Full Catalog** tab to the BPH library page showing all 27,879 works in the Bibliotheca Philosophica Hermetica collection
- Table shows title, author, year, **shelfmark**, subject classification, and a link icon for works digitized on Source Library
- Searchable by title, author, or shelfmark; filterable by subject (hermetica, alchemy, mysticism, etc.); sortable by title, author, year, or shelfmark
- UBN-based linking: BPH books on Source Library (via `dublin_core.dc_identifier`) get clickable links in the catalog

## New files
- `src/app/api/catalog/bph/route.ts` — API route querying `bph_works` on Supabase
- `src/components/libraries/BphCatalogBrowser.tsx` — client component with search/filter/pagination
- `src/components/libraries/LibraryViewTabs.tsx` — tab switcher (Translated Books / Full Catalog)

## Test plan
- [ ] Visit `/libraries/bibliotheca-philosophica-hermetica` — should show two tabs
- [ ] "Translated Books" tab shows existing card grid (no regression)
- [ ] "Full Catalog" tab shows searchable table with shelfmarks
- [ ] Search for "Böhme" — should return Jacob Böhme works
- [ ] Filter by "alchemy" subject — should narrow results
- [ ] Sort by shelfmark — should work
- [ ] Click book icon on digitized work — should link to Source Library book page
- [ ] Other library pages (IA, Gallica, etc.) — no tabs, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)