### PR TITLE
Fix author browse and library page timeouts

### DIFF
--- a/src/app/browse/authors/[letter]/page.tsx
+++ b/src/app/browse/authors/[letter]/page.tsx
@@ -45,14 +45,16 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
   try {
     const db = await getDb();
 
-    // Get all visible books with translations, starting with this letter
+    // Get all visible books with translations, starting with this letter.
+    // Use case-sensitive regex ^[Aa] so MongoDB can use the author_1 index
+    // ($options:'i' forces a full collection scan and times out on Atlas).
     const books = await db.collection('books').find(
       {
         visible: true,
-        author: { $regex: `^${l}`, $options: 'i' },
+        author: { $regex: `^[${l}${l.toLowerCase()}]` },
         pages_translated: { $gt: 0 },
       },
-      { projection: { author: 1, author_entity_id: 1 } }
+      { projection: { author: 1, author_entity_id: 1 }, maxTimeMS: 15_000 }
     ).toArray();
 
     // Group by entity when available, fall back to raw author string
@@ -61,7 +63,7 @@ export default async function BrowseAuthorsPage({ params }: PageProps) {
     if (entityIds.length > 0) {
       const entities = await db.collection('entities').find(
         { _id: { $in: entityIds.map(id => { try { return new ObjectId(id); } catch { return null; } }).filter((v): v is ObjectId => v !== null) } },
-        { projection: { canonical_name: 1, name: 1 } }
+        { projection: { canonical_name: 1, name: 1 }, maxTimeMS: 10_000 }
       ).toArray();
       for (const e of entities) {
         entityMap.set(e._id.toString(), e.canonical_name || e.name);

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -115,7 +115,7 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
         { $replaceRoot: { newRoot: '$images' } },
         { $sort: { gallery_quality: -1 } },
         { $limit: 12 },
-      ]).toArray();
+      ], { maxTimeMS: 15_000 }).toArray();
     } catch { /* Gallery is optional */ }
   }
 
@@ -157,7 +157,7 @@ async function fetchBphDigitizedMap(): Promise<Record<string, { id: string; slug
     const db = await getDb();
     const bphBooks = await db.collection('books').find(
       { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true } },
-      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 } }
+      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 15_000 }
     ).toArray();
 
     const map: Record<string, { id: string; slug: string }> = {};


### PR DESCRIPTION
## Summary
- `/browse/authors/[letter]` was returning **504s** — case-insensitive regex (`$options:'i'`) forced full collection scan on 17K+ books, bypassing the `author_1` index
- Fix: use case-sensitive regex `^[Aa]` which lets MongoDB use the index
- Added `maxTimeMS` safety nets to all MongoDB queries on author browse and library detail pages

## Pages fixed
- `/browse/authors/A`, `/F`, `/M`, `/P` — all returning 504 (confirmed via e2e tests + curl)
- `/libraries/embassy-of-the-free-mind` — also timing out (gallery aggregation + BPH query without timeouts)

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify `/browse/authors/A` loads within 5s after deploy
- [ ] Verify `/libraries/embassy-of-the-free-mind` loads
- [ ] Re-run `npx playwright test` e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)