### PR TITLE
Supabase-first book detail reads for fast cold renders

### DIFF
--- a/scripts/migration/add-book-detail-columns.sql
+++ b/scripts/migration/add-book-detail-columns.sql
@@ -1,0 +1,31 @@
+-- Add columns to books_catalog for serving /book/[id] detail pages from Supabase.
+-- Run this in the Supabase SQL editor before deploying the sync script update.
+--
+-- These fields are needed for the book detail page shell (above-the-fold render).
+-- Page content (OCR, translation text) stays on MongoDB.
+
+ALTER TABLE books_catalog
+  ADD COLUMN IF NOT EXISTS summary_text text,
+  ADD COLUMN IF NOT EXISTS publisher text,
+  ADD COLUMN IF NOT EXISTS place_published text,
+  ADD COLUMN IF NOT EXISTS doi text,
+  ADD COLUMN IF NOT EXISTS work_id text,
+  ADD COLUMN IF NOT EXISTS resource_type text,
+  ADD COLUMN IF NOT EXISTS source_url text,
+  ADD COLUMN IF NOT EXISTS provider_name text,
+  ADD COLUMN IF NOT EXISTS image_attribution text,
+  ADD COLUMN IF NOT EXISTS image_license text,
+  ADD COLUMN IF NOT EXISTS cover_image text,
+  ADD COLUMN IF NOT EXISTS dedication text,
+  ADD COLUMN IF NOT EXISTS subtitle text,
+  ADD COLUMN IF NOT EXISTS source_work_dates jsonb,
+  ADD COLUMN IF NOT EXISTS ft_disposition text,
+  ADD COLUMN IF NOT EXISTS ft_reasoning text,
+  ADD COLUMN IF NOT EXISTS description text,
+  ADD COLUMN IF NOT EXISTS subject_keywords text[];
+
+-- Index for slug-based lookups (the primary access pattern for book detail pages)
+CREATE INDEX IF NOT EXISTS idx_books_catalog_slug ON books_catalog (slug) WHERE slug IS NOT NULL;
+
+-- Index for work_id lookups (related editions)
+CREATE INDEX IF NOT EXISTS idx_books_catalog_work_id ON books_catalog (work_id) WHERE work_id IS NOT NULL;

--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -32,6 +32,17 @@ const BATCH_SIZE = 200;
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, { auth: { persistSession: false } });
 
