### PR TITLE
Fix identify: retry, compression, error handling

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -3,6 +3,10 @@ import { getNextApiKey } from '@/lib/gemini-client';
 import { getDb } from '@/lib/mongodb';
 
 export const maxDuration = 30;
+export const dynamic = 'force-dynamic';
+
+// Max image size: 4MB (Vercel serverless body limit is 4.5MB)
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
 
 const IDENTIFY_PROMPT = `You are an art historian identifying a physical artwork or book page from a photograph taken in a museum or library.
 
@@ -48,6 +52,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'No image provided' }, { status: 400 });
     }
 
+    if (file.size > MAX_IMAGE_BYTES) {
+      return NextResponse.json(
+        { error: `Image too large (${(file.size / 1024 / 1024).toFixed(1)}MB). Maximum is 4MB.` },
+        { status: 400 },
+      );
+    }
+
     // Convert to base64
     const bytes = await file.arrayBuffer();
     const base64 = Buffer.from(bytes).toString('base64');
@@ -76,19 +87,24 @@ export async function POST(request: NextRequest) {
     if (!resp.ok) {
       const err = await resp.text();
       console.error('[identify] Gemini error:', resp.status, err);
-      return NextResponse.json({ error: 'Vision API failed' }, { status: 502 });
+      const detail = resp.status === 429 ? 'Rate limited — try again in a moment' : `Vision API error (${resp.status})`;
+      return NextResponse.json({ error: detail }, { status: 502 });
     }
 
     const geminiData = await resp.json();
     const text = geminiData.candidates?.[0]?.content?.parts?.[0]?.text || '';
 
     // Parse JSON from response
-    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) || [null, text];
+    if (!text) {
+      return NextResponse.json({ error: 'Vision API returned empty response — try a different image' }, { status: 502 });
+    }
+    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    const jsonStr = (jsonMatch?.[1] || text).trim();
     let identification: IdentifyResult;
     try {
-      identification = JSON.parse(jsonMatch[1].trim());
+      identification = JSON.parse(jsonStr);
     } catch {
-      return NextResponse.json({ error: 'Failed to parse vision response', raw: text.substring(0, 500) }, { status: 500 });
+      return NextResponse.json({ error: 'Could not parse vision response — try a clearer image', detail: text.substring(0, 300) }, { status: 500 });
     }
 
     // Search the library for matches

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -42,37 +42,69 @@ export default function IdentifyPage() {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<Result | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const lastFileRef = useRef<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
-  const handleFile = useCallback(async (file: File) => {
-    // Preview
-    const reader = new FileReader();
-    reader.onload = (e) => setImage(e.target?.result as string);
-    reader.readAsDataURL(file);
-
-    // Submit
+  const submitFile = useCallback(async (file: File) => {
     setLoading(true);
     setError(null);
     setResult(null);
 
+    // Compress large images client-side (phone cameras produce 5-10MB files)
+    let imageFile = file;
+    if (file.size > 3 * 1024 * 1024) {
+      try {
+        const bitmap = await createImageBitmap(file);
+        const scale = Math.min(1, 2000 / Math.max(bitmap.width, bitmap.height));
+        const canvas = new OffscreenCanvas(bitmap.width * scale, bitmap.height * scale);
+        const ctx = canvas.getContext('2d')!;
+        ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+        const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.85 });
+        imageFile = new File([blob], 'photo.jpg', { type: 'image/jpeg' });
+      } catch {
+        // Fall through with original file if compression fails
+      }
+    }
+
     const formData = new FormData();
-    formData.append('image', file);
+    formData.append('image', imageFile);
 
     try {
       const res = await fetch('/api/identify', { method: 'POST', body: formData });
-      const data = await res.json();
+      let data;
+      try {
+        data = await res.json();
+      } catch {
+        setError(`Server error (${res.status}) — try again`);
+        return;
+      }
       if (!res.ok) {
-        setError(data.error || 'Failed to identify');
+        setError(data.detail || data.error || `Failed to identify (${res.status})`);
       } else {
         setResult(data);
       }
     } catch {
-      setError('Network error — please try again');
+      setError('Network error — check your connection and try again');
     } finally {
       setLoading(false);
     }
   }, []);
+
+  const handleFile = useCallback(async (file: File) => {
+    lastFileRef.current = file;
+    // Preview
+    const reader = new FileReader();
+    reader.onload = (e) => setImage(e.target?.result as string);
+    reader.readAsDataURL(file);
+    submitFile(file);
+  }, [submitFile]);
+
+  const retry = useCallback(() => {
+    if (lastFileRef.current) {
+      submitFile(lastFileRef.current);
+    }
+  }, [submitFile]);
 
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -172,8 +204,15 @@ export default function IdentifyPage() {
 
         {/* Error */}
         {error && (
-          <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800">
-            {error}
+          <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800 space-y-2">
+            <p>{error}</p>
+            <button
+              onClick={retry}
+              disabled={loading}
+              className="text-accent-rust font-medium hover:underline cursor-pointer disabled:opacity-50"
+            >
+              Try again
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Retry button on errors (keeps the photo, resubmits)
- Client-side image compression for phone cameras (5-10MB → ~500KB JPEG)
- Server-side 4MB limit with clear error
- Better error messages (rate limit, parse failure, empty response)
- Fix null crash on empty Gemini response
- Add force-dynamic

## Bugs fixed
- Large phone photos hit Vercel body limit → now auto-compressed
- No way to retry after error → retry button added
- Vague error messages → now shows detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)