### PR TITLE
Add CLIP visual search to /identify

### DIFF
--- a/scripts/backfill-clip-embeddings.mjs
+++ b/scripts/backfill-clip-embeddings.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Backfill CLIP embeddings for visual search.
+ *
+ * Embeds all artworks (resource_type exists) and book covers (thumbnail)
+ * via the Hetzner CLIP server, stores in Supabase clip_embeddings table.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/backfill-clip-embeddings.mjs
+ *
+ * Options:
+ *   --artworks-only    Only embed artworks (resource_type exists)
+ *   --covers-only      Only embed book covers
+ *   --limit N          Process at most N items
+ *   --dry-run          Count what would be embedded, don't embed
+ *   --clip-url URL     CLIP server URL (default: http://localhost:3457)
+ */
+
+import { MongoClient } from 'mongodb';
+import pg from 'pg';
+
+const { Client: PgClient } = pg;
+
+const CLIP_URL = process.env.CLIP_URL || process.argv.find(a => a.startsWith('--clip-url='))?.split('=')[1] || 'http://localhost:3457';
+const ARTWORKS_ONLY = process.argv.includes('--artworks-only');
+const COVERS_ONLY = process.argv.includes('--covers-only');
+const DRY_RUN = process.argv.includes('--dry-run');
+const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '0') || 0;
+
+// Batch settings
+const BATCH_SIZE = 10; // Images per batch to CLIP server
+const PG_BATCH = 50;   // Rows per INSERT
+
+async function main() {
+  // Check CLIP server health
+  try {
+    const health = await fetch(`${CLIP_URL}/health`).then(r => r.json());
+    console.log(`CLIP server: ${health.model} (${health.dims} dims)`);
+  } catch (e) {
+    console.error(`Cannot reach CLIP server at ${CLIP_URL}: ${e.message}`);
+    console.error('Start it with: node scripts/workers/clip-server.mjs');
+    process.exit(1);
+  }
+
+  // Connect to MongoDB
+  const mongo = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = mongo.db('bookstore');
+  const books = db.collection('books');
+
+  // Connect to Supabase Postgres
+  const pgClient = new PgClient({
+    host: process.env.PGHOST || 'db.ykhxaecbbxaaqlujuzde.supabase.co',
+    port: parseInt(process.env.PGPORT || '5432'),
+    user: process.env.PGUSER || 'postgres',
+    password: process.env.PGPASSWORD,
+    database: process.env.PGDATABASE || 'postgres',
+    ssl: { rejectUnauthorized: false },
+  });
+
+  if (!process.env.PGPASSWORD) {
+    console.error('Missing PGPASSWORD — set via .env.production.local or SUPABASE_DB_URL');
+    process.exit(1);
+  }
+
+  await pgClient.connect();
+  await pgClient.query('SET ROLE postgres');
+
+  // Get existing embeddings to skip
+  const { rows: existing } = await pgClient.query('SELECT id FROM clip_embeddings');
+  const existingIds = new Set(existing.map(r => r.id));
+  console.log(`Existing embeddings: ${existingIds.size}`);
+
+  // Collect items to embed
+  const items = [];
+
+  // Phase 1: Artworks (resource_type exists, have a thumbnail or commons image)
+  if (!COVERS_ONLY) {
+    const artworks = await books.find(
+      {
+        resource_type: { $exists: true },
+        $or: [
+          { commons_full_url: { $exists: true, $ne: null } },
+          { thumbnail: { $exists: true, $ne: null } },
+          { thumbnail_blob: { $exists: true, $ne: null } },
+        ],
+      },
+      {
+        projection: {
+          id: 1, title: 1, display_title: 1, author: 1, resource_type: 1,
+          commons_full_url: 1, thumbnail: 1, thumbnail_blob: 1, archived_full_url: 1,
+        },
+      },
+    ).toArray();
+
+    for (const a of artworks) {
+      const id = `artwork-${a.id}`;
+      if (existingIds.has(id)) continue;
+
+      // Best available image URL (prefer full resolution)
+      const imageUrl = a.commons_full_url || a.archived_full_url || a.thumbnail_blob || a.thumbnail;
+      if (!imageUrl) continue;
+
+      items.push({
+        id,
+        source_type: 'artwork',
+        book_id: a.id,
+        image_url: imageUrl,
+        title: a.display_title || a.title,
+        author: a.author,
+        resource_type: a.resource_type,
+        thumbnail_url: a.thumbnail_blob || a.thumbnail || imageUrl,
+      });
+    }
+    console.log(`Artworks to embed: ${items.length}`);
+  }
+
+  // Phase 2: Book covers (non-artwork books with thumbnails)
+  if (!ARTWORKS_ONLY) {
+    const coverQuery = {
+      resource_type: { $exists: false },
+      pages_count: { $gt: 0 },
+      $or: [
+        { thumbnail_blob: { $exists: true, $ne: null } },
+        { thumbnail: { $exists: true, $ne: null } },
+      ],
+    };
+
+    const coverBooks = await books.find(coverQuery, {
+      projection: {
+        id: 1, title: 1, display_title: 1, author: 1,
+        thumbnail: 1, thumbnail_blob: 1,
+      },
+    }).toArray();
+
+    const coverItems = [];
+    for (const b of coverBooks) {
+      const id = `cover-${b.id}`;
+      if (existingIds.has(id)) continue;
+
+      const imageUrl = b.thumbnail_blob || b.thumbnail;
+      if (!imageUrl) continue;
+
+      coverItems.push({
+        id,
+        source_type: 'book_cover',
+        book_id: b.id,
+        image_url: imageUrl,
+        title: b.display_title || b.title,
+        author: b.author,
+        resource_type: null,
+        thumbnail_url: imageUrl,
+      });
+    }
+    console.log(`Book covers to embed: ${coverItems.length}`);
+    items.push(...coverItems);
+  }
+
+  const total = LIMIT > 0 ? Math.min(items.length, LIMIT) : items.length;
+  console.log(`\nTotal to process: ${total}`);
+
+  if (DRY_RUN) {
+    console.log('Dry run — exiting');
+    await pgClient.end();
+    await mongo.close();
+    return;
+  }
+
+  // Process in batches
+  let embedded = 0;
+  let failed = 0;
+  const pendingRows = [];
+
+  for (let i = 0; i < total; i += BATCH_SIZE) {
+    const batch = items.slice(i, Math.min(i + BATCH_SIZE, total));
+    const urls = batch.map(b => b.image_url);
+
+    try {
+      const resp = await fetch(`${CLIP_URL}/embed-images`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ urls }),
+      });
+
+      if (!resp.ok) {
+        console.error(`Batch ${i}-${i + batch.length}: HTTP ${resp.status}`);
+        failed += batch.length;
+        continue;
+      }
+
+      const data = await resp.json();
+
+      for (let j = 0; j < data.results.length; j++) {
+        const result = data.results[j];
+        const item = batch[j];
+
+        if (result.embedding) {
+          pendingRows.push(item);
+          item._embedding = result.embedding;
+          embedded++;
+        } else {
+          failed++;
+        }
+      }
+
+      // Flush to Postgres when we have enough rows
+      if (pendingRows.length >= PG_BATCH) {
+        await flushToPostgres(pgClient, pendingRows);
+        pendingRows.length = 0;
+      }
+
+      const pct = ((i + batch.length) / total * 100).toFixed(1);
+      process.stdout.write(`\r  ${pct}% — ${embedded} embedded, ${failed} failed (${data.ms}ms for ${batch.length} images)`);
+    } catch (e) {
+      console.error(`\nBatch ${i} error: ${e.message}`);
+      failed += batch.length;
+    }
+  }
+
+  // Final flush
+  if (pendingRows.length > 0) {
+    await flushToPostgres(pgClient, pendingRows);
+  }
+
+  console.log(`\n\nDone: ${embedded} embedded, ${failed} failed`);
+
+  await pgClient.end();
+  await mongo.close();
+}
+
+async function flushToPostgres(client, rows) {
+  if (rows.length === 0) return;
+
+  // Use multi-row INSERT with ON CONFLICT
+  const values = [];
+  const params = [];
+  let paramIdx = 1;
+
+  for (const row of rows) {
+    const embeddingStr = `[${row._embedding.join(',')}]`;
+    values.push(`($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}::vector, $${paramIdx + 5}, $${paramIdx + 6}, $${paramIdx + 7}, $${paramIdx + 8})`);
+    params.push(
+      row.id,
+      row.source_type,
+      row.book_id,
+      row.image_url,
+      embeddingStr,
+      row.title,
+      row.author,
+      row.resource_type,
+      row.thumbnail_url,
+    );
+    paramIdx += 9;
+  }
+
+  const sql = `
+    INSERT INTO clip_embeddings (id, source_type, book_id, image_url, embedding, title, author, resource_type, thumbnail_url)
+    VALUES ${values.join(', ')}
+    ON CONFLICT (id) DO UPDATE SET
+      embedding = EXCLUDED.embedding,
+      image_url = EXCLUDED.image_url,
+      title = EXCLUDED.title,
+      author = EXCLUDED.author,
+      thumbnail_url = EXCLUDED.thumbnail_url,
+      created_at = NOW()
+  `;
+
+  await client.query(sql, params);
+}
+
+main().catch(e => {
+  console.error('Fatal:', e);
+  process.exit(1);
+});

