### PR TITLE
Add inscription translation to artwork enrichment

### DIFF
--- a/scripts/artwork-enrichment.mjs
+++ b/scripts/artwork-enrichment.mjs
@@ -90,6 +90,8 @@ Analyze this artwork image and return JSON with these fields:
     }
   ],
   "inscriptions": "If the image contains readable text (Latin inscriptions, titles, captions, cartouches, verses, dedications, labels), transcribe it here verbatim. Preserve line breaks. If no readable text, set to null.",
+  "inscriptions_translation": "If inscriptions is non-null and NOT already in English, provide an English translation. Preserve line breaks to match the original. If inscriptions is null or already English, set to null.",
+  "inscriptions_language": "The language of the inscription (e.g., 'Latin', 'Dutch', 'German', 'French', 'Italian'). Null if no inscription.",
   "has_readable_text": true,
   "figures_depicted": ["Named figures, historical persons, or figure types (e.g., 'Mercury', 'alchemist', 'Hermes Trismegistus')"],
   "symbols": ["Identifiable symbols with specific iconographic meaning (e.g., 'caduceus', 'ouroboros', 'pelican-in-her-piety'). NOT generic items like 'tree' or 'building'."]
@@ -225,6 +227,8 @@ async function main() {
             genre: enrichment.genre,
             cross_references: enrichment.cross_references || [],
             inscriptions: enrichment.inscriptions || null,
+            inscriptions_translation: enrichment.inscriptions_translation || null,
+            inscriptions_language: enrichment.inscriptions_language || null,
             has_readable_text: !!enrichment.has_readable_text,
             figures_depicted: enrichment.figures_depicted || [],
             symbols: enrichment.symbols || [],


### PR DESCRIPTION
## Summary
- Enrichment prompt now produces `inscriptions_translation` and `inscriptions_language` alongside verbatim inscription transcription
- Enrichment save code writes the new fields to MongoDB

## Context
Artwork pages showed raw Latin/Dutch inscriptions with no English translation. The UI already supported `inscriptions_translation` but the enrichment pipeline never produced it.

Backfill of 2,274 substantive inscriptions running separately via `scripts/tmp-backfill-inscription-translations.mjs` (filtered from 5,683 — skips numbers, attribution lines, English text, museum IDs).

## Test plan
- [ ] Verify https://sourcelibrary.org/book/drebbel-retorica shows English translation under inscriptions (already live via manual DB fix)
- [ ] Run enrichment on a new artwork and confirm translation fields are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)