### PR TITLE
Deploy unified scheduler with enrichment + phase workers

### DIFF
--- a/scripts/workers/crontab.conf
+++ b/scripts/workers/crontab.conf
@@ -1,0 +1,39 @@
+# === Source Library Crontab ===
+# Installed: 2026-04-10
+# All pipeline workers managed by unified scheduler (issue #646)
+# Heavy jobs staggered across 2-hour windows to avoid Atlas contention
+
+# ── Unified Scheduler (manages all pipeline workers) ──
+# Runs every 2 min, health-gated, connection-budgeted
+*/2 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-scheduler.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/scheduler.mjs" >> /var/log/sourcelibrary/scheduler.log 2>&1
+
+# ── Heavy periodic jobs (staggered across 2h windows) ──
+# These run infrequently but are expensive — never overlap them
+0 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-sync.lock bash -c 'set -a; source .env.production.local; set +a; node scripts/workers/sync-worker.mjs' >> /var/log/sourcelibrary/sync.log 2>&1
+15 1,3,5,7,9,11,13,15,17,19,21,23 * * * cd /root/sourcelibrary && flock -n /tmp/sl-enrichment-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/enrichment-snapshot.mjs" >> /var/log/sourcelibrary/enrichment-snapshot.log 2>&1
+30 */2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-supabase-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/supabase-sync.mjs" >> /var/log/sourcelibrary/supabase-sync.log 2>&1
+45 1,3,5,7,9,11,13,15,17,19,21,23 * * * cd /root/sourcelibrary && flock -n /tmp/sl-books-catalog-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-books-catalog.mjs" >> /var/log/sourcelibrary/books-catalog-sync.log 2>&1
+
+# ── Daily maintenance (early morning, staggered) ──
+0 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-hires-gallery.lock bash -c "set -a; source .env.production.local; set +a; node --import tsx scripts/workers/backfill-hires-gallery.mjs --batch=2000 --concurrency=3" >> /var/log/sourcelibrary/hires-gallery.log 2>&1
+30 3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-entity-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-entities.mjs" >> /var/log/sourcelibrary/entity-sync.log 2>&1
+0 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-thumb-regen.lock bash -c "set -a; source .env.production.local; set +a; node scripts/tmp-regen-page-thumbs.mjs --limit=200" >> /var/log/sourcelibrary/thumb-regen.log 2>&1
+30 4 * * * cd /root/sourcelibrary && flock -n /tmp/sl-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/catalog-coverage/snapshot-stats.mjs" >> /var/log/sourcelibrary/snapshot.log 2>&1
+0 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-warm-authors.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/warm-author-pages.mjs" >> /var/log/sourcelibrary/warm-authors.log 2>&1
+15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1
+
+# ── HTTP-only / monitoring (no Atlas load) ──
+0 */3 * * * cd /root/sourcelibrary && flock -n /tmp/sl-social-post.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs social-post" >> /var/log/sourcelibrary/cron-caller.log 2>&1
+0 0 * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs social-reset" >> /var/log/sourcelibrary/cron-caller.log 2>&1
+0 6 * * * cd /root/sourcelibrary && bash -c "set -a; source .env.production.local; set +a; node scripts/workers/cron-caller.mjs daily-pipeline-report" >> /var/log/sourcelibrary/cron-caller.log 2>&1
+0 7 * * * cd /root/sourcelibrary && flock -n /tmp/sl-health.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/pipeline-health-alert.mjs" >> /var/log/sourcelibrary/health-alert.log 2>&1
+*/5 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-uptime.lock bash -c "set -a; source .env.production.local; set +a; node scripts/uptime-monitor.mjs" >> /var/log/sourcelibrary/uptime-monitor.log 2>&1
+*/5 * * * * echo "$(date -u +'\%Y-\%m-\%dT\%H:\%M:\%SZ') $(uptime | sed 's/.*load average: //')" >> /var/log/sourcelibrary/cpu-load.log
+
+# ── Non-Source Library ──
+0 */4 * * * /root/moltbook-heartbeat.sh
+*/5 * * * * /root/oura/healthcheck.sh
+0 8 * * * /usr/local/bin/oura-digest >> /var/log/oura-digest.log 2>&1
+0 8 * * * /root/moltbook-poster.sh
+0 14 * * * /root/moltbook-poster.sh
+0 20 * * * /root/moltbook-poster.sh

