### PR TITLE
Bump /api/health maxDuration for cold starts

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 10;
+export const maxDuration = 30;
 
 /**
  * GET /api/health — lightweight health check for uptime monitoring.


### PR DESCRIPTION
Cold serverless function starts can exceed 10s for MongoDB connection. Bump to 30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)