### PR TITLE
Show translated text excerpt on book detail pages

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -167,7 +167,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 interface GalleryImagePreview { id: string; extracted_url?: string; thumbnail_url?: string; image_url?: string; description?: string; type?: string; page_number?: number; gallery_quality?: number }
 interface BookCollectionPreview { slug: string; name: string; subtitle?: string; color?: string; book_count?: number; featured_images?: Array<{ extracted_url?: string; thumbnail_url?: string; image_url?: string }> }
 
-async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean } | null> {
+async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; translatedExcerpt: string | null; excerptPageNumber: number | null; matchedBySlug: boolean } | null> {
   // Reuse the cached book lookup (shared with generateMetadata — saves a full DB round trip)
   const [result, db] = await Promise.all([
     getCachedBookLookup(id),
@@ -183,7 +183,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
   // Inclusion projection — only fetch fields the book detail UI actually uses
   // Status dots need .updated_at; image count needs array length via .type
   // All queries have maxTimeMS to fail fast during DB degradation
-  const [pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw] = await Promise.all([
+  const [pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw, excerptPageRaw] = await Promise.all([
     // Drop $ne filter — it prevents use of the {book_id,page_number} compound
     // index and forces a collection scan. Filter digitizer-inserts in JS instead.
     db.collection('pages')
@@ -241,6 +241,13 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
           .toArray()
           .catch(() => [])
       : Promise.resolve([]),
+    // First non-blank translated page for excerpt preview
+    db.collection('pages')
+      .findOne(
+        { book_id: bookId, 'translation.data': { $exists: true, $ne: '' } },
+        { sort: { page_number: 1 }, projection: { _id: 0, 'translation.data': 1, page_number: 1 }, maxTimeMS: 3000 },
+      )
+      .catch(() => null),
   ]);
 
   // Serialize MongoDB objects to plain JavaScript objects
@@ -249,7 +256,30 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
   const galleryImages = JSON.parse(JSON.stringify(galleryImagesRaw)) as GalleryImagePreview[];
   const bookCollections = JSON.parse(JSON.stringify(bookCollectionsRaw)) as BookCollectionPreview[];
 
-  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, matchedBySlug };
+  // Extract and truncate translated excerpt at a sentence boundary
+  let translatedExcerpt: string | null = null;
+  let excerptPageNumber: number | null = null;
+  if (excerptPageRaw?.translation?.data) {
+    const raw = excerptPageRaw.translation.data as string;
+    // Strip XML/HTML tags that translation data may contain
+    const cleaned = raw.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+    if (cleaned.length > 0) {
+      excerptPageNumber = excerptPageRaw.page_number ?? null;
+      if (cleaned.length <= 300) {
+        translatedExcerpt = cleaned;
+      } else {
+        // Find the last sentence boundary before 300 chars
+        const truncated = cleaned.slice(0, 350);
+        const lastPeriod = truncated.lastIndexOf('. ', 300);
+        const lastQuestion = truncated.lastIndexOf('? ', 300);
+        const lastExclaim = truncated.lastIndexOf('! ', 300);
+        const boundary = Math.max(lastPeriod, lastQuestion, lastExclaim);
+        translatedExcerpt = boundary > 80 ? truncated.slice(0, boundary + 1) : cleaned.slice(0, 300) + '...';
+      }
+    }
+  }
+
+  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, translatedExcerpt, excerptPageNumber, matchedBySlug };
 }
 
 // Skeleton for book info while loading
@@ -312,7 +342,7 @@ async function BookInfo({ id }: { id: string }) {
     notFound();
   }
 
-  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections } = data;
+  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, translatedExcerpt, excerptPageNumber } = data;
 
   // Empty shell books (0 pages from failed imports) should 404
   // But visual art (paintings, prints, etc.) legitimately has no page documents
@@ -694,6 +724,25 @@ async function BookInfo({ id }: { id: string }) {
                 </p>
               )}
             </div>
+
+            {/* Translated Excerpt */}
+            {translatedExcerpt && (
+              <div className="card p-6 mt-6">
+                <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>
+                  <BookText className="w-4 h-4 inline-block mr-2 -mt-0.5 opacity-60" />
+                  From the Translation
+                </h2>
+                <blockquote className="border-l-3 border-accent-gold/40 pl-4 italic text-secondary leading-relaxed">
+                  {translatedExcerpt}
+                </blockquote>
+                <Link
+                  href={`/book/${book.slug || book.id}${excerptPageNumber ? `/page-number/${excerptPageNumber}` : ''}`}
+                  className="inline-block mt-3 text-sm text-accent-rust hover:text-accent-gold-dark transition-colors"
+                >
+                  Continue reading &rarr;
+                </Link>
+              </div>
+            )}
 
             {/* Editions Panel */}
             {book.editions?.length ? (


### PR DESCRIPTION
## Summary
- Adds a 2-3 sentence excerpt from the first translated page on the book detail page, displayed as a styled blockquote below the "About This Book" card
- Excerpt is truncated at a sentence boundary (~300 chars), with a "Continue reading" link to the relevant page in the reader
- Query runs in parallel with existing data fetches (`maxTimeMS: 3000`, projection limited to `translation.data` and `page_number`) — no added latency on the hot path
- Only rendered for books that have translations

## Test plan
- [ ] Visit a book with translations (e.g. https://sourcelibrary.org/book/fludd-utriusque-cosmi-historia-1617) — excerpt should appear below the summary
- [ ] Visit a book without translations — no excerpt section should appear
- [ ] "Continue reading" link goes to the correct page in the reader
- [ ] Excerpt text is clean (no XML/HTML tags leaking through)
- [ ] Visual art pages (paintings, etc.) are unaffected

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)