### PR TITLE
Fix batch OCR cross-contamination in batch-collector

### DIFF
--- a/scripts/maintenance/fix-batch-contamination.mjs
+++ b/scripts/maintenance/fix-batch-contamination.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Fix batch OCR cross-contamination from 2026-03-24.
+ *
+ * The batch-collector.mjs had a bug where it fell back to index-based
+ * page matching when metadata.key was missing from Batch API responses.
+ * This caused OCR text from other books (Middle Dutch, Chinese) to be
+ * written to pages of 4 books in the medieval-heresies collection.
+ *
+ * This script:
+ * 1. Identifies contaminated pages (OCR language doesn't match book language)
+ * 2. Creates revisions of the contaminated data (safety net)
+ * 3. Clears OCR and translation on contaminated pages
+ * 4. Resets book-level page counts
+ *
+ * After running, the pipeline will re-OCR and re-translate these pages naturally.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/fix-batch-contamination.mjs --dry-run
+ *   node scripts/maintenance/fix-batch-contamination.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+import crypto from 'crypto';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// The 4 confirmed contaminated books (batch-OCR'd 2026-03-24)
+const CONTAMINATED_SLUGS = [
+  'histoire-et-doctrine-de-la-secte-des-cathares-ou-albigeois-schmidt',
+  'the-key-of-truth-a-manual-of-the-paulician-church-of-armenia-conybeare',
+  'histoire-des-albigeois-les-albigeois-et-l-inquisition-peyrat',
+  'les-albigeois-leurs-origines-action-de-l-eglise-au-xiie-douais',
+];
+
+// Known contamination markers
+const CONTAMINATION_PATTERNS = [
+  // Middle Dutch (Reynard the Fox)
+  /\b(vanden|waer|sijn|dese|gheen|reynaert|uwe)\b/i,
+  // Chinese characters
+  /[\u4e00-\u9fff]{3,}/,
+];
+
+function isContaminated(text, expectedLang) {
+  if (!text || text.length < 20) return false;
+  for (const pattern of CONTAMINATION_PATTERNS) {
+    if (pattern.test(text)) return true;
+  }
+  return false;
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  console.log(DRY_RUN ? '=== DRY RUN ===' : '=== LIVE RUN ===');
+
+  for (const slug of CONTAMINATED_SLUGS) {
+    const book = await db.collection('books').findOne({ slug });
+    if (!book) {
+      console.log(`SKIP: Book not found: ${slug}`);
+      continue;
+    }
+
+    console.log(`\n--- ${book.title} (${book.id}) ---`);
+    console.log(`  Language: ${book.language}, Pages: ${book.pages_count}`);
+
+    // Get all pages with OCR data
+    const pages = await db.collection('pages').find(
+      { book_id: book.id, 'ocr.data': { $exists: true, $ne: null } },
+      { projection: { id: 1, page_number: 1, 'ocr.data': 1, 'ocr.updated_at': 1, 'translation.data': 1 } }
+    ).toArray();
+
+    const contaminated = [];
+    const clean = [];
+
+    for (const page of pages) {
+      if (isContaminated(page.ocr?.data, book.language)) {
+        contaminated.push(page);
+      } else {
+        clean.push(page);
+      }
+    }
+
+    console.log(`  Total pages with OCR: ${pages.length}`);
+    console.log(`  Contaminated: ${contaminated.length}`);
+    console.log(`  Clean: ${clean.length}`);
+
+    if (contaminated.length === 0) {
+      console.log(`  No contamination detected, skipping`);
+      continue;
+    }
+
+    // Sample contaminated content
+    if (contaminated.length > 0) {
+      const sample = contaminated[0];
+      console.log(`  Sample contaminated page ${sample.page_number}: "${sample.ocr.data.substring(0, 80)}..."`);
+    }
+
+    if (DRY_RUN) {
+      console.log(`  [DRY RUN] Would clear ${contaminated.length} pages and create revisions`);
+      continue;
+    }
+
+    // Create revisions before wiping
+    const now = new Date();
+    const revisionDocs = contaminated.map(page => ({
+      id: crypto.randomUUID(),
+      page_id: page.id,
+      field: 'ocr',
+      data: page.ocr.data,
+      created_at: now,
+      reason: 'batch-contamination-cleanup-2026-04-06',
+    }));
+
+    // Also save translation revisions
+    const translationRevisions = contaminated
+      .filter(p => p.translation?.data)
+      .map(page => ({
+        id: crypto.randomUUID(),
+        page_id: page.id,
+        field: 'translation',
+        data: page.translation.data,
+        created_at: now,
+        reason: 'batch-contamination-cleanup-2026-04-06',
+      }));
+
+    if (revisionDocs.length > 0) {
+      await db.collection('page_revisions').insertMany([...revisionDocs, ...translationRevisions]);
+      console.log(`  Saved ${revisionDocs.length + translationRevisions.length} revisions`);
+    }
+
+    // Clear contaminated OCR and translation data
+    const pageIds = contaminated.map(p => p.id);
+    const result = await db.collection('pages').updateMany(
+      { id: { $in: pageIds } },
+      {
+        $unset: {
+          'ocr.data': '',
+          'ocr.model': '',
+          'ocr.updated_at': '',
+          'ocr.prompt_version': '',
+          'ocr.prompt_id': '',
+          'ocr.prompt_hash': '',
+          'translation.data': '',
+          'translation.model': '',
+          'translation.updated_at': '',
+          'translation.prompt_version': '',
+          'translation.prompt_id': '',
+        },
+        $set: { updated_at: new Date() }
+      }
+    );
+    console.log(`  Cleared OCR+translation on ${result.modifiedCount} pages`);
+
+    // Reset book-level counts
+    const remainingOcr = clean.length;
+    const remainingTranslated = clean.filter(p => p.translation?.data).length;
+    await db.collection('books').updateOne(
+      { id: book.id },
+      { $set: { pages_ocr: remainingOcr, pages_translated: remainingTranslated, updated_at: new Date() } }
+    );
+    console.log(`  Updated book counts: ocr=${remainingOcr}, translated=${remainingTranslated}`);
+  }
+
+  // Summary
+  console.log('\n=== DONE ===');
+  if (!DRY_RUN) {
+    console.log('Contaminated pages have been cleared. The pipeline will re-OCR and re-translate them.');
+    console.log('Run smart-cover-selection.mjs next for missing thumbnails.');
+  }
+
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -258,8 +258,14 @@ async function processOneJob(db, job) {
     } else {
       for (let idx = 0; idx < responses.length; idx++) {
         const r = responses[idx];
-        const pageId = r.metadata?.key || (job.page_ids && job.page_ids[idx]);
-        if (!pageId) { failCount++; continue; }
+        const pageId = r.metadata?.key;
+        if (!pageId) {
+          // NEVER fall back to index-based matching — response order is not guaranteed.
+          // Index fallback caused cross-book contamination (2026-03-24 incident).
+          console.warn(`  SKIP: response ${idx} missing metadata.key (book: ${job.book_id})`);
+          failCount++;
+          continue;
+        }
         const candidate = r.response?.candidates?.[0];
         if (candidate?.finishReason === 'RECITATION') { recitationCount++; failCount++; continue; }
         const text = candidate?.content?.parts?.[0]?.text;


### PR DESCRIPTION
## Summary
- **Bug:** `batch-collector.mjs` fell back to index-based page matching when `metadata.key` was missing from Gemini Batch API responses. Response order isn't guaranteed, so OCR text from unrelated books got written to wrong pages.
- **Impact:** 4 books in medieval-heresies had ~1,025 pages contaminated with Middle Dutch (Reynard the Fox) and Chinese text from other batch jobs. Translations were also garbage (translated the wrong OCR).
- **Fix:** Reject responses without `metadata.key` instead of guessing by index. Added cleanup script.

## Data fixes already applied
- Cleared contaminated OCR + translation on 1,025 pages (revisions saved in `page_revisions`)
- Reset book-level page counts for all 4 books
- Set cover images on 6 books in medieval-heresies that had no thumbnail

## Affected books
- Histoire et Doctrine de la Secte des Cathares ou Albigeois (212 pages cleared)
- The Key of Truth: A Manual of the Paulician Church of Armenia (201 pages cleared)  
- Histoire des Albigeois: Les Albigeois et l'Inquisition (298 pages cleared)
- Les Albigeois: Leurs Origines (314 pages cleared)

## Test plan
- [ ] Verify the 4 books show correct (partial) OCR on first ~25 pages
- [ ] Verify collection page shows cover images for all books
- [ ] Cleared pages will re-OCR and re-translate via the pipeline naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)