### PR TITLE
Fix regex escaping in identify API

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -99,7 +99,8 @@ export async function POST(request: NextRequest) {
 
     // Strategy 1: Artist + title regex (strongest signal)
     if (identification.artist) {
-      const artistRegex = identification.artist.split(/\s+/).pop() || identification.artist;
+      const artistLast = identification.artist.split(/\s+/).pop() || identification.artist;
+      const artistRegex = artistLast.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const artistQuery: Record<string, unknown> = {
         author: { $regex: artistRegex, $options: 'i' },
         $or: [


### PR DESCRIPTION
Escape special regex chars in artist name search to prevent crashes.