### PR TITLE
Self-service API key requests with admin approval

### DIFF
--- a/src/app/admin/api-keys/page.tsx
+++ b/src/app/admin/api-keys/page.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface KeyRequest {
+  _id: string;
+  name: string;
+  email: string;
+  organization: string | null;
+  use_case: string;
+  requested_tier: string;
+  status: string;
+  created_at: string;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
+  approved_tier?: string;
+  api_key_prefix?: string;
+  notes: string | null;
+}
+
+interface ApiKey {
+  _id: string;
+  key_prefix: string;
+  user_id: string;
+  name: string;
+  tier: string;
+  status: string;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export default function ApiKeysAdminPage() {
+  const [requests, setRequests] = useState<KeyRequest[]>([]);
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [tab, setTab] = useState<'pending' | 'reviewed' | 'keys'>('pending');
+  const [loading, setLoading] = useState(true);
+  const [actionResult, setActionResult] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (tab === 'keys') {
+        const res = await fetch('/api/admin/api-keys');
+        const data = await res.json();
+        setKeys(data.keys || []);
+      } else {
+        const status = tab === 'pending' ? 'pending' : 'approved';
+        const res = await fetch(`/api/admin/api-key-requests?status=${status}`);
+        const data = await res.json();
+        setRequests(data.requests || []);
+        // Also fetch denied for the reviewed tab
+        if (tab === 'reviewed') {
+          const res2 = await fetch('/api/admin/api-key-requests?status=denied');
+          const data2 = await res2.json();
+          setRequests(prev => [...prev, ...(data2.requests || [])].sort(
+            (a, b) => new Date(b.reviewed_at || b.created_at).getTime() - new Date(a.reviewed_at || a.created_at).getTime()
+          ));
+        }
+      }
+    } catch {
+      setActionResult({ type: 'error', message: 'Failed to fetch data' });
+    }
+    setLoading(false);
+  }, [tab]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  async function handleAction(requestId: string, action: 'approve' | 'deny') {
+    setActionResult(null);
+    try {
+      const res = await fetch('/api/admin/api-key-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ request_id: requestId, action }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setActionResult({ type: 'error', message: data.error });
+        return;
+      }
+
+      if (action === 'approve' && data.key) {
+        setActionResult({
+          type: 'success',
+          message: `Key minted for ${data.email}: ${data.key}`,
+        });
+      } else {
+        setActionResult({ type: 'success', message: `Request ${action}d.` });
+      }
+
+      fetchData();
+    } catch {
+      setActionResult({ type: 'error', message: 'Network error' });
+    }
+  }
+
+  async function handleRevoke(keyId: string) {
+    if (!confirm('Revoke this key?')) return;
+    try {
+      const res = await fetch('/api/admin/api-keys', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key_id: keyId }),
+      });
+      if (res.ok) {
+        setActionResult({ type: 'success', message: 'Key revoked.' });
+        fetchData();
+      }
+    } catch {
+      setActionResult({ type: 'error', message: 'Failed to revoke' });
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-stone-900 mb-6">API Keys</h1>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 border-b border-stone-200">
+        {(['pending', 'reviewed', 'keys'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              tab === t
+                ? 'border-stone-800 text-stone-900'
+                : 'border-transparent text-stone-500 hover:text-stone-700'
+            }`}
+          >
+            {t === 'pending' ? 'Pending Requests' : t === 'reviewed' ? 'Reviewed' : 'Active Keys'}
+          </button>
+        ))}
+      </div>
+
+      {/* Action result banner */}
+      {actionResult && (
+        <div
+          className={`mb-4 p-3 rounded-lg text-sm ${
+            actionResult.type === 'success'
+              ? 'bg-green-50 border border-green-200 text-green-800'
+              : 'bg-red-50 border border-red-200 text-red-800'
+          }`}
+        >
+          {actionResult.type === 'success' && actionResult.message.includes('sl_data_') ? (
+            <div>
+              <p className="font-medium mb-1">Key minted — copy it now (shown once):</p>
+              <code className="block bg-green-100 p-2 rounded text-xs break-all select-all">
+                {actionResult.message.split(': ').slice(1).join(': ')}
+              </code>
+            </div>
+          ) : (
+            actionResult.message
+          )}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-stone-500">Loading...</p>
+      ) : tab === 'keys' ? (
+        /* Active keys table */
+        <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-stone-50 border-b border-stone-200">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-stone-600">Name</th>
+                <th className="text-left px-4 py-3 font-medium text-stone-600">User</th>
+                <th className="text-left px-4 py-3 font-medium text-stone-600">Tier</th>
+                <th className="text-left px-4 py-3 font-medium text-stone-600">Status</th>
+                <th className="text-left px-4 py-3 font-medium text-stone-600">Last Used</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-stone-100">
+              {keys.length === 0 ? (
+                <tr><td colSpan={6} className="px-4 py-8 text-center text-stone-400">No keys yet</td></tr>
+              ) : keys.map(k => (
+                <tr key={k._id}>
+                  <td className="px-4 py-3 text-stone-900">{k.name}</td>
+                  <td className="px-4 py-3 text-stone-600 font-mono text-xs">{k.user_id}</td>
+                  <td className="px-4 py-3">
+                    <span className="px-2 py-0.5 bg-stone-100 text-stone-700 text-xs rounded">{k.tier}</span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`px-2 py-0.5 text-xs rounded ${
+                      k.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                    }`}>{k.status}</span>
+                  </td>
+                  <td className="px-4 py-3 text-stone-500 text-xs">
+                    {k.last_used_at ? new Date(k.last_used_at).toLocaleDateString() : 'Never'}
+                  </td>
+                  <td className="px-4 py-3">
+                    {k.status === 'active' && (
+                      <button
+                        onClick={() => handleRevoke(k._id)}
+                        className="text-xs text-red-600 hover:text-red-800"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        /* Requests */
+        <div className="space-y-4">
+          {requests.length === 0 ? (
+            <p className="text-stone-400 py-8 text-center">No {tab} requests</p>
+          ) : requests.map(r => (
+            <div key={r._id} className="bg-white rounded-xl border border-stone-200 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-medium text-stone-900">{r.name}</span>
+                    {r.organization && (
+                      <span className="text-stone-500">— {r.organization}</span>
+                    )}
+                    <span className={`px-2 py-0.5 text-xs rounded ${
+                      r.status === 'pending' ? 'bg-yellow-100 text-yellow-700'
+                        : r.status === 'approved' ? 'bg-green-100 text-green-700'
+                        : 'bg-red-100 text-red-700'
+                    }`}>{r.status}</span>
+                  </div>
+                  <p className="text-sm text-stone-600 mb-2">{r.email}</p>
+                  <p className="text-sm text-stone-700">{r.use_case}</p>
+                  <p className="text-xs text-stone-400 mt-2">
+                    Requested: {new Date(r.created_at).toLocaleDateString()} · Tier: {r.requested_tier}
+                    {r.reviewed_at && ` · Reviewed: ${new Date(r.reviewed_at).toLocaleDateString()} by ${r.reviewed_by}`}
+                    {r.api_key_prefix && ` · Key: ${r.api_key_prefix}`}
+                  </p>
+                </div>
+                {r.status === 'pending' && (
+                  <div className="flex gap-2 shrink-0">
+                    <button
+                      onClick={() => handleAction(r._id, 'approve')}
+                      className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg hover:bg-green-700 transition-colors"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => handleAction(r._id, 'deny')}
+                      className="px-3 py-1.5 bg-stone-200 text-stone-700 text-sm rounded-lg hover:bg-stone-300 transition-colors"
+                    >
+                      Deny
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/api-key-requests/route.ts
+++ b/src/app/api/admin/api-key-requests/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { generateApiKey } from '@/lib/dataset/api-keys';
+import { DatasetTier, DATASET_TIERS } from '@/lib/dataset/types';
+import { getDb } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+
+/**
+ * GET /api/admin/api-key-requests — List key requests
+ *
+ * Query: ?status=pending|approved|denied (default: pending)
+ */
+export const GET = withAdminAuth(async (request: NextRequest) => {
+  const db = await getDb();
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status') || 'pending';
+
+  const requests = await db.collection('api_key_requests')
+    .find({ status })
+    .sort({ created_at: -1 })
+    .toArray();
+
+  return NextResponse.json({ requests, count: requests.length });
+});
+
+/**
+ * POST /api/admin/api-key-requests — Approve or deny a request
+ *
+ * Body: {
+ *   request_id: string,
+ *   action: "approve" | "deny",
+ *   tier?: DatasetTier,    // override requested tier (default: use what they asked for)
+ *   notes?: string,        // optional admin notes
+ * }
+ *
+ * On approve: mints the key and returns it (admin sends to requester).
+ */
+export const POST = withAdminAuth(async (request: NextRequest, session) => {
+  const db = await getDb();
+  const body = await request.json();
+  const { request_id, action, tier, notes } = body;
+
+  if (!request_id || !action) {
+    return NextResponse.json(
+      { error: 'request_id and action are required' },
+      { status: 400 },
+    );
+  }
+
+  if (action !== 'approve' && action !== 'deny') {
+    return NextResponse.json(
+      { error: 'action must be "approve" or "deny"' },
+      { status: 400 },
+    );
+  }
+
+  let objectId: ObjectId;
+  try {
+    objectId = new ObjectId(request_id);
+  } catch {
+    return NextResponse.json({ error: 'Invalid request_id' }, { status: 400 });
+  }
+
+  const keyRequest = await db.collection('api_key_requests').findOne({
+    _id: objectId,
+    status: 'pending',
+  });
+
+  if (!keyRequest) {
+    return NextResponse.json(
+      { error: 'Request not found or already reviewed' },
+      { status: 404 },
+    );
+  }
+
+  const reviewedBy = session.user?.email || 'admin';
+
+  if (action === 'deny') {
+    await db.collection('api_key_requests').updateOne(
+      { _id: objectId },
+      {
+        $set: {
+          status: 'denied',
+          reviewed_at: new Date(),
+          reviewed_by: reviewedBy,
+          notes: notes || null,
+        },
+      },
+    );
+    return NextResponse.json({ status: 'denied', request_id });
+  }
+
+  // Approve — mint the key
+  const selectedTier: DatasetTier = tier || keyRequest.requested_tier || 'full';
+  if (!DATASET_TIERS[selectedTier]) {
+    return NextResponse.json(
+      { error: `Invalid tier: ${selectedTier}` },
+      { status: 400 },
+    );
+  }
+
+  const keyName = keyRequest.organization
+    ? `${keyRequest.name} — ${keyRequest.organization}`
+    : keyRequest.name;
+
+  const { key, doc } = await generateApiKey(
+    keyRequest.email,
+    selectedTier,
+    keyName,
+  );
+
+  await db.collection('api_key_requests').updateOne(
+    { _id: objectId },
+    {
+      $set: {
+        status: 'approved',
+        reviewed_at: new Date(),
+        reviewed_by: reviewedBy,
+        approved_tier: selectedTier,
+        api_key_prefix: doc.key_prefix,
+        notes: notes || null,
+      },
+    },
+  );
+
+  return NextResponse.json({
+    status: 'approved',
+    request_id,
+    key, // Admin copies this and sends to the requester
+    prefix: doc.key_prefix,
+    tier: selectedTier,
+    name: keyName,
+    email: keyRequest.email,
+    message: 'Key minted. Send it to the requester — it cannot be retrieved again.',
+  });
+});

--- a/src/app/api/dataset/v1/request-key/route.ts
+++ b/src/app/api/dataset/v1/request-key/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * POST /api/dataset/v1/request-key — Public endpoint to request an API key
+ *
+ * Body: { name, email, organization, use_case, tier? }
+ *
+ * Creates a pending request that an admin can approve.
+ */
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { name, email, organization, use_case, tier } = body;
+
+  if (!name || !email || !use_case) {
+    return NextResponse.json(
+      { error: 'name, email, and use_case are required' },
+      { status: 400 },
+    );
+  }
+
+  // Basic email validation
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json(
+      { error: 'Invalid email address' },
+      { status: 400 },
+    );
+  }
+
+  const db = await getDb();
+
+  // Check for existing pending request from same email
+  const existing = await db.collection('api_key_requests').findOne({
+    email: email.toLowerCase(),
+    status: 'pending',
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: 'You already have a pending request. We\'ll be in touch.' },
+      { status: 409 },
+    );
+  }
+
+  const doc = {
+    name,
+    email: email.toLowerCase(),
+    organization: organization || null,
+    use_case,
+    requested_tier: tier || 'full',
+    status: 'pending' as const,
+    created_at: new Date(),
+    reviewed_at: null,
+    reviewed_by: null,
+    notes: null,
+  };
+
+  await db.collection('api_key_requests').insertOne(doc);
+
+  return NextResponse.json({
+    message: 'Request received. We review requests within 24 hours.',
+    status: 'pending',
+  }, { status: 201 });
+}

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
@@ -357,6 +358,19 @@ source-library search "alchemy" --json | jq .results`}
             backpressure controls. Live counts, diagrams, cost breakdowns.
           </p>
         </Link>
+      </section>
+
+      {/* API Key Request */}
+      <section className="mb-16">
+        <h2 className="text-2xl font-semibold text-primary mb-2">Dataset API</h2>
+        <p className="text-secondary mb-6 max-w-2xl">
+          Need bulk access to the full corpus for research or integration?
+          Request an API key and we&apos;ll review it within 24 hours.
+          The MCP server above doesn&apos;t require a key.
+        </p>
+        <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
+          <ApiKeyRequestForm />
+        </div>
       </section>
 
       {/* Links */}

--- a/src/components/developers/ApiKeyRequestForm.tsx
+++ b/src/components/developers/ApiKeyRequestForm.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ApiKeyRequestForm() {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    organization: '',
+    use_case: '',
+  });
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus('submitting');
+
+    try {
+      const res = await fetch('/api/dataset/v1/request-key', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus('error');
+        setMessage(data.error || 'Something went wrong');
+        return;
+      }
+
+      setStatus('success');
+      setMessage(data.message);
+    } catch {
+      setStatus('error');
+      setMessage('Network error — please try again');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+        <h3 className="text-lg font-semibold text-green-800 mb-2">Request received</h3>
+        <p className="text-green-700">{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium text-stone-700 mb-1">Name *</label>
+          <input
+            id="name"
+            type="text"
+            required
+            value={form.name}
+            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+            className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+            placeholder="Your name"
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-stone-700 mb-1">Email *</label>
+          <input
+            id="email"
+            type="email"
+            required
+            value={form.email}
+            onChange={e => setForm(f => ({ ...f, email: e.target.value }))}
+            className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+            placeholder="you@example.com"
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="organization" className="block text-sm font-medium text-stone-700 mb-1">Organization</label>
+        <input
+          id="organization"
+          type="text"
+          value={form.organization}
+          onChange={e => setForm(f => ({ ...f, organization: e.target.value }))}
+          className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+          placeholder="University, company, or project"
+        />
+      </div>
+      <div>
+        <label htmlFor="use_case" className="block text-sm font-medium text-stone-700 mb-1">What will you use it for? *</label>
+        <textarea
+          id="use_case"
+          required
+          rows={3}
+          value={form.use_case}
+          onChange={e => setForm(f => ({ ...f, use_case: e.target.value }))}
+          className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust resize-none"
+          placeholder="Research project, app integration, dataset access..."
+        />
+      </div>
+
+      {status === 'error' && (
+        <p className="text-sm text-red-600">{message}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="px-5 py-2.5 bg-stone-800 text-white rounded-lg hover:bg-stone-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {status === 'submitting' ? 'Submitting...' : 'Request API Key'}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Public API key request form on `/developers` — name, email, org, use case
- `POST /api/dataset/v1/request-key` — public endpoint, deduplicates by email
- Admin approval flow at `/admin/api-keys` — pending/reviewed/active keys tabs
- On approve: mints key instantly, shown once for admin to copy and send
- On deny: marks as denied with optional notes

## Flow
1. User fills out form on /developers
2. Request lands in `api_key_requests` collection as "pending"
3. Admin visits /admin/api-keys, sees pending requests
4. Click Approve → key minted, displayed once → admin sends to requester
5. Click Deny → request marked denied

## Test plan
- [ ] Submit a request on /developers, verify it appears in /admin/api-keys
- [ ] Approve a request, verify key is displayed and works against /api/dataset/v1/books
- [ ] Deny a request, verify it moves to Reviewed tab
- [ ] Duplicate submission from same email returns 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)