### PR TITLE
Skip Vercel deploys when only non-app files change

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "regions": ["fra1"],
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- src/ public/ next.config.ts vercel.json package.json package-lock.json",
   "crons": [
     {
       "path": "/api/cron/social-post",


### PR DESCRIPTION
## Summary
- Adds `ignoreCommand` to `vercel.json` — pushes that only touch docs, scripts, handoffs, `.claude/`, or other non-app files won't trigger production deploys
- Deploys still trigger for: `src/`, `public/`, `next.config.ts`, `vercel.json`, `package.json`, `package-lock.json`

## Why
Every Vercel deploy purges the ISR cache for 17K+ book pages. With ~2 deploys/day, the cache barely has time to warm before it's wiped again. Many pushes to main only change pipeline scripts, docs, or handoffs — no reason to redeploy the site for those.

## Test plan
- [ ] Push a commit that only touches `scripts/` or `.claude/` — verify Vercel skips the build
- [ ] Push a commit that touches `src/` — verify Vercel deploys normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)