### PR TITLE
Identify: deep-link to exact page within book

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -199,13 +199,107 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Phase 2: Find the exact page within top book matches using inscription text
+    const topMatches = matches.slice(0, 5);
+    const pages = db.collection('pages');
+
+    // Build search terms from inscriptions — pick distinctive multi-word phrases
+    const inscriptionText = identification.inscriptions || '';
+    const searchPhrases = inscriptionText
+      .split('\n')
+      .map(l => l.trim())
+      .filter(l => l.length > 5 && !/^\d+$/.test(l))
+      .slice(0, 8);
+
+    // Also use subject keywords as fallback
+    const subjectWords = (identification.subject || '')
+      .split(/\s+/)
+      .filter(w => w.length > 4)
+      .slice(0, 5);
+
+    const pageMatches: { bookId: string; pageNumber: number; score: number }[] = [];
+
+    if (searchPhrases.length > 0 && topMatches.length > 0) {
+      const bookIds = topMatches.map(m => m.id);
+
+      // Search OCR text of pages in candidate books for inscription phrases
+      for (const phrase of searchPhrases.slice(0, 4)) {
+        const escaped = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const found = await pages
+          .find(
+            {
+              book_id: { $in: bookIds },
+              'ocr.data': { $regex: escaped, $options: 'i' },
+            },
+            {
+              projection: { book_id: 1, page_number: 1 },
+              maxTimeMS: 5000,
+            },
+          )
+          .limit(10)
+          .toArray()
+          .catch(() => []);
+
+        for (const p of found) {
+          const existing = pageMatches.find(
+            pm => pm.bookId === p.book_id && pm.pageNumber === p.page_number,
+          );
+          if (existing) {
+            existing.score += 10;
+          } else {
+            pageMatches.push({ bookId: p.book_id, pageNumber: p.page_number, score: 10 });
+          }
+        }
+      }
+    }
+
+    // Also check detected_images descriptions if no page match from OCR
+    if (pageMatches.length === 0 && subjectWords.length > 0 && topMatches.length > 0) {
+      const bookIds = topMatches.map(m => m.id);
+      const subjectRegex = subjectWords.slice(0, 3).map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+      const imgPages = await db.collection('gallery_images')
+        .find(
+          {
+            book_id: { $in: bookIds },
+            $or: [
+              { description: { $regex: subjectRegex, $options: 'i' } },
+              { type: { $regex: subjectRegex, $options: 'i' } },
+            ],
+          },
+          { projection: { book_id: 1, page_number: 1 }, maxTimeMS: 5000 },
+        )
+        .limit(10)
+        .toArray()
+        .catch(() => []);
+
+      for (const img of imgPages) {
+        if (img.page_number) {
+          pageMatches.push({ bookId: img.book_id, pageNumber: img.page_number, score: 5 });
+        }
+      }
+    }
+
+    // Sort page matches by score and attach to book results
+    pageMatches.sort((a, b) => b.score - a.score);
+    const bestPage = pageMatches[0] || null;
+
     return NextResponse.json({
       identification,
-      matches: matches.slice(0, 10).map(({ _score, enrichment, ...rest }) => ({
-        ...rest,
-        score: _score,
-        subject: enrichment?.subject,
-      })),
+      matches: matches.slice(0, 10).map(({ _score, enrichment, ...rest }) => {
+        // Attach page match if this book has one
+        const pm = pageMatches.find(p => p.bookId === rest.id);
+        return {
+          ...rest,
+          score: _score,
+          subject: enrichment?.subject,
+          ...(pm ? { page_number: pm.pageNumber, page_score: pm.score } : {}),
+        };
+      }),
+      page: bestPage ? {
+        book_id: bestPage.bookId,
+        page_number: bestPage.pageNumber,
+        score: bestPage.score,
+      } : null,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -17,6 +17,8 @@ interface Match {
   resource_type?: string;
   subject?: string;
   score: number;
+  page_number?: number;
+  page_score?: number;
 }
 
 interface Identification {
@@ -32,6 +34,7 @@ interface Identification {
 interface Result {
   identification: Identification;
   matches: Match[];
+  page?: { book_id: string; page_number: number; score: number } | null;
 }
 
 export default function IdentifyPage() {
@@ -231,10 +234,14 @@ export default function IdentifyPage() {
                   {result.matches.length === 1 ? 'Match Found' : `${result.matches.length} Possible Matches`}
                 </h2>
                 <div className="space-y-2">
-                  {result.matches.map((match, i) => (
+                  {result.matches.map((match, i) => {
+                    const pageUrl = match.page_number
+                      ? `${bookUrl({ slug: match.slug, id: match.id })}/page-number/${match.page_number}`
+                      : bookUrl({ slug: match.slug, id: match.id });
+                    return (
                     <Link
                       key={match.id}
-                      href={bookUrl({ slug: match.slug, id: match.id })}
+                      href={pageUrl}
                       className="flex gap-4 p-3 rounded-lg bg-white border border-border-light hover:border-accent-rust/30 hover:shadow-sm transition-all group"
                     >
                       {(match.thumbnail_blob || match.thumbnail) && (
@@ -262,14 +269,18 @@ export default function IdentifyPage() {
                           {match.resource_type && (
                             <span className="capitalize">{match.resource_type}</span>
                           )}
-                          {match.subject && (
+                          {match.page_number && (
+                            <span className="font-medium text-accent-rust">Page {match.page_number}</span>
+                          )}
+                          {match.subject && !match.page_number && (
                             <span className="line-clamp-1">{match.subject}</span>
                           )}
                         </div>
                       </div>
                       <ExternalLink className="w-4 h-4 text-muted group-hover:text-accent-rust flex-shrink-0 mt-1" />
                     </Link>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- After finding candidate books, searches pages' OCR text for inscription phrases
- Deep-links to the specific page (e.g. `/book/slug/page-number/47`)
- Falls back to gallery_images descriptions if OCR matching fails
- UI shows "Page N" badge and links directly to that page

## Test plan
- [ ] Upload Fludd diagram photo → should link to specific page in Utriusque Cosmi
- [ ] Upload Goltzius print → should find page if book has OCR
- [ ] Artworks (no pages) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)