### PR TITLE
Add uptime monitor for Source Library

### DIFF
--- a/scripts/uptime-monitor.mjs
+++ b/scripts/uptime-monitor.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Uptime monitor for Source Library.
+ * Checks key endpoints, logs to MongoDB, alerts via ntfy.sh on new failures.
+ *
+ * Usage:
+ *   node scripts/uptime-monitor.mjs          # Run checks, write to DB, alert on failure
+ *   node scripts/uptime-monitor.mjs --check  # Print status only, no DB writes
+ *
+ * Cron (every 5 min on Hetzner):
+ *   See below for crontab line — run with env sourced.
+ */
+
+import { MongoClient } from 'mongodb';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const ENDPOINTS = [
+  { name: 'home', url: 'https://sourcelibrary.org/' },
+  { name: 'book_page', url: 'https://sourcelibrary.org/book/de-voluptate-marsilio-ficino' },
+  { name: 'api', url: 'https://sourcelibrary.org/api/books?limit=1' },
+];
+
+const TIMEOUT_MS = 15_000;
+const NTFY_TOPIC = 'https://ntfy.sh/sourcelibrary-uptime';
+// How long to suppress repeat alerts for the same endpoint (1 hour)
+const ALERT_COOLDOWN_MS = 60 * 60 * 1000;
+
+const DRY_RUN = process.argv.includes('--check');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function checkEndpoint(endpoint) {
+  const start = Date.now();
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const res = await fetch(endpoint.url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'SourceLibrary-UptimeMonitor/1.0' },
+      redirect: 'follow',
+    });
+    clearTimeout(timer);
+
+    const latency_ms = Date.now() - start;
+    const ok = res.status >= 200 && res.status < 300;
+
+    return {
+      endpoint: endpoint.name,
+      url: endpoint.url,
+      status: res.status,
+      ok,
+      latency_ms,
+      error: ok ? null : `HTTP ${res.status}`,
+      checked_at: new Date(),
+    };
+  } catch (err) {
+    return {
+      endpoint: endpoint.name,
+      url: endpoint.url,
+      status: 0,
+      ok: false,
+      latency_ms: Date.now() - start,
+      error: err.name === 'AbortError' ? `Timeout after ${TIMEOUT_MS}ms` : err.message,
+      checked_at: new Date(),
+    };
+  }
+}
+
+async function sendAlert(message) {
+  try {
+    await fetch(NTFY_TOPIC, {
+      method: 'POST',
+      headers: {
+        'Title': 'Source Library DOWN',
+        'Priority': 'high',
+        'Tags': 'warning',
+      },
+      body: message,
+    });
+  } catch (err) {
+    console.error(`[uptime] Failed to send ntfy alert: ${err.message}`);
+  }
+}
+
+function printResults(results) {
+  const ts = new Date().toISOString();
+  console.log(`\n[uptime] ${ts}`);
+  for (const r of results) {
+    const icon = r.ok ? 'OK' : 'FAIL';
+    const detail = r.ok ? `${r.latency_ms}ms` : r.error;
+    console.log(`  ${icon}  ${r.endpoint.padEnd(12)} ${detail}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Run all checks in parallel
+  const results = await Promise.all(ENDPOINTS.map(checkEndpoint));
+
+  printResults(results);
+
+  if (DRY_RUN) {
+    process.exit(0);
+  }
+
+  // Connect to MongoDB
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('[uptime] MONGODB_URI not set, skipping DB write');
+    process.exit(1);
+  }
+
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    const db = client.db('bookstore');
+    const checksCol = db.collection('uptime_checks');
+    const errorsCol = db.collection('application_errors');
+
+    // Write all results
+    await checksCol.insertMany(results);
+
+    // Ensure TTL index exists (auto-delete after 30 days)
+    await checksCol.createIndex(
+      { checked_at: 1 },
+      { expireAfterSeconds: 30 * 24 * 3600, background: true }
+    ).catch(() => {}); // ignore if already exists
+
+    // Ensure query index for the API route
+    await checksCol.createIndex(
+      { endpoint: 1, checked_at: -1 },
+      { background: true }
+    ).catch(() => {});
+
+    // Handle failures
+    const failures = results.filter(r => !r.ok);
+    if (failures.length > 0) {
+      // Write to application_errors
+      const errorDocs = failures.map(f => ({
+        source: 'uptime_monitor',
+        endpoint: f.endpoint,
+        url: f.url,
+        error: f.error,
+        status: f.status,
+        latency_ms: f.latency_ms,
+        timestamp: f.checked_at,
+      }));
+      await errorsCol.insertMany(errorDocs);
+
+      // Check cooldown: only alert if we haven't alerted for this endpoint recently
+      for (const f of failures) {
+        const recentAlert = await checksCol.findOne({
+          endpoint: f.endpoint,
+          ok: false,
+          alerted: true,
+          checked_at: { $gte: new Date(Date.now() - ALERT_COOLDOWN_MS) },
+        });
+
+        if (!recentAlert) {
+          const msg = `${f.endpoint} is down: ${f.error} (${f.url})`;
+          console.log(`[uptime] ALERTING: ${msg}`);
+          await sendAlert(msg);
+          // Mark this check as alerted
+          await checksCol.updateOne(
+            { _id: results.find(r => r.endpoint === f.endpoint)?._id },
+            { $set: { alerted: true } }
+          );
+        } else {
+          console.log(`[uptime] ${f.endpoint} still down, alert suppressed (cooldown)`);
+        }
+      }
+    }
+
+    // Also send recovery notification if endpoint was down and is now up
+    for (const r of results.filter(r => r.ok)) {
+      const lastFail = await checksCol.findOne(
+        { endpoint: r.endpoint, ok: false, checked_at: { $gte: new Date(Date.now() - ALERT_COOLDOWN_MS) } },
+        { sort: { checked_at: -1 } }
+      );
+      if (lastFail) {
+        // Check if there was a successful check after the last failure
+        const recoveryAlreadySent = await checksCol.findOne({
+          endpoint: r.endpoint,
+          ok: true,
+          recovery_sent: true,
+          checked_at: { $gt: lastFail.checked_at },
+        });
+        if (!recoveryAlreadySent) {
+          const msg = `${r.endpoint} recovered (${r.latency_ms}ms)`;
+          console.log(`[uptime] RECOVERY: ${msg}`);
+          await sendAlert(msg);
+          await checksCol.updateOne(
+            { _id: results.find(res => res.endpoint === r.endpoint)?._id },
+            { $set: { recovery_sent: true } }
+          );
+        }
+      }
+    }
+
+    console.log(`[uptime] Wrote ${results.length} checks to DB`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => {
+  console.error('[uptime] Fatal:', err);
+  process.exit(1);
+});

--- a/src/app/api/admin/uptime/route.ts
+++ b/src/app/api/admin/uptime/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 10;
+
+/**
+ * GET /api/admin/uptime — returns uptime check results.
+ *
+ * Query params:
+ *   hours=24       — how many hours of history (default 24, max 168)
+ *   endpoint=home  — filter by endpoint name (optional)
+ *   summary=true   — return aggregated stats instead of raw checks
+ */
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  try {
+    const db = await getDb();
+    const col = db.collection('uptime_checks');
+
+    const params = request.nextUrl.searchParams;
+    const hours = Math.min(parseInt(params.get('hours') || '24'), 168);
+    const endpoint = params.get('endpoint');
+    const summary = params.get('summary') === 'true';
+
+    const since = new Date(Date.now() - hours * 3600_000);
+    const filter: Record<string, unknown> = { checked_at: { $gte: since } };
+    if (endpoint) filter.endpoint = endpoint;
+
+    if (summary) {
+      // Aggregated per-endpoint stats
+      const stats = await col.aggregate([
+        { $match: filter },
+        {
+          $group: {
+            _id: '$endpoint',
+            total_checks: { $sum: 1 },
+            failures: { $sum: { $cond: ['$ok', 0, 1] } },
+            avg_latency_ms: { $avg: '$latency_ms' },
+            max_latency_ms: { $max: '$latency_ms' },
+            min_latency_ms: { $min: '$latency_ms' },
+            last_check: { $max: '$checked_at' },
+            last_error: {
+              $last: {
+                $cond: [{ $eq: ['$ok', false] }, '$error', '$$REMOVE'],
+              },
+            },
+          },
+        },
+        {
+          $project: {
+            endpoint: '$_id',
+            _id: 0,
+            total_checks: 1,
+            failures: 1,
+            uptime_pct: {
+              $round: [
+                { $multiply: [{ $divide: [{ $subtract: ['$total_checks', '$failures'] }, '$total_checks'] }, 100] },
+                2,
+              ],
+            },
+            avg_latency_ms: { $round: ['$avg_latency_ms', 0] },
+            max_latency_ms: 1,
+            min_latency_ms: 1,
+            last_check: 1,
+            last_error: 1,
+          },
+        },
+        { $sort: { endpoint: 1 } },
+      ], { maxTimeMS: 10000 }).toArray();
+
+      return NextResponse.json({
+        period_hours: hours,
+        since: since.toISOString(),
+        endpoints: stats,
+      });
+    }
+
+    // Raw check results, most recent first
+    const checks = await col
+      .find(filter, { projection: { _id: 0, alerted: 0, recovery_sent: 0 } })
+      .sort({ checked_at: -1 })
+      .limit(500)
+      .toArray();
+
+    return NextResponse.json({
+      period_hours: hours,
+      since: since.toISOString(),
+      count: checks.length,
+      checks,
+    });
+  } catch (error) {
+    console.error('[uptime] API error:', error);
+    return NextResponse.json({ error: 'Failed to fetch uptime data' }, { status: 500 });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/uptime-monitor.mjs` — a lightweight Node.js uptime checker that monitors 3 key endpoints (home, book page, API)
- Logs every check to MongoDB `uptime_checks` collection with 30-day TTL auto-cleanup
- Alerts via [ntfy.sh](https://ntfy.sh) on new failures (1-hour cooldown to avoid spam), sends recovery notifications
- Adds admin API route `GET /api/admin/uptime` with raw checks and `?summary=true` aggregated stats (uptime %, latency, last error)
- Designed for cron on Hetzner: `*/5 * * * *`

## Setup on Hetzner
After merge + `git pull` on Hetzner, add to crontab:
```
*/5 * * * * set -a; source /root/sourcelibrary/.env.production.local; set +a; node /root/sourcelibrary/scripts/uptime-monitor.mjs >> /var/log/uptime-monitor.log 2>&1
```

Subscribe to alerts on phone: open `https://ntfy.sh/sourcelibrary-uptime` or use the ntfy app.

## Test plan
- [x] `node scripts/uptime-monitor.mjs --check` — all 3 endpoints OK, no DB writes
- [ ] Run without `--check` against production MongoDB to verify writes
- [ ] Verify `GET /api/admin/uptime?summary=true` returns stats after data exists
- [ ] Test alert by temporarily checking a bad URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)