### PR TITLE
Fix art collections showing 0 works

### DIFF
--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -117,9 +117,13 @@ export default function CollectionAllBooks({
       const res = await fetch(`/api/collections/${collectionId}?mode=manifest`);
       if (!res.ok) throw new Error('Failed to fetch');
       const data = await res.json();
-      // Filter out artworks — they have their own section on the collection page
-      const booksOnly = (data.books || []).filter((b: BookItem & { resource_type?: string }) => !b.resource_type);
-      setAllBooks(booksOnly);
+      // For book collections, filter out artworks — they have their own section.
+      // For art collections, keep everything (all items have resource_type).
+      const isArt = collectionType === 'visual_art';
+      const books = isArt
+        ? (data.books || [])
+        : (data.books || []).filter((b: BookItem & { resource_type?: string }) => !b.resource_type);
+      setAllBooks(books);
     } catch {
       // Manifest failed (timeout, etc.) — fall back to server-rendered compact books
       // so the page still shows something rather than "0 books"


### PR DESCRIPTION
## Summary
- Art collections like "The Visionary" (442 works) showed an empty page
- `CollectionAllBooks` manifest fetch filtered out all items with `resource_type`, but art collection items *are* artworks — they all have `resource_type` set
- Skip the filter when `collectionType === 'visual_art'`

## Test plan
- [ ] Visit https://sourcelibrary.org/collections/the-visionary — should show 442 works
- [ ] Visit a book collection with mixed art (e.g. florentine-neoplatonism) — artworks should still be separated into their own section, not duplicated in the books list

🤖 Generated with [Claude Code](https://claude.com/claude-code)