+function extractSummaryText(book) {
+  // Priority: index.bookSummary.brief > reading_summary.overview > summary.data
+  const indexBrief = book.index?.bookSummary?.brief;
+  if (indexBrief) return indexBrief;
+  const readingOverview = book.reading_summary?.overview;
+  if (readingOverview) return readingOverview;
+  if (typeof book.summary === 'string') return book.summary;
+  if (book.summary?.data) return book.summary.data;
+  return null;
+}
+
 function transformBook(book) {
   return {
     id: book.id,
@@ -62,7 +73,26 @@ function transformBook(book) {
     collection_relevance: book.collection_relevance || null,
     image_source_provider: book.image_source?.provider || null,
     contributing_library: book.image_source?.contributing_library || null,
-    // Computed columns (require ALTER TABLE first — see issue #xxx)
+    // Book detail fields (for serving /book/[id] from Supabase)
+    summary_text: extractSummaryText(book),
+    publisher: book.publisher || null,
+    place_published: book.place_published || null,
+    doi: book.doi || null,
+    work_id: book.work_id || null,
+    resource_type: book.resource_type || null,
+    source_url: book.image_source?.source_url || null,
+    provider_name: book.image_source?.provider_name || null,
+    image_attribution: book.image_source?.attribution || null,
+    image_license: book.image_source?.license || null,
+    cover_image: book.cover_image || null,
+    dedication: book.dedication || null,
+    subtitle: book.subtitle || null,
+    source_work_dates: Array.isArray(book.source_work_dates) ? book.source_work_dates : null,
+    ft_disposition: book.translation_verification?.disposition || null,
+    ft_reasoning: book.translation_verification?.reasoning || null,
+    description: book.ai_metadata?.description || book.description || null,
+    subject_keywords: Array.isArray(book.subject_keywords) ? book.subject_keywords : null,
+    // Computed columns
     translation_pct: (() => {
       const denom = (book.pages_count || 0) - (book.pages_blank || 0);
       return denom > 0 ? Math.round(((book.pages_translated || 0) / denom) * 100) : 0;
@@ -115,8 +145,19 @@ const projection = {
   categories: 1, collections: 1, collection_relevance: 1,
   'image_source.provider': 1,
   'image_source.contributing_library': 1,
+  'image_source.source_url': 1,
+  'image_source.provider_name': 1,
+  'image_source.attribution': 1,
+  'image_source.license': 1,
   'pipeline_auto.status': 1,
   needs_splitting: 1,
+  // Book detail fields
+  summary: 1, 'index.bookSummary.brief': 1, 'reading_summary.overview': 1,
+  publisher: 1, place_published: 1, doi: 1, work_id: 1,
+  resource_type: 1, cover_image: 1, dedication: 1, subtitle: 1,
+  source_work_dates: 1,
+  'translation_verification.disposition': 1, 'translation_verification.reasoning': 1,
+  'ai_metadata.description': 1, description: 1, subject_keywords: 1,
 };
 
 const cursor = db.collection('books')

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { getBookDetail } from '@/lib/books-catalog';
 import { Calendar, Globe, FileText, BookText, BookMarked, Images } from 'lucide-react';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
 import SearchPanel from '@/components/search/SearchPanel';
@@ -58,14 +59,37 @@ interface PageProps {
 }
 
 // Cached book lookup — deduplicates between generateMetadata and BookInfo
-// within a single server render. Uses the broader projection from getBook
-// so the result is reusable by both code paths.
-const getCachedBookLookup = cache(async (id: string) => {
+// within a single server render.
+//
+// Tries Supabase first (<50ms) for the book shell, then falls back to Atlas.
+// When Supabase succeeds, getBook() can start ALL Atlas queries in parallel
+// (pages, gallery, collections, full book refetch) instead of waiting for the
+// book lookup before starting page queries.
+const getCachedBookLookup = cache(async (id: string): Promise<{
+  book: Record<string, unknown>;
+  matchedBySlug: boolean;
+  fromCatalog: boolean;
+} | null> => {
+  // Try Supabase first — instant lookup from the books_catalog mirror
+  try {
+    const catalogResult = await getBookDetail(id);
+    if (catalogResult) {
+      return {
+        book: catalogResult.book as unknown as Record<string, unknown>,
+        matchedBySlug: catalogResult.matchedBySlug,
+        fromCatalog: true,
+      };
+    }
+  } catch {
+    // Supabase down — fall through to Atlas
+  }
+
+  // Fall back to Atlas (slower but has everything)
   const db = await Promise.race([
     getDb(),
     new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 15000)),
   ]);
-  return findBookByIdOrSlug(db, id, {
+  const result = await findBookByIdOrSlug(db, id, {
     chapters: 0,
     reading_sections: 0,
     pipeline: 0,
@@ -77,6 +101,8 @@ const getCachedBookLookup = cache(async (id: string) => {
     'index.concepts': 0,
     'index.keyTerms': 0,
   });
+  if (!result) return null;
+  return { book: result.book as Record<string, unknown>, matchedBySlug: result.matchedBySlug, fromCatalog: false };
 });
 
 // Lightweight book fetch for metadata — reuses cached lookup
@@ -180,21 +206,40 @@ interface BookCollectionPreview { slug: string; name: string; subtitle?: string;
 
 async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; translatedExcerpt: string | null; excerptPageNumber: number | null; matchedBySlug: boolean } | null> {
   // Reuse the cached book lookup (shared with generateMetadata — saves a full DB round trip)
+  // When Supabase serves the lookup (<50ms), we get the bookId instantly and can start
+  // ALL Atlas queries in parallel — including a full book refetch for fields not in the catalog.
   const [result, db] = await Promise.all([
     getCachedBookLookup(id),
     getDb(),
   ]);
 
   if (!result) return null;
-  const { book, matchedBySlug } = result;
+  const { book: quickBook, matchedBySlug, fromCatalog } = result;
 
   // Use the book's id field, or fall back to _id string
-  const bookId = book.id || book._id?.toString();
+  const bookId = (quickBook.id || quickBook._id?.toString()) as string;
 
-  // Inclusion projection — only fetch fields the book detail UI actually uses
-  // Status dots need .updated_at; image count needs array length via .type
+  // When the lookup came from Supabase catalog, we need to fetch the full book from Atlas
+  // for fields not in the catalog (editions, translation_verification, index, etc.).
+  // This runs in parallel with pages/gallery/collections — no sequential bottleneck.
+  const fullBookPromise = fromCatalog
+    ? findBookByIdOrSlug(db, bookId, {
+        chapters: 0,
+        reading_sections: 0,
+        pipeline: 0,
+        pipeline_auto: 0,
+        split_check: 0,
+        'index.sectionSummaries': 0,
+        'index.people': 0,
+        'index.places': 0,
+        'index.concepts': 0,
+        'index.keyTerms': 0,
+      }).catch(() => null)
+    : Promise.resolve(null); // Already have full book from Atlas
+
   // All queries have maxTimeMS to fail fast during DB degradation
-  const [pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw, excerptPageRaw] = await Promise.all([
+  const [fullBookResult, pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw, excerptPageRaw] = await Promise.all([
+    fullBookPromise,
     // Drop $ne filter — it prevents use of the {book_id,page_number} compound
     // index and forces a collection scan. Filter digitizer-inserts in JS instead.
     db.collection('pages')
@@ -242,10 +287,10 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
       )
       .catch(() => 0),
     // Collections this book belongs to
-    book.collections?.length
+    (quickBook.collections as string[] | undefined)?.length
       ? db.collection('collections')
           .find(
-            { slug: { $in: book.collections }, visible: true },
+            { slug: { $in: quickBook.collections as string[] }, visible: true },
             { projection: { _id: 0, slug: 1, name: 1, subtitle: 1, color: 1, book_count: 1, featured_images: 1 }, maxTimeMS: 5000 },
           )
           .sort({ order: 1 })
@@ -260,6 +305,10 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
       )
       .catch(() => null),
   ]);
+
+  // Use the full Atlas book when available (has editions, translation_verification, etc.)
+  // Fall back to the catalog book (Supabase) if Atlas fetch failed
+  const book = fullBookResult?.book ?? quickBook;
 
   // Fetch full index data from dedicated collection (keeps book docs small)
   const bookIndexDoc = await db.collection('book_indexes').findOne(

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -34,6 +34,31 @@ export interface CatalogBook {
   collections: string[];
 }
 
+/** Extended book detail from Supabase — includes fields for the /book/[id] page shell. */
+export interface CatalogBookDetail extends CatalogBook {
+  contributing_library: string | null;
+  summary_text: string | null;
+  publisher: string | null;
+  place_published: string | null;
+  doi: string | null;
+  work_id: string | null;
+  resource_type: string | null;
+  source_url: string | null;
+  provider_name: string | null;
+  image_attribution: string | null;
+  image_license: string | null;
+  cover_image: string | null;
+  dedication: string | null;
+  subtitle: string | null;
+  source_work_dates: Array<{ type: string; date_display: string; author?: string }> | null;
+  ft_disposition: string | null;
+  ft_reasoning: string | null;
+  description: string | null;
+  subject_keywords: string[] | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
 const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
@@ -249,4 +274,66 @@ export async function getCategoryCounts(): Promise<Map<string, number>> {
     }
   }
   return counts;
+}
+
+// All fields needed for the book detail page shell
+const BOOK_DETAIL_SELECT = [
+  BOOK_SELECT,
+  'contributing_library',
+  'summary_text',
+  'publisher',
+  'place_published',
+  'doi',
+  'work_id',
+  'resource_type',
+  'source_url',
+  'provider_name',
+  'image_attribution',
+  'image_license',
+  'cover_image',
+  'dedication',
+  'subtitle',
+  'source_work_dates',
+  'ft_disposition',
+  'ft_reasoning',
+  'description',
+  'subject_keywords',
+  'created_at',
+  'updated_at',
+].join(', ');
+
+/**
+ * Fetch a single book by slug or id from Supabase books_catalog.
+ *
+ * Used by /book/[id] for fast cold renders (<50ms vs 1-5s from Atlas).
+ * Returns null if not found. Falls through to Atlas in the caller.
+ *
+ * Lookup order matches findBookByIdOrSlug: slug first, then id.
+ */
+export async function getBookDetail(idOrSlug: string): Promise<{ book: CatalogBookDetail; matchedBySlug: boolean } | null> {
+  // Try slug first (the common case for SEO URLs)
+  const { data: bySlug } = await supabase
+    .from('books_catalog')
+    .select(BOOK_DETAIL_SELECT)
+    .eq('slug', idOrSlug)
+    .limit(1)
+    .maybeSingle();
+
+  if (bySlug) {
+    return { book: bySlug as unknown as CatalogBookDetail, matchedBySlug: true };
+  }
+
+  // Fall back to id
+  const { data: byId } = await supabase
+    .from('books_catalog')
+    .select(BOOK_DETAIL_SELECT)
+    .eq('id', idOrSlug)
+    .limit(1)
+    .maybeSingle();
+
+  if (byId) {
+    return { book: byId as unknown as CatalogBookDetail, matchedBySlug: false };
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- Book page now tries Supabase `books_catalog` first (<50ms) before Atlas (1-5s)
- When Supabase serves the lookup, ALL Atlas queries run in parallel instead of sequentially
- 18 new fields added to the catalog sync for the book detail page shell
- SQL migration + sync script update included

## Architecture
```
Before:  Atlas book lookup (1-5s) → then pages + gallery + collections in parallel (1-3s)
After:   Supabase book lookup (50ms) → Atlas full book + pages + gallery + collections ALL in parallel (1-3s)
```

Cold render time: ~4-8s → ~1-3s (Atlas parallel batch only, no sequential bottleneck)

## Activation (after merge)
1. Run `scripts/migration/add-book-detail-columns.sql` in Supabase SQL editor
2. Run `sync-books-catalog.mjs --full` on Hetzner to populate new columns
3. Incremental sync (already running every 5 min) keeps it fresh

Until activation, the code gracefully falls back to Atlas-only (no behavior change).

## Test plan
- [ ] Run SQL migration in Supabase
- [ ] Run `--full` sync, verify new columns populated
- [ ] Visit a cold book page, verify it loads correctly
- [ ] Check Vercel function logs for Supabase-first path
- [ ] Verify Atlas fallback works (book not yet in catalog)

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)