### PR TITLE
Add curator role for restricted import access

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from 'next/cache';
 import { getDb, getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 
@@ -97,7 +97,7 @@ export async function GET(
   }
 }
 
-export const DELETE = withAuth(async (request, session, context) => {
+export const DELETE = withAdminAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
     const { searchParams } = new URL(request.url);
@@ -213,7 +213,7 @@ export const DELETE = withAuth(async (request, session, context) => {
   }
 });
 
-export const PATCH = withAuth(async (request, session, context) => {
+export const PATCH = withCuratorAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
     const body = await request.json();

--- a/src/app/api/books/[id]/visibility/route.ts
+++ b/src/app/api/books/[id]/visibility/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { withAdminAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 /**
  * POST /api/books/[id]/visibility
@@ -8,7 +8,7 @@ import { withAdminAuth } from '@/lib/auth-helpers';
  * Toggle book visibility for curation.
  * Body: { hidden: boolean, reason?: string }
  */
-export const POST = withAdminAuth(async (
+export const POST = withCuratorAuth(async (
   request: NextRequest,
 ) => {
   try {

--- a/src/app/api/import/bl/route.ts
+++ b/src/app/api/import/bl/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF v3 manifest: https://bl.digirati.io/iiif/ark:/81055/{ark}
  * Viewer: https://www.bl.uk/manuscripts/Viewer.aspx?ref={shelfmark}
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { ark, shelfmark, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/bodleian/route.ts
+++ b/src/app/api/import/bodleian/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -18,7 +18,7 @@ export const maxDuration = 300;
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { uuid, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/cambridge/route.ts
+++ b/src/app/api/import/cambridge/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -18,7 +18,7 @@ export const maxDuration = 300;
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { ms_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -74,7 +74,7 @@ function parseOAIMetadata(xml: string): OAIMetadata {
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/europeana/route.ts
+++ b/src/app/api/import/europeana/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -25,7 +25,7 @@ export const maxDuration = 300;
  * Browse: https://www.europeana.eu/
  * API docs: https://pro.europeana.eu/page/record
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -40,7 +40,7 @@ interface IIIFManifest {
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/getty/route.ts
+++ b/src/app/api/import/getty/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -23,7 +23,7 @@ export const maxDuration = 300;
  * Getty uses UUID-based IIIF v3 manifests. Manifest URLs vary by collection.
  * Provide manifest_url directly, or object_id for lookup.
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { object_id, manifest_url, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -28,7 +28,7 @@ export const maxDuration = 300;
  * books are mirrored on Internet Archive with identifiers like `bub_gb_<id>`.
  * This route checks IA for the mirror and imports from there.
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/hab/route.ts
+++ b/src/app/api/import/hab/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -24,7 +24,7 @@ export const maxDuration = 300;
  *   https://diglib.hab.de/iiif/manifest/${hab_id}.json
  *   https://diglib.hab.de/mss/${hab_id}/manifest.json
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { hab_id, manifest_url, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/harvard/route.ts
+++ b/src/app/api/import/harvard/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF v2 manifest: https://iiif.lib.harvard.edu/manifests/drs:{drs_id}
  * Viewer: https://id.lib.harvard.edu/curiosity/{drs_id}
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { drs_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/huntington/route.ts
+++ b/src/app/api/import/huntington/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  *
  * IIIF v2 manifest: https://hdl.huntington.org/iiif/2/{collection}:{item_id}/manifest.json
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { collection, item_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -24,7 +24,7 @@ export const maxDuration = 300;
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -160,7 +160,7 @@ function parseLicense(licenseUrl: string | null, attribution: string | null, pro
  *   end_page?: number        // 1-indexed end page (inclusive)
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/kyoto/route.ts
+++ b/src/app/api/import/kyoto/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF v3 manifest: https://rmda.kulib.kyoto-u.ac.jp/iiif/metadata_manifest/{rb_id}/manifest.json
  * Browse: https://rmda.kulib.kyoto-u.ac.jp/en/item/{rb_id}
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { rb_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -124,7 +124,7 @@ function extractAuthor(contributorNames?: string[]): string {
  *   end_page?: number       // 1-indexed end page (inclusive)
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { lccn, title, display_title, author, language, published, categories, work_id, start_page, end_page } = body;

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -51,7 +51,7 @@ interface IIIFManifest {
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/onb/route.ts
+++ b/src/app/api/import/onb/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -24,7 +24,7 @@ export const maxDuration = 300;
  *   ABO:  https://iiif.onb.ac.at/presentation/ABO/{z_id}/manifest
  *   REPO: https://iiif.onb.ac.at/presentation/REPO/{numeric_id}/manifest
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { z_id, collection, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/pdf/route.ts
+++ b/src/app/api/import/pdf/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { execFileSync } from 'child_process';
@@ -43,7 +43,7 @@ export const maxDuration = 300;
  *   catalog_metadata?: object,   // Full original catalog record for provenance
  * }
  */
-export const POST = withAuth(async (request) => {
+export const POST = withCuratorAuth(async (request) => {
   const tmpDir = mkdtempSync(join(tmpdir(), 'sl-pdf-'));
 
   try {

--- a/src/app/api/import/penn/route.ts
+++ b/src/app/api/import/penn/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF v2 manifest: https://colenda.library.upenn.edu/items/ark:/81431/{ark_id}/manifest
  * Browse: https://colenda.library.upenn.edu/catalog/ark:/81431/{ark_id}
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { ark_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import fs from 'fs';
 import path from 'path';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 
 /**
@@ -21,7 +21,7 @@ import { generateUniqueBookSlug } from '@/lib/slugify';
  *   ia_identifier?: string
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/sbb/route.ts
+++ b/src/app/api/import/sbb/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF v2 manifest: https://content.staatsbibliothek-berlin.de/dc/PPN{id}/manifest
  * Viewer: https://digital.staatsbibliothek-berlin.de/werkansicht?PPN={id}
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { ppn, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/vatican/route.ts
+++ b/src/app/api/import/vatican/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -21,7 +21,7 @@ export const maxDuration = 300;
  * The manuscript ID is normalized: dots become periods in the URL,
  * e.g. "Pal.lat.235" → "MSS_Pal.lat.235" in the IIIF manifest path.
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { mss_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/vatlib/route.ts
+++ b/src/app/api/import/vatlib/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF manifest pattern: https://digi.vatlib.it/iiif/MSS_{shelfmark}/manifest.json
  * Shelfmark encoding: spaces → underscores, dots preserved
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { mss_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -3,7 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { notifyBookImport } from '@/lib/indexnow';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 import { generateUniqueBookSlug } from '@/lib/slugify';
 import { queuePreviewOcr } from '@/lib/preview-ocr';
 import { normalizeTitle, normalizeAuthor, sourceFingerprint, checkDuplicate } from '@/lib/dedup';
@@ -60,7 +60,7 @@ interface IIIFManifest {
  *   categories?: string[]
  * }
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const {

--- a/src/app/api/import/yale/route.ts
+++ b/src/app/api/import/yale/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { importBookFromIIIF } from '@/lib/import-utils';
-import { withAuth } from '@/lib/auth-helpers';
+import { withCuratorAuth } from '@/lib/auth-helpers';
 
 export const maxDuration = 300;
 
@@ -22,7 +22,7 @@ export const maxDuration = 300;
  * IIIF v3 manifest: https://collections.library.yale.edu/manifests/{catalog_id}
  * Browse: https://collections.library.yale.edu/catalog/{catalog_id}
  */
-export const POST = withAuth(async (request, session) => {
+export const POST = withCuratorAuth(async (request, session) => {
   try {
     const body = await request.json();
     const { catalog_id, title, display_title, author, language, published, categories, work_id } = body;

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -180,6 +180,44 @@ export function withInnerCircleAuth(
 }
 
 /**
+ * Wrapper for API routes requiring curator or admin role.
+ * Curators can import books and edit metadata. Admins can do everything curators can.
+ * Returns 401 if not authenticated, 403 if not curator/admin.
+ */
+export function withCuratorAuth(
+  handler: (request: NextRequest, session: Session, context?: any) => Promise<NextResponse>
+): (request: NextRequest, context?: any) => Promise<NextResponse> {
+  return async (request: NextRequest, context?: any) => {
+    // Check for CRON_SECRET bearer token (internal service-to-service calls)
+    const cronSecret = process.env.CRON_SECRET;
+    const authHeader = request.headers.get('authorization');
+    if (cronSecret && authHeader === `Bearer ${cronSecret}`) {
+      const cronSession: Session = {
+        user: { name: 'Pipeline Cron', email: 'cron@sourcelibrary.org', role: 'admin' } as any,
+        expires: new Date(Date.now() + 3600000).toISOString(),
+      };
+      return handler(request, cronSession, context);
+    }
+
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'Unauthorized - Authentication required' },
+        { status: 401 }
+      );
+    }
+    const role = (session.user as any).role;
+    if (role !== 'admin' && role !== 'curator') {
+      return NextResponse.json(
+        { error: 'Forbidden - Curator access required' },
+        { status: 403 }
+      );
+    }
+    return handler(request, session, context);
+  };
+}
+
+/**
  * Wrapper for API routes requiring admin role.
  * Accepts NextAuth admin sessions OR CRON_SECRET bearer tokens
  * (pipeline crons need to call admin routes too).

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -68,7 +68,7 @@ const WELCOME_HTML = `
 
 // Helper: check user role from admin_users whitelist
 // Returns 'admin', 'inner_circle', or null
-async function getUserRole(email: string): Promise<'admin' | 'inner_circle' | null> {
+async function getUserRole(email: string): Promise<'admin' | 'curator' | 'inner_circle' | null> {
   try {
     const client = await clientPromise;
     const db = client.db(dbName);
@@ -77,8 +77,10 @@ async function getUserRole(email: string): Promise<'admin' | 'inner_circle' | nu
       active: true,
     });
     if (!entry) return null;
+    if (entry.role === 'inner_circle') return 'inner_circle';
+    if (entry.role === 'curator') return 'curator';
     // Default to 'admin' for existing entries without a role field (backward compat)
-    return entry.role === 'inner_circle' ? 'inner_circle' : 'admin';
+    return 'admin';
   } catch (error) {
     console.error('[auth] Error checking user role:', error);
     return null;


### PR DESCRIPTION
## Summary
- Adds `curator` role to the auth system — can import books and edit metadata, but cannot access pipeline controls, email, bulk operations, or delete books
- New `withCuratorAuth()` wrapper accepts both `admin` and `curator` roles
- All 25 import routes switched from `withAuth` to `withCuratorAuth`
- Book PATCH uses `withCuratorAuth`, DELETE elevated to `withAdminAuth`
- Book visibility toggle uses `withCuratorAuth`

## Context
Mike (etherhill@gmail.com) needs to add books but shouldn't have access to emergency stop, adaptive limits, email blasts, or bulk re-OCR. This role lets us safely onboard curators.

## Test plan
- [ ] Curator can import via API with CRON_SECRET
- [ ] Curator can edit book metadata
- [ ] Curator can toggle book visibility
- [ ] Curator CANNOT delete books (403)
- [ ] Curator CANNOT access admin endpoints (403)
- [ ] Admin can still do everything
- [ ] CRON_SECRET bypass still works as admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)