### PR TITLE
Static book pages with on-demand revalidation

### DIFF
--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -37,6 +37,15 @@
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
+/** Trigger on-demand revalidation for a book page after enrichment completes. */
+async function revalidateBookPage(bookId) {
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (process.env.REVALIDATE_SECRET) headers['x-revalidate-secret'] = process.env.REVALIDATE_SECRET;
+    await fetch(`https://sourcelibrary.org/api/admin/revalidate-book/${bookId}`, { method: 'POST', headers });
+  } catch { /* best-effort */ }
+}
+
 // ── Config ──
 const MONGODB_URI = process.env.MONGODB_URI;
 const DEFAULT_MODEL = 'gemini-3-flash-preview';
@@ -1272,6 +1281,7 @@ async function main() {
         await enrichBook(db, book);
 
         await setPipelineStatus(db, book.id, 'summary_indexed', { 'pipeline_auto.retry_count': 0 });
+        revalidateBookPage(book.id).catch(() => {});
         enriched++;
       } catch (err) {
         const retries = book.pipeline_auto?.retry_count || 0;
@@ -1321,6 +1331,7 @@ async function main() {
         await extractChaptersForBook(db, book.id);
 
         await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
+        revalidateBookPage(book.id).catch(() => {});
         chaptersExtracted++;
       } catch (err) {
         if (err.message?.includes('429') || err.message?.includes('RESOURCE_EXHAUSTED')) rotateKey();

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -54,6 +54,15 @@ if (API_KEYS.length === 0) {
   process.exit(1);
 }
 
+/** Trigger on-demand revalidation for a book page after translation completes. */
+async function revalidateBookPage(bookId) {
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (process.env.REVALIDATE_SECRET) headers['x-revalidate-secret'] = process.env.REVALIDATE_SECRET;
+    await fetch(`https://sourcelibrary.org/api/admin/revalidate-book/${bookId}`, { method: 'POST', headers });
+  } catch { /* best-effort */ }
+}
+
 let currentKeyIndex = 0;
 function getClient() {
   return new GoogleGenerativeAI(API_KEYS[currentKeyIndex % API_KEYS.length]);
@@ -707,6 +716,9 @@ async function processBook(db, book, job, globalCounter, deadline) {
       label,
       bookId: book.id,
     });
+
+    // Trigger on-demand revalidation so the book page reflects new translations
+    revalidateBookPage(book.id).catch(() => {});
   } else {
     // Circuit breaker: if 0 pages translated this run AND the book was already attempted before,
     // it's stuck (e.g. Gemini safety filters blocking all pages). Mark needs_attention instead of spinning.

--- a/src/app/api/admin/revalidate-book/[id]/route.ts
+++ b/src/app/api/admin/revalidate-book/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import { getDb } from '@/lib/mongodb';
+import { findBookByIdOrSlug } from '@/lib/book-lookup';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // Optional: verify a simple shared secret for pipeline calls
+  const authHeader = request.headers.get('x-revalidate-secret');
+  const secret = process.env.REVALIDATE_SECRET;
+  if (secret && authHeader !== secret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const db = await getDb();
+  const result = await findBookByIdOrSlug(db, id);
+
+  if (!result) {
+    return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+  }
+
+  const book = result.book;
+  const slug = book.slug || id;
+
+  // Revalidate the book page and all sub-pages
+  revalidatePath(`/book/${slug}`);
+  revalidatePath(`/book/${slug}/search`);
+  // Also revalidate by ID in case both are cached
+  revalidatePath(`/book/${id}`);
+
+  // Revalidate individual page routes via layout invalidation
+  revalidatePath(`/book/${slug}`, 'layout');
+
+  return NextResponse.json({
+    success: true,
+    revalidated: [`/book/${slug}`, `/book/${id}`],
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -266,12 +266,16 @@ export const PATCH = withAuth(async (request, session, context) => {
       }
     }
 
-    // Revalidate caches when visible metadata changes
+    // Revalidate book page for any field change (pages are statically cached)
     const bookSlug = book.slug || bookId;
-    if (changedFields.some(f => ['thumbnail', 'thumbnail_blob', 'title', 'display_title', 'author'].includes(f))) {
+    if (changedFields.length > 0) {
       revalidatePath(`/book/${bookSlug}`);
-      // Thumbnail/title changes affect listing pages (home, collections, search)
-      revalidatePath('/', 'layout');
+      revalidatePath(`/book/${bookSlug}`, 'layout');
+      revalidatePath(`/book/${bookId}`);
+      // Thumbnail/title changes also affect listing pages (home, collections, search)
+      if (changedFields.some(f => ['thumbnail', 'thumbnail_blob', 'title', 'display_title', 'author'].includes(f))) {
+        revalidatePath('/', 'layout');
+      }
     }
 
     return NextResponse.json({ success: true, updated: Object.keys(updates) });

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -39,8 +39,8 @@ import { formatAuthor } from '@/lib/utils';
 import AuthorName from '@/components/AuthorName';
 import SiteHeader from '@/components/layout/SiteHeader';
 
-// ISR: rebuild at most every hour (requires no searchParams/headers() usage)
-export const revalidate = 600;
+// Static until on-demand revalidation. Pipeline calls /api/admin/revalidate-book after OCR/translation/enrichment.
+export const revalidate = false;
 
 // Run SSR near the database to cut cross-region latency (~200ms RTT savings)
 export const preferredRegion = 'fra1';

--- a/src/app/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/page.tsx
@@ -4,8 +4,8 @@ import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import type { Book, Page } from '@/lib/types';
 import PageEditorClient from './PageEditorClient';
 
-// ISR: rebuild at most every hour (content changes infrequently)
-export const revalidate = 600;
+// Static until on-demand revalidation. Pipeline calls /api/admin/revalidate-book after OCR/translation/enrichment.
+export const revalidate = false;
 
 interface PageProps {
   params: Promise<{ id: string; pageId: string }>;

--- a/src/app/book/[id]/search/page.tsx
+++ b/src/app/book/[id]/search/page.tsx
@@ -3,7 +3,8 @@ import { getDb } from '@/lib/mongodb';
 import { bookUrl } from '@/lib/slugify';
 import BookSearchResults from './BookSearchResults';
 
-export const revalidate = 600;
+// Static until on-demand revalidation. Pipeline calls /api/admin/revalidate-book after OCR/translation/enrichment.
+export const revalidate = false;
 
 interface Props {
   params: Promise<{ id: string }>;

--- a/src/lib/job-completion.ts
+++ b/src/lib/job-completion.ts
@@ -12,6 +12,7 @@ import { getDb } from '@/lib/mongodb';
 import type { PageJobType } from '@/lib/types/job';
 import { SKIP_TRANSLATION_PAGE_TYPES } from '@/lib/types/prompts/defaults';
 import { queuePreviewTranslation } from '@/lib/preview-translate';
+import { revalidateBook } from '@/lib/revalidate';
 
 /** Type alias for the Db returned by getDb() */
 type Db = Awaited<ReturnType<typeof getDb>>;
@@ -240,6 +241,11 @@ async function handleJobCompletion(
       break;
     }
   }
+
+  // Trigger on-demand revalidation so the book page reflects new content
+  revalidateBook(bookId).catch(() => {
+    // Best-effort — logged inside revalidateBook
+  });
 }
 
 /**

--- a/src/lib/revalidate.ts
+++ b/src/lib/revalidate.ts
@@ -1,0 +1,27 @@
+/**
+ * Trigger on-demand revalidation for a book page after pipeline processing.
+ * Call this after OCR, translation, enrichment, or image extraction completes.
+ */
+export async function revalidateBook(bookId: string): Promise<boolean> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
+    || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null)
+    || 'https://sourcelibrary.org';
+
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (process.env.REVALIDATE_SECRET) {
+      headers['x-revalidate-secret'] = process.env.REVALIDATE_SECRET;
+    }
+
+    const res = await fetch(`${baseUrl}/api/admin/revalidate-book/${bookId}`, {
+      method: 'POST',
+      headers,
+    });
+
+    return res.ok;
+  } catch {
+    // Non-fatal — stale cache is acceptable
+    console.warn(`[revalidate] Failed to revalidate book ${bookId}`);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Book pages (`/book/[id]`, page viewer, search) now use `revalidate = false` — cached indefinitely instead of every 10 minutes
- New `POST /api/admin/revalidate-book/[id]` endpoint triggers on-demand ISR revalidation
- Pipeline workers (job-completion, translate-worker, enrich-worker) call the endpoint after completing OCR, translation, enrichment, or chapter extraction
- PATCH `/api/books/[id]` now revalidates on ALL field changes, not just thumbnail/title/author

## How it works
Books are essentially static content. Instead of re-rendering every 10 minutes (wasting compute on ~17K+ books that rarely change), pages are cached forever and explicitly invalidated when content changes. The revalidation is best-effort — if it fails, the page stays stale until the next trigger.

The `REVALIDATE_SECRET` env var is optional. Without it, the endpoint is unprotected (acceptable since it only invalidates cache, not destructive).

## Test plan
- [ ] Verify book pages still render correctly after deploy
- [ ] Edit a book via admin and confirm the page updates
- [ ] Watch pipeline logs for `[revalidate]` messages after translation/enrichment completes
- [ ] Spot-check a recently-translated book to confirm fresh content appears without waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)