### PR TITLE
Add /api/health endpoint for uptime monitor

### DIFF
--- a/scripts/uptime-monitor.mjs
+++ b/scripts/uptime-monitor.mjs
@@ -18,8 +18,8 @@ import { MongoClient } from 'mongodb';
 // ---------------------------------------------------------------------------
 
 const ENDPOINTS = [
-  { name: 'home', url: 'https://sourcelibrary.org/' },
-  { name: 'book_page', url: 'https://sourcelibrary.org/book/de-voluptate-marsilio-ficino' },
+  // /api/health bypasses Cloudflare JS challenge (no browser required)
+  { name: 'health', url: 'https://sourcelibrary.org/api/health' },
   { name: 'api', url: 'https://sourcelibrary.org/api/books?limit=1' },
 ];
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 10;
+
+/**
+ * GET /api/health — lightweight health check for uptime monitoring.
+ * No auth required. Returns 200 if the app + MongoDB are reachable.
+ */
+export async function GET() {
+  try {
+    const db = await getDb();
+    // Minimal ping — don't query a large collection
+    await db.command({ ping: 1 });
+
+    return NextResponse.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('[health] MongoDB ping failed:', error);
+    return NextResponse.json(
+      { status: 'error', error: 'Database unreachable' },
+      { status: 503 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `/api/health` — unauthenticated endpoint that pings MongoDB and returns 200/503
- Fixes uptime monitor: Cloudflare JS challenges block curl from Hetzner (403 on all public pages), so switch to `/api/health` + `/api/books` endpoints

## Context
Follow-up to #835. The monitor was DOA because Cloudflare issues JS challenges to Hetzner's IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)