### PR TITLE
Census: work-level matching + honest methodology caveats

### DIFF
--- a/scripts/catalog-coverage/build-census.mjs
+++ b/scripts/catalog-coverage/build-census.mjs
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+/**
+ * Build the Translation Census — the work-level join between USTC editions
+ * and known English translations.
+ *
+ * This replaces the surname-level matching in build.mjs with proper
+ * title-level matching using pg_trgm similarity.
+ *
+ * Steps:
+ *   1. Sync translation_catalogs from MongoDB → Supabase
+ *   2. Create materialized view joining ustc_enrichments × translation_catalogs
+ *   3. Create RPC for the census page
+ *
+ * Usage:
+ *   secret-lover run -- node scripts/catalog-coverage/build-census.mjs
+ *
+ * Env: MONGODB_URI, SUPABASE_DB_URL
+ */
+
+import { MongoClient } from 'mongodb';
+import pg from 'pg';
+
+const MONGO_URI = process.env.MONGODB_URI;
+const PG_URL = process.env.SUPABASE_DB_URL;
+
+if (!MONGO_URI) { console.error('MONGODB_URI required'); process.exit(1); }
+if (!PG_URL) { console.error('SUPABASE_DB_URL required'); process.exit(1); }
+
+const pool = new pg.Pool({ connectionString: PG_URL, ssl: { rejectUnauthorized: false } });
+
+async function run() {
+  const mongo = new MongoClient(MONGO_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  console.log('=== Step 1: Sync translation_catalogs to Supabase ===');
+  await syncCatalogs(db);
+
+  console.log('\n=== Step 2: Build census materialized view ===');
+  await buildCensusView();
+
+  console.log('\n=== Step 3: Create census RPC ===');
+  await createCensusRPC();
+
+  console.log('\n=== Step 4: Refresh and verify ===');
+  await refreshAndVerify();
+
+  await mongo.close();
+  await pool.end();
+  console.log('\nDone.');
+}
+
+async function syncCatalogs(db) {
+  const client = await pool.connect();
+  try {
+    // Create table if needed
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS translation_catalogs (
+        id serial PRIMARY KEY,
+        source text NOT NULL,
+        author text,
+        author_surname text,
+        canonical_author text,
+        english_title text,
+        original_title text,
+        canonical_work text,
+        translator text,
+        pub_year text,
+        publisher text,
+        series text,
+        completeness text,
+        english_title_lower text GENERATED ALWAYS AS (lower(english_title)) STORED,
+        canonical_work_lower text GENERATED ALWAYS AS (lower(canonical_work)) STORED,
+        original_title_lower text GENERATED ALWAYS AS (lower(original_title)) STORED,
+        author_surname_lower text GENERATED ALWAYS AS (lower(author_surname)) STORED
+      );
+
+      CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    `);
+
+    // Check current count
+    const { rows: [{ count: existing }] } = await client.query('SELECT count(*) FROM translation_catalogs');
+    console.log(`  Existing rows: ${existing}`);
+
+    // Load from MongoDB
+    const docs = await db.collection('translation_catalogs')
+      .find({})
+      .project({
+        source: 1, author: 1, author_surname: 1, canonical_author: 1,
+        english_title: 1, original_title: 1, canonical_work: 1,
+        translator: 1, pub_year: 1, publisher: 1, series: 1, completeness: 1,
+      })
+      .toArray();
+
+    console.log(`  MongoDB records: ${docs.length}`);
+
+    if (parseInt(existing) >= docs.length - 100) {
+      console.log('  Already synced, skipping (use --force to re-sync)');
+      if (!process.argv.includes('--force')) return;
+    }
+
+    // Truncate and re-insert
+    await client.query('TRUNCATE translation_catalogs RESTART IDENTITY');
+
+    const BATCH = 500;
+    for (let i = 0; i < docs.length; i += BATCH) {
+      const batch = docs.slice(i, i + BATCH);
+      const values = [];
+      const params = [];
+      let paramIdx = 1;
+
+      for (const d of batch) {
+        values.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++})`);
+        params.push(
+          d.source || '', d.author || '', d.author_surname || '', d.canonical_author || '',
+          d.english_title || '', d.original_title || '', d.canonical_work || '',
+          d.translator || '', d.pub_year || '', d.publisher || '', d.series || '', d.completeness || '',
+        );
+      }
+
+      await client.query(`
+        INSERT INTO translation_catalogs (source, author, author_surname, canonical_author, english_title, original_title, canonical_work, translator, pub_year, publisher, series, completeness)
+        VALUES ${values.join(', ')}
+      `, params);
+
+      if ((i + BATCH) % 5000 === 0 || i + BATCH >= docs.length) {
+        console.log(`  Inserted ${Math.min(i + BATCH, docs.length)} / ${docs.length}`);
+      }
+    }
+
+    // Create indexes for matching
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_tc_author_surname_trgm ON translation_catalogs USING gin (author_surname_lower gin_trgm_ops);
+      CREATE INDEX IF NOT EXISTS idx_tc_english_title_trgm ON translation_catalogs USING gin (english_title_lower gin_trgm_ops);
+      CREATE INDEX IF NOT EXISTS idx_tc_canonical_work_trgm ON translation_catalogs USING gin (canonical_work_lower gin_trgm_ops);
+      CREATE INDEX IF NOT EXISTS idx_tc_original_title_trgm ON translation_catalogs USING gin (original_title_lower gin_trgm_ops);
+      CREATE INDEX IF NOT EXISTS idx_tc_author_surname ON translation_catalogs (author_surname_lower);
+    `);
+
+    console.log(`  Synced ${docs.length} records with trigram indexes`);
+  } finally {
+    client.release();
+  }
+}
+
+async function buildCensusView() {
+  const client = await pool.connect();
+  try {
+    // Drop old view if exists
+    await client.query('DROP MATERIALIZED VIEW IF EXISTS translation_census_by_language CASCADE');
+
+    // The core matching logic:
+    // For each USTC enrichment, check if there's a translation_catalog entry where:
+    //   - Author surname matches (exact or very close)
+    //   - AND either:
+    //     a. english_title is similar (trigram similarity > 0.3), OR
+    //     b. canonical_work matches the std_title (for original-language matching), OR
+    //     c. original_title matches the std_title
+    //
+    // We do this as a lateral join to avoid N×M explosion, grouped by language.
+    //
+    // Key insight: we match at the WORK level by deduplicating on
+    // (author_surname, normalized english_title) — so multiple editions
+    // of the same work count once.
+
+    console.log('  Creating translation_census_by_language materialized view...');
+
+    // First: create a helper view of distinct works from USTC enrichments
+    await client.query(`
+      DROP MATERIALIZED VIEW IF EXISTS ustc_distinct_works CASCADE;
+
+      CREATE MATERIALIZED VIEW ustc_distinct_works AS
+      SELECT
+        MIN(e.id) AS sample_id,
+        -- Normalize: lowercase, strip punctuation for grouping
+        lower(regexp_replace(
+          CASE WHEN position(',' IN ue.author_1) > 0
+               THEN left(ue.author_1, position(',' IN ue.author_1) - 1)
+               ELSE split_part(ue.author_1, ' ', 1)
+          END,
+          '[^a-z ]', '', 'g'
+        )) AS author_surname,
+        lower(regexp_replace(e.std_title, '[^a-z0-9 ]', '', 'g')) AS work_key,
+        e.detected_language AS language,
+        MIN(e.english_title) AS english_title,
+        MIN(e.std_title) AS std_title,
+        MIN(ue.author_1) AS author,
+        MIN(ue.year) AS year,
+        count(*) AS edition_count
+      FROM ustc_enrichments e
+      JOIN ustc_editions ue ON ue.id = e.id
+      WHERE e.std_title IS NOT NULL
+        AND e.std_title != ''
+        AND ue.year BETWEEN 1450 AND 1700
+      GROUP BY author_surname, work_key, e.detected_language;
+    `);
+
+    const { rows: [{ count: workCount }] } = await client.query('SELECT count(*) FROM ustc_distinct_works');
+    console.log(`  Distinct works: ${parseInt(workCount).toLocaleString()}`);
+
+    // Now: match works against translation catalogs
+    // Use a two-pass approach:
+    // Pass 1: exact author_surname match + title similarity
+    // This avoids full trigram cross-join (too expensive at scale)
+
+    await client.query(`
+      DROP MATERIALIZED VIEW IF EXISTS translation_census_matches CASCADE;
+
+      CREATE MATERIALIZED VIEW translation_census_matches AS
+      WITH catalog_normalized AS (
+        SELECT
+          id,
+          author_surname_lower AS surname,
+          lower(regexp_replace(english_title, '[^a-z0-9 ]', '', 'g')) AS eng_title_norm,
+          lower(regexp_replace(coalesce(canonical_work, ''), '[^a-z0-9 ]', '', 'g')) AS work_norm,
+          lower(regexp_replace(coalesce(original_title, ''), '[^a-z0-9 ]', '', 'g')) AS orig_title_norm,
+          source,
+          english_title,
+          translator,
+          pub_year,
+          completeness
+        FROM translation_catalogs
+        WHERE english_title IS NOT NULL AND english_title != ''
+      )
+      SELECT DISTINCT ON (w.author_surname, w.work_key)
+        w.author_surname,
+        w.work_key,
+        w.language,
+        w.english_title AS ustc_english_title,
+        w.std_title AS ustc_std_title,
+        w.author,
+        w.year,
+        w.edition_count,
+        c.english_title AS catalog_english_title,
+        c.translator,
+        c.pub_year AS translation_year,
+        c.source AS catalog_source,
+        c.completeness,
+        -- Match quality score
+        GREATEST(
+          similarity(w.english_title, c.eng_title_norm),
+          CASE WHEN c.work_norm != '' THEN similarity(w.work_key, c.work_norm) ELSE 0 END,
+          CASE WHEN c.orig_title_norm != '' THEN similarity(w.work_key, c.orig_title_norm) ELSE 0 END
+        ) AS match_score
+      FROM ustc_distinct_works w
+      JOIN catalog_normalized c
+        ON c.surname = w.author_surname
+        AND (
+          similarity(lower(w.english_title), c.eng_title_norm) > 0.25
+          OR (c.work_norm != '' AND similarity(w.work_key, c.work_norm) > 0.3)
+          OR (c.orig_title_norm != '' AND similarity(w.work_key, c.orig_title_norm) > 0.3)
+        )
+      ORDER BY w.author_surname, w.work_key, match_score DESC;
+    `);
+
+    const { rows: [{ count: matchCount }] } = await client.query('SELECT count(*) FROM translation_census_matches');
+    console.log(`  Work-level matches: ${parseInt(matchCount).toLocaleString()}`);
+
+    // Finally: the summary view by language
+    await client.query(`
+      CREATE MATERIALIZED VIEW translation_census_by_language AS
+      SELECT
+        w.language,
+        count(*) AS total_works,
+        sum(w.edition_count) AS total_editions,
+        count(m.author_surname) AS works_with_translation,
+        sum(CASE WHEN m.author_surname IS NOT NULL THEN w.edition_count ELSE 0 END) AS editions_with_translation,
+        round(count(m.author_surname)::numeric / NULLIF(count(*), 0) * 100, 2) AS pct_works_translated,
+        count(DISTINCT w.author_surname) AS distinct_authors,
+        count(DISTINCT CASE WHEN m.author_surname IS NOT NULL THEN w.author_surname END) AS authors_with_translation
+      FROM ustc_distinct_works w
+      LEFT JOIN translation_census_matches m
+        ON m.author_surname = w.author_surname AND m.work_key = w.work_key
+      GROUP BY w.language
+      ORDER BY total_works DESC;
+    `);
+
+    // Create indexes on materialized views
+    await client.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_census_lang ON translation_census_by_language (language);
+      CREATE INDEX IF NOT EXISTS idx_census_matches_surname ON translation_census_matches (author_surname);
+      CREATE INDEX IF NOT EXISTS idx_census_matches_lang ON translation_census_matches (language);
+      CREATE INDEX IF NOT EXISTS idx_udw_surname ON ustc_distinct_works (author_surname);
+      CREATE INDEX IF NOT EXISTS idx_udw_lang ON ustc_distinct_works (language);
+    `);
+
+    console.log('  Materialized views created with indexes');
+  } finally {
+    client.release();
+  }
+}
+
+async function createCensusRPC() {
+  const client = await pool.connect();
+  try {
+    await client.query(`
+      CREATE OR REPLACE FUNCTION get_translation_census()
+      RETURNS json
+      LANGUAGE sql
+      STABLE
+      AS $$
+        SELECT json_build_object(
+          'by_language', (
+            SELECT json_agg(row_to_json(t) ORDER BY t.total_works DESC)
+            FROM translation_census_by_language t
+          ),
+          'totals', (
+            SELECT json_build_object(
+              'total_works', sum(total_works),
+              'total_editions', sum(total_editions),
+              'works_with_translation', sum(works_with_translation),
+              'editions_with_translation', sum(editions_with_translation),
+              'pct_works_translated', round(sum(works_with_translation)::numeric / NULLIF(sum(total_works), 0) * 100, 2),
+              'distinct_authors', sum(distinct_authors),
+              'authors_with_translation', sum(authors_with_translation)
+            )
+            FROM translation_census_by_language
+          ),
+          'built_at', now()
+        );
+      $$;
+    `);
+
+    // Also: a search function for the census page
+    await client.query(`
+      CREATE OR REPLACE FUNCTION search_translation_census(query text, max_results int DEFAULT 30)
+      RETURNS json
+      LANGUAGE sql
+      STABLE
+      AS $$
+        WITH search_results AS (
+          SELECT
+            w.author_surname,
+            w.work_key,
+            w.language,
+            w.english_title AS ustc_english_title,
+            w.std_title,
+            w.author,
+            w.year,
+            w.edition_count,
+            m.catalog_english_title,
+            m.translator,
+            m.translation_year,
+            m.catalog_source,
+            m.match_score,
+            m.completeness,
+            CASE WHEN m.author_surname IS NOT NULL THEN 'translated' ELSE 'untranslated' END AS status
+          FROM ustc_distinct_works w
+          LEFT JOIN translation_census_matches m
+            ON m.author_surname = w.author_surname AND m.work_key = w.work_key
+          WHERE w.author_surname % lower(query)
+             OR lower(w.english_title) ILIKE '%' || lower(query) || '%'
+             OR lower(w.std_title) ILIKE '%' || lower(query) || '%'
+          ORDER BY
+            CASE WHEN m.author_surname IS NOT NULL THEN 0 ELSE 1 END,
+            similarity(w.author_surname, lower(query)) DESC,
+            w.edition_count DESC
+          LIMIT max_results
+        )
+        SELECT json_build_object(
+          'results', (SELECT coalesce(json_agg(row_to_json(r)), '[]'::json) FROM search_results r),
+          'total', (SELECT count(*) FROM search_results)
+        );
+      $$;
+    `);
+
+    console.log('  RPCs created: get_translation_census, search_translation_census');
+  } finally {
+    client.release();
+  }
+}
+
+async function refreshAndVerify() {
+  const client = await pool.connect();
+  try {
+    // Show results
+    const { rows } = await client.query('SELECT * FROM translation_census_by_language ORDER BY total_works DESC LIMIT 10');
+    console.log('\n  Census results:');
+    console.log('  ' + 'Language'.padEnd(14) + 'Works'.padStart(10) + 'Translated'.padStart(12) + 'Pct'.padStart(8));
+    console.log('  ' + '-'.repeat(44));
+
+    let totalWorks = 0, totalTrans = 0;
+    for (const r of rows) {
+      totalWorks += parseInt(r.total_works);
+      totalTrans += parseInt(r.works_with_translation);
+      console.log('  ' +
+        r.language.padEnd(14) +
+        parseInt(r.total_works).toLocaleString().padStart(10) +
+        parseInt(r.works_with_translation).toLocaleString().padStart(12) +
+        (r.pct_works_translated + '%').padStart(8)
+      );
+    }
+    console.log('  ' + '-'.repeat(44));
+    console.log('  ' +
+      'TOTAL'.padEnd(14) +
+      totalWorks.toLocaleString().padStart(10) +
+      totalTrans.toLocaleString().padStart(12) +
+      ((totalTrans / totalWorks * 100).toFixed(2) + '%').padStart(8)
+    );
+
+    // Sample some matches for spot-checking
+    console.log('\n  Sample matches (spot-check):');
+    const { rows: samples } = await client.query(`
+      SELECT author_surname, ustc_std_title, catalog_english_title, catalog_source, match_score
+      FROM translation_census_matches
+      ORDER BY match_score DESC
+      LIMIT 10
+    `);
+    for (const s of samples) {
+      console.log(`  [${s.match_score.toFixed(2)}] ${s.author_surname}: "${s.ustc_std_title}" → "${s.catalog_english_title}" (${s.catalog_source})`);
+    }
+
+    // Also show some low-score matches to check for false positives
+    console.log('\n  Lowest-score matches (check for false positives):');
+    const { rows: lowSamples } = await client.query(`
+      SELECT author_surname, ustc_std_title, catalog_english_title, catalog_source, match_score
+      FROM translation_census_matches
+      WHERE match_score < 0.35
+      ORDER BY match_score ASC
+      LIMIT 10
+    `);
+    for (const s of lowSamples) {
+      console.log(`  [${s.match_score.toFixed(2)}] ${s.author_surname}: "${s.ustc_std_title}" → "${s.catalog_english_title}" (${s.catalog_source})`);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+run().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/src/app/api/census/search/route.ts
+++ b/src/app/api/census/search/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -8,167 +7,131 @@ export const dynamic = 'force-dynamic';
  * Translation Census Search API
  *
  * GET /api/census/search?q=ficino
- *   Search USTC editions and translation catalogs to answer:
+ *   Search the translation census to answer:
  *   "Has this author/work been translated into English?"
  *
- * Returns USTC editions with translation status, plus matching catalog entries.
+ * Primary: Supabase RPC search_translation_census (work-level, title-matched)
+ * Fallback: direct ustc_enrichments + translation_catalogs query
  */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q')?.trim();
-    const language = searchParams.get('language');
     const limit = Math.min(parseInt(searchParams.get('limit') || '30'), 100);
 
     if (!query || query.length < 2) {
       return NextResponse.json({ results: [], total: 0 });
     }
 
-    // Search in parallel: USTC enrichments (with English titles) + translation catalogs
-    const [ustcResults, catalogResults] = await Promise.all([
-      searchUstcEditions(query, language, limit),
-      searchTranslationCatalogs(query),
-    ]);
-
-    // Build a set of translated author surnames from catalogs for cross-referencing
-    const translatedSurnames = new Set(
-      catalogResults.map(c => c.author_surname?.toLowerCase()).filter(Boolean)
+    // Try the census RPC first (uses materialized view with proper work-level matching)
+    const { data: censusData, error: censusError } = await supabase.rpc(
+      'search_translation_census',
+      { query, max_results: limit }
     );
 
-    // Merge: annotate USTC results with catalog matches
-    const results = ustcResults.map(edition => {
-      const surname = extractSurname(edition.author);
-      const hasKnownTranslation = edition.has_english_translation ||
-        translatedSurnames.has(surname?.toLowerCase() || '');
+    if (!censusError && censusData) {
+      const parsed = typeof censusData === 'string' ? JSON.parse(censusData) : censusData;
+      if (parsed?.results?.length > 0) {
+        return NextResponse.json({
+          results: parsed.results.map((r: any) => ({
+            title: r.std_title || r.ustc_english_title || '',
+            english_title: r.ustc_english_title || null,
+            author: r.author || r.author_surname || '',
+            year: r.year || null,
+            language: r.language || '',
+            edition_count: r.edition_count || 1,
+            translation_status: r.status,
+            catalog_matches: r.status === 'translated' ? [{
+              english_title: r.catalog_english_title || '',
+              translator: r.translator || '',
+              pub_year: r.translation_year || '',
+              source: r.catalog_source || '',
+              match_score: r.match_score || 0,
+              completeness: r.completeness || 'unknown',
+            }] : [],
+          })),
+          total: parsed.total || parsed.results.length,
+          query,
+          source: 'census_view',
+        });
+      }
+    }
 
-      // Find specific catalog matches for this author
-      const catalogMatches = surname
-        ? catalogResults.filter(c =>
-            c.author_surname?.toLowerCase() === surname.toLowerCase()
-          )
-        : [];
-
-      return {
-        ...edition,
-        translation_status: hasKnownTranslation ? 'translated' : 'untranslated',
-        catalog_matches: catalogMatches.slice(0, 5),
-      };
-    });
-
-    return NextResponse.json({
-      results,
-      catalog_entries: catalogResults.length,
-      total: results.length,
-      query,
-    });
+    // Fallback: direct search against ustc_enrichments
+    return fallbackSearch(query, limit);
   } catch (err) {
     console.error('Census search error:', err);
     return NextResponse.json({ error: 'Search failed' }, { status: 500 });
   }
 }
 
-async function searchUstcEditions(query: string, language: string | null, limit: number) {
-  // Search enrichments first (have English titles), then raw editions
-  const enrichQuery = supabase
+async function fallbackSearch(query: string, limit: number) {
+  const { data: enriched } = await supabase
     .from('ustc_enrichments')
     .select('id, std_title, english_title, original_author, detected_language, work_type')
     .or(`std_title.ilike.%${query}%,english_title.ilike.%${query}%,original_author.ilike.%${query}%`)
     .limit(limit);
 
-  const { data: enriched } = await enrichQuery;
-
-  if (enriched && enriched.length > 0) {
-    // Get the full edition data for these IDs
-    const ids = enriched.map(e => e.id);
-    const { data: editions } = await supabase
-      .from('ustc_editions')
-      .select('id, sn, title, author_1, year, language_1, place, has_iiif_scan, has_english_translation, in_source_library')
-      .in('id', ids);
-
-    const editionMap = new Map((editions || []).map(e => [e.id, e]));
-
-    return enriched.map(e => {
-      const ed = editionMap.get(e.id);
-      return {
-        ustc_id: ed?.sn || e.id,
-        title: e.std_title || ed?.title || '',
-        english_title: e.english_title || null,
-        author: e.original_author || ed?.author_1 || '',
-        year: ed?.year || null,
-        language: e.detected_language || ed?.language_1 || '',
-        place: ed?.place || '',
-        has_iiif_scan: ed?.has_iiif_scan || false,
-        has_english_translation: ed?.has_english_translation || false,
-        in_source_library: ed?.in_source_library || false,
-        work_type: e.work_type || null,
-      };
-    });
+  if (!enriched || enriched.length === 0) {
+    return NextResponse.json({ results: [], total: 0, query, source: 'fallback' });
   }
 
-  // Fallback: search raw editions by author
+  const ids = enriched.map(e => e.id);
   const { data: editions } = await supabase
     .from('ustc_editions')
-    .select('id, sn, title, author_1, year, language_1, place, has_iiif_scan, has_english_translation, in_source_library')
-    .ilike('author_1', `%${query}%`)
-    .limit(limit);
+    .select('id, sn, title, author_1, year, language_1, place, has_english_translation, in_source_library')
+    .in('id', ids);
 
-  return (editions || []).map(ed => ({
-    ustc_id: ed.sn || ed.id,
-    title: ed.title || '',
-    english_title: null,
-    author: ed.author_1 || '',
-    year: ed.year || null,
-    language: ed.language_1 || '',
-    place: ed.place || '',
-    has_iiif_scan: ed.has_iiif_scan || false,
-    has_english_translation: ed.has_english_translation || false,
-    in_source_library: ed.in_source_library || false,
-    work_type: null,
-  }));
-}
+  const editionMap = new Map((editions || []).map(e => [e.id, e]));
 
-async function searchTranslationCatalogs(query: string) {
-  try {
-    const db = await getDb();
-    const words = query.toLowerCase().split(/\s+/).filter(w => w.length >= 2);
-    if (words.length === 0) return [];
+  // Also search translation_catalogs in Supabase for matching catalog entries
+  const { data: catalogs } = await supabase
+    .from('translation_catalogs')
+    .select('author_surname, english_title, translator, pub_year, source, completeness')
+    .or(`author_surname.ilike.%${query}%,english_title.ilike.%${query}%`)
+    .limit(50);
 
-    // Search by canonical author/work fields (indexed)
-    const conditions = words.map(word => ({
-      $or: [
-        { canonical_author_normalized: { $regex: word, $options: 'i' } },
-        { canonical_work_normalized: { $regex: word, $options: 'i' } },
-        { english_title: { $regex: word, $options: 'i' } },
-        { author_surname: { $regex: word, $options: 'i' } },
-      ]
-    }));
-
-    const results = await db.collection('translation_catalogs')
-      .find({ $and: conditions })
-      .project({
-        source: 1,
-        author: 1,
-        author_surname: 1,
-        english_title: 1,
-        original_title: 1,
-        translator: 1,
-        pub_year: 1,
-        publisher: 1,
-        series: 1,
-        completeness: 1,
-      })
-      .limit(50)
-      .toArray();
-
-    return results;
-  } catch {
-    return [];
+  const catalogBySurname = new Map<string, any[]>();
+  for (const c of catalogs || []) {
+    const key = c.author_surname?.toLowerCase() || '';
+    if (!catalogBySurname.has(key)) catalogBySurname.set(key, []);
+    catalogBySurname.get(key)!.push(c);
   }
+
+  const results = enriched.map(e => {
+    const ed = editionMap.get(e.id);
+    const author = e.original_author || ed?.author_1 || '';
+    const surname = extractSurname(author)?.toLowerCase() || '';
+    const matches = catalogBySurname.get(surname) || [];
+
+    return {
+      title: e.std_title || ed?.title || '',
+      english_title: e.english_title || null,
+      author,
+      year: ed?.year || null,
+      language: e.detected_language || ed?.language_1 || '',
+      edition_count: 1,
+      translation_status: (ed?.has_english_translation || matches.length > 0) ? 'translated' : 'untranslated',
+      catalog_matches: matches.slice(0, 3).map(m => ({
+        english_title: m.english_title || '',
+        translator: m.translator || '',
+        pub_year: m.pub_year || '',
+        source: m.source || '',
+        completeness: m.completeness || 'unknown',
+      })),
+    };
+  });
+
+  return NextResponse.json({
+    results,
+    total: results.length,
+    query,
+    source: 'fallback',
+  });
 }
 
 function extractSurname(author: string | null | undefined): string | null {
   if (!author) return null;
-  // USTC format: "Surname, Given" or just "Surname"
   const comma = author.indexOf(',');
   if (comma > 0) return author.substring(0, comma).trim();
   return author.split(/\s+/)[0]?.trim() || null;

--- a/src/app/census/page.tsx
+++ b/src/app/census/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
-import { getDb } from '@/lib/mongodb';
 import ContentPageLayout, { SubPageHeader } from '@/components/layout/ContentPageLayout';
 import { BookOpen, Languages, Search, BarChart3, Sparkles, ExternalLink } from 'lucide-react';
 import CensusSearch from './CensusSearch';
@@ -38,119 +37,85 @@ interface CensusData {
 
 async function getCensusData(): Promise<CensusData | null> {
   try {
-    // 1. Get USTC coverage stats from Supabase
-    const { data: coverageRows } = await supabase.rpc('get_coverage_stats');
+    // Primary source: Supabase materialized view via RPC
+    // Built by scripts/catalog-coverage/build-census.mjs
+    const [censusResult, slResult] = await Promise.all([
+      supabase.rpc('get_translation_census'),
+      supabase.rpc('get_sl_progress'),
+    ]);
 
-    // 2. Get live SL stats
-    const { data: slProgress } = await supabase.rpc('get_sl_progress');
+    const census = censusResult.data as any;
+    const slData = slResult.data as any;
 
-    // 3. Load pre-computed census results (from analysis scripts)
-    // These contain the detailed per-language work-level estimates
-    let censusJson: any = null;
-    try {
-      const db = await getDb();
-      censusJson = await db.collection('system_config').findOne({ _id: 'census_data' as any });
-    } catch { /* census data may not be in DB yet */ }
+    if (census?.totals && census?.by_language) {
+      // Live census data from materialized view
+      const languages: CensusLanguage[] = (census.by_language as any[])
+        .filter((l: any) => parseInt(l.total_works) >= 500)
+        .map((l: any) => ({
+          language: l.language || 'Unknown',
+          editions: Number(l.total_editions),
+          distinct_works: Number(l.total_works),
+          estimated_translated: Number(l.works_with_translation),
+          pct_works_translated: Number(l.pct_works_translated),
+          top_untranslated: [], // populated separately if needed
+        }));
 
-    // If no DB census data, use the coverage stats directly
-    const languages: CensusLanguage[] = [];
-
-    // Pre-computed census data (from scripts/analysis/translation-census-all-languages.mjs)
-    // These are the best estimates of work-level translation rates
-    const CENSUS_ESTIMATES: Record<string, { works: number; translated: number; topUntranslated: { surname: string; works: number }[] }> = censusJson?.languages || {
-      Latin: {
-        works: 362263, translated: 3501,
-        topUntranslated: [
-          { surname: 'Martini', works: 1299 }, { surname: 'Fabricius', works: 763 },
-          { surname: 'Bartolus de Saxoferrato', works: 477 }, { surname: 'Goclenius', works: 565 },
-        ],
-      },
-      German: {
-        works: 124394, translated: 1032,
-        topUntranslated: [
-          { surname: 'Sachs', works: 628 }, { surname: 'Spangenberg', works: 554 },
-          { surname: 'Olearius', works: 448 }, { surname: 'Dach', works: 384 },
-        ],
-      },
-      French: {
-        works: 65266, translated: 1223,
-        topUntranslated: [
-          { surname: 'Corneille', works: 377 }, { surname: 'Ronsard', works: 187 },
-          { surname: 'Du Moulin', works: 246 }, { surname: 'Arnauld', works: 314 },
-        ],
-      },
-      Italian: {
-        works: 70284, translated: 642,
-        topUntranslated: [
-          { surname: 'Croce', works: 909 }, { surname: 'Segneri', works: 291 },
-          { surname: 'Cicognini', works: 304 }, { surname: 'Aretino', works: 168 },
-        ],
-      },
-      Dutch: {
-        works: 29649, translated: 683,
-        topUntranslated: [
-          { surname: 'Vondel', works: 293 }, { surname: 'Cats', works: 173 },
-          { surname: 'Teellinck', works: 212 }, { surname: 'Goes', works: 279 },
-        ],
-      },
-      Spanish: {
-        works: 37484, translated: 323,
-        topUntranslated: [
-          { surname: 'Calderon de la Barca', works: 294 }, { surname: 'Vega Carpio', works: 178 },
-          { surname: 'Guevara', works: 130 }, { surname: 'Salazar', works: 213 },
-        ],
-      },
-      Portuguese: {
-        works: 3795, translated: 36,
-        topUntranslated: [
-          { surname: 'Vieira', works: 87 }, { surname: 'Camoes', works: 25 },
-          { surname: 'Carvalho', works: 79 }, { surname: 'Almeida', works: 47 },
-        ],
-      },
-    };
-
-    if (coverageRows) {
-      for (const row of coverageRows as any[]) {
-        const lang = row.language;
-        const census = CENSUS_ESTIMATES[lang];
-        if (!census) continue;
-
-        languages.push({
-          language: lang,
-          editions: Number(row.editions),
-          distinct_works: census.works,
-          estimated_translated: census.translated,
-          pct_works_translated: census.works > 0
-            ? +((census.translated / census.works) * 100).toFixed(2)
-            : 0,
-          top_untranslated: census.topUntranslated,
-        });
-      }
+      const t = census.totals;
+      return {
+        total_editions: Number(t.total_editions),
+        total_works: Number(t.total_works),
+        total_translated: Number(t.works_with_translation),
+        pct_translated: Number(t.pct_works_translated),
+        catalog_records: 13862,
+        languages,
+        sl_first_translations: Number(slData?.totals?.first_translations || 0),
+        sl_books_translated: Number(slData?.totals?.translated_by_sl || 0),
+      };
     }
 
-    // Sort by editions descending
-    languages.sort((a, b) => b.editions - a.editions);
-
-    const totalWorks = languages.reduce((s, l) => s + l.distinct_works, 0);
-    const totalTranslated = languages.reduce((s, l) => s + l.estimated_translated, 0);
-    const totalEditions = languages.reduce((s, l) => s + l.editions, 0);
-
-    const slData = slProgress as any;
-
-    return {
-      total_editions: totalEditions,
-      total_works: totalWorks,
-      total_translated: totalTranslated,
-      pct_translated: totalWorks > 0 ? +((totalTranslated / totalWorks) * 100).toFixed(2) : 0,
-      catalog_records: 13862,
-      languages,
-      sl_first_translations: Number(slData?.totals?.first_translations || 0),
-      sl_books_translated: Number(slData?.totals?.translated_by_sl || 0),
-    };
+    // Fallback: use coverage stats RPC (edition-level, less precise)
+    // This is the surname-level matching — honest about its limitations
+    console.warn('Translation census RPC not available — falling back to coverage stats');
+    return getCensusFromCoverageStats(slData);
   } catch (err) {
     console.error('Census data load error:', err);
     return null;
   }
+}
+
+async function getCensusFromCoverageStats(slData: any): Promise<CensusData | null> {
+  // Falls back to edition-level coverage stats from get_coverage_stats()
+  // These use surname-level matching (less precise) and count editions not works
+  const { data: coverageRows, error } = await supabase.rpc('get_coverage_stats');
+  if (error || !coverageRows) return null;
+
+  const languages: CensusLanguage[] = (coverageRows as any[])
+    .filter((r: any) => Number(r.editions) >= 1000)
+    .map((r: any) => ({
+      language: r.language,
+      editions: Number(r.editions),
+      distinct_works: 0, // not available in this mode
+      estimated_translated: Number(r.with_translation),
+      pct_works_translated: Number(r.editions) > 0
+        ? +((Number(r.with_translation) / Number(r.editions)) * 100).toFixed(1)
+        : 0,
+      top_untranslated: [],
+    }))
+    .sort((a, b) => b.editions - a.editions);
+
+  const totalEditions = languages.reduce((s, l) => s + l.editions, 0);
+  const totalTranslated = languages.reduce((s, l) => s + l.estimated_translated, 0);
+
+  return {
+    total_editions: totalEditions,
+    total_works: 0, // not available in fallback
+    total_translated: totalTranslated,
+    pct_translated: totalEditions > 0 ? +((totalTranslated / totalEditions) * 100).toFixed(1) : 0,
+    catalog_records: 13862,
+    languages,
+    sl_first_translations: Number(slData?.totals?.first_translations || 0),
+    sl_books_translated: Number(slData?.totals?.translated_by_sl || 0),
+  };
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -184,7 +149,11 @@ export default async function CensusPage() {
     );
   }
 
-  const gap = data.total_works - data.total_translated;
+  // Work-level data available when census view exists, otherwise edition-level
+  const hasWorkData = data.total_works > 0;
+  const denominator = hasWorkData ? data.total_works : data.total_editions;
+  const gap = denominator - data.total_translated;
+  const unitLabel = hasWorkData ? 'works' : 'editions';
 
   return (
     <ContentPageLayout maxWidth="narrow" bg="bg-stone-50">
@@ -200,19 +169,27 @@ export default async function CensusPage() {
             {data.pct_translated}%
           </div>
           <p className="text-secondary text-lg">
-            of pre-1700 European works have a known English translation
+            of pre-1700 European {unitLabel} have a known English translation
           </p>
+          {!hasWorkData && (
+            <p className="text-xs text-stone-400 mt-2">
+              Counted at the edition level. The true figure at the work level is likely lower
+              &mdash; one translated work covers many editions.
+            </p>
+          )}
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <div className={`grid grid-cols-2 ${hasWorkData ? 'md:grid-cols-4' : 'md:grid-cols-3'} gap-4 mb-8`}>
           <div className="text-center">
             <div className="text-2xl font-semibold text-primary">{fmt(data.total_editions)}</div>
             <div className="text-xs text-stone-500 mt-0.5">editions cataloged</div>
           </div>
-          <div className="text-center">
-            <div className="text-2xl font-semibold text-primary">{fmt(data.total_works)}</div>
-            <div className="text-xs text-stone-500 mt-0.5">distinct works</div>
-          </div>
+          {hasWorkData && (
+            <div className="text-center">
+              <div className="text-2xl font-semibold text-primary">{fmt(data.total_works)}</div>
+              <div className="text-xs text-stone-500 mt-0.5">distinct works</div>
+            </div>
+          )}
           <div className="text-center">
             <div className="text-2xl font-semibold text-emerald-700">{fmt(data.total_translated)}</div>
             <div className="text-xs text-stone-500 mt-0.5">with English translation</div>
@@ -223,7 +200,7 @@ export default async function CensusPage() {
           </div>
         </div>
 
-        <ProgressBar value={data.total_translated} max={data.total_works} color="bg-emerald-600" />
+        <ProgressBar value={data.total_translated} max={denominator} color="bg-emerald-600" />
         <div className="flex justify-between text-xs text-stone-400 mt-1.5">
           <span>0%</span>
           <span>{data.pct_translated}% translated</span>
@@ -243,14 +220,25 @@ export default async function CensusPage() {
           <p>
             Between the invention of the printing press (c. 1450) and 1700, European presses
             produced over {fmt(data.total_editions)} recorded editions in Latin, German, French,
-            Italian, Dutch, Spanish, Portuguese, and other languages. These represent roughly {fmt(data.total_works)} distinct
-            works &mdash; the intellectual output of the Renaissance, Reformation, and Scientific Revolution.
+            Italian, Dutch, Spanish, Portuguese, and other languages.
+            {hasWorkData && <> These represent roughly {fmt(data.total_works)} distinct works &mdash;</>}
+            {' '}The intellectual output of the Renaissance, Reformation, and Scientific Revolution.
           </p>
           <p>
-            Of these, only about {fmt(data.total_translated)} have a known English translation.
-            That&apos;s {data.pct_translated}%. The other {(100 - data.pct_translated).toFixed(1)}% &mdash;
-            roughly {fmt(gap)} works &mdash; remain inaccessible to English readers.
+            Of these, {hasWorkData ? 'only about' : 'roughly'} {fmt(data.total_translated)} {unitLabel} have
+            a known English translation. That&apos;s {data.pct_translated}%.
+            The other {(100 - data.pct_translated).toFixed(1)}% &mdash;
+            roughly {fmt(gap)} {unitLabel} &mdash; remain inaccessible to English readers.
           </p>
+          {!hasWorkData && (
+            <p className="text-stone-400 italic">
+              Note: These counts are at the edition level. Multiple editions of the same work
+              (e.g. 14 printings of Cicero&apos;s <em>De Officiis</em>) are each counted separately.
+              An author-level match also means all editions by that author are marked as &ldquo;translated&rdquo;
+              even if only one of their works has a translation. The true percentage of distinct
+              works translated is lower &mdash; likely between 1% and 4%.
+            </p>
+          )}
           <p>
             This census is built by joining the <a href="https://www.ustc.ac.uk" className="text-amber-700 hover:underline" target="_blank" rel="noopener noreferrer">Universal Short Title Catalogue</a> ({fmt(data.total_editions)} editions) against {fmt(data.catalog_records)} known
             English translations from UNESCO Index Translationum, Open Library, HathiTrust,
@@ -293,11 +281,11 @@ export default async function CensusPage() {
                 <h3 className="font-medium text-primary">{lang.language}</h3>
                 <div className="text-sm">
                   <span className="text-emerald-700 font-medium">{fmt(lang.estimated_translated)}</span>
-                  <span className="text-stone-400"> / {fmt(lang.distinct_works)} works</span>
+                  <span className="text-stone-400"> / {fmt(hasWorkData ? lang.distinct_works : lang.editions)} {unitLabel}</span>
                   <span className="text-stone-400 ml-1">({lang.pct_works_translated}%)</span>
                 </div>
               </div>
-              <ProgressBar value={lang.estimated_translated} max={lang.distinct_works} color="bg-emerald-600" />
+              <ProgressBar value={lang.estimated_translated} max={hasWorkData ? lang.distinct_works : lang.editions} color="bg-emerald-600" />
 
               {/* Top untranslated authors */}
               {lang.top_untranslated.length > 0 && (


### PR DESCRIPTION
## Summary

Follow-up to #938. Addresses the data quality issues with the census numbers.

**Problem:** The original census page showed hardcoded numbers from a March 15 script run using surname-level matching. This inflated the "translated" count — marking all editions by any author who has *any* translation as "translated." The USTC `has_english_translation` flag says 6.7% but the actual work-level translation rate is likely 1-4%.

**Changes:**

- **`build-census.mjs`**: New script that builds the census properly in Supabase:
  - Syncs 13.8K translation_catalogs from MongoDB to Supabase
  - Creates `ustc_distinct_works` materialized view (deduplicates editions into works)
  - Joins works against catalogs using `pg_trgm` title similarity (not just surname)
  - Creates `get_translation_census()` and `search_translation_census()` RPCs
  - Needs to run on Hetzner where `SUPABASE_DB_URL` resolves

- **Census page**: No more hardcoded `CENSUS_ESTIMATES` object. Reads from:
  1. Census RPC (work-level, title-matched) — when available
  2. Fallback: `get_coverage_stats()` (edition-level) with explicit caveats

- **Honest caveats in fallback mode**: When showing edition-level data, the page explains:
  - "Counted at the edition level. The true figure at the work level is likely lower"
  - "An author-level match means all editions by that author are marked as translated"
  - "The true percentage is likely between 1% and 4%"

- **Search API**: Uses census RPC when available, falls back to enrichments + catalog query

## Next steps after merge

1. Run `build-census.mjs` on Hetzner to materialize the census view
2. Verify the work-level numbers are reasonable
3. Schedule periodic refresh (or add to Hetzner cron)

## Test plan

- [ ] Page loads with fallback data when census RPC doesn't exist
- [ ] Caveats text appears in fallback mode
- [ ] Search still works via fallback path
- [ ] Run build-census.mjs on Hetzner and verify census view populates
- [ ] After build, page shows work-level data without caveats

Relates to #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)