### PR TITLE
Store width/height on page documents (#556)

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -245,12 +245,17 @@ async function processBook(book, db) {
           const urls = await uploadPageVariants(jpegBuffer, page.book_id, page.page_number, uploadToR2);
           stats.bytesUploaded += jpegBuffer.length;
 
+          const dimFields = {};
+          if (urls.width) dimFields.image_width = urls.width;
+          if (urls.height) dimFields.image_height = urls.height;
+
           await db.collection('pages').updateOne(
             { _id: page._id },
             { $set: {
               archived_photo: urls.archived,
               display_photo: urls.display,
               thumbnail_blob: urls.thumb,
+              ...dimFields,
               'archive_metadata.archived_at': new Date(),
               'archive_metadata.source': 'bulk_jp2',
               'archive_metadata.bytes': jpegBuffer.length,

--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -217,6 +217,10 @@ async function processBook(book, db) {
           const urls = await uploadPageVariants(jpegBuffer, page.book_id, page.page_number, uploadToR2);
           stats.bytesUploaded += jpegBuffer.length;
 
+          const dimFields = {};
+          if (urls.width) dimFields.image_width = urls.width;
+          if (urls.height) dimFields.image_height = urls.height;
+
           await db.collection('pages').updateOne(
             { _id: page._id },
             {
@@ -224,6 +228,7 @@ async function processBook(book, db) {
                 archived_photo: urls.archived,
                 display_photo: urls.display,
                 thumbnail_blob: urls.thumb,
+                ...dimFields,
                 'archive_metadata.archived_at': new Date(),
                 'archive_metadata.source': 'erara_pdf',
                 'archive_metadata.source_url': `https://www.e-rara.ch/download/pdf/${eraraId}`,

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -167,6 +167,10 @@ async function archivePage(page, db) {
     // Upload full-res + generate and upload display (1200px) + thumbnail (150px)
     const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
 
+    const dimFields = {};
+    if (urls.width) dimFields.image_width = urls.width;
+    if (urls.height) dimFields.image_height = urls.height;
+
     await db.collection('pages').updateOne(
       { _id: page._id },
       {
@@ -174,6 +178,7 @@ async function archivePage(page, db) {
           archived_photo: urls.archived,
           display_photo: urls.display,
           thumbnail_blob: urls.thumb,
+          ...dimFields,
           'archive_metadata.archived_at': new Date(),
           'archive_metadata.source_url': sourceUrl,
           'archive_metadata.original_url': originalUrl,

--- a/scripts/workers/lib/display-image.mjs
+++ b/scripts/workers/lib/display-image.mjs
@@ -170,6 +170,11 @@ export async function uploadPageVariants(fullResBuffer, bookId, pageNumber, uplo
   if (!bookId) throw new Error(`uploadPageVariants: bookId is ${bookId} for page ${pageNumber}`);
   const num = String(pageNumber).padStart(4, '0');
 
+  // Read full-res dimensions before any resizing
+  const meta = await sharp(fullResBuffer).metadata();
+  const width = meta.width || null;
+  const height = meta.height || null;
+
   // Upload full-res (to the existing archived/ path for backward compat)
   const archivedKey = `archived/${bookId}/${pageNumber}.jpg`;
   validateR2Key(archivedKey);
@@ -188,5 +193,5 @@ export async function uploadPageVariants(fullResBuffer, bookId, pageNumber, uplo
   validateR2Key(thumbKey);
   const thumbUrl = await uploadFn(thumbKey, thumb, 'image/jpeg');
 
-  return { archived: archivedUrl, display: displayUrl, thumb: thumbUrl };
+  return { archived: archivedUrl, display: displayUrl, thumb: thumbUrl, width, height };
 }

--- a/src/app/api/books/[id]/archive-images/route.ts
+++ b/src/app/api/books/[id]/archive-images/route.ts
@@ -4,6 +4,7 @@ import { getDb } from '@/lib/mongodb';
 import { images } from '@/lib/api-client/images';
 import { compress_photo } from '@/lib/image-manipulation';
 import { withAuth } from '@/lib/auth-helpers';
+import sharp from 'sharp';
 
 // Increase timeout for archiving many images
 export const maxDuration = 300;
@@ -135,6 +136,17 @@ export const POST = withAuth(async (request, session, context) => {
               // Non-fatal — thumbnail can be generated later
             }
 
+            // Read image dimensions from the full-res buffer
+            let imageWidth: number | undefined;
+            let imageHeight: number | undefined;
+            try {
+              const meta = await sharp(buffer).metadata();
+              imageWidth = meta.width;
+              imageHeight = meta.height;
+            } catch {
+              // Non-fatal — dimensions can be backfilled later
+            }
+
             // Update page record
             const updateFields: Record<string, unknown> = {
               archived_photo: blob.url,
@@ -143,6 +155,8 @@ export const POST = withAuth(async (request, session, context) => {
               'archive_metadata.bytes': bytes,
               updated_at: new Date()
             };
+            if (imageWidth) updateFields.image_width = imageWidth;
+            if (imageHeight) updateFields.image_height = imageHeight;
             if (thumbnailUrl) {
               updateFields.thumbnail_blob = thumbnailUrl;
             }

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -52,6 +52,10 @@ export interface Page {
   split_position?: number;      // 0-1000 gutter position used for cropping
   split_source_page?: string;   // ID of original spread page (for right pages)
 
+  // Image dimensions (populated during archiving)
+  image_width?: number;         // Full-res image width in pixels
+  image_height?: number;        // Full-res image height in pixels
+
   // Split/crop workflow (legacy — stale on split_from_spread pages)
   photo_original?: string;      // Original S3 URL before cropping
   cropped_photo?: string;       // Local path to cropped image


### PR DESCRIPTION
## Summary
- Adds `image_width` and `image_height` optional fields to the `Page` type interface
- Populates dimensions during image archiving via Sharp metadata, covering all three archive workers (bulk, ocr, erara) and the archive-images API route
- The shared `uploadPageVariants` helper now reads dimensions from the full-res buffer and returns them alongside URLs
- No backfill script — dimensions populate going forward as pages are archived

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Archive a test book and confirm `image_width`/`image_height` are written to page documents
- [ ] Verify existing archive flows are unaffected (dimensions are additive, never required)

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)