### PR TITLE
Fix batch collector ghost cleanup for stuck parent jobs

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -267,6 +267,8 @@ async function processOneJob(db, job) {
   const state = normalizeState(rawState);
 
   if (state === 'JOB_STATE_SUCCEEDED') {
+    const stats = geminiData.metadata?.batchStats || {};
+    console.log(`  Collecting: ${job.book_id} | ${job.type} | ${stats.successfulRequestCount || '?'}/${stats.requestCount || '?'} pages | ${rawState}`);
     if (DRY_RUN) return { status: 'would_collect', bookId: job.book_id };
 
     const responses = await extractResults(geminiData, workingKey);
@@ -1053,14 +1055,17 @@ async function run() {
   } catch (e) { console.error(`[zombie-reaper] Error: ${e.message}`); }
 
   // ── Ghost Cleanup: mark orphaned parent batch jobs as saved ──
-  // Parent jobs (no job_name) get stuck at 'completed' because the collector
-  // only queries jobs with job_name. Their children already saved the pages.
+  // Parent jobs (no job_name) get stuck at 'completed' or 'processing' because
+  // the collector only queries jobs with job_name. Their children already saved
+  // the pages. Parent jobs enter 'processing' when some children complete, and
+  // 'completed' when all children are done — but both states can linger forever.
   let ghostsCleaned = 0;
   try {
     const ghostResult = await db.collection('batch_jobs').updateMany(
       {
-        status: 'completed',
+        status: { $in: ['completed', 'processing'] },
         parent_job_id: { $exists: false },
+        child_job_ids: { $exists: true },
         $or: [
           { job_name: { $in: [null, ''] } },
           { job_name: { $exists: false } },


### PR DESCRIPTION
## Summary
- Parent batch jobs (no `job_name`, only `child_job_ids`) were getting stuck in `processing` status forever. The ghost cleanup only matched `completed` status, missing the `processing` case.
- Added `processing` to the ghost cleanup status filter, with a `child_job_ids` existence check to avoid accidentally cleaning up non-parent jobs.
- Added collection logging for better observability when SUCCEEDED jobs are picked up.

## Context
Investigated a report of 177 pending batch OCR jobs with some SUCCEEDED on Gemini but not collected. Findings:
- **No state field mismatch bug** -- the collector correctly normalizes `BATCH_STATE_*` to `JOB_STATE_*`
- **The collector IS running** and collecting jobs every 10 min on Hetzner
- **The "stuck" SUCCEEDED jobs were simply waiting for the next collector cycle** -- they were collected in the subsequent run
- **File storage quota is clean** -- only 12MB across all keys (well under 20GB limit)
- The only actual bug was parent jobs (job trackers with no Gemini job) getting stuck in `processing`

## Test plan
- [x] Verified the ghost cleanup query targets the right documents (parent jobs with `child_job_ids` but no `job_name`)
- [x] Confirmed collector code correctly handles `BATCH_STATE_*` prefix normalization
- [ ] Deploy to Hetzner and verify stuck parent jobs are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)