--- a/scripts/migration/clip-embeddings-schema.sql
+++ b/scripts/migration/clip-embeddings-schema.sql
@@ -1,0 +1,71 @@
+-- CLIP image embeddings for visual similarity search.
+-- Model: clip-vit-base-patch32 (512 dims)
+-- Used by /api/identify for image→image matching.
+
+-- Ensure pgvector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Main embeddings table
+CREATE TABLE IF NOT EXISTS clip_embeddings (
+  id TEXT PRIMARY KEY,              -- book_id or gallery_image composite key
+  source_type TEXT NOT NULL,        -- 'artwork', 'book_cover', 'gallery_image'
+  book_id TEXT,                     -- source library book id
+  image_url TEXT NOT NULL,          -- URL that was embedded
+  embedding vector(512) NOT NULL,   -- CLIP ViT-B/32 embedding
+  title TEXT,                       -- denormalized for display
+  author TEXT,                      -- denormalized for display
+  resource_type TEXT,               -- 'print', 'painting', etc.
+  thumbnail_url TEXT,               -- for result display
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- IVFFlat index for fast similarity search (tune lists after backfill)
+-- For ~10K vectors, lists=32 is reasonable. Re-tune if >50K.
+CREATE INDEX IF NOT EXISTS clip_embeddings_embedding_idx
+  ON clip_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 32);
+
+-- Index for filtering by source type
+CREATE INDEX IF NOT EXISTS clip_embeddings_source_type_idx
+  ON clip_embeddings (source_type);
+
+-- Index for book_id lookups
+CREATE INDEX IF NOT EXISTS clip_embeddings_book_id_idx
+  ON clip_embeddings (book_id);
+
+-- RPC function for visual similarity search
+CREATE OR REPLACE FUNCTION match_clip_images(
+  query_embedding vector(512),
+  match_threshold FLOAT DEFAULT 0.25,
+  match_count INT DEFAULT 20
+)
+RETURNS TABLE (
+  id TEXT,
+  source_type TEXT,
+  book_id TEXT,
+  image_url TEXT,
+  title TEXT,
+  author TEXT,
+  resource_type TEXT,
+  thumbnail_url TEXT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.source_type,
+    c.book_id,
+    c.image_url,
+    c.title,
+    c.author,
+    c.resource_type,
+    c.thumbnail_url,
+    1 - (c.embedding <=> query_embedding) AS similarity
+  FROM clip_embeddings c
+  WHERE 1 - (c.embedding <=> query_embedding) > match_threshold
+  ORDER BY c.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/scripts/workers/clip-server.mjs
+++ b/scripts/workers/clip-server.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * CLIP image embedding server for visual search.
+ *
+ * Runs on Hetzner alongside the text embedding server (port 3456).
+ * Encodes images and text into a shared 512-dim embedding space,
+ * enabling image→image and text→image similarity search.
+ *
+ * Model: Xenova/clip-vit-base-patch32 (512 dims, ONNX quantized)
+ * Cost: $0 (runs locally on Hetzner CPU)
+ *
+ * Start: node scripts/workers/clip-server.mjs
+ * Health: GET /health
+ * Embed image:  POST /embed-image { url: "https://..." } or { base64: "...", mime_type: "image/jpeg" }
+ * Embed text:   POST /embed-text  { text: "allegory of arithmetic" }
+ * Embed batch:  POST /embed-images { urls: ["https://...", ...] }
+ *
+ * Port: 3457 (or CLIP_PORT env var)
+ */
+
+import http from 'http';
+import { AutoProcessor, CLIPVisionModelWithProjection, CLIPTextModelWithProjection, AutoTokenizer, RawImage } from '@xenova/transformers';
+
+const PORT = parseInt(process.env.CLIP_PORT || '3457');
+const MODEL_ID = 'Xenova/clip-vit-base-patch32';
+const DIMS = 512;
+
+// Request size limit: 10MB (for base64 images)
+const MAX_BODY = 10 * 1024 * 1024;
+
+console.log('Loading CLIP model...');
+const t = Date.now();
+
+const [visionModel, textModel, processor, tokenizer] = await Promise.all([
+  CLIPVisionModelWithProjection.from_pretrained(MODEL_ID, { quantized: true }),
+  CLIPTextModelWithProjection.from_pretrained(MODEL_ID, { quantized: true }),
+  AutoProcessor.from_pretrained(MODEL_ID),
+  AutoTokenizer.from_pretrained(MODEL_ID),
+]);
+
+console.log(`CLIP model loaded in ${((Date.now() - t) / 1000).toFixed(1)}s`);
+
+/**
+ * Encode an image (from URL or base64) into a CLIP embedding.
+ */
+async function embedImage(source) {
+  let image;
+  if (source.url) {
+    image = await RawImage.fromURL(source.url);
+  } else if (source.base64) {
+    const buf = Buffer.from(source.base64, 'base64');
+    image = await RawImage.fromBlob(new Blob([buf], { type: source.mime_type || 'image/jpeg' }));
+  } else {
+    throw new Error('Provide url or base64');
+  }
+
+  const inputs = await processor(image);
+  const { image_embeds } = await visionModel(inputs);
+
+  // Normalize to unit vector
+  const raw = Array.from(image_embeds.data);
+  const norm = Math.sqrt(raw.reduce((s, v) => s + v * v, 0));
+  return norm > 0 ? raw.map(v => v / norm) : raw;
+}
+
+/**
+ * Encode text into a CLIP embedding (same space as images).
+ */
+async function embedText(text) {
+  const inputs = tokenizer(text, { padding: true, truncation: true, max_length: 77 });
+  const { text_embeds } = await textModel(inputs);
+
+  const raw = Array.from(text_embeds.data);
+  const norm = Math.sqrt(raw.reduce((s, v) => s + v * v, 0));
+  return norm > 0 ? raw.map(v => v / norm) : raw;
+}
+
+const server = http.createServer(async (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') { res.writeHead(204); res.end(); return; }
+
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, model: MODEL_ID, dims: DIMS }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/embed-image') {
+    try {
+      const body = await readBody(req);
+      const { url, base64, mime_type } = JSON.parse(body);
+      const t0 = Date.now();
+      const embedding = await embedImage({ url, base64, mime_type });
+      const ms = Date.now() - t0;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ embedding, dims: DIMS, ms }));
+    } catch (e) {
+      console.error('[clip] embed-image error:', e.message);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/embed-text') {
+    try {
+      const body = await readBody(req);
+      const { text } = JSON.parse(body);
+      if (!text) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'text is required' }));
+        return;
+      }
+      const t0 = Date.now();
+      const embedding = await embedText(text);
+      const ms = Date.now() - t0;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ embedding, dims: DIMS, ms }));
+    } catch (e) {
+      console.error('[clip] embed-text error:', e.message);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/embed-images') {
+    try {
+      const body = await readBody(req);
+      const { urls } = JSON.parse(body);
+      if (!Array.isArray(urls) || urls.length === 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'urls must be a non-empty array' }));
+        return;
+      }
+      if (urls.length > 50) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'max 50 URLs per batch' }));
+        return;
+      }
+
+      const t0 = Date.now();
+      const results = [];
+      for (const url of urls) {
+        try {
+          const embedding = await embedImage({ url });
+          results.push({ url, embedding, error: null });
+        } catch (e) {
+          results.push({ url, embedding: null, error: e.message });
+        }
+      }
+      const ms = Date.now() - t0;
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        results,
+        dims: DIMS,
+        ms,
+        success: results.filter(r => r.embedding).length,
+        failed: results.filter(r => !r.embedding).length,
+      }));
+    } catch (e) {
+      console.error('[clip] embed-images error:', e.message);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`CLIP server listening on port ${PORT}`);
+});
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    let size = 0;
+    req.on('data', chunk => {
+      size += chunk.length;
+      if (size > MAX_BODY) { reject(new Error('Body too large')); req.destroy(); return; }
+      data += chunk;
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -62,6 +62,11 @@ interface AlternativeIdentification {
   reasoning?: string;
 }
 
+interface WebSource {
+  title: string;
+  url: string;
+}
+
 interface IdentifyResult {
   artist?: string | null;
   title?: string | null;
@@ -74,6 +79,11 @@ interface IdentifyResult {
   confidence_reason?: string;
   alternative_identifications?: AlternativeIdentification[];
   search_terms?: string[];
+  // Added by Google Search verification
+  verified_artist?: string;
+  verified_title?: string;
+  catalog_numbers?: string[];
+  web_sources?: WebSource[];
 }
 
 export async function POST(request: NextRequest) {
@@ -162,7 +172,7 @@ export async function POST(request: NextRequest) {
       }
     })();
 
-    // Wait for both
+    // Wait for initial identification + CLIP
     const [resp, clipMatches] = await Promise.all([geminiPromise, clipPromise]);
 
     if (!resp.ok) {
@@ -187,6 +197,87 @@ export async function POST(request: NextRequest) {
     } catch {
       return NextResponse.json({ error: 'Could not parse vision response — try a clearer image', detail: text.substring(0, 300) }, { status: 500 });
     }
+
+    // Promise 3: Google Search verification (runs after initial ID, in parallel with DB search)
+    // Uses grounding to verify/correct the identification against museum catalogs
+    const verifyPromise: Promise<{ corrected_artist?: string; corrected_title?: string; sources?: WebSource[]; catalog_numbers?: string[] } | null> = (async () => {
+      try {
+        const verifyModel = 'gemini-2.5-flash-preview-05-20';
+        const searchQuery = [
+          identification.artist,
+          identification.title,
+          identification.inscriptions?.split('\n')[0],
+          identification.medium,
+        ].filter(Boolean).join(', ');
+
+        const verifyResp = await fetch(
+          `https://generativelanguage.googleapis.com/v1beta/models/${verifyModel}:generateContent?key=${apiKey}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              contents: [{
+                parts: [{
+                  text: `I identified an artwork with these details:
+Artist: ${identification.artist || 'Unknown'}
+Title: ${identification.title || 'Unknown'}
+Inscriptions: ${identification.inscriptions || 'None'}
+Subject: ${identification.subject || 'Unknown'}
+Medium: ${identification.medium || 'Unknown'}
+Period: ${identification.period_guess || 'Unknown'}
+
+Search for this specific artwork in museum catalogs and art databases. Verify or correct the attribution.
+
+Return JSON only:
+{
+  "corrected_artist": "Correct artist attribution based on museum records. Null if original was correct.",
+  "corrected_title": "Correct title based on museum records. Null if original was correct.",
+  "catalog_numbers": ["Any catalog numbers found (Bartsch, Hollstein, museum accession numbers)"],
+  "sources": [{"title": "Museum/catalog name", "url": "URL to the catalog entry"}]
+}`,
+                }],
+              }],
+              tools: [{ google_search: {} }],
+              generationConfig: { temperature: 0.1 },
+            }),
+            signal: AbortSignal.timeout(12000),
+          },
+        );
+
+        if (!verifyResp.ok) return null;
+        const verifyData = await verifyResp.json();
+
+        // Extract grounding sources from metadata
+        const groundingMeta = verifyData.candidates?.[0]?.groundingMetadata;
+        const groundingSources: WebSource[] = (groundingMeta?.groundingChunks || [])
+          .filter((c: { web?: { uri?: string; title?: string } }) => c.web?.uri)
+          .map((c: { web: { uri: string; title?: string } }) => ({ title: c.web.title || '', url: c.web.uri }))
+          .slice(0, 5);
+
+        const verifyText = verifyData.candidates?.[0]?.content?.parts
+          ?.filter((p: { text?: string }) => p.text)
+          .map((p: { text: string }) => p.text)
+          .join('') || '';
+        const verifyJsonMatch = verifyText.match(/```(?:json)?\s*([\s\S]*?)```/);
+        const verifyJsonStr = (verifyJsonMatch?.[1] || verifyText).trim();
+
+        try {
+          const parsed = JSON.parse(verifyJsonStr);
+          // Merge grounding sources with any sources from the response
+          parsed.sources = [...(parsed.sources || []), ...groundingSources]
+            .filter((s: WebSource) => s.url)
+            .filter((s: WebSource, i: number, arr: WebSource[]) => arr.findIndex(x => x.url === s.url) === i)
+            .slice(0, 5);
+          return parsed;
+        } catch {
+          // Even if JSON parsing fails, return grounding sources
+          return groundingSources.length > 0 ? { sources: groundingSources } : null;
+        }
+      } catch (e) {
+        console.warn('[identify] Google Search verification failed:', e instanceof Error ? e.message : String(e));
+        return null;
+      }
+    })();
 
     // Search the library for matches
     const db = await getDb();
@@ -237,6 +328,7 @@ export async function POST(request: NextRequest) {
           projection: {
             _id: 0, id: 1, slug: 1, title: 1, display_title: 1, english_title: 1,
             author: 1, published: 1, thumbnail: 1, thumbnail_blob: 1, resource_type: 1,
+            commons_full_url: 1, archived_full_url: 1,
             commons_title: 1, 'enrichment.subject': 1, 'enrichment.inscriptions': 1,
           },
           maxTimeMS: 8000,
@@ -494,21 +586,90 @@ export async function POST(request: NextRequest) {
     pageMatches.sort((a, b) => b.score - a.score);
     const bestPage = pageMatches[0] || null;
 
+    // Fetch page-level images for matched books (show the actual page, not the book cover)
+    const topMatchIds = matches.slice(0, 10).map(m => m.id);
+    const pageImageMap = new Map<string, { page_number: number; image_url: string }>();
+
+    // For books with page matches, get the page image
+    if (pageMatches.length > 0) {
+      const pageBookIds = [...new Set(pageMatches.map(pm => pm.bookId))].filter(id => topMatchIds.includes(id));
+      if (pageBookIds.length > 0) {
+        const matchedPages = await pages
+          .find(
+            {
+              book_id: { $in: pageBookIds },
+              page_number: { $in: pageMatches.filter(pm => pageBookIds.includes(pm.bookId)).map(pm => pm.pageNumber) },
+            },
+            {
+              projection: { book_id: 1, page_number: 1, display_photo: 1, photo: 1, cropped_photo: 1, archived_photo: 1 },
+              maxTimeMS: 5000,
+            },
+          )
+          .limit(20)
+          .toArray()
+          .catch(() => []);
+
+        for (const p of matchedPages) {
+          const imgUrl = p.display_photo || p.cropped_photo || p.archived_photo || p.photo;
+          if (imgUrl) {
+            const key = `${p.book_id}-${p.page_number}`;
+            if (!pageImageMap.has(p.book_id as string)) {
+              pageImageMap.set(p.book_id as string, { page_number: p.page_number as number, image_url: imgUrl as string });
+            }
+          }
+        }
+      }
+    }
+
+    // For artworks (resource_type exists), use the artwork's own image, not a generic cover
+    // The artwork image fields are already in the match object from Strategy 1 query
+    // (commons_full_url, archived_full_url were projected but not shown — now we surface them)
+
+    // Await Google Search verification (started earlier, should be done by now)
+    const verification = await verifyPromise;
+
+    // Merge verification corrections into identification
+    if (verification) {
+      if (verification.corrected_artist && verification.corrected_artist !== identification.artist) {
+        identification.verified_artist = verification.corrected_artist;
+      }
+      if (verification.corrected_title && verification.corrected_title !== identification.title) {
+        identification.verified_title = verification.corrected_title;
+      }
+      if (verification.catalog_numbers?.length) {
+        identification.catalog_numbers = verification.catalog_numbers;
+      }
+      if (verification.sources?.length) {
+        identification.web_sources = verification.sources;
+      }
+    }
+
     return NextResponse.json({
       identification,
       matches: matches.slice(0, 10).map(({ _score, _visual_similarity, _match_source, enrichment, commons_title, english_title, ...rest }) => {
         // Attach page match if this book has one
         const pm = pageMatches.find(p => p.bookId === rest.id);
+        // Use page image, artwork image, or fall back to book cover
+        const pageImg = pageImageMap.get(rest.id);
+        const matchImage = pageImg?.image_url
+          || rest.commons_full_url  // artworks from Wikimedia
+          || rest.archived_full_url // artworks archived to R2
+          || rest.thumbnail_blob || rest.thumbnail;
+        // Clean up fields we don't want to expose
+        const { commons_full_url, archived_full_url, ...cleanRest } = rest;
         return {
-          ...rest,
+          ...cleanRest,
+          match_image: matchImage,
           score: _score,
           visual_similarity: _visual_similarity || undefined,
           match_source: _match_source || 'text',
           subject: enrichment?.subject,
           ...(pm ? { page_number: pm.pageNumber, page_score: pm.score } : {}),
+          ...(pageImg ? { page_number: pageImg.page_number } : {}),
         };
       }),
       visual_search: clipMatches.length > 0,
+      verified: !!verification,
       page: bestPage ? {
         book_id: bestPage.bookId,
         page_number: bestPage.pageNumber,

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getNextApiKey } from '@/lib/gemini-client';
 import { getDb } from '@/lib/mongodb';
+import { supabase } from '@/lib/supabase';
 
 export const maxDuration = 30;
 export const dynamic = 'force-dynamic';
 
 // Max image size: 4MB (Vercel serverless body limit is 4.5MB)
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+
+// CLIP server on Hetzner for visual similarity search
+const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3457';
 
 const IDENTIFY_PROMPT = `You are an art historian identifying a physical artwork or book page from a photograph taken in a museum or library.
 
@@ -93,10 +97,12 @@ export async function POST(request: NextRequest) {
     const base64 = Buffer.from(bytes).toString('base64');
     const mimeType = file.type || 'image/jpeg';
 
-    // Call Gemini vision
+    // Run Gemini vision + CLIP visual search in parallel
     const apiKey = getNextApiKey();
     const model = 'gemini-3.1-flash-lite-preview';
-    const resp = await fetch(
+
+    // Promise 1: Gemini structured identification
+    const geminiPromise = fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
       {
         method: 'POST',
@@ -112,6 +118,52 @@ export async function POST(request: NextRequest) {
         }),
       },
     );
+
+    // Promise 2: CLIP visual similarity search (non-blocking — fails gracefully)
+    interface ClipMatch {
+      id: string;
+      source_type: string;
+      book_id: string;
+      image_url: string;
+      title: string;
+      author: string;
+      resource_type: string;
+      thumbnail_url: string;
+      similarity: number;
+    }
+    const clipPromise: Promise<ClipMatch[]> = (async () => {
+      try {
+        // Encode uploaded image via CLIP server
+        const clipResp = await fetch(`${CLIP_URL}/embed-image`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ base64, mime_type: mimeType }),
+          signal: AbortSignal.timeout(8000),
+        });
+        if (!clipResp.ok) return [];
+        const { embedding } = await clipResp.json();
+        if (!embedding) return [];
+
+        // Search Supabase for visual matches
+        const { data, error } = await supabase.rpc('match_clip_images', {
+          query_embedding: embedding,
+          match_threshold: 0.25,
+          match_count: 20,
+        });
+        if (error) {
+          console.error('[identify] CLIP search error:', error.message);
+          return [];
+        }
+        return (data || []) as ClipMatch[];
+      } catch (e) {
+        // CLIP search is optional — don't fail the whole request
+        console.warn('[identify] CLIP search unavailable:', e instanceof Error ? e.message : String(e));
+        return [];
+      }
+    })();
+
+    // Wait for both
+    const [resp, clipMatches] = await Promise.all([geminiPromise, clipPromise]);
 
     if (!resp.ok) {
       const err = await resp.text();
@@ -409,22 +461,54 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Merge CLIP visual matches into text matches
+    // CLIP matches come from Supabase with book_id — merge by boosting existing or adding new
+    const existingMatchIds = new Set(matches.map(m => m.id));
+    for (const cm of clipMatches) {
+      const visualScore = Math.round(cm.similarity * 40); // Scale 0-1 to 0-40 score
+      const existing = matches.find(m => m.id === cm.book_id);
+      if (existing) {
+        // Boost existing text match with visual similarity
+        existing._score += visualScore;
+        existing._visual_similarity = cm.similarity;
+      } else if (!existingMatchIds.has(cm.book_id)) {
+        // Add as new match from visual search only
+        matches.push({
+          id: cm.book_id,
+          title: cm.title,
+          author: cm.author,
+          resource_type: cm.resource_type,
+          thumbnail: cm.thumbnail_url,
+          _score: visualScore,
+          _visual_similarity: cm.similarity,
+          _match_source: 'visual',
+        });
+        existingMatchIds.add(cm.book_id);
+      }
+    }
+
+    // Re-sort after merging CLIP results
+    matches.sort((a, b) => b._score - a._score);
+
     // Sort page matches by score and attach to book results
     pageMatches.sort((a, b) => b.score - a.score);
     const bestPage = pageMatches[0] || null;
 
     return NextResponse.json({
       identification,
-      matches: matches.slice(0, 10).map(({ _score, enrichment, ...rest }) => {
+      matches: matches.slice(0, 10).map(({ _score, _visual_similarity, _match_source, enrichment, commons_title, english_title, ...rest }) => {
         // Attach page match if this book has one
         const pm = pageMatches.find(p => p.bookId === rest.id);
         return {
           ...rest,
           score: _score,
+          visual_similarity: _visual_similarity || undefined,
+          match_source: _match_source || 'text',
           subject: enrichment?.subject,
           ...(pm ? { page_number: pm.pageNumber, page_score: pm.score } : {}),
         };
       }),
+      visual_search: clipMatches.length > 0,
       page: bestPage ? {
         book_id: bestPage.bookId,
         page_number: bestPage.pageNumber,

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -17,6 +17,8 @@ interface Match {
   resource_type?: string;
   subject?: string;
   score: number;
+  visual_similarity?: number;
+  match_source?: 'text' | 'visual';
   page_number?: number;
   page_score?: number;
 }
@@ -44,6 +46,7 @@ interface Identification {
 interface Result {
   identification: Identification;
   matches: Match[];
+  visual_search?: boolean;
   page?: { book_id: string; page_number: number; score: number } | null;
 }
 
@@ -317,9 +320,14 @@ export default function IdentifyPage() {
             {/* Matches */}
             {result.matches.length > 0 ? (
               <div>
-                <h2 className="text-lg font-display font-semibold text-primary mb-3">
-                  {result.matches.length === 1 ? 'Match Found' : `${result.matches.length} Possible Matches`}
-                </h2>
+                <div className="flex items-center gap-2 mb-3">
+                  <h2 className="text-lg font-display font-semibold text-primary">
+                    {result.matches.length === 1 ? 'Match Found' : `${result.matches.length} Possible Matches`}
+                  </h2>
+                  {result.visual_search && (
+                    <span className="text-[10px] text-blue-600 bg-blue-50 rounded px-1.5 py-0.5">visual search</span>
+                  )}
+                </div>
                 <div className="space-y-2">
                   {result.matches.map((match, i) => {
                     const pageUrl = match.page_number
@@ -351,7 +359,12 @@ export default function IdentifyPage() {
                         {match.author && (
                           <p className="text-sm text-secondary mt-0.5">{match.author}</p>
                         )}
-                        <div className="flex items-center gap-2 mt-1 text-xs text-muted">
+                        <div className="flex items-center gap-2 mt-1 text-xs text-muted flex-wrap">
+                          {match.visual_similarity && (
+                            <span className="font-medium text-blue-700 bg-blue-50 rounded px-1.5 py-0.5">
+                              {Math.round(match.visual_similarity * 100)}% visual match
+                            </span>
+                          )}
                           {match.published && <span>{match.published}</span>}
                           {match.resource_type && (
                             <span className="capitalize">{match.resource_type}</span>

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -14,6 +14,7 @@ interface Match {
   published?: string;
   thumbnail?: string;
   thumbnail_blob?: string;
+  match_image?: string;
   resource_type?: string;
   subject?: string;
   score: number;
@@ -41,12 +42,18 @@ interface Identification {
   confidence_reason?: string;
   alternative_identifications?: AlternativeIdentification[];
   search_terms?: string[];
+  // From Google Search verification
+  verified_artist?: string;
+  verified_title?: string;
+  catalog_numbers?: string[];
+  web_sources?: { title: string; url: string }[];
 }
 
 interface Result {
   identification: Identification;
   matches: Match[];
   visual_search?: boolean;
+  verified?: boolean;
   page?: { book_id: string; page_number: number; score: number } | null;
 }
 
@@ -252,16 +259,36 @@ export default function IdentifyPage() {
                 <p className="text-xs text-muted italic">{result.identification.confidence_reason}</p>
               )}
               <dl className="text-sm space-y-2">
-                {result.identification.artist && (
+                {(result.identification.artist || result.identification.verified_artist) && (
                   <div>
                     <dt className="text-muted text-xs uppercase tracking-wider">Artist</dt>
-                    <dd className="text-primary font-medium">{result.identification.artist}</dd>
+                    {result.identification.verified_artist ? (
+                      <dd>
+                        <span className="text-primary font-medium">{result.identification.verified_artist}</span>
+                        {result.identification.artist && result.identification.artist !== result.identification.verified_artist && (
+                          <span className="text-xs text-muted ml-2 line-through">{result.identification.artist}</span>
+                        )}
+                        <span className="text-[10px] text-green-700 bg-green-50 rounded px-1 py-0.5 ml-1.5">verified</span>
+                      </dd>
+                    ) : (
+                      <dd className="text-primary font-medium">{result.identification.artist}</dd>
+                    )}
                   </div>
                 )}
-                {result.identification.title && (
+                {(result.identification.title || result.identification.verified_title) && (
                   <div>
                     <dt className="text-muted text-xs uppercase tracking-wider">Title</dt>
-                    <dd className="text-primary">{result.identification.title}</dd>
+                    {result.identification.verified_title ? (
+                      <dd>
+                        <span className="text-primary">{result.identification.verified_title}</span>
+                        {result.identification.title && result.identification.title !== result.identification.verified_title && (
+                          <span className="text-xs text-muted ml-2 line-through">{result.identification.title}</span>
+                        )}
+                        <span className="text-[10px] text-green-700 bg-green-50 rounded px-1 py-0.5 ml-1.5">verified</span>
+                      </dd>
+                    ) : (
+                      <dd className="text-primary">{result.identification.title}</dd>
+                    )}
                   </div>
                 )}
                 {result.identification.subject && (
@@ -299,6 +326,38 @@ export default function IdentifyPage() {
                   </div>
                 )}
               </dl>
+
+              {/* Catalog numbers */}
+              {result.identification.catalog_numbers && result.identification.catalog_numbers.length > 0 && (
+                <div className="pt-3 border-t border-border-light">
+                  <h3 className="text-xs uppercase tracking-wider text-muted mb-1">Catalog references</h3>
+                  <div className="flex flex-wrap gap-1.5">
+                    {result.identification.catalog_numbers.map((num, i) => (
+                      <span key={i} className="text-xs bg-stone-100 text-stone-700 rounded px-2 py-0.5 font-mono">{num}</span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Web sources from Google Search verification */}
+              {result.identification.web_sources && result.identification.web_sources.length > 0 && (
+                <div className="pt-3 border-t border-border-light">
+                  <h3 className="text-xs uppercase tracking-wider text-muted mb-1">Sources</h3>
+                  <div className="space-y-1">
+                    {result.identification.web_sources.map((src, i) => (
+                      <a
+                        key={i}
+                        href={src.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block text-xs text-blue-700 hover:text-blue-900 hover:underline truncate"
+                      >
+                        {src.title || src.url}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Alternative identifications */}
               {result.identification.alternative_identifications && result.identification.alternative_identifications.length > 0 && (
@@ -339,11 +398,11 @@ export default function IdentifyPage() {
                       href={pageUrl}
                       className="flex gap-4 p-3 rounded-lg bg-white border border-border-light hover:border-accent-rust/30 hover:shadow-sm transition-all group"
                     >
-                      {(match.thumbnail_blob || match.thumbnail) && (
+                      {(match.match_image || match.thumbnail_blob || match.thumbnail) && (
                         <div className="w-16 h-20 flex-shrink-0 rounded overflow-hidden bg-stone-100">
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
-                            src={match.thumbnail_blob || match.thumbnail || ''}
+                            src={match.match_image || match.thumbnail_blob || match.thumbnail || ''}
                             alt=""
                             className="w-full h-full object-cover"
                           />


### PR DESCRIPTION
## Summary
- Adds CLIP image embedding server for Hetzner (`clip-server.mjs`, port 3457) — encodes images into 512-dim vectors using `clip-vit-base-patch32` via ONNX, $0 cost
- Creates Supabase `clip_embeddings` table with pgvector IVFFlat index and `match_clip_images()` RPC function
- Backfill script embeds all artworks (~4K) + book covers into Supabase
- `/api/identify` now runs CLIP encoding **in parallel** with Gemini vision — no added latency
- Visual matches merged with text matches (boosted if both agree), falls back gracefully if CLIP unavailable
- Frontend shows "visual search" badge and per-match similarity percentage

## Deployment steps
1. Run SQL migration: `node scripts/migration/run-supabase-sql.mjs scripts/migration/clip-embeddings-schema.sql`
2. Install `@xenova/transformers` on Hetzner (already installed for e5-base)
3. Start CLIP server: `node scripts/workers/clip-server.mjs` (port 3457)
4. Run backfill: `node scripts/backfill-clip-embeddings.mjs`
5. Merge and deploy

## Test plan
- [ ] Verify CLIP server starts and `/health` endpoint responds
- [ ] Run backfill with `--dry-run` first to check counts
- [ ] Test /identify with Drebbel Arithmetic print — should get visual match
- [ ] Test /identify with an image not in the collection — should gracefully show "Not found"
- [ ] Verify existing text-only search still works when CLIP server is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)