### PR TITLE
Add essay: The Moon — history of thought through primary sources

### DIFF
--- a/docs/blog-the-moon.md
+++ b/docs/blog-the-moon.md
@@ -1,0 +1,179 @@
+# The Moon: A History of Thought Through Primary Sources
+
+*An intellectual history traced through the holdings of Source Library*
+
+---
+
+There is no older shared object of human contemplation than the moon. Before writing, before agriculture, before the first city wall was laid, every human being who tilted their head back at night saw the same scarred face hanging in the dark. And yet the questions they asked of it were radically different. Is it the border between mortality and eternity? The feminine principle in a cosmic marriage? A world with its own geography, weather, and inhabitants? A computational input for predicting eclipses and harvests? The moon has been all of these things, often simultaneously, often in the same text.
+
+What follows is not an astronomy lesson but an intellectual history --- a tracing of the moon through the minds that wrote about it, drawn from primary sources held in [Source Library](https://sourcelibrary.org), many translated into English for the first time. The texts span four millennia, seven languages, and nearly every mode of human inquiry: cosmology, alchemy, fiction, mathematics, astrology, and prayer.
+
+---
+
+## I. The Cosmological Boundary
+
+The oldest sustained philosophical argument about the moon in the Western tradition appears in Cicero's *Dream of Scipio*, written around 51 BCE and preserved in Source Library in a [1517 Aldine Press edition](https://sourcelibrary.org/book/cicero-de-officiis-de-senectute-de-amicitia-somnium-cicero). In this short text --- appended to Cicero's *Republic* --- the Roman general Scipio Aemilianus falls asleep and is carried by the ghost of his grandfather to a vantage point among the stars. From there he looks down and sees the Earth for what it is: small, fragile, and fundamentally unimportant.
+
+The passage on the moon is brief but decisive. Scipio is told that the region below the moon is the realm of mortality, while everything above it partakes of the eternal:
+
+> "For unless that god, whose temple is this whole that you see, shall have freed you from this guard of the body, the passage to the free cannot be opened; for men have been born to this world to be the guardians of that sphere which you see in this temple, which is called Earth." --- Cicero, *Dream of Scipio* (1517), [p. 339](https://sourcelibrary.org/api/books/69b2224208069e96e84331ba/quote?page=339)
+
+The moon, in Cicero's scheme, is not merely a celestial body. It is a threshold. Above it: the music of the spheres, the fires of the stars, the immortality of the soul. Below it: floods, conflagrations, the forgetting of fame, the brief and brutal span of a human life. Scipio's grandfather warns him that earthly glory cannot even cross the Ganges or the Caucasus, let alone outlast the cosmic year.
+
+This idea --- the moon as cosmological boundary --- would have been a footnote in intellectual history if not for Macrobius. Writing around 400 CE, Macrobius composed a commentary on Cicero's *Dream* that became one of the most widely read books in medieval Europe. Source Library holds multiple editions, including a [richly translated 1550 printing](https://sourcelibrary.org/book/commentary-on-the-dream-of-scipio-the-saturnalia-macrobius) and a [12th-century manuscript from Leiden](https://sourcelibrary.org/book/macrobius-on-the-dream-of-scipio-12th-century-ms-cicero).
+
+Macrobius took Cicero's passing reference to the lunar boundary and built it into a full Neoplatonic system. In his account, the soul descends from the Milky Way through the planetary spheres, acquiring a new faculty at each stage --- reason from Saturn, courage from Mars, desire from Venus --- until it reaches the moon, where it crosses from the eternal into the perishable:
+
+> "They have handed down the teaching that there are two deaths: one of the soul, the other of the living creature. The living creature 'dies' when the soul departs from the body; the soul itself 'dies' when it descends from the immortal regions into a mortal body." --- Macrobius, *Commentary on the Dream of Scipio* (1550), [p. 59](https://sourcelibrary.org/api/books/695573a0f63a757109172141/quote?page=59)
+
+The moon is where the soul dies into flesh. The gate is the zodiac sign of Cancer; the exit, Capricorn. Macrobius drew on Homer, Pythagoras, and Plato, weaving them into a single system in which the lunar orbit is the membrane between two kinds of existence. As the soul passes through, it experiences what Macrobius calls a *sylvestrem tumultum* --- a "wooded tumult," the first shock of materiality:
+
+> "When the soul is drawn toward the body, in this first stage of its production, it begins to experience a 'wooded tumult' --- that is, the first awareness of matter flowing into it." --- Macrobius, *Commentary on the Dream of Scipio* (1550), [p. 63](https://sourcelibrary.org/api/books/695573a0f63a757109172141/quote?page=63)
+
+This idea persisted for fifteen hundred years. It was read by Boethius, by the Carolingian scholars who copied these manuscripts, by the cathedral schools of the twelfth century, and by the Renaissance Neoplatonists who printed the text that Source Library now holds. The moon as the border of death and life: it is one of the longest-running ideas in European thought.
+
+---
+
+## II. Luna the Queen
+
+If the Neoplatonists saw the moon as a gate, the alchemists saw it as a bride.
+
+In the symbolic language of alchemy, the moon is Luna, silver, the feminine receptive principle. The sun is Sol, gold, the active masculine force. The entire drama of the alchemical Great Work --- the *opus magnum* --- can be described as the courtship, marriage, and consummation of Sol and Luna. Their union produces the Philosopher's Stone, the agent of transmutation, the reconciliation of all opposites.
+
+This symbolism pervades the alchemical holdings of Source Library. The [*Splendor Solis*](https://sourcelibrary.org/book/splendor-solis-solomon-trismosin) (1582), attributed to Salomon Trismosin, is one of the most beautiful alchemical manuscripts ever produced. Its painted plates depict the stages of the Great Work in luminous color. The text instructs the adept to work with the marriage of solar and lunar principles:
+
+> "From two waters make one. That which you seek, make from Sun and Moon. And give the enemy it to drink, and you will see him dead. Then from water, make earth." --- *Splendor Solis* (1582), [p. 30](https://sourcelibrary.org/api/books/6952dbf977f38f6761bc7720/quote?page=30)
+
+The Sun and Moon here are not astronomical objects but chemical and spiritual principles. The "two waters" are two forms of mercury; the "enemy" is the impure base metal that must be dissolved and reconstituted. The language is deliberately obscure --- the alchemists called it their "Aesop's Cloak" --- but the underlying symbolism is consistent: Luna receives, purifies, and transforms.
+
+In the [*Musaeum Hermeticum*](https://sourcelibrary.org/book/musaeum-hermeticum-reformatum-et-amplificatum-1678) (1678), the great anthology of alchemical treatises, the *Gloria Mundi* makes the relationship explicit:
+
+> "The Sun is the father, and the Moon is the mother, the earth the sustainer, and the mass also created by God through singular premeditation." --- *Gloria Mundi*, in *Musaeum Hermeticum* (1678), [p. 300](https://sourcelibrary.org/api/books/695203a5ab34727b1f041c53/quote?page=300)
+
+This echoes the *Emerald Tablet* of Hermes Trismegistus --- "its father is the Sun, its mother the Moon" --- which John Dee also quoted in his [*Monas Hieroglyphica*](https://sourcelibrary.org/book/monas-hieroglyphica-1564) (1564):
+
+> "That great Hermes once admonished us: stating that its Father is the SUN, and its Mother the MOON: and we know it is truly nourished in the Earth." --- Dee, *Monas Hieroglyphica* (1564), [p. 30](https://sourcelibrary.org/api/books/69520571ab34727b1f042c78/quote?page=30)
+
+The [Ripley Scroll](https://sourcelibrary.org/book/ripley-scroll-ms-bodl-rolls-1) (c. 1450), a six-foot parchment roll attributed to George Ripley and held in the Bodleian Library, compresses the entire process into visual poetry. Among its cascading fountains and coiled serpents, the alchemical verse declares:
+
+> "The Sun is too high to gather, / And of the Moon, it is also so; / The which Sun is born there too, / The first with his father." --- *Ripley Scroll* (c. 1450), [p. 3](https://sourcelibrary.org/api/books/699065973dc2ed39a49f1e71/quote?page=3)
+
+And in the scroll's iconography, the labels are stark: **The White Moon**, **The White Sun**, **The White Sea** --- the stages of purification rendered as a cosmological diagram. The "red son," the "white son," and the "black son" represent the three phases of the work (rubedo, albedo, nigredo), and at the base of the genealogy: "the sun is my father, the moon is my mother."
+
+For the alchemists, the moon was not distant. It was intimate, present in every retort and crucible, embodied in silver and in mercury, in the receptive darkness that precedes illumination.
+
+---
+
+## III. Lunar Astronomy Across Civilizations
+
+While European Neoplatonists debated the moon's metaphysical status and alchemists married it to the sun, astronomers in India, China, and the Islamic world were measuring it.
+
+The oldest systematic lunar astronomy in Source Library comes from the Sanskrit tradition. The [*Chandra Bhavadhyaya*](https://sourcelibrary.org/book/chandra-bhavadhyaya-lunar-mansions) (c. 1780), a manuscript from the M.T.B. College in Surat, opens with an invocation and immediately begins cataloging the effects of planetary positions relative to the moon:
+
+> "Salutations to the Illustrious Ganesha. Now begins the Chapter on the Moon." --- *Chandra Bhavadhyaya* (c. 1780), [p. 3](https://sourcelibrary.org/api/books/699066ef249ce014347d20c8/quote?page=3)
+
+What follows is not mythology but computation. When Jupiter is in the fifth house from the moon, "the man becomes divine in appearance. He is never lacking in luster or vital energy." When Saturn is in the second house, "the person experiences great trembling." The moon here is not a symbol but a reference point --- the origin of a coordinate system for human destiny.
+
+This framework rests on the *nakshatras*, the twenty-eight lunar mansions that divide the ecliptic into segments defined by the moon's daily motion. The same system appears in the monumental [*Surya Siddhanta*](https://sourcelibrary.org/book/surya-siddhanta-with-gudhartha-prakasaka-1859), the foundational text of Indian mathematical astronomy, held in Source Library with Ranganatha's commentary. The *Surya Siddhanta* treats the moon as a computational object whose position can be determined by epicyclic calculation:
+
+> "At the end of the even and odd quadrants, and at a distance of three signs from the perigee and apogee, the previously mentioned degrees of the slow epicycle, when reduced by twenty minutes, become the degrees of the slow epicycles..." --- *Surya Siddhanta* (1859), [p. 80](https://sourcelibrary.org/api/books/69905f3d40bc3a0478efb0a8/quote?page=80)
+
+The precision is startling. These are not vague gestures toward celestial harmony but rigorous geometric models, worked out over centuries and refined through observation.
+
+The Chinese tradition developed a parallel system. The [*Investigation into Celestial Coordinates and Stellar Positions*](https://sourcelibrary.org/book/study-of-celestial-star-positions-and-lunar-mansions) (Qing dynasty), a meticulous star catalog, organizes the entire visible sky by lunar mansions (*xiu*) and precise coordinate measurements. The "Supreme Palace Enclosure" --- the celestial government of the heavens --- is mapped star by star, each located by its mansion degree and latitude:
+
+> "An Investigation into the Celestial Coordinates and Stellar Positions of the Entire Sky." --- *Zhou Tian Xing Wei Jing Wei Xiu Du Kao*, [p. 1](https://sourcelibrary.org/api/books/6992c93c69b777d72c76353e/quote?page=1)
+
+Where European astronomy organized the sky around the sun (the ecliptic, the zodiac), Chinese astronomy organized it around the moon's path, the twenty-eight *xiu* serving as the fundamental grid. The [Ming Imperial Calendar of 1524](https://sourcelibrary.org/book/ming-imperial-calendar-jiajing-year-3) applies this system practically, calculating the "Awakening of Insects" and the "Grain in Ear" --- solar terms keyed to the agricultural cycle but computed through lunar-solar intercalation.
+
+The collision of these traditions produced one of the most dramatic episodes in the history of astronomy. Ferdinand Verbiest, a Flemish Jesuit serving at the Kangxi Emperor's court, was ordered to prove that European astronomical methods were superior to both the traditional Chinese and Islamic (*Huihui*) systems. His [*Imperial Astronomical Tests*](https://sourcelibrary.org/book/imperial-astronomical-tests-verbiest-1669) (1669) records the contest with bureaucratic precision:
+
+> "Astronomy is the most precise and subtle of arts, and the calendrical method concerns the essential affairs of the State. Do not harbor old grudges, each clinging to your own views, considering yourselves right and others wrong." --- Verbiest, *Imperial Astronomical Tests* (1669), [p. 10](https://sourcelibrary.org/api/books/69af1226b8bbede5a0084e63/quote?page=10)
+
+That is the Kangxi Emperor speaking, ordering a head-to-head comparison of eclipse predictions. Verbiest won. The Islamic calendar was "late by eighty-seven quarters and twelve minutes." European Copernican methods --- smuggled into China inside Jesuit robes --- became the basis of the imperial calendar. The moon, once again, was the arbiter.
+
+In Europe itself, the transition from medieval to modern lunar astronomy can be traced through two works in the library. Georg von Peurbach's [*Tabulae Eclypsium*](https://sourcelibrary.org/book/tabulae-eclypsium-peurbach-1514) (1514) represents the Viennese school at its peak: precise eclipse tables computed by hand, the crowning achievement of Ptolemaic methods. Giovanni Battista Riccioli's [*Almagestum Novum*](https://sourcelibrary.org/book/almagestum-novum-riccioli-1651) (1651), a century and a half later, represents the post-Galilean reckoning --- a Jesuit astronomer attempting to rebuild the entire edifice of celestial knowledge after the telescope had shattered the old certainties.
+
+---
+
+## IV. The Lunar Voyages
+
+Between 1634 and 1657, three books were published that, taken together, invented a genre. All three imagined a journey to the moon. All three used the journey to say something about the Earth. None of them agreed on what the moon was for.
+
+Johannes Kepler's [*Somnium*](https://sourcelibrary.org/book/the-dream-somnium-kepler) was published posthumously in 1634, though Kepler had been working on it since his student days at Tubingen in the 1590s. It is, by any reasonable definition, the first work of science fiction. The frame is a dream: a young Icelander named Duracotus, whose mother is a sorceress, summons a daemon who describes the lunar world in detail. But the details are not fanciful. They are *computed*. Kepler, the man who discovered the laws of planetary motion, applied his own astronomical knowledge to imagine what the moon would actually look like from its surface:
+
+> "But the most pleasant of all sights in Levania is the contemplation of their Volva" --- the Earth, so named because it appears to revolve. --- Kepler, *Somnium* (1634), [p. 21](https://sourcelibrary.org/api/books/69905d0baaa7f10ed4cfd66e/quote?page=21)
+
+Kepler imagined earthrise. He calculated the apparent size of the Earth from the lunar surface, the length of the lunar day (fourteen of our days), the extreme temperature swings, and the behavior of light in a world without atmosphere. He even imagined life --- pine-cone-shaped creatures that open their shells at nightfall:
+
+> "Scattered everywhere on the ground are masses shaped like pine cones; during the day their shells are scorched, but in the evening, as if their hiding places were opened, they give birth to living creatures." --- Kepler, *Somnium* (1634), [p. 35](https://sourcelibrary.org/api/books/69905d0baaa7f10ed4cfd66e/quote?page=35)
+
+The journey itself is harrowing. The daemon warns that humans must be drugged with narcotics, their limbs carefully arranged "so that the lower body is not carried away from the torso, nor the head from the body." The transit takes four hours. The gravitational midpoint --- where the Earth's pull gives way to the moon's --- is described with eerie prescience:
+
+> "The whole journey, as long as it is, is completed in the space of four hours at most." --- Kepler, *Somnium* (1634), [p. 12](https://sourcelibrary.org/api/books/69905d0baaa7f10ed4cfd66e/quote?page=12)
+
+Four years later, Francis Godwin published [*The Man in the Moone*](https://sourcelibrary.org/book/the-man-in-the-moone-1638-francis-godwin) (1638), the first lunar voyage in the English language. Where Kepler's journey was demonic and mathematical, Godwin's is comic and charming. His protagonist, Domingo Gonsales, a Spanish adventurer, trains a flock of wild swans (*gansas*) to carry him aloft in a harness. The swans, it turns out, migrate to the moon every year.
+
+Gonsales arrives to find a utopian society of giants, thirty times the size of humans, who live in perfect harmony:
+
+> "Everyone --- young and old --- hates every kind of vice. They live in such love, peace, and friendship that it seems to be another Paradise." --- Godwin, *The Man in the Moone* (1638), [p. 110](https://sourcelibrary.org/api/books/69905cf8aaa7f10ed4cfd202/quote?page=110)
+
+Their language is music. They communicate in tones and melodies rather than words:
+
+> "Many words consist of tunes only. Thus, if they wish, they can express their thoughts through tunes without any words at all." --- Godwin, *The Man in the Moone* (1638), [p. 100](https://sourcelibrary.org/api/books/69905cf8aaa7f10ed4cfd202/quote?page=100)
+
+The lunar people sort their population by moral quality. "Genuine, natural, and true Lunars" are noble and enormous. Those deemed deficient are sent to Earth --- which is to say, we are the moon's rejects. Gonsales himself, when he finally returns home, is carried back to China, where he lands near Peking and is promptly imprisoned in a wooden seat with only his head free.
+
+Cyrano de Bergerac's [*Les Oeuvres Diverses*](https://sourcelibrary.org/book/les-oeuvres-diverses-histoire-comique-de-la-lune-cyrano-de-bergerac) (1654), containing his *Histoire comique de la Lune*, completes the trilogy. Where Kepler was scientific and Godwin utopian, Cyrano was satirical. His narrator straps bottles of dew to his body (the sun draws dew upward, and the narrator with it), crash-lands in New France, and eventually reaches the moon, where he discovers a civilization that inverts every assumption of seventeenth-century Europe. Books are eaten rather than read. Walking on two legs is considered barbaric. The moon-dwellers debate whether the narrator is even human or merely a sophisticated parrot.
+
+These three books --- published within twenty years of each other, each aware of or responding to its predecessors --- mark the moment when the moon stopped being purely a philosophical or astronomical object and became a *place*. A place with weather, geography, inhabitants, and politics. The imagination had finally caught up with the telescope.
+
+---
+
+## V. Dee's Monad and the Moon as Glyph
+
+Before the lunar voyagers made the moon a destination, John Dee compressed it into a symbol.
+
+Dee's [*Monas Hieroglyphica*](https://sourcelibrary.org/book/monas-hieroglyphica-1564) (1564) is one of the strangest and most concentrated texts in the Western esoteric tradition. In it, Dee constructs a single hieroglyphic symbol --- the Monad --- from the basic elements of astronomical and alchemical notation: the circle of the Sun, the crescent of the Moon, the cross of the elements, and the dot of the Earth. Each component is both geometric and metaphysical.
+
+The crescent moon occupies a privileged position. It sits atop the solar circle, and Dee is careful to note the relationship:
+
+> "The semi-circle of the Moon, although here it is placed as if above and prior to the Solar circle, nevertheless observes the SUN as its Master and King. It seems to rejoice so much in the Sun's form and proximity that it emulates the Sun's [perfection]." --- Dee, *Monas Hieroglyphica* (1564), [p. 25](https://sourcelibrary.org/api/books/69520571ab34727b1f042c78/quote?page=25)
+
+The moon is subordinate to the sun but also essential. Without the crescent, the Monad is incomplete. Luna is the mirror, the reflector, the principle that makes the solar light visible to mortal eyes. The monad cannot exist without both.
+
+Dee went further. He argued that the shapes of letters in Hebrew, Greek, and Latin were not arbitrary but divinely constructed from the same geometric primitives --- points, lines, and circles --- that compose his Monad. The moon's crescent, then, is not just an astronomical symbol. It is a letter in the alphabet of creation, a glyph that encodes the relationship between the receptive and the active, the material and the divine.
+
+> "Our MONAD meanwhile admits nothing of external things, whether of Units or of Numbers: Since it is most exactly sufficient unto itself: most absolute in all its own numbers." --- Dee, *Monas Hieroglyphica* (1564), [p. 40](https://sourcelibrary.org/api/books/69520571ab34727b1f042c78/quote?page=40)
+
+The Monad is self-sufficient. And the moon, within it, is the necessary incompleteness --- the open crescent that allows the closed circle to mean something.
+
+---
+
+## VI. The Moon Before Writing
+
+The earliest text in Source Library that mentions the moon is not a treatise but a letter. It is Sumerian, dating to the Ur III period (c. 2100--1600 BCE), and it is addressed to a king:
+
+> "Say this to the king who has made his radiance resplendent over all the lands like the moonlight." --- *Letter from Lugal-nesage to a king radiant as the moon* (c. 2100 BCE), [p. 1](https://sourcelibrary.org/api/books/69aff08b57adc49dbfc42491/quote?page=1)
+
+The king is compared to the moon not for his wisdom or power but for his *radiance* --- his capacity to illuminate. The letter is a petition from a displaced citizen, and the lunar simile is a plea: you who shine over all the lands, notice me. The letter continues with images of devastating loss --- "Like a sheep I use my mouth for eating grass"; "As happens to a bird, men take my nest away" --- and closes with a single request: "May my king care for me and may I return to my former status."
+
+Four thousand years separate this letter from Kepler's *Somnium*. The moon has gone from simile to cosmological boundary to alchemical bride to computable object to destination. But the underlying gesture is the same: a human being looking up at something luminous and asking it to look back.
+
+---
+
+## VII. What the Moon Holds
+
+What connects Cicero's threshold, Macrobius's gate of souls, the alchemists' silver queen, Dee's crescent glyph, and Kepler's computed landscape is that none of them treated the moon as merely an object. It was always a mirror --- for death, for transformation, for the limits of knowledge, for the boundary between what can and cannot be seen.
+
+The Sanskrit astrologers used the moon as the fixed point from which all planetary influences are measured. The Chinese imperial astronomers built their entire coordinate system around the twenty-eight lunar mansions. Verbiest wagered his life on the accuracy of his lunar eclipse predictions. Peurbach spent decades refining eclipse tables to minutes of arc. The moon was where theory met observation, where calculation either matched reality or did not.
+
+For the literary voyagers, the moon was a stage on which to perform thought experiments about human nature. Kepler asked: what would it be like to stand there and look back? Godwin asked: what if the people there were better than us? Cyrano asked: what if they thought *we* were the strange ones?
+
+Source Library holds these texts in their original languages --- Latin, French, English, German, Sanskrit, Chinese, Sumerian --- many of them translated into modern English for the first time through AI-assisted translation reviewed against the originals. The texts referenced in this essay represent a fraction of the library's lunar holdings, which span astronomical treatises, alchemical manuscripts, literary fiction, astrological manuals, imperial calendars, and devotional prayers.
+
+The moon is still there. The same face, the same scarred surface, the same light. But the questions have changed, and the old questions --- preserved in these manuscripts --- are worth reading again. Not because they were right about the moon, but because they were asking the right questions about us.
+
+---
+
+*All texts referenced are freely available at [sourcelibrary.org](https://sourcelibrary.org). Source Library is an open-access digital library of pre-modern texts in their original languages, with AI-assisted English translations. The library holds over 17,000 works spanning 4,000 years and dozens of languages.*


### PR DESCRIPTION
## Summary
- New essay at `docs/blog-the-moon.md` tracing lunar thought across 4,000 years of intellectual history
- Draws from 15+ books in the Source Library collection across 7 languages (Latin, French, English, German, Sanskrit, Chinese, Sumerian)
- All quotes are drawn from actual translated content in the production database, with citation links to the `/api/books/BOOK_ID/quote?page=N` endpoint
- Covers: Cicero's Dream of Scipio, Macrobius's Neoplatonic soul-descent, alchemical Sol/Luna symbolism (Splendor Solis, Musaeum Hermeticum, Ripley Scroll), Sanskrit lunar mansions (Chandra Bhavadhyaya, Surya Siddhanta), Chinese star catalogs, Verbiest's imperial astronomical tests, Peurbach/Riccioli, the 1634-1657 lunar voyage trilogy (Kepler, Godwin, Cyrano), Dee's Monas Hieroglyphica, and a Sumerian moon letter from c. 2100 BCE

## Test plan
- [ ] Verify quote links resolve correctly
- [ ] Review essay for factual accuracy against the primary sources
- [ ] Check that all referenced books are accessible on sourcelibrary.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)