### PR TITLE
Add artist pages for visual creators

### DIFF
--- a/src/app/artist/[name]/page.tsx
+++ b/src/app/artist/[name]/page.tsx
@@ -1,0 +1,414 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { getDb } from '@/lib/mongodb';
+import { notFound, redirect } from 'next/navigation';
+import { bookUrl, authorSlug, authorUrl } from '@/lib/slugify';
+import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
+import { ObjectId, type Db } from 'mongodb';
+
+export const revalidate = 86400;
+export const dynamicParams = true;
+export async function generateStaticParams() {
+  return [];
+}
+
+interface Book {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  language: string;
+  published: string;
+  year?: number;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+  pages_count?: number;
+  resource_type?: string;
+}
+
+interface GalleryImage {
+  _id: string;
+  page_id: string;
+  book_id: string;
+  page_number: number;
+  image_url?: string;
+  thumbnail_url?: string;
+  extracted_url?: string;
+  description?: string;
+  type?: string;
+  gallery_quality?: number;
+  book_title?: string;
+  book_year?: number;
+  extracted_width?: number;
+  extracted_height?: number;
+}
+
+interface ArtistEntity {
+  _id: ObjectId;
+  name: string;
+  canonical_name?: string;
+  description?: string;
+  aliases?: string[];
+  viaf_id?: string;
+  wikidata_id?: string;
+  wikipedia_url?: string;
+  wikidata_birth_date?: string;
+  wikidata_death_date?: string;
+  portrait_url?: string;
+}
+
+async function getPortraitUrl(db: Db, entity: ArtistEntity | null): Promise<string | null> {
+  if (!entity) return null;
+  if (entity.portrait_url) return entity.portrait_url;
+  if (!entity.wikidata_id) return null;
+
+  try {
+    const res = await fetch(
+      `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${entity.wikidata_id}&props=claims&format=json`,
+      { next: { revalidate: 86400 } }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    const filename = data.entities?.[entity.wikidata_id]?.claims?.P18?.[0]?.mainsnak?.datavalue?.value;
+    if (!filename) return null;
+
+    const thumbUrl = `https://commons.wikimedia.org/w/thumb.php?f=${encodeURIComponent(filename)}&w=300`;
+
+    db.collection('entities').updateOne(
+      { _id: entity._id },
+      { $set: { portrait_url: thumbUrl } }
+    ).catch(() => {});
+
+    return thumbUrl;
+  } catch {
+    return null;
+  }
+}
+
+interface ArtistPageProps {
+  params: Promise<{ name: string }>;
+}
+
+const BOOK_PROJECTION = {
+  _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
+  author_entity_id: 1, language: 1, published: 1, thumbnail: 1, thumbnail_blob: 1,
+  pages_count: 1, year: 1, resource_type: 1,
+};
+
+async function loadArtistData(db: Db, slug: string): Promise<{
+  artistName: string;
+  entity: ArtistEntity | null;
+  books: Book[];
+  galleryImages: GalleryImage[];
+  hasAuthorPage: boolean;
+} | null> {
+  // Look up from system_config author_slugs cache (artists share the same slug space)
+  const config = await db.collection('system_config').findOne(
+    { _id: 'author_slugs' as any },
+    { projection: { slugs: 1 } }
+  );
+
+  let artistName: string | undefined;
+  if (config?.slugs?.[slug]) {
+    artistName = config.slugs[slug];
+  } else {
+    const guess = slug.split('-').map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    const check = await db.collection('books').findOne(
+      { author: guess, visible: true },
+      { projection: { _id: 1 } }
+    );
+    if (check) artistName = guess;
+  }
+
+  if (!artistName) return null;
+
+  // Find all books by this author
+  const allBooks = await db.collection('books').find(
+    { author: artistName, visible: true },
+    { projection: BOOK_PROJECTION }
+  ).sort({ year: 1, title: 1 }).toArray() as unknown as (Book & { author_entity_id?: string })[];
+
+  // Check if this author has any visual works
+  const visualBooks = allBooks.filter(b => b.resource_type && VISUAL_RESOURCE_TYPES.includes(b.resource_type));
+  const textBooks = allBooks.filter(b => !b.resource_type || !VISUAL_RESOURCE_TYPES.includes(b.resource_type));
+
+  if (visualBooks.length === 0) {
+    // Not an artist — no visual works at all
+    return null;
+  }
+
+  // Resolve entity
+  let entity: ArtistEntity | null = null;
+  const entityBookId = allBooks.find((b: any) => b.author_entity_id)?.author_entity_id;
+  if (entityBookId) {
+    try {
+      entity = await db.collection('entities').findOne(
+        { _id: new ObjectId(String(entityBookId)) },
+        { projection: { name: 1, canonical_name: 1, description: 1, aliases: 1, viaf_id: 1, wikidata_id: 1, wikipedia_url: 1, wikidata_birth_date: 1, wikidata_death_date: 1, portrait_url: 1 } }
+      ) as ArtistEntity | null;
+    } catch { /* invalid ObjectId */ }
+  }
+
+  // Fetch gallery images for this artist's books
+  const bookIds = allBooks.map(b => b.id);
+  const galleryImages = await db.collection('gallery_images').find(
+    { book_id: { $in: bookIds }, book_visible: true, extracted_url: { $exists: true, $ne: null } },
+    { projection: { page_id: 1, book_id: 1, page_number: 1, image_url: 1, thumbnail_url: 1, extracted_url: 1, description: 1, type: 1, gallery_quality: 1, book_title: 1, book_year: 1, extracted_width: 1, extracted_height: 1 } }
+  ).sort({ gallery_quality: -1 }).limit(60).toArray() as unknown as GalleryImage[];
+
+  const displayName = entity?.canonical_name || entity?.name || artistName;
+
+  return {
+    artistName: displayName,
+    entity,
+    books: visualBooks as Book[],
+    galleryImages,
+    hasAuthorPage: textBooks.length > 0,
+  };
+}
+
+export async function generateMetadata({ params }: ArtistPageProps): Promise<Metadata> {
+  const { name } = await params;
+  const decoded = decodeURIComponent(name);
+  const artistName = decoded !== name
+    ? decoded
+    : name.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+  return {
+    title: `${artistName} — Artist — Source Library`,
+    description: `Visual works by ${artistName} in Source Library's collection of rare historical prints, paintings, and drawings, digitized and catalogued with AI.`,
+    alternates: { canonical: `/artist/${name}` },
+    openGraph: {
+      title: `${artistName} — Artist — Source Library`,
+      description: `Visual works by ${artistName} in Source Library`,
+    },
+  };
+}
+
+export default async function ArtistPage({ params }: ArtistPageProps) {
+  const { name } = await params;
+  const decoded = decodeURIComponent(name);
+
+  if (decoded !== name) {
+    redirect(`/artist/${authorSlug(decoded)}`);
+  }
+
+  const db = await getDb();
+  const data = await loadArtistData(db, name);
+  if (!data) notFound();
+
+  const { artistName, entity, books, galleryImages, hasAuthorPage } = data;
+
+  const years = books.map(b => b.published).filter(Boolean).map(p => parseInt(p)).filter(y => !isNaN(y));
+  const yearRange = years.length > 0
+    ? years.length === 1 || Math.min(...years) === Math.max(...years)
+      ? `${Math.min(...years)}`
+      : `${Math.min(...years)}–${Math.max(...years)}`
+    : null;
+
+  const birthYear = entity?.wikidata_birth_date?.split('-')[0];
+  const deathYear = entity?.wikidata_death_date?.split('-')[0];
+  const lifeDates = birthYear ? `${birthYear}–${deathYear || '?'}` : null;
+
+  const portraitUrl = await getPortraitUrl(db, entity);
+
+  const wikipediaUrl = entity?.wikipedia_url
+    || (entity?.wikidata_id ? `https://www.wikidata.org/wiki/Special:GoToLinkedPage/enwiki/${entity.wikidata_id}` : null);
+
+  const nameVariants = entity?.aliases?.length
+    ? entity.aliases.filter(a => a.toLowerCase() !== artistName.toLowerCase())
+    : [];
+  const bookVariants = [...new Set(books.map(b => b.author))]
+    .filter(a => a && a !== artistName && !nameVariants.some(v => v.toLowerCase() === a.toLowerCase()));
+  const allVariants = [...nameVariants, ...bookVariants].slice(0, 8);
+
+  // Medium breakdown
+  const mediaCounts = new Map<string, number>();
+  for (const b of books) {
+    if (b.resource_type) mediaCounts.set(b.resource_type, (mediaCounts.get(b.resource_type) || 0) + 1);
+  }
+  const media = [...mediaCounts.entries()].sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Artists', href: '/browse/artists' }]} />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">
+        <div className="max-w-5xl mx-auto px-4 py-12 sm:py-16 flex gap-8 items-start">
+          {portraitUrl && (
+            <div className="hidden sm:block shrink-0 w-28 h-36 rounded-lg overflow-hidden bg-stone-700">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={portraitUrl}
+                alt={`Portrait of ${artistName}`}
+                className="w-full h-full object-cover"
+                loading="lazy"
+              />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-xs uppercase tracking-widest text-stone-400 mb-1">Artist</p>
+            <h1 className="text-3xl sm:text-4xl font-display font-bold">
+              {artistName}
+            </h1>
+            {lifeDates && (
+              <p className="text-stone-400 mt-1 text-lg">{lifeDates}</p>
+            )}
+            {!lifeDates && yearRange && (
+              <p className="text-stone-400 mt-1">fl. {yearRange}</p>
+            )}
+            {entity?.description && (
+              <p className="text-stone-300 mt-3 text-sm max-w-2xl leading-relaxed">
+                {entity.description}
+              </p>
+            )}
+            {allVariants.length > 0 && (
+              <p className="text-stone-500 mt-2 text-xs">
+                Also known as: {allVariants.join(' · ')}
+              </p>
+            )}
+
+            {/* Stats row */}
+            <div className="flex flex-wrap items-center gap-4 mt-5 text-sm">
+              <span className="text-accent-gold font-medium">
+                {books.length} work{books.length !== 1 ? 's' : ''}
+              </span>
+              {galleryImages.length > 0 && (
+                <span className="text-stone-400">
+                  {galleryImages.length} extracted image{galleryImages.length !== 1 ? 's' : ''}
+                </span>
+              )}
+              {media.length > 0 && (
+                <span className="text-stone-400">
+                  {media.map(([type, count]) => `${count} ${type}${count !== 1 ? 's' : ''}`).join(', ')}
+                </span>
+              )}
+            </div>
+
+            {/* External links */}
+            <div className="flex flex-wrap gap-2 mt-5">
+              {hasAuthorPage && (
+                <Link
+                  href={authorUrl(artistName) || '#'}
+                  className="inline-block px-3 py-1.5 text-sm bg-accent-rust/20 text-accent-gold hover:bg-accent-rust/30 rounded-full transition-colors"
+                >
+                  Author page
+                </Link>
+              )}
+              {wikipediaUrl && (
+                <a
+                  href={wikipediaUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-3 py-1.5 text-sm bg-stone-700/50 text-stone-300 hover:bg-stone-700 rounded-full transition-colors"
+                >
+                  Wikipedia
+                </a>
+              )}
+              {entity?.viaf_id && (
+                <a
+                  href={`https://viaf.org/viaf/${entity.viaf_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-3 py-1.5 text-sm bg-stone-700/50 text-stone-300 hover:bg-stone-700 rounded-full transition-colors"
+                >
+                  VIAF
+                </a>
+              )}
+              {entity?.wikidata_id && (
+                <a
+                  href={`https://www.wikidata.org/wiki/${entity.wikidata_id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-3 py-1.5 text-sm bg-stone-700/50 text-stone-300 hover:bg-stone-700 rounded-full transition-colors"
+                >
+                  Wikidata
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Gallery grid of extracted images */}
+      {galleryImages.length > 0 && (
+        <div className="border-b" style={{ borderColor: 'var(--border-light)', background: 'var(--bg-warm)' }}>
+          <div className="max-w-6xl mx-auto px-6 md:px-12 py-8">
+            <h2 className="text-lg font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+              Images
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+              {galleryImages.map(img => {
+                const src = img.extracted_url || img.thumbnail_url || img.image_url;
+                if (!src) return null;
+                return (
+                  <Link
+                    key={img._id?.toString()}
+                    href={`/book/${img.book_id}?page=${img.page_number}`}
+                    className="group"
+                  >
+                    <div className="relative aspect-square rounded overflow-hidden bg-stone-200">
+                      <Image
+                        src={src}
+                        alt={img.description || `Image from ${img.book_title || 'unknown'}`}
+                        fill
+                        className="object-cover group-hover:scale-105 transition-transform duration-300"
+                        sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
+                      />
+                    </div>
+                    {img.description && (
+                      <p className="text-[11px] mt-1 line-clamp-2 leading-snug" style={{ color: 'var(--text-faint)' }}>
+                        {img.description}
+                      </p>
+                    )}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Works bibliography */}
+      <main className="max-w-6xl mx-auto px-6 md:px-12 py-8 md:py-12">
+        <h2 className="text-lg font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+          Works in Collection
+        </h2>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          {books.map(book => (
+            <Link key={book.id} href={bookUrl(book)} className="group">
+              <div className="aspect-[3/4] relative rounded overflow-hidden bg-stone-200">
+                {(book.thumbnail_blob || book.thumbnail) ? (
+                  <Image
+                    src={(book.thumbnail_blob || book.thumbnail)!}
+                    alt={book.display_title || book.title}
+                    fill
+                    className="object-cover group-hover:scale-105 transition-transform duration-300"
+                    sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center p-3">
+                    <p className="text-[10px] text-center" style={{ color: 'var(--text-faint)' }}>
+                      {book.display_title || book.title}
+                    </p>
+                  </div>
+                )}
+              </div>
+              <p className="text-xs mt-1.5 font-medium line-clamp-2" style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-serif)' }}>
+                {book.display_title || book.title}
+              </p>
+              <p className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                {book.year || book.published || ''}
+                {book.resource_type && <span className="ml-1 opacity-60">· {book.resource_type}</span>}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -4,8 +4,9 @@ import Image from 'next/image';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { getDb } from '@/lib/mongodb';
 import { notFound, redirect } from 'next/navigation';
-import { bookUrl, authorSlug } from '@/lib/slugify';
+import { bookUrl, authorSlug, artistUrl } from '@/lib/slugify';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId, type Db } from 'mongodb';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
@@ -102,7 +103,7 @@ const BOOK_PROJECTION = {
   author_entity_id: 1, language: 1, published: 1, thumbnail: 1, thumbnail_blob: 1,
   pages_count: 1, pages_ocr: 1, pages_translated: 1, pages_blank: 1, year: 1,
   summary: 1, is_first_translation: 1, ft_disposition: 1,
-  publisher: 1, place_of_publication: 1,
+  publisher: 1, place_of_publication: 1, resource_type: 1,
   'image_source.contributing_library': 1, 'image_source.provider_name': 1,
 };
 
@@ -296,6 +297,9 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     .filter(a => a && a !== authorName && !nameVariants.some(v => v.toLowerCase() === a.toLowerCase()));
   const allVariants = [...nameVariants, ...bookVariants].slice(0, 8);
 
+  // Check if this author also has visual works (show artist page link)
+  const hasVisualWorks = books.some((b: any) => b.resource_type && VISUAL_RESOURCE_TYPES.includes(b.resource_type));
+
   // Language breakdown for stats
   const langCounts = new Map<string, number>();
   for (const b of books) {
@@ -356,6 +360,14 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
 
           {/* External links */}
           <div className="flex flex-wrap gap-2 mt-5">
+            {hasVisualWorks && artistUrl(authorName) && (
+              <Link
+                href={artistUrl(authorName)!}
+                className="inline-block px-3 py-1.5 text-sm bg-accent-rust/20 text-accent-gold hover:bg-accent-rust/30 rounded-full transition-colors"
+              >
+                Artist page
+              </Link>
+            )}
             {encyclopediaEntity && (
               <Link
                 href={`/encyclopedia/${encodeURIComponent(encyclopediaEntity.name)}`}

--- a/src/app/browse/artists/[letter]/page.tsx
+++ b/src/app/browse/artists/[letter]/page.tsx
@@ -1,0 +1,100 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { authorSlug } from '@/lib/slugify';
+import { browseArtists } from '@/lib/books-catalog';
+import { notFound } from 'next/navigation';
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+export const revalidate = 86400;
+export const maxDuration = 60;
+export const dynamicParams = true;
+
+export function generateStaticParams() {
+  return [];
+}
+
+interface PageProps {
+  params: Promise<{ letter: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { letter } = await params;
+  const l = letter.toUpperCase();
+  return {
+    title: `Artists starting with ${l} - Source Library`,
+    description: `Browse visual artists in Source Library whose names begin with the letter ${l}.`,
+    alternates: { canonical: `/browse/artists/${l}` },
+  };
+}
+
+export default async function BrowseArtistsPage({ params }: PageProps) {
+  const { letter } = await params;
+  const l = letter.toUpperCase();
+  if (l.length !== 1 || !/[A-Z]/.test(l)) notFound();
+
+  let artists: { name: string; count: number }[] = [];
+  try {
+    artists = await browseArtists(l);
+  } catch {
+    // Supabase error — render empty page
+  }
+
+  return (
+    <>
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Browse', href: '/browse' }]} />
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+        Artists: {l}
+      </h1>
+      <p className="text-sm mb-8" style={{ color: 'var(--text-muted)' }}>
+        {artists.length.toLocaleString('en-US')} {artists.length === 1 ? 'artist' : 'artists'}
+      </p>
+
+      {/* Letter nav */}
+      <div className="flex flex-wrap gap-1.5 mb-10">
+        {LETTERS.map(lt => (
+          <Link
+            key={lt}
+            href={`/browse/artists/${lt}`}
+            className={`w-8 h-8 flex items-center justify-center rounded text-xs font-medium transition-colors ${
+              lt === l ? 'text-white' : 'hover:opacity-70'
+            }`}
+            style={lt === l
+              ? { background: 'var(--text-primary)', color: '#fff' }
+              : { color: 'var(--text-muted)' }
+            }
+          >
+            {lt}
+          </Link>
+        ))}
+      </div>
+
+      {/* Artist list */}
+      <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+        {artists.map(artist => (
+          <Link
+            key={artist.name}
+            href={`/artist/${authorSlug(artist.name)}`}
+            className="flex items-baseline justify-between py-3 hover:opacity-70 transition-opacity"
+          >
+            <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
+              {artist.name}
+            </p>
+            <p className="text-xs tabular-nums" style={{ color: 'var(--text-muted)' }}>
+              {artist.count} {artist.count === 1 ? 'work' : 'works'}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      {artists.length === 0 && (
+        <p className="py-12 text-center" style={{ color: 'var(--text-muted)' }}>
+          No artists found starting with {l}.
+        </p>
+      )}
+    </div>
+    </>
+  );
+}

--- a/src/app/browse/artists/page.tsx
+++ b/src/app/browse/artists/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function BrowseArtistsIndex() {
+  redirect('/browse/artists/A');
+}

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -70,6 +70,28 @@ export default function BrowsePage() {
         </div>
       </section>
 
+      {/* By Artist */}
+      <section className="mb-12">
+        <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+          By Artist
+        </h2>
+        <p className="text-sm mb-4" style={{ color: 'var(--text-muted)' }}>
+          Painters, engravers, and printmakers in the collection.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {LETTERS.map(letter => (
+            <Link
+              key={letter}
+              href={`/browse/artists/${letter}`}
+              className="w-10 h-10 flex items-center justify-center rounded-lg text-sm font-medium transition-colors hover:opacity-80"
+              style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-light)' }}
+            >
+              {letter}
+            </Link>
+          ))}
+        </div>
+      </section>
+
       {/* By Period */}
       <section className="mb-12">
         <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -223,6 +223,47 @@ export async function browseAuthors(letter: string): Promise<{ name: string; cou
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** Visual resource types that identify an artist (vs text author) */
+export const VISUAL_RESOURCE_TYPES = ['painting', 'drawing', 'print', 'fresco', 'engraving', 'woodcut'];
+
+/**
+ * Browse artists by letter prefix.
+ * Artists are authors of visual works (paintings, prints, drawings, etc.).
+ * Returns alphabetically sorted list of { name, count }.
+ */
+export async function browseArtists(letter: string): Promise<{ name: string; count: number }[]> {
+  const allRows: { author: string | null }[] = [];
+  const PAGE = 1000;
+  let offset = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { data, error } = await supabase
+      .from('books_catalog')
+      .select('author')
+      .eq('visible', true)
+      .gt('pages_count', 0)
+      .in('resource_type', VISUAL_RESOURCE_TYPES)
+      .ilike('author', `${letter}%`)
+      .range(offset, offset + PAGE - 1);
+
+    if (error) throw new Error(`browseArtists query failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    allRows.push(...data);
+    if (data.length < PAGE) break;
+    offset += PAGE;
+  }
+
+  const counts = new Map<string, number>();
+  for (const row of allRows) {
+    if (row.author) counts.set(row.author, (counts.get(row.author) || 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 /**
  * Search books by title/author text — returns matching book IDs.
  *

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -145,3 +145,9 @@ export function authorUrl(author: string): string | null {
   if (!author || author === 'Unknown' || author === 'Anonymous') return null;
   return `/author/${authorSlug(author)}`;
 }
+
+/** Artist page URL — same slug logic as authors */
+export function artistUrl(artist: string): string | null {
+  if (!artist || artist === 'Unknown' || artist === 'Anonymous') return null;
+  return `/artist/${authorSlug(artist)}`;
+}


### PR DESCRIPTION
## Summary
- New `/artist/[name]` pages for painters, engravers, and printmakers — gallery grid of visual works + extracted images from `gallery_images` collection
- `/browse/artists/[letter]` browse pages querying books with visual `resource_type` (painting, print, drawing, fresco, engraving, woodcut)
- "By Artist" section added to `/browse` index
- Author pages now cross-link to artist pages when the author has visual works
- 6,463 visible visual works across 172 distinct artists

## Implementation
- `browseArtists()` in `books-catalog.ts` — queries Supabase `books_catalog` filtered by visual `resource_type`
- Artist page loads books by author name, filters to visual resource types, fetches top 60 `gallery_images` sorted by `gallery_quality`
- Reuses entity resolution from author pages (shared slug space via `authorSlug()`)
- `artistUrl()` helper in `slugify.ts`

## Test plan
- [ ] Visit `/artist/albrecht-durer` — should show gallery grid of Dürer prints
- [ ] Visit `/browse/artists/A` — should list artists starting with A
- [ ] Visit `/browse` — should show "By Artist" section with A-Z nav
- [ ] Visit an author page for someone with visual works (e.g., Leonardo da Vinci) — should show "Artist page" link
- [ ] Visit `/artist/marsilio-ficino` — should 404 (not a visual artist)

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)