### PR TITLE
Add maxDuration to IA, MDZ, and PDF import routes

### DIFF
--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -8,6 +8,8 @@ import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
 
+export const maxDuration = 300;
+
 /**
  * Import a book from Internet Archive
  *

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -8,6 +8,8 @@ import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
 
+export const maxDuration = 300;
+
 interface IIIFCanvas {
   '@id'?: string;
   label?: string;

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -13,6 +13,8 @@ import { join } from 'path';
 import { storagePut } from '@/lib/storage';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
 
+export const maxDuration = 300;
+
 /**
  * Import a book from a PDF URL
  *


### PR DESCRIPTION
## Summary
- IA, MDZ, and PDF import routes were missing `export const maxDuration = 300`
- All other 21 import routes already had this — these 3 were missed
- Without it, Vercel defaults to a short timeout causing all IA imports to fail

## Test plan
- [ ] Deploy and test IA import (e.g., `POST /api/import/ia` with a known identifier)
- [ ] Verify imports complete within 300s instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)