### PR TITLE
Fix explore stats: remove impossible $lookup, use snapshot

### DIFF
--- a/src/app/api/explore/stats/route.ts
+++ b/src/app/api/explore/stats/route.ts
@@ -12,8 +12,8 @@ let cachedResult: { data: unknown; timestamp: number } | null = null;
  *
  * Aggregated overview data for the /explore dashboard:
  * - Entity totals (overall, with dates, with coordinates, with wikidata)
- * - Century × type heatmap data
- * - Top entities per era
+ * - Century × type heatmap data (from snapshot — too expensive to compute live)
+ * - Top entities per era (from snapshot)
  * - Type distribution
  */
 export async function GET() {
@@ -26,25 +26,15 @@ export async function GET() {
     }
 
     const db = await getDb();
+    const MAX_TIME = 15000;
 
-    // Try pre-computed snapshot first (these aggregations take 30-80s on Atlas)
-    const snapshot = await db.collection('system_config').findOne(
+    // Load snapshot for expensive heatmap/topByEra data (pre-computed by cron/script)
+    const snapshotPromise = db.collection('system_config').findOne(
       { _id: 'explore_stats_snapshot' } as any,
       { maxTimeMS: 3000 },
     );
 
-    if (snapshot?.data && snapshot?.updated_at) {
-      const age = Date.now() - new Date(snapshot.updated_at).getTime();
-      if (age < 24 * 60 * 60 * 1000) { // 24h — this data changes slowly
-        cachedResult = { data: snapshot.data, timestamp: Date.now() };
-        return NextResponse.json(snapshot.data, {
-          headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
-        });
-      }
-    }
-
-    const MAX_TIME = 15000;
-
+    // Run cheap queries live for fresh counts
     const [
       totalEntities,
       withDates,
@@ -52,8 +42,7 @@ export async function GET() {
       withWikidata,
       totalBooks,
       typeDistribution,
-      heatmapData,
-      topByEra,
+      snapshot,
     ] = await Promise.all([
       db.collection('entities').countDocuments({}, { maxTimeMS: MAX_TIME }),
 
@@ -78,99 +67,8 @@ export async function GET() {
         { $group: { _id: '$type', count: { $sum: 1 } } },
       ], { maxTimeMS: MAX_TIME }).toArray(),
 
-      db.collection('entities').aggregate([
-        { $match: { books: { $exists: true, $type: 'array' } } },
-        { $unwind: '$books' },
-        {
-          $lookup: {
-            from: 'books',
-            localField: 'books.book_id',
-            foreignField: 'id',
-            as: 'book_doc',
-          },
-        },
-        { $unwind: '$book_doc' },
-        { $match: { 'book_doc.year': { $exists: true, $gt: 0 } } },
-        {
-          $group: {
-            _id: {
-              entity: '$name',
-              type: '$type',
-              century: {
-                $add: [
-                  { $floor: { $divide: [{ $subtract: ['$book_doc.year', 1] }, 100] } },
-                  1,
-                ],
-              },
-            },
-          },
-        },
-        {
-          $group: {
-            _id: { century: '$_id.century', type: '$_id.type' },
-            count: { $sum: 1 },
-          },
-        },
-        { $sort: { '_id.century': 1 } },
-      ], { maxTimeMS: 30000 }).toArray(),
-
-      db.collection('entities').aggregate([
-        { $match: { book_count: { $gte: 2 }, books: { $exists: true, $type: 'array' } } },
-        { $unwind: '$books' },
-        {
-          $lookup: {
-            from: 'books',
-            localField: 'books.book_id',
-            foreignField: 'id',
-            as: 'book_doc',
-          },
-        },
-        { $unwind: '$book_doc' },
-        { $match: { 'book_doc.year': { $exists: true, $gt: 0 } } },
-        {
-          $group: {
-            _id: {
-              entity: '$name',
-              type: '$type',
-              century: {
-                $add: [
-                  { $floor: { $divide: [{ $subtract: ['$book_doc.year', 1] }, 100] } },
-                  1,
-                ],
-              },
-            },
-            book_count: { $first: '$book_count' },
-          },
-        },
-        { $sort: { book_count: -1 } },
-        {
-          $group: {
-            _id: '$_id.century',
-            entities: {
-              $push: {
-                name: '$_id.entity',
-                type: '$_id.type',
-                book_count: '$book_count',
-              },
-            },
-          },
-        },
-        {
-          $project: {
-            century: '$_id',
-            entities: { $slice: ['$entities', 5] },
-          },
-        },
-        { $sort: { century: 1 } },
-      ], { maxTimeMS: 30000 }).toArray(),
+      snapshotPromise,
     ]);
-
-    // Format heatmap data
-    const heatmap = heatmapData.map((row) => ({
-      century: row._id.century as number,
-      type: row._id.type as string,
-      count: row.count as number,
-    }));
 
     // Format type distribution
     const types: Record<string, number> = {};
@@ -178,13 +76,10 @@ export async function GET() {
       types[row._id as string] = row.count as number;
     }
 
-    // Format top by era
-    const topEntitiesByEra = topByEra.map((row) => ({
-      century: row.century as number,
-      entities: row.entities as Array<{ name: string; type: string; book_count: number }>,
-    }));
+    // Use snapshot for expensive cross-collection data, empty arrays if not available
+    const heatmap = snapshot?.data?.heatmap ?? [];
+    const topEntitiesByEra = snapshot?.data?.top_entities_by_era ?? [];
 
-    // Data sources — what alignment produced these numbers
     const dataSources = {
       entities: {
         label: 'Entity Index',
@@ -230,13 +125,6 @@ export async function GET() {
 
     cachedResult = { data, timestamp: Date.now() };
 
-    // Write snapshot for next cold start (fire-and-forget)
-    db.collection('system_config').updateOne(
-      { _id: 'explore_stats_snapshot' } as any,
-      { $set: { data, updated_at: new Date().toISOString() } },
-      { upsert: true },
-    ).catch(() => {});
-
     return NextResponse.json(data, {
       headers: {
         'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200',
@@ -259,9 +147,15 @@ export async function GET() {
       }
     } catch { /* ignore */ }
 
-    return NextResponse.json(
-      { error: 'Failed to fetch explore stats' },
-      { status: 500 }
-    );
+    // Return empty-but-valid structure so the UI doesn't break
+    return NextResponse.json({
+      totals: { entities: 0, with_dates: 0, with_coordinates: 0, with_wikidata: 0, books: 0 },
+      type_distribution: {},
+      heatmap: [],
+      top_entities_by_era: [],
+      data_sources: {},
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30' },
+    });
   }
 }


### PR DESCRIPTION
## Summary
- The `$lookup` from 499K entities → books always timed out on Atlas (even at 120s)
- Rewrote `/api/explore/stats` to run only cheap queries live (counts, type distribution)
- Heatmap and topByEra now read from a pre-computed snapshot in `system_config`
- Returns empty-but-valid JSON instead of 500 when no snapshot exists
- Seeded the snapshot via a book-side streaming script (57 heatmap cells, 19 centuries)

## Test plan
- [ ] `GET /api/explore/stats` returns 200 with live counts + snapshot heatmap
- [ ] If snapshot is deleted, route still returns 200 with empty heatmap/topByEra

🤖 Generated with [Claude Code](https://claude.com/claude-code)