### PR TITLE
Gallery: prefer 4000px hires crop for display

### DIFF
--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -90,9 +90,9 @@ export async function GET(
           id,
           pageId,
           detectionIndex,
-          imageUrl: galleryDoc.extracted_url || galleryDoc.thumbnail_url || galleryDoc.image_url,
+          imageUrl: galleryDoc.hires_url || galleryDoc.extracted_url || galleryDoc.thumbnail_url || galleryDoc.image_url,
           fullPageUrl: galleryDoc.image_url,
-          highResUrl: galleryDoc.extracted_url || galleryDoc.image_url,
+          highResUrl: galleryDoc.hires_url || galleryDoc.extracted_url || galleryDoc.image_url,
           extractedUrl: galleryDoc.extracted_url ?? null,
           thumbnailUrl: galleryDoc.thumbnail_url ?? null,
           rotation: galleryDoc.rotation ?? 0,
@@ -140,9 +140,9 @@ export async function GET(
           id,
           pageId,
           detectionIndex,
-          imageUrl: galleryDoc.extracted_url || galleryDoc.thumbnail_url || galleryDoc.image_url,
+          imageUrl: galleryDoc.hires_url || galleryDoc.extracted_url || galleryDoc.thumbnail_url || galleryDoc.image_url,
           fullPageUrl: galleryDoc.image_url,
-          highResUrl: galleryDoc.extracted_url || galleryDoc.image_url,
+          highResUrl: galleryDoc.hires_url || galleryDoc.extracted_url || galleryDoc.image_url,
           extractedUrl: galleryDoc.extracted_url ?? null,
           thumbnailUrl: galleryDoc.thumbnail_url ?? null,
           rotation: galleryDoc.rotation ?? 0,
@@ -185,9 +185,9 @@ export async function GET(
           id,
           pageId,
           detectionIndex,
-          imageUrl: galleryDoc.extracted_url || galleryDoc.thumbnail_url || galleryDoc.image_url,
+          imageUrl: galleryDoc.hires_url || galleryDoc.extracted_url || galleryDoc.thumbnail_url || galleryDoc.image_url,
           fullPageUrl: galleryDoc.image_url,
-          highResUrl: galleryDoc.extracted_url || galleryDoc.image_url,
+          highResUrl: galleryDoc.hires_url || galleryDoc.extracted_url || galleryDoc.image_url,
           extractedUrl: galleryDoc.extracted_url ?? null,
           thumbnailUrl: galleryDoc.thumbnail_url ?? null,
           rotation: galleryDoc.rotation ?? 0,
@@ -277,8 +277,8 @@ export async function GET(
       highResUrl = `/api/crop-image?${highResCropParams}`;
     }
 
-    // Prefer pre-generated extracted_url, fall back to on-the-fly crop, then raw page
-    const croppedUrl = detection.extracted_url || cropUrl || imageUrl;
+    // Prefer highest-resolution pre-generated crop, fall back to standard crop, then on-the-fly
+    const croppedUrl = detection.hires_url || detection.extracted_url || cropUrl || imageUrl;
 
     // Build the response
     const response = {
@@ -290,7 +290,7 @@ export async function GET(
       // Image URLs
       imageUrl: croppedUrl,
       fullPageUrl: imageUrl,
-      highResUrl: highResUrl, // For magnifier/high-resolution viewing
+      highResUrl: detection.hires_url || highResUrl, // For magnifier/high-resolution viewing
       extractedUrl: detection.extracted_url ?? null,
       thumbnailUrl: detection.thumbnail_url ?? null,
       hiresUrl: detection.hires_url ?? null, // Cached high-res download (4000px crop in R2)


### PR DESCRIPTION
## Summary
- Gallery image viewer was showing `extracted_url` (cropped from 2000px IIIF source), producing visibly soft images for large emblems/illustrations
- Now prefers `hires_url` (4000px R2-cached crop) as the primary display image when available
- Falls back through: `hires_url` → `extracted_url` → on-the-fly crop → raw page
- Also uses `hires_url` for the magnifier high-res source
- Applied to all 4 response paths (normal, orphaned, stale, corrupt fallbacks)

## Context
Backfilled 180 high-res crops for Maier's *Atalanta Fugiens* — this PR makes the viewer actually use them.

## Test plan
- [ ] Visit https://sourcelibrary.org/gallery/image/69520c46ab34727b1f04420c-0 — should show sharp 4000px crop
- [ ] Gallery images without `hires_url` still display correctly (falls back to `extracted_url`)
- [ ] Magnifier zoom still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)