### PR TITLE
Fix collection manifest timeout + card images

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -68,8 +68,7 @@ export async function GET(
         [`collection_scores.${id}.relevance`]: 1,
       };
       const allBooks = await db.collection('books')
-        .find(filter, { projection: manifestProjectionWithScore })
-        .sort({ published: 1 })
+        .find(filter, { projection: manifestProjectionWithScore, maxTimeMS: 15000 })
         .toArray();
 
       // Flatten relevance score to top level
@@ -123,12 +122,12 @@ export async function GET(
     };
 
     const total = (q || language)
-      ? await db.collection('books').countDocuments(filter)
+      ? await db.collection('books').countDocuments(filter, { maxTimeMS: 10000 })
       : (collection.book_count as number) || 0;
 
     const [books, highlights] = await Promise.all([
       db.collection('books')
-        .find(filter, { projection })
+        .find(filter, { projection, maxTimeMS: 15000 })
         .sort(sortObj)
         .skip(offset)
         .limit(limit)
@@ -139,7 +138,7 @@ export async function GET(
           isArtCollection
             ? { collections: id, resource_type: { $exists: true } }
             : { collections: id, visible: true, pages_translated: { $gt: 0 }, resource_type: { $exists: false } },
-          { projection: highlightProjection },
+          { projection: highlightProjection, maxTimeMS: 10000 },
         )
         .sort(isArtCollection ? { title: 1 } : { quality_score: -1, read_count: -1, pages_translated: -1 })
         .limit(5)

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -121,11 +121,13 @@ export default function CollectionAllBooks({
       const booksOnly = (data.books || []).filter((b: BookItem & { resource_type?: string }) => !b.resource_type);
       setAllBooks(booksOnly);
     } catch {
-      // Keep existing state on error
+      // Manifest failed (timeout, etc.) — fall back to server-rendered compact books
+      // so the page still shows something rather than "0 books"
+      setAllBooks(prev => prev.length === 0 ? compactBooks : prev);
     } finally {
       setLoading(false);
     }
-  }, [collectionId]);
+  }, [collectionId, compactBooks]);
 
   // Auto-expand and fetch manifest on mount.
   // Read URL params for deep-linked state (avoids useSearchParams SSR bailout).


### PR DESCRIPTION
## Summary
- Jung's Library collection page showed "0 books" because the manifest API timed out (504)
- Root cause: unnecessary `.sort({published: 1})` forced in-memory sort on Atlas; no `maxTimeMS` guard
- Added graceful fallback: when manifest fails, show server-rendered books instead of empty state
- Updated card images for Medieval Heresies and Jung's Library (Wikimedia Commons, public domain)

## Changes
- `src/app/api/collections/[id]/route.ts` — removed manifest sort, added maxTimeMS to all queries
- `src/components/collections/CollectionAllBooks.tsx` — fallback to compactBooks on fetch error
- **DB**: Medieval Heresies → Berruguete *Auto-de-fe* (Prado); Jung's Library → *Splendor Solis* plate 4 (BL)

## Test plan
- [ ] Visit https://sourcelibrary.org/collections/jungs-library — should show books, not "0 books"
- [ ] Collections page cards for Medieval Heresies and Jung's Library show new images

🤖 Generated with [Claude Code](https://claude.com/claude-code)