### PR TITLE
Archive original full-res spreads to R2 before splitting

### DIFF
--- a/scripts/workers/batch-split-bph.mjs
+++ b/scripts/workers/batch-split-bph.mjs
@@ -189,7 +189,12 @@ async function processBook(r2, db, book) {
         return;
       }
 
-      // It's a spread — split at center
+      // It's a spread — archive the original full-res spread to R2 before splitting
+      const originalUrl = page.photo;
+      const spreadKey = `archived/${book.id}/${page.page_number}-spread.jpg`;
+      const spreadR2Url = await uploadToR2(r2, spreadKey, buf);
+
+      // Split at center
       const imgWidth = pageMeta.width || 1000;
       const imgHeight = pageMeta.height || 1000;
       const splitX = Math.round(imgWidth / 2);
@@ -256,6 +261,8 @@ async function processBook(r2, db, book) {
               archived_photo: leftFullUrl,
               display_photo: leftDisplayUrl,
               thumbnail_blob: leftThumbUrl,
+              photo_original: originalUrl,
+              spread_archived: spreadR2Url,
               crop: leftCrop,
               split_from_spread: true,
               split_side: 'left',
@@ -268,7 +275,7 @@ async function processBook(r2, db, book) {
               },
               updated_at: new Date(),
             },
-            $unset: { ocr: '', translation: '', summary: '', photo_original: '', cropped_photo: '' },
+            $unset: { ocr: '', translation: '', summary: '', cropped_photo: '' },
           },
         },
       });
@@ -285,6 +292,8 @@ async function processBook(r2, db, book) {
         archived_photo: rightFullUrl,
         display_photo: rightDisplayUrl,
         thumbnail_blob: rightThumbUrl,
+        photo_original: originalUrl,
+        spread_archived: spreadR2Url,
         crop: rightCrop,
         split_from: page.id,
         split_from_spread: true,


### PR DESCRIPTION
## Summary
- The split pipeline was downloading full-res spreads from BPH, cropping to 2000px, then discarding the original — no full-res copy was preserved
- `photo_original` was `$unset`, losing the source URL entirely
- Now uploads the original spread to `archived/{bookId}/{num}-spread.jpg` in R2 before cropping
- Preserves `photo_original` (BPH source URL) and adds `spread_archived` (R2 URL) on both halves
- Future re-cropping or higher-res extraction can use the archived spread

## Test plan
- [ ] Run on a test BPH book: verify `spread_archived` points to a valid R2 URL
- [ ] Verify `photo_original` is preserved on both left and right pages
- [ ] Check R2 bucket for `archived/{bookId}/` spread files

🤖 Generated with [Claude Code](https://claude.com/claude-code)