--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -31,7 +31,7 @@ const VERBOSE = process.argv.includes('--verbose') || process.argv.includes('-v'
 
 // Global Atlas connection budget. With capped pools (maxPoolSize 5-20 per worker),
 // actual peak is well under Atlas M10 limits. 60 leaves headroom for Vercel SSR/ISR.
-const MAX_CONNECTIONS = 60;
+const MAX_CONNECTIONS = 65;
 
 // ── Worker Definitions ──
 // Each worker has:
@@ -56,6 +56,56 @@ const WORKERS = [
     healthMin: 'degraded',
     log: '/var/log/sourcelibrary/pipeline.log',
   },
+  {
+    name: 'pipeline-enroll',
+    cmd: 'node scripts/workers/pipeline-orchestrator.mjs --phase 0',
+    lock: '/tmp/sl-enroll.lock',
+    connections: 5,
+    tier: 1,
+    interval: 600,      // every 10 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/enroll.log',
+  },
+  {
+    name: 'pipeline-archive-check',
+    cmd: 'node scripts/workers/pipeline-orchestrator.mjs --phase 1',
+    lock: '/tmp/sl-archive-check.lock',
+    connections: 5,
+    tier: 1,
+    interval: 600,      // every 10 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/archive-check.log',
+  },
+  {
+    name: 'pipeline-preview-ocr',
+    cmd: 'node scripts/workers/pipeline-orchestrator.mjs --phase 1.5',
+    lock: '/tmp/sl-preview-ocr.lock',
+    connections: 5,
+    tier: 1,
+    interval: 120,      // every 2 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/preview-ocr.log',
+  },
+  {
+    name: 'pipeline-ocr-submit',
+    cmd: 'node scripts/workers/pipeline-orchestrator.mjs --phase 2',
+    lock: '/tmp/sl-ocr-submit.lock',
+    connections: 5,
+    tier: 1,
+    interval: 600,      // every 10 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/ocr-submit.log',
+  },
+  {
+    name: 'pipeline-ocr-complete',
+    cmd: 'node scripts/workers/pipeline-orchestrator.mjs --phase 3',
+    lock: '/tmp/sl-ocr-complete.lock',
+    connections: 5,
+    tier: 1,
+    interval: 600,      // every 10 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/ocr-complete.log',
+  },
 
   // Tier 2: Translation — the heaviest single worker
   {
@@ -68,6 +118,16 @@ const WORKERS = [
     healthMin: 'healthy',
     log: '/var/log/sourcelibrary/translate.log',
   },
+  {
+    name: 'pipeline-translate-complete',
+    cmd: 'node scripts/workers/pipeline-orchestrator.mjs --phase 5',
+    lock: '/tmp/sl-translate-complete.lock',
+    connections: 5,
+    tier: 2,
+    interval: 300,      // every 5 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/translate-complete.log',
+  },
 
   // Tier 3: Batch collection — lightweight, collects Gemini results
   {
@@ -79,6 +139,38 @@ const WORKERS = [
     interval: 600,      // every 10 min
     healthMin: 'critical', // always run — finishes in-flight batch jobs
     log: '/var/log/sourcelibrary/collector.log',
+  },
+
+  // Tier 3: Enrichment — Gemini API bound, moderate Atlas reads
+  {
+    name: 'enrich-worker',
+    cmd: 'node scripts/workers/enrich-worker.mjs',
+    lock: '/tmp/sl-enrich.lock',
+    connections: 5,
+    tier: 3,
+    interval: 300,      // every 5 min
+    healthMin: 'degraded',
+    log: '/var/log/sourcelibrary/enrich.log',
+  },
+  {
+    name: 'enrich-scoring',
+    cmd: 'node scripts/workers/enrich-worker.mjs --phase=7.5 --limit=50',
+    lock: '/tmp/sl-enrich-scoring.lock',
+    connections: 5,
+    tier: 3,
+    interval: 300,      // every 5 min
+    healthMin: 'healthy',
+    log: '/var/log/sourcelibrary/enrich-scoring.log',
+  },
+  {
+    name: 'enrich-collections',
+    cmd: 'node scripts/workers/enrich-worker.mjs --phase=7.6 --limit=100',
+    lock: '/tmp/sl-enrich-collections.lock',
+    connections: 5,
+    tier: 3,
+    interval: 300,      // every 5 min
+    healthMin: 'healthy',
+    log: '/var/log/sourcelibrary/enrich-collections.log',
   },
 
   // Tier 4: Archiving — I/O bound (HTTP downloads), light on Atlas
@@ -94,7 +186,7 @@ const WORKERS = [
   },
   {
     name: 'archive-bulk',
-    cmd: 'node scripts/workers/archive-bulk.mjs --limit=100 --concurrency=6',
+    cmd: 'node scripts/workers/archive-bulk.mjs --limit=100 --concurrency=3',
     lock: '/tmp/sl-archive-bulk.lock',
     connections: 5,
     tier: 4,
@@ -125,26 +217,19 @@ const WORKERS = [
     log: '/var/log/sourcelibrary/display-backfill.log',
   },
 
-  // Tier 6: Sync — infrequent, moderate load
-  {
-    name: 'sync-worker',
-    cmd: 'node scripts/workers/sync-worker.mjs',
-    lock: '/tmp/sl-sync.lock',
-    connections: 5,
-    tier: 6,
-    interval: 7200,     // every 2 hours
-    healthMin: 'healthy',
-    log: '/var/log/sourcelibrary/sync.log',
-  },
 ];
 
-// Workers NOT managed by the scheduler (HTTP-only, no Atlas load):
+// Workers NOT managed by the scheduler (HTTP-only, no Atlas load, or staggered independently):
+// - sync-worker.mjs (staggered at 0 */2 in crontab — precise timing needed)
 // - cron-caller.mjs (social-post, social-reset, daily-pipeline-report)
 // - warm-author-pages.mjs (HTTP revalidation)
 // - prewarm-browse.mjs (HTTP revalidation)
 // - pipeline-health-alert.mjs (reads only, runs daily)
 // - embedding-server.mjs (long-running, Supabase not Atlas)
 // - snapshot-stats.mjs (daily 4:30am, catalog coverage + SL progress snapshot)
+// - enrichment-snapshot.mjs (staggered at :15 odd hours)
+// - supabase-sync.mjs (staggered at :30 even hours)
+// - sync-books-catalog.mjs (staggered at :45 odd hours)
 // These keep their own cron lines.
 
 // ── Health grades ranked for comparison ──


### PR DESCRIPTION
## Summary
- Adds 9 new workers to `scheduler.mjs`: 6 pipeline phase workers (enroll, archive-check, preview-ocr, ocr-submit, ocr-complete, translate-complete) and 3 enrichment workers (enrich-worker, enrich-scoring, enrich-collections)
- Removes sync-worker from scheduler (keeps its own staggered `0 */2` cron entry for precise timing)
- Reduces archive-bulk concurrency from 6 to 3 (was eating 291% CPU)
- Bumps `MAX_CONNECTIONS` from 60 to 65 to accommodate new workers while staying safe for M10
- Creates `crontab.conf` as the complete replacement crontab with heavy jobs staggered across 2-hour windows to avoid Atlas contention

## Test plan
- [ ] Review worker entries match existing scripts (`pipeline-orchestrator.mjs --phase N`, `enrich-worker.mjs --phase=7.x`)
- [ ] Verify crontab.conf timing: no two heavy jobs overlap in the same 15-min window
- [ ] Deploy to Hetzner: `git pull`, then `crontab scripts/workers/crontab.conf`
- [ ] Monitor `scheduler.log` for correct health-gating and connection budgeting
- [ ] Confirm Atlas connection count stays under 65 via MongoDB Atlas dashboard

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)