### PR TITLE
Fix reader image layout shift when flipping pages

### DIFF
--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -41,6 +41,8 @@ export default function ImageWithMagnifier({
   const [fullImageLoaded, setFullImageLoaded] = useState(false);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
   const [showFullscreen, setShowFullscreen] = useState(false);
+  // Track last known image height to prevent layout shift during page transitions
+  const [lastImageHeight, setLastImageHeight] = useState<number>(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
 
@@ -224,9 +226,12 @@ export default function ImageWithMagnifier({
         onMouseLeave={() => setShowMagnifier(false)}
         onClick={handleClick}
       >
-        {/* Loading skeleton */}
+        {/* Loading skeleton — use last known height in scrollable mode to prevent layout shift */}
         {!isLoaded && (
-          <div className={`flex items-center justify-center ${darkMode ? 'bg-black' : 'bg-stone-100 animate-pulse'} ${scrollable ? 'w-full h-48' : 'absolute inset-0'}`}>
+          <div
+            className={`flex items-center justify-center ${darkMode ? 'bg-black' : 'bg-stone-100 animate-pulse'} ${scrollable ? 'w-full' : 'absolute inset-0'}`}
+            style={scrollable && lastImageHeight > 0 ? { height: lastImageHeight } : scrollable ? { height: '12rem' } : undefined}
+          >
             <div className={`text-sm ${darkMode ? 'text-stone-600' : 'text-stone-400'}`}>Loading...</div>
           </div>
         )}
@@ -252,6 +257,9 @@ export default function ImageWithMagnifier({
             if (imgRef.current) {
               const rect = imgRef.current.getBoundingClientRect();
               setImageDimensions({ width: rect.width, height: rect.height });
+              if (scrollable && rect.height > 0) {
+                setLastImageHeight(rect.height);
+              }
             }
           }}
           onError={() => {


### PR DESCRIPTION
## Summary
- Fixes #784 — page image shifts down during page navigation, then jumps back up
- Root cause: when the image `src` changes, `ImageWithMagnifier` resets to a tiny `h-48` skeleton while the new image loads, collapsing the container height
- Fix: track the last loaded image's rendered height and reuse it as the skeleton height during transitions, so the container maintains stable dimensions

## Changes
- `src/components/ui/ImageWithMagnifier.tsx`: Added `lastImageHeight` state that captures the rendered height on each successful load. The loading skeleton uses this height instead of a fixed `12rem` fallback (which is still used for the very first page load when no prior height is known).

## Test plan
- [ ] Open any book in the reader, flip through pages with arrow keys — image panel should no longer shift vertically during transitions
- [ ] First page load should still show the default skeleton height
- [ ] Verify magnifier and fullscreen viewer still work correctly
- [ ] Test on mobile (touch devices) — no regression in tap-to-fullscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)