### PR TITLE
Fix four SEO issues: breadcrumbs, sameAs, descriptions, h1 tags

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -102,7 +102,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const title = book.display_title || book.title;
   const ogTitle = book.published ? `${title} (${book.published})` : title;
-  const description = `Read the English translation of "${title}" by ${formatAuthor(book.author).name || book.author}${book.published ? ` (${book.published})` : ''}. Digitized and translated with AI from the original ${book.language || 'manuscript'}.`;
+  const author = formatAuthor(book.author).name || book.author;
+  const year = book.published ? ` (${book.published})` : '';
+  // Build description front-loading title+author+date, truncated to 155 chars for SEO
+  let description = `${title} by ${author}${year} — read the full English translation online.`;
+  if (description.length > 155) {
+    description = `${title} by ${author}${year}`.slice(0, 152) + '...';
+  }
   const bookUrl = `/book/${book.slug || book.id}`;
 
   // Get publication date for OG tags

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -19,6 +19,7 @@ export default async function GalleryPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <h1 className="sr-only">Image Gallery — Illustrations from Rare Historical Texts</h1>
       <Suspense>
         <GalleryClient
           initialData={initialData}

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -27,5 +27,10 @@ export default function SearchLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <Suspense>{children}</Suspense>;
+  return (
+    <Suspense>
+      <h1 className="sr-only">Search Source Library</h1>
+      {children}
+    </Suspense>
+  );
 }

--- a/src/components/seo/HomePageSchema.tsx
+++ b/src/components/seo/HomePageSchema.tsx
@@ -49,6 +49,8 @@ export default function HomePageSchema({ books, bookCount, translatedCount }: Ho
     },
     sameAs: [
       'https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2',
+      'https://x.com/SourceLibrary_',
+      'https://en.wikipedia.org/wiki/Embassy_of_the_Free_Mind',
     ],
   };
 

--- a/src/components/seo/SchemaOrgMetadata.tsx
+++ b/src/components/seo/SchemaOrgMetadata.tsx
@@ -157,26 +157,46 @@ export default function SchemaOrgMetadata({
   };
 
   // Breadcrumb navigation
-  const breadcrumbItems = [
+  // Insert primary collection as intermediate level when available
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const collections = (book as any).collections as string[] | undefined;
+  const primaryCollection = collections?.[0];
+  const primaryCollectionName = primaryCollection
+    ? primaryCollection.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+    : undefined;
+
+  const breadcrumbItems: Array<{ '@type': string; position: number; name: string; item: string }> = [
     {
       '@type': 'ListItem',
       position: 1,
       name: 'Home',
       item: baseUrl,
     },
-    {
-      '@type': 'ListItem',
-      position: 2,
-      name: book.display_title || book.title,
-      item: `${baseUrl}/book/${bookPath}`,
-    },
   ];
+
+  let nextPosition = 2;
+
+  if (primaryCollection && primaryCollectionName) {
+    breadcrumbItems.push({
+      '@type': 'ListItem',
+      position: nextPosition++,
+      name: primaryCollectionName,
+      item: `${baseUrl}/collections/${primaryCollection}`,
+    });
+  }
+
+  breadcrumbItems.push({
+    '@type': 'ListItem',
+    position: nextPosition++,
+    name: book.display_title || book.title,
+    item: `${baseUrl}/book/${bookPath}`,
+  });
 
   // Add page breadcrumb if viewing a specific page
   if (currentPage) {
     breadcrumbItems.push({
       '@type': 'ListItem',
-      position: 3,
+      position: nextPosition++,
       name: `Page ${currentPage}`,
       item: `${baseUrl}/book/${bookPath}/page/${currentPage}`,
     });


### PR DESCRIPTION
## Summary

- **#771** Add primary collection as intermediate breadcrumb level in Schema.org BreadcrumbList (Home → Collection → Book) when `book.collections` is available
- **#772** Add Twitter/X (`@SourceLibrary_`) and Wikipedia (Embassy of the Free Mind) to Organization `sameAs` array in homepage schema
- **#773** Truncate book page meta descriptions to <=155 chars, front-loading title + author + date for better SERP display
- **#775** Add server-rendered `<h1>` to `/search` and `/gallery` pages (visually hidden via `sr-only`, accessible to crawlers)

## Test plan
- [ ] Verify Schema.org breadcrumbs on a book page with collections (use Google Rich Results Test)
- [ ] Verify homepage JSON-LD includes new sameAs entries
- [ ] Spot-check meta descriptions on book pages — should be <=155 chars
- [ ] Inspect /search and /gallery source for `<h1>` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)