### PR TITLE
Fix image loading: prefer thumbnails for card grids (52x smaller)

### DIFF
--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -78,9 +78,9 @@ export default async function ArtworkLandingPage() {
                 href={`/collections/${col.slug}`}
                 className="group relative aspect-[4/3] rounded-lg overflow-hidden bg-stone-200"
               >
-                {col.featured_images?.[0] && sanitizeThumbnail(col.featured_images[0].extracted_url || col.featured_images[0].thumbnail_url || col.featured_images[0].image_url || '') && (
+                {col.featured_images?.[0] && sanitizeThumbnail(col.featured_images[0].thumbnail_url || col.featured_images[0].extracted_url || col.featured_images[0].image_url || '') && (
                   <Image
-                    src={sanitizeThumbnail(col.featured_images[0].extracted_url || col.featured_images[0].thumbnail_url || col.featured_images[0].image_url || '') as string}
+                    src={sanitizeThumbnail(col.featured_images[0].thumbnail_url || col.featured_images[0].extracted_url || col.featured_images[0].image_url || '') as string}
                     alt=""
                     fill
                     className="object-cover group-hover:scale-[1.03] transition-transform duration-700"

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -496,7 +496,7 @@ export default async function CollectionDetailPage({ params }: Props) {
   const imagePool: typeof galleryImages = [];
   const bookImageCounts = new Map<string, number>();
   for (const img of galleryImages) {
-    const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
+    const thumb = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
     if (!thumb) continue;
     const bid = img.book_id || img.bookId;
     const count = bookImageCounts.get(bid) || 0;
@@ -520,8 +520,8 @@ export default async function CollectionDetailPage({ params }: Props) {
     ? (collection.hero_image as string | undefined)
       || (() => {
         const fi = (collection.featured_images as { extracted_url?: string; image_url?: string; thumbnail_url?: string }[] | undefined);
-        const first = fi?.find(img => img.extracted_url || img.image_url || img.thumbnail_url);
-        return first?.extracted_url || first?.image_url || first?.thumbnail_url;
+        const first = fi?.find(img => img.thumbnail_url || img.extracted_url || img.image_url);
+        return first?.thumbnail_url || first?.extracted_url || first?.image_url;
       })()
       || null
     : null;
@@ -581,7 +581,7 @@ export default async function CollectionDetailPage({ params }: Props) {
             'grid-cols-3 sm:grid-cols-6'
           }`}>
             {heroImages.map((img: { pageId?: string; page_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string }) => {
-              const src = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
+              const src = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
               const key = `${img.pageId || img.page_id}-${img.detectionIndex ?? img.detection_index}`;
               if (!src) return null;
               return (
@@ -662,9 +662,9 @@ export default async function CollectionDetailPage({ params }: Props) {
             <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
               {childCollections.map((child) => {
                 const hero = child.featured_images?.find(
-                  (img) => img.extracted_url || img.image_url || img.thumbnail_url
+                  (img) => img.thumbnail_url || img.extracted_url || img.image_url
                 );
-                const heroUrl = hero?.extracted_url || hero?.image_url || hero?.thumbnail_url;
+                const heroUrl = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
                 return (
                   <Link
                     key={child.slug}
@@ -776,7 +776,7 @@ export default async function CollectionDetailPage({ params }: Props) {
             </p>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4">
               {diverseGalleryImages.map((img: { pageId?: string; page_id?: string; bookId?: string; book_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
-                const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
+                const thumb = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
                 const pageId = img.pageId || img.page_id;
                 const bookId = img.bookId || img.book_id;
                 const detIdx = img.detectionIndex ?? img.detection_index;

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -104,9 +104,10 @@ async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total:
 
 function CollectionCard({ col, priority = false }: { col: CollectionDoc; priority?: boolean }) {
   const hero = col.featured_images?.find(
-    img => img.extracted_url || img.image_url || img.thumbnail_url
+    img => img.thumbnail_url || img.extracted_url || img.image_url
   );
-  const heroUrl = hero?.extracted_url || hero?.image_url || hero?.thumbnail_url;
+  // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
+  const heroUrl = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
 
   return (
     <Link

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -43,9 +43,10 @@ interface CuratedCollection {
 
 function getHeroImage(col: CuratedCollection): string | undefined {
   const hero = col.featured_images?.find(
-    (img) => img.extracted_url || img.image_url || img.thumbnail_url,
+    (img) => img.thumbnail_url || img.extracted_url || img.image_url,
   );
-  const raw = hero?.extracted_url || hero?.image_url || hero?.thumbnail_url;
+  // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
+  const raw = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
   return sanitizeThumbnail(raw);
 }
 

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -82,7 +82,7 @@ async function resolveImages(db: any, imageIds: string[]): Promise<CollectionIma
     if (!doc) continue;
     results.push({
       id: doc.id,
-      imageUrl: doc.extracted_url || doc.thumbnail_url || doc.image_url,
+      imageUrl: doc.thumbnail_url || doc.extracted_url || doc.image_url,
       bookTitle: doc.book_title || 'Unknown',
       description: doc.description || '',
       type: doc.type,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -126,7 +126,8 @@ async function getFeaturedCollections() {
       const hero = images.find(
         (img: unknown) => typeof img === 'string' || (img && typeof img === 'object' && ((img as Record<string, unknown>).extracted_url || (img as Record<string, unknown>).image_url || (img as Record<string, unknown>).thumbnail_url))
       );
-      heroUrl = typeof hero === 'string' ? hero : ((hero as Record<string, unknown>)?.extracted_url || (hero as Record<string, unknown>)?.image_url || (hero as Record<string, unknown>)?.thumbnail_url || null) as string | null;
+      // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
+      heroUrl = typeof hero === 'string' ? hero : ((hero as Record<string, unknown>)?.thumbnail_url || (hero as Record<string, unknown>)?.extracted_url || (hero as Record<string, unknown>)?.image_url || null) as string | null;
     }
 
     const books = (booksBySlug.get(collection.slug as string) || []).map(({ collections: _c, ...rest }) => rest);
@@ -157,9 +158,10 @@ async function getRemainingCollections(): Promise<CollectionForGrid[]> {
   const result = docs.map(({ _id, ...rest }) => {
     const images = rest.featured_images || [];
     const hero = images.find(
-      (img: unknown) => typeof img === 'string' || (img && typeof img === 'object' && ((img as Record<string, unknown>).extracted_url || (img as Record<string, unknown>).image_url || (img as Record<string, unknown>).thumbnail_url))
+      (img: unknown) => typeof img === 'string' || (img && typeof img === 'object' && ((img as Record<string, unknown>).thumbnail_url || (img as Record<string, unknown>).extracted_url || (img as Record<string, unknown>).image_url))
     );
-    const heroUrl = typeof hero === 'string' ? hero : ((hero as Record<string, unknown>)?.extracted_url || (hero as Record<string, unknown>)?.image_url || (hero as Record<string, unknown>)?.thumbnail_url || null) as string | null;
+    // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
+    const heroUrl = typeof hero === 'string' ? hero : ((hero as Record<string, unknown>)?.thumbnail_url || (hero as Record<string, unknown>)?.extracted_url || (hero as Record<string, unknown>)?.image_url || null) as string | null;
     const languageValues = Array.isArray(rest.languages)
       ? rest.languages
       : [];

--- a/src/components/collections/ExhibitionLayout.tsx
+++ b/src/components/collections/ExhibitionLayout.tsx
@@ -60,7 +60,7 @@ function bookTitle(book: BookRef): string {
 }
 
 function imageUrl(img: GalleryImage): string {
-  return img.extracted_url || img.thumbnail_url || img.image_url || '';
+  return img.thumbnail_url || img.extracted_url || img.image_url || '';
 }
 
 function imagePageHref(img: GalleryImage): string {

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -635,7 +635,8 @@ function GalleryCard({ item, priority = false }: { item: GalleryItem; priority?:
   const [useCropFallback, setUseCropFallback] = useState(false);
 
   const cropUrl = item.bbox ? getCroppedImageUrl(item.imageUrl, item.bbox) : null;
-  const blobUrl = item.extractedUrl || item.thumbnailUrl;
+  // Prefer thumbnail for grid cards — extracted images are ~2MB vs ~38KB thumbnails
+  const blobUrl = item.thumbnailUrl || item.extractedUrl;
 
   const displayUrl = useCropFallback
     ? (cropUrl || toThumbnailUrl(item.imageUrl))

--- a/src/components/home/CollectionsShowcase.tsx
+++ b/src/components/home/CollectionsShowcase.tsx
@@ -19,9 +19,9 @@ export interface CollectionSummary {
 
 function CollectionCard({ col, size }: { col: CollectionSummary; size: 'large' | 'small' }) {
   const hero = col.featured_images?.find(
-    img => img.extracted_url || img.thumbnail_url || img.image_url
+    img => img.thumbnail_url || img.extracted_url || img.image_url
   );
-  const heroUrl = hero?.extracted_url || hero?.thumbnail_url || hero?.image_url;
+  const heroUrl = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
   const topLangs = (col.languages || []).slice(0, 3).map(l => l.lang).join(', ');
 
   return (

--- a/src/components/prototype/FromTheCollection.tsx
+++ b/src/components/prototype/FromTheCollection.tsx
@@ -52,7 +52,7 @@ export default function FromTheCollection({ items }: FromTheCollectionProps) {
                 <Link href={`/gallery/image/${galleryId}`}>
                   <div className="relative aspect-[3/4] bg-cream rounded-lg overflow-hidden border border-border-light group-hover:shadow-lg transition-all">
                     <Image
-                      src={item.extracted_url || item.thumbnail_url}
+                      src={item.thumbnail_url || item.extracted_url || ''}
                       alt={item.museum_description || 'Gallery image'}
                       fill
                       quality={85}


### PR DESCRIPTION
## Summary
- Card grids across the entire site were loading full-size extracted images (~2MB each) when 38KB thumbnail variants exist on R2
- With 8+ priority images loading simultaneously on `/collections`, that's ~16MB vs ~300KB — explaining why 3 of 4 first-row cards were still blank after 5 seconds
- Swapped URL preference order to `thumbnail_url > extracted_url` across all 10 files with image card grids

## Files changed
- `src/app/collections/page.tsx` — main collections grid
- `src/app/collections/[id]/page.tsx` — collection detail (hero, sub-collections, gallery)
- `src/app/curated/page.tsx` — curated exhibitions
- `src/app/page.tsx` — homepage collection sections
- `src/app/artwork/page.tsx` — artwork collection cards
- `src/app/gallery/collections/[slug]/page.tsx` — gallery collection detail
- `src/components/gallery/GalleryClient.tsx` — gallery image grid
- `src/components/prototype/FromTheCollection.tsx` — homepage gallery showcase
- `src/components/collections/ExhibitionLayout.tsx` — exhibition image helper
- `src/components/home/CollectionsShowcase.tsx` — homepage collection cards

## Test plan
- [ ] Load `/collections` — first-row cards should appear within 1-2s instead of 5+
- [ ] Load `/gallery` and search "alchemy" — images should load promptly
- [ ] Verify image quality is acceptable at thumbnail resolution for card sizes
- [ ] Check collection detail pages still show images in hero banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)