### PR TITLE
Add archive_status tracking to bulk archive workers

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -297,9 +297,10 @@ async function processBook(book, db) {
         { book_id: book.id, archived_photo: { $exists: true, $nin: [null, ''] } },
         { maxTimeMS: 10000 }
       );
+      const archiveStatus = archivedCount >= book.pages_count ? 'archive_complete' : 'archive_partial';
       await db.collection('books').updateOne(
         { id: book.id },
-        { $set: { pages_archived: archivedCount, updated_at: new Date() } }
+        { $set: { pages_archived: archivedCount, archive_status: archiveStatus, updated_at: new Date() } }
       );
     }
 

--- a/scripts/workers/archive-erara.mjs
+++ b/scripts/workers/archive-erara.mjs
@@ -262,9 +262,10 @@ async function processBook(book, db) {
         { book_id: book.id, archived_photo: { $exists: true, $nin: [null, ''] } },
         { maxTimeMS: 10000 }
       );
+      const archiveStatus = archivedCount >= book.pages_count ? 'archive_complete' : 'archive_partial';
       await db.collection('books').updateOne(
         { id: book.id },
-        { $set: { pages_archived: archivedCount, updated_at: new Date() } }
+        { $set: { pages_archived: archivedCount, archive_status: archiveStatus, updated_at: new Date() } }
       );
     }
 


### PR DESCRIPTION
## Summary

- Sets `archive_status` on books after archiving pages to R2
- `archive_complete` when all pages archived, `archive_partial` otherwise
- Applied to both `archive-bulk.mjs` (IA/general) and `archive-erara.mjs`

## Why

`archive_status` was never set on any of the 17K books, making it impossible to track R2 archiving progress without scanning millions of page docs (which times out on Atlas). This fix enables `db.collection('books').countDocuments({ archive_status: 'archive_complete' })` for instant progress checks.

## Changes

Merged `archive_status` into the existing `pages_archived` sync `$set` call — no additional DB writes.

Closes phase 1 of #875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)