### PR TITLE
Route 112 user-facing reads to secondary replicas

### DIFF
--- a/src/app/about/processing/page.tsx
+++ b/src/app/about/processing/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const metadata: Metadata = {
   title: 'How Processing Works | Source Library',
@@ -18,7 +18,7 @@ export const maxDuration = 60;
 
 async function getStats() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const books = db.collection('books');
 
     const maxTimeMS = 45000;

--- a/src/app/about/progress/page.tsx
+++ b/src/app/about/progress/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import Link from 'next/link';
 import ContentPageLayout, { SubPageHeader } from '@/components/layout/ContentPageLayout';
@@ -89,7 +89,7 @@ async function getCoverageData(): Promise<CoverageData | null> {
 /** Fallback: read from MongoDB catalog_coverage_meta if Supabase RPC fails */
 async function getCoverageDataFallback(): Promise<CoverageData | null> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const meta = await db.collection('catalog_coverage_meta').findOne({ _id: 'latest_build' as any });
     if (!meta) return null;
 

--- a/src/app/api/analytics/canon/route.ts
+++ b/src/app/api/analytics/canon/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { withAuth } from '@/lib/auth-helpers';
 
@@ -25,7 +25,7 @@ export const GET = withAuth(async () => {
       return NextResponse.json(cache.data);
     }
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // All queries use book-level cached counts (fast, no pages scan)
     const [

--- a/src/app/api/analytics/stats/route.ts
+++ b/src/app/api/analytics/stats/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 // In-memory cache for global stats (called on every page load via footer)
 let globalStatsCache: { data: Record<string, unknown>; timestamp: number } | null = null;
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const bookId = searchParams.get('book_id');
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     if (bookId) {
       // Get stats for specific book

--- a/src/app/api/auth/oidc/debug/route.ts
+++ b/src/app/api/auth/oidc/debug/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
 
 export const dynamic = 'force-dynamic';
 
 export const GET = withAdminAuth(async () => {
-  const db = await getDb();
+  const db = await getReadDb();
   const count = await db.collection('oidc_auth_codes').countDocuments();
   return NextResponse.json({
     version: 'mongodb-v3',

--- a/src/app/api/batch-jobs/[id]/route.ts
+++ b/src/app/api/batch-jobs/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 /**
@@ -10,7 +10,7 @@ export const GET = withAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
 
-    const db = await getDb();
+    const db = await getReadDb();
     const job = await db.collection('batch_jobs').findOne({ id });
 
     if (!job) {

--- a/src/app/api/batch-jobs/list/route.ts
+++ b/src/app/api/batch-jobs/list/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import type { BatchJob } from '@/lib/types/batch-job';
 import { withAuth } from '@/lib/auth-helpers';
 
@@ -16,7 +16,7 @@ export const GET = withAuth(async (request, session) => {
     const { searchParams } = new URL(request.url);
     const limit = parseInt(searchParams.get('limit') || '100');
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Only fetch PARENT jobs (for UI display)
     // Child jobs are tracked internally but not shown in the main list

--- a/src/app/api/books/[id]/qa/route.ts
+++ b/src/app/api/books/[id]/qa/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { validateTranslation, ValidationIssue } from '@/lib/validateTranslation';
 import { withAuth } from '@/lib/auth-helpers';
 
@@ -13,7 +13,7 @@ interface PageIssue {
 export const GET = withAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get book to verify it exists
     const book = await db.collection('books').findOne({ id });

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
@@ -139,7 +139,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Invalid page number' }, { status: 400 });
     }
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get book by id, slug, or _id
     let book = await db.collection('books').findOne({ id: bookId }) as unknown as Book | null;

--- a/src/app/api/books/facets/route.ts
+++ b/src/app/api/books/facets/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
 
 /**
@@ -24,7 +24,7 @@ import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const db = await getDb();
+  const db = await getReadDb();
 
   const countsOnly = searchParams.get('counts') === 'true';
 

--- a/src/app/api/books/status/route.ts
+++ b/src/app/api/books/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 interface BookStatus {
   id: string;
@@ -19,7 +19,7 @@ interface BookStatus {
 // GET /api/books/status - Get summary readiness status for all books
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Aggregate book data with page counts
     const books = await db.collection('books').aggregate([

--- a/src/app/api/books/timeline/route.ts
+++ b/src/app/api/books/timeline/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
     const language = searchParams.get('language') || '';
     const collection = searchParams.get('collection') || '';
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Base filter: has year, not hidden
     const baseMatch: Record<string, unknown> = {

--- a/src/app/api/catalog/coverage/route.ts
+++ b/src/app/api/catalog/coverage/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
@@ -21,7 +21,7 @@ export const dynamic = 'force-dynamic';
  */
 export async function GET(request: NextRequest) {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const { searchParams } = new URL(request.url);
     const mode = searchParams.get('mode') || 'summary';
 

--- a/src/app/api/catalog/route.ts
+++ b/src/app/api/catalog/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get all books with projection (use cached pages_count and reading_summary)
     const books = await db.collection('books')

--- a/src/app/api/catalog/search/route.ts
+++ b/src/app/api/catalog/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Split query into words and search for all of them
     const words = query.split(/\s+/).filter(w => w.length >= 2);

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { LIBRARY_CATEGORIES } from '../route';
 
 // GET /api/categories/[id] - Get books in a category
@@ -9,7 +9,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Find the category
     const category = LIBRARY_CATEGORIES.find(c => c.id === id);

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { browseBooks, type SortOption } from '@/lib/books-catalog';
 
 export const maxDuration = 30;
@@ -32,7 +32,7 @@ export async function GET(
     const limit = Math.min(parseInt(searchParams.get('limit') || '60'), 200);
     const offset = parseInt(searchParams.get('offset') || '0');
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get collection metadata from MongoDB (small doc, fast)
     const collection = await db.collection('collections').findOne({ slug: id });

--- a/src/app/api/comparisons/stats/route.ts
+++ b/src/app/api/comparisons/stats/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 // GET /api/comparisons/stats - Get win rates between experiments
 export const GET = withAuth(async (request, session) => {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const { searchParams } = new URL(request.url);
     const experimentA = searchParams.get('experiment_a');
     const experimentB = searchParams.get('experiment_b');

--- a/src/app/api/contribute/books/route.ts
+++ b/src/app/api/contribute/books/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { ContributeBook } from '@/lib/api-client';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     const searchParams = request.nextUrl.searchParams;
     const type = searchParams.get('type') || 'ocr';

--- a/src/app/api/contribute/stats/route.ts
+++ b/src/app/api/contribute/stats/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,7 +11,7 @@ interface Contribution {
 
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get aggregated contributor stats
     const stats = await db.collection('contributions').aggregate([

--- a/src/app/api/dataset/v1/books/route.ts
+++ b/src/app/api/dataset/v1/books/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { validateApiKey } from '@/lib/dataset/api-keys';
 
 export const maxDuration = 15;
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const filter: any = { visible: true, pages_count: { $gt: 0 } };
   if (language) filter.language = language;
   if (cluster) filter['taxonomy.cluster'] = cluster;

--- a/src/app/api/dataset/v1/pages/route.ts
+++ b/src/app/api/dataset/v1/pages/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { validateApiKey } from '@/lib/dataset/api-keys';
 import { logAccess, getDailyPageCount } from '@/lib/dataset/access-logger';
 import { DatasetPageRecord } from '@/lib/dataset/types';
@@ -69,7 +69,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Build book filter
   const bookFilter: any = { visible: true };

--- a/src/app/api/dataset/v1/stats/route.ts
+++ b/src/app/api/dataset/v1/stats/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 15;
@@ -11,7 +11,7 @@ export const maxDuration = 15;
  * Returns corpus statistics for the marketing page and API consumers.
  */
 export async function GET() {
-  const db = await getDb();
+  const db = await getReadDb();
   const books = db.collection('books');
   const visible = { visible: true };
 

--- a/src/app/api/debug/book-order/route.ts
+++ b/src/app/api/debug/book-order/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 export const dynamic = 'force-dynamic';
 
 export const GET = withAuth(async (request, session) => {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     const books = await db.collection('books').aggregate([
       {

--- a/src/app/api/dts/collection/route.ts
+++ b/src/app/api/dts/collection/route.ts
@@ -16,7 +16,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 const BASE = 'https://sourcelibrary.org';
 const PAGE_SIZE = 50;
@@ -121,7 +121,7 @@ export async function GET(request: NextRequest) {
     const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
     const nav = searchParams.get('nav') || 'children';
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // No id → return root collection
     if (!id) {

--- a/src/app/api/dts/document/route.ts
+++ b/src/app/api/dts/document/route.ts
@@ -13,7 +13,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 
 const BASE = 'https://sourcelibrary.org';
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     const book = await db.collection('books').findOne(
       { $or: [{ id: resourceId }, { slug: resourceId }] },

--- a/src/app/api/dts/navigation/route.ts
+++ b/src/app/api/dts/navigation/route.ts
@@ -20,7 +20,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -93,7 +93,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     const book = await db.collection('books').findOne(
       { $or: [{ id: resourceId }, { slug: resourceId }] },

--- a/src/app/api/embassy/threads/[id]/route.ts
+++ b/src/app/api/embassy/threads/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 
 /**
@@ -16,7 +16,7 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid thread ID' }, { status: 400 });
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
 
   const thread = await db.collection('embassy_threads').findOne({
     _id: new ObjectId(id),

--- a/src/app/api/embassy/threads/route.ts
+++ b/src/app/api/embassy/threads/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 /**
  * GET /api/embassy/threads — List public Embassy threads (activity feed).
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(parseInt(url.searchParams.get('limit') || '20'), 50);
   const offset = parseInt(url.searchParams.get('offset') || '0');
 
-  const db = await getDb();
+  const db = await getReadDb();
 
   const threads = await db.collection('embassy_threads')
     .find({ visibility: 'public', messageCount: { $gte: 2 } }) // Only show threads with at least one exchange

--- a/src/app/api/experiments/ocr-quality/[id]/results/route.ts
+++ b/src/app/api/experiments/ocr-quality/[id]/results/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 // ELO rating calculation
@@ -66,7 +66,7 @@ function normalCDF(z: number): number {
 export const GET = withAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get experiment (for condition labels)
     const experiment = await db.collection('ocr_experiments').findOne({ id });

--- a/src/app/api/experiments/ocr-quality/[id]/route.ts
+++ b/src/app/api/experiments/ocr-quality/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { getOcrPrompt } from '@/lib/prompts';
 import { withAuth } from '@/lib/auth-helpers';
 
@@ -8,7 +8,7 @@ export const GET = withAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
 
-    const db = await getDb();
+    const db = await getReadDb();
     const experiment = await db.collection('ocr_experiments').findOne({ id });
 
     if (!experiment) {

--- a/src/app/api/explore/map/route.ts
+++ b/src/app/api/explore/map/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,7 +11,7 @@ export const dynamic = 'force-dynamic';
  */
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get all entities with coordinates — lookup books for century data
     const entities = await db.collection('entities').aggregate([

--- a/src/app/api/feed/books/route.ts
+++ b/src/app/api/feed/books/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const preferredRegion = 'fra1';
@@ -16,7 +16,7 @@ function escapeXml(text: string): string {
 }
 
 export async function GET() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   const books = await db.collection('books')
     .find({ visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } })

--- a/src/app/api/feed/gallery/route.ts
+++ b/src/app/api/feed/gallery/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const preferredRegion = 'fra1';
@@ -16,7 +16,7 @@ function escapeXml(text: string): string {
 }
 
 export async function GET() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Find the 50 most recent high-quality gallery images from materialized collection
   const rawImages = await db.collection('gallery_images')

--- a/src/app/api/ficino/discussions/[id]/route.ts
+++ b/src/app/api/ficino/discussions/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 
 /**
@@ -15,7 +15,7 @@ export async function GET(
     return NextResponse.json({ error: 'Sign in required' }, { status: 401 });
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const user = await db.collection('users').findOne(
     { _id: session.user.id as any },
     { projection: { membership: 1 } }

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { generateQueryEmbedding, cosineSimilarity } from '@/lib/embeddings';
 
 export const maxDuration = 30;
@@ -79,7 +79,7 @@ export async function GET(request: NextRequest) {
     if (includeArchive) minQuality = 0.5;
     if (searchParams.get('minQuality')) minQuality = parseFloat(searchParams.get('minQuality')!);
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Check if gallery_images collection exists and has data
     const galleryCount = await db.collection('gallery_images').estimatedDocumentCount();
@@ -273,7 +273,7 @@ export async function GET(request: NextRequest) {
 /**
  * Get filter options from gallery_images (cached for 30 min)
  */
-async function getGalleryFilters(db: Awaited<ReturnType<typeof getDb>>) {
+async function getGalleryFilters(db: Awaited<ReturnType<typeof getReadDb>>) {
   if (cachedFilters && (Date.now() - cachedFilters.timestamp) < FILTER_CACHE_TTL_MS) {
     return cachedFilters.data;
   }
@@ -310,7 +310,7 @@ async function getGalleryFilters(db: Awaited<ReturnType<typeof getDb>>) {
 /**
  * Get book info for book-filtered gallery views
  */
-async function getBookInfo(db: Awaited<ReturnType<typeof getDb>>, bookId: string) {
+async function getBookInfo(db: Awaited<ReturnType<typeof getReadDb>>, bookId: string) {
   const book = await db.collection('books').findOne({ id: bookId });
   if (!book) return null;
 
@@ -347,7 +347,7 @@ async function semanticGallerySearch(searchParams: URLSearchParams, query: strin
   const offset = parseInt(searchParams.get('offset') || '0');
   const imageType = searchParams.get('type');
 
-  const db = await getDb();
+  const db = await getReadDb();
   const queryEmbedding = await generateQueryEmbedding(query);
 
   const candidates = await db
@@ -422,7 +422,7 @@ async function semanticGallerySearch(searchParams: URLSearchParams, query: strin
 /**
  * Legacy aggregation pipeline — used as fallback when gallery_images collection is empty.
  */
-async function legacyGalleryQuery(db: Awaited<ReturnType<typeof getDb>>, searchParams: URLSearchParams) {
+async function legacyGalleryQuery(db: Awaited<ReturnType<typeof getReadDb>>, searchParams: URLSearchParams) {
   const limit = Math.min(parseInt(searchParams.get('limit') || '24'), 200);
   const offset = parseInt(searchParams.get('offset') || '0');
   const bookId = searchParams.get('bookId') || searchParams.get('book');

--- a/src/app/api/gallery/wall/route.ts
+++ b/src/app/api/gallery/wall/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
@@ -22,7 +22,7 @@ export const maxDuration = 30;
  */
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Cap at 20K images with quality filter for manageable payload
     const LIMIT = 20_000;

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
@@ -10,7 +10,7 @@ export const maxDuration = 30;
  */
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     // Minimal ping — don't query a large collection
     await db.command({ ping: 1 });
 

--- a/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
+++ b/src/app/api/iiif/[id]/canvas/[pageNumber]/[type]/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -57,7 +57,7 @@ export async function GET(
       );
     }
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Fetch only the field we need
     const projection =

--- a/src/app/api/iiif/[id]/manifest/route.ts
+++ b/src/app/api/iiif/[id]/manifest/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 const BASE = 'https://sourcelibrary.org';
 
@@ -91,7 +91,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const db = await getDb();
+    const db = await getReadDb();
 
     const book = await db.collection('books').findOne({ id });
     if (!book) {

--- a/src/app/api/iiif/[id]/search/route.ts
+++ b/src/app/api/iiif/[id]/search/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 
 const BASE = 'https://sourcelibrary.org';
@@ -83,7 +83,7 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
       );
     }
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     const book = await db.collection('books').findOne(
       { $or: [{ id }, { slug: id }] },

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 
@@ -12,7 +12,7 @@ export const GET = withAuth(async (request, session) => {
     const bookId = searchParams.get('book_id');
     const limit = parseInt(searchParams.get('limit') || '50', 10);
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     const query: Record<string, unknown> = {};
     if (status) query.status = status;

--- a/src/app/api/likes/mine/route.ts
+++ b/src/app/api/likes/mine/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
 import { buildCropUrl } from '@/lib/social-image-selector';
 
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
 
     const limit = Math.min(parseInt(searchParams.get('limit') || '100'), 5000);
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     const myLikes = await db.collection('likes')
       .find({ visitor_id: visitorId, target_type: targetType })

--- a/src/app/api/likes/popular/route.ts
+++ b/src/app/api/likes/popular/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
 import { buildCropUrl } from '@/lib/social-image-selector';
 
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
     const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 50);
     const minLikes = parseInt(searchParams.get('min_likes') || '1');
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Get most liked targets
     const popularPipeline = [

--- a/src/app/api/membership/members/route.ts
+++ b/src/app/api/membership/members/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 /**
  * Public endpoint: returns all visible Ficino Society members.
  * Only shows members who have opted in (visible: true, the default).
  */
 export async function GET() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Include both free members (joined) and financial contributors (active)
   const members = await db.collection('users').find(

--- a/src/app/api/membership/route.ts
+++ b/src/app/api/membership/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getMembership } from '@/lib/membership';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export async function GET() {
   const session = await auth();
@@ -11,7 +11,7 @@ export async function GET() {
 
   const [membership, db] = await Promise.all([
     getMembership(session.user.id),
-    getDb(),
+    getReadDb(),
   ]);
 
   // Check if they've joined the Society (free) — separate from financial contribution

--- a/src/app/api/nde/dataset/route.ts
+++ b/src/app/api/nde/dataset/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic'; // Skip prerender — MongoDB times out during build
 
@@ -16,7 +16,7 @@ export const dynamic = 'force-dynamic'; // Skip prerender — MongoDB times out 
  * NDE's crawler periodically fetches this URL after registration.
  */
 export async function GET() {
-  const db = await getDb();
+  const db = await getReadDb();
   const books = db.collection('books');
 
   // Live stats for the BPH subset

--- a/src/app/api/oai/route.ts
+++ b/src/app/api/oai/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { Document } from 'mongodb';
 
 /**
@@ -185,7 +185,7 @@ function buildQuery(from?: string, until?: string, set?: string): Document {
 // ─── Verb handlers ───
 
 async function handleIdentify(now: string): Promise<NextResponse> {
-  const db = await getDb();
+  const db = await getReadDb();
   const earliest = await db.collection('books').findOne(
     { pages_count: { $gt: 0 } },
     { sort: { created_at: 1 }, projection: { created_at: 1 }, maxTimeMS: 15000 }
@@ -231,7 +231,7 @@ function handleListMetadataFormats(now: string): NextResponse {
 }
 
 async function handleListSets(now: string): Promise<NextResponse> {
-  const db = await getDb();
+  const db = await getReadDb();
   const categories = await db.collection('books').distinct('categories', { pages_count: { $gt: 0 } });
   const sets = categories
     .filter(Boolean)
@@ -280,7 +280,7 @@ async function handleListRecords(
     set = params.get('set') || undefined;
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const query = buildQuery(from, until, set);
   const total = await db.collection('books').countDocuments(query, { maxTimeMS: 30000 });
 
@@ -326,7 +326,7 @@ async function handleGetRecord(now: string, params: URLSearchParams): Promise<Ne
   const parts = identifier.split(':');
   const bookId = parts.length === 3 ? parts[2] : parts[parts.length - 1];
 
-  const db = await getDb();
+  const db = await getReadDb();
   const book = await db.collection('books').findOne({
     $or: [{ id: bookId }, { slug: bookId }],
   });

--- a/src/app/api/progress/route.ts
+++ b/src/app/api/progress/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -11,7 +11,7 @@ export const maxDuration = 60;
  */
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Book imports by week — small collection, fast
     const booksByWeek = await db.collection('books').aggregate([

--- a/src/app/api/redirect/book-page/route.ts
+++ b/src/app/api/redirect/book-page/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 
 /**
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/', request.url), 302);
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const result = await findBookByIdOrSlug(db, bookIdOrSlug, { id: 1, slug: 1 });
 
   if (!result) {

--- a/src/app/api/redirect/book-slug/route.ts
+++ b/src/app/api/redirect/book-slug/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 
 /**
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/', request.url), 302);
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const result = await findBookByIdOrSlug(db, bookIdOrSlug, { id: 1, slug: 1 });
 
   if (!result) {

--- a/src/app/api/research/[id]/route.ts
+++ b/src/app/api/research/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const maxDuration = 15;
 
@@ -22,7 +22,7 @@ export async function GET(
     const page = Math.max(1, parseInt(searchParams.get('page') || '1'));
     const perPage = Math.min(parseInt(searchParams.get('per_page') || '50'), 200);
 
-    const db = await getDb();
+    const db = await getReadDb();
     const session = await db.collection('curator_sessions').findOne({ id });
 
     if (!session) {

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const maxDuration = 15;
 
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
     const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);
     const offset = parseInt(searchParams.get('offset') || '0');
 
-    const db = await getDb();
+    const db = await getReadDb();
     const collection = db.collection('curator_sessions');
 
     // Build filter

--- a/src/app/api/scan/recent/route.ts
+++ b/src/app/api/scan/recent/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 /**
  * GET /api/scan/recent
@@ -11,7 +11,7 @@ import { getDb } from '@/lib/mongodb';
  */
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     const books = await db.collection('books')
       .find({

--- a/src/app/api/search/vocabulary/route.ts
+++ b/src/app/api/search/vocabulary/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const preferredRegion = 'fra1';
 
@@ -18,7 +18,7 @@ export async function GET() {
   const now = Date.now();
 
   if (!cachedVocabulary || now - cacheTimestamp > CACHE_TTL) {
-    const db = await getDb();
+    const db = await getReadDb();
     const books = await db.collection('books')
       .find(
         { visible: true, pages_count: { $gt: 0 } },

--- a/src/app/api/shwep/route.ts
+++ b/src/app/api/shwep/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { SHWEP_PERIODS, getAllTags } from '@/data/shwep-episodes';
 
 export const dynamic = 'force-dynamic';
@@ -26,7 +26,7 @@ interface MatchedBook {
  */
 export async function GET() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const allTags = getAllTags();
 
     // Build regex patterns for each tag to match against author and title fields

--- a/src/app/api/social/candidates/route.ts
+++ b/src/app/api/social/candidates/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { selectImagesForPosts, buildCropUrl } from '@/lib/social-image-selector';
 import { withAuth } from '@/lib/auth-helpers';
 
@@ -32,7 +32,7 @@ export const GET = withAuth(async (request: NextRequest) => {
     const excludeRecent = searchParams.get('excludeRecent') !== 'false';
     const recentDays = parseInt(searchParams.get('recentDays') || '30');
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     const candidates = await selectImagesForPosts(db, count, {
       minGalleryQuality: minQuality,

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 10;
@@ -19,7 +19,7 @@ export async function GET() {
   // 1. MongoDB ping
   let db;
   try {
-    db = await getDb();
+    db = await getReadDb();
     const t = Date.now();
     await db.command({ ping: 1 });
     latency.db_ping = Date.now() - t;

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 /**
@@ -26,7 +26,7 @@ export const GET = withAuth(async (request: NextRequest) => {
     const bookId = searchParams.get('book_id');
     const groupBy = searchParams.get('group_by');
 
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Build match query
     const match: Record<string, unknown> = {

--- a/src/app/artist/[name]/page.tsx
+++ b/src/app/artist/[name]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { notFound, redirect } from 'next/navigation';
 import { bookUrl, authorSlug, authorUrl } from '@/lib/slugify';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
@@ -196,7 +196,7 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
     redirect(`/artist/${authorSlug(decoded)}`);
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const data = await loadArtistData(db, name);
   if (!data) notFound();
 

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { isInnerCircle } from '@/lib/auth-helpers';
 import { Book } from '@/lib/types';
 import SiteHeader from '@/components/layout/SiteHeader';
@@ -14,7 +14,7 @@ interface PageProps {
 }
 
 async function getArtwork(slug: string) {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Try exact slug match, then with art- prefix
   const slugsToTry = [slug, `art-${slug}`];

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import { notFound, redirect } from 'next/navigation';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { isInnerCircle } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
@@ -22,7 +22,7 @@ function isNonArtist(name: string): boolean {
 }
 
 async function getArtist(slug: string) {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Slug can be "Leonardo-da-Vinci" (dashes) or "Leonardo%20da%20Vinci" (encoded)
   const artistName = decodeURIComponent(slug).replace(/-/g, ' ');

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import { redirect } from 'next/navigation';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { isInnerCircle } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
@@ -24,7 +24,7 @@ interface ArtCollection {
 }
 
 async function getData() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Only query the small collections table (19 docs) — fast and reliable.
   // Skip the expensive books aggregation that was causing timeouts.

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { notFound, redirect } from 'next/navigation';
 import { bookUrl, authorSlug, artistUrl } from '@/lib/slugify';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
@@ -253,7 +253,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
     redirect(`/author/${authorSlug(decoded)}`);
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
   const data = await loadAuthorData(db, name);
   if (!data) notFound();
 

--- a/src/app/book/[id]/opengraph-image.tsx
+++ b/src/app/book/[id]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/og';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { Book } from '@/lib/types';
 
@@ -12,7 +12,7 @@ export const contentType = 'image/png';
 
 async function getBookForOG(id: string): Promise<Book | null> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const result = await findBookByIdOrSlug(db, id, {
       _id: 0, id: 1, title: 1, display_title: 1, author: 1,
       published: 1, language: 1, thumbnail: 1, slug: 1,

--- a/src/app/book/[id]/overview/page.tsx
+++ b/src/app/book/[id]/overview/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import type { Metadata } from 'next';
 import BookOverview from '@/components/reader/BookOverview';
@@ -46,7 +46,7 @@ const PAGE_PROJECTION = {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const db = await getDb();
+  const db = await getReadDb();
   const result = await findBookByIdOrSlug(db, id, { _id: 0, title: 1, display_title: 1 });
   if (!result) return { title: 'Book Not Found - Source Library' };
   const title = result.book.display_title || result.book.title;
@@ -60,7 +60,7 @@ export default async function BookOverviewPage({ params }: PageProps) {
   const { id } = await params;
 
   const db = await Promise.race([
-    getDb(),
+    getReadDb(),
     new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 15000)),
   ]);
 

--- a/src/app/book/[id]/page-number/[num]/page.tsx
+++ b/src/app/book/[id]/page-number/[num]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound, redirect } from 'next/navigation';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 
 interface Props {
@@ -14,7 +14,7 @@ export default async function PageNumberRedirect({ params }: Props) {
     notFound();
   }
 
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Resolve slug/id/ObjectId to actual book
   const result = await findBookByIdOrSlug(db, id, { id: 1, slug: 1 });

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense, cache } from 'react';
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
@@ -86,7 +86,7 @@ const getCachedBookLookup = cache(async (id: string): Promise<{
 
   // Fall back to Atlas (slower but has everything)
   const db = await Promise.race([
-    getDb(),
+    getReadDb(),
     new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 15000)),
   ]);
   const result = await findBookByIdOrSlug(db, id, {
@@ -210,7 +210,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
   // ALL Atlas queries in parallel — including a full book refetch for fields not in the catalog.
   const [result, db] = await Promise.all([
     getCachedBookLookup(id),
-    getDb(),
+    getReadDb(),
   ]);
 
   if (!result) return null;

--- a/src/app/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/book/[id]/page/[pageId]/layout.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { Book, Page } from '@/lib/types';
 
@@ -21,7 +21,7 @@ const PAGE_META_PROJECTION = {
 
 async function getPageData(bookId: string, pageId: string): Promise<{ book: Book | null; page: Page | null }> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const [bookResult, page] = await Promise.all([
       findBookByIdOrSlug(db, bookId, BOOK_META_PROJECTION),
       db.collection('pages').findOne({ id: pageId }, { projection: PAGE_META_PROJECTION }),

--- a/src/app/book/[id]/page/[pageId]/opengraph-image.tsx
+++ b/src/app/book/[id]/page/[pageId]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/og';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { Book, Page } from '@/lib/types';
 
@@ -20,7 +20,7 @@ const OG_PAGE_PROJECTION = {
 
 async function getPageData(bookId: string, pageId: string): Promise<{ book: Book | null; page: Page | null }> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     const [bookResult, page] = await Promise.all([
       findBookByIdOrSlug(db, bookId, OG_BOOK_PROJECTION),

--- a/src/app/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/book/[id]/page/[pageId]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import type { Book, Page } from '@/lib/types';
 import PageEditorClient from './PageEditorClient';
@@ -20,7 +20,7 @@ const BOOK_NAV_PROJECTION = {
 
 export default async function PageEditorPage({ params }: PageProps) {
   const { id, pageId } = await params;
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Step 1: Get current page (fast indexed lookup by id, gives us book_id for nav)
   const currentPage = await db.collection('pages').findOne(

--- a/src/app/book/[id]/search/page.tsx
+++ b/src/app/book/[id]/search/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { bookUrl } from '@/lib/slugify';
 import BookSearchResults from './BookSearchResults';
 
@@ -14,7 +14,7 @@ interface Props {
 export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { id } = await params;
   const { q } = await searchParams;
-  const db = await getDb();
+  const db = await getReadDb();
   const book = await db.collection('books').findOne(
     { id },
     { projection: { title: 1, display_title: 1 } }
@@ -29,7 +29,7 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 export default async function BookSearchPage({ params, searchParams }: Props) {
   const { id: bookId } = await params;
   const { q } = await searchParams;
-  const db = await getDb();
+  const db = await getReadDb();
 
   const book = await db.collection('books').findOne(
     { id: bookId },

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, Book as BookIcon } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { LIBRARY_CATEGORIES } from '@/app/api/categories/route';
 import { notFound } from 'next/navigation';
 import CategorySchema from '@/components/seo/CategorySchema';
@@ -42,7 +42,7 @@ function getCategory(id: string) {
 
 async function getCategoryBooks(id: string): Promise<Book[]> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     // Use cached pages_translated on books — no $lookup against 9.5M pages collection
     const books = await db.collection('books').find(
       { categories: id, visible: true, pages_translated: { $gt: 0 } },

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { BookOpen, ChevronRight } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { LIBRARY_CATEGORIES, CategoryWithCount } from '@/app/api/categories/route';
 
 // ISR: rebuild every 6 hours. Categories change rarely.
@@ -23,7 +23,7 @@ async function getCategoriesWithCounts(): Promise<CategoryWithCount[]> {
   let countMap = new Map<string, number>();
 
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const categoryCounts = await db.collection('books').aggregate([
       { $match: { visible: true, categories: { $exists: true } } },
       { $unwind: '$categories' },

--- a/src/app/collections/[id]/opengraph-image.tsx
+++ b/src/app/collections/[id]/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { generateBrandedOGImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og-image';
 
 export const alt = 'Collection - Source Library';
@@ -10,7 +10,7 @@ export default async function Image({ params }: { params: Promise<{ id: string }
 
   try {
     const db = await Promise.race([
-      getDb(),
+      getReadDb(),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), 5000)),
     ]);
     const collection = await db.collection('collections').findOne(

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Metadata } from 'next';
 import { ArrowLeft, BookOpen, Images, Library } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import { unstable_noStore } from 'next/cache';
 import CollectionSchema from '@/components/seo/CollectionSchema';
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const db = await Promise.race([
-      getDb(),
+      getReadDb(),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 15000)),
     ]);
     const collection = await db.collection('collections').findOne({ slug: id });
@@ -194,9 +194,9 @@ const COMPACT_LIMIT = 14;
  *  The /api/image wrapper crashes Next.js Image during SSR. */
 
 async function fetchCollectionData(id: string) {
-  // Wrap getDb() in a timeout — when MongoDB Atlas is overloaded, the connection
+  // Wrap getReadDb() in a timeout — when MongoDB Atlas is overloaded, the connection
   // itself can hang for 60+ seconds. Better to fail fast and let ISR retry.
-  const db = await withTimeout(getDb(), 10000, null as unknown as Awaited<ReturnType<typeof getDb>>);
+  const db = await withTimeout(getReadDb(), 10000, null as unknown as Awaited<ReturnType<typeof getReadDb>>);
   if (!db) throw new Error('DB connection timeout');
 
   const collection = await withTimeout(

--- a/src/app/collections/contemplative-traditions/page.tsx
+++ b/src/app/collections/contemplative-traditions/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import { ArrowLeft, BookOpen } from 'lucide-react';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
 export const revalidate = false;
@@ -103,7 +103,7 @@ interface TraditionCollection {
 async function getTraditions(): Promise<{ traditions: TraditionCollection[]; totalBooks: number }> {
   try {
     const db = await Promise.race([
-      getDb(),
+      getReadDb(),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 10000)),
     ]);
 

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
@@ -41,7 +41,7 @@ interface CollectionDoc {
 }
 
 async function fetchCollections(): Promise<CollectionDoc[]> {
-  const db = await getDb();
+  const db = await getReadDb();
   const [docs, childCounts] = await Promise.all([
     db.collection('collections').find({
       parent: { $exists: false },
@@ -67,7 +67,7 @@ async function fetchCollections(): Promise<CollectionDoc[]> {
 
 async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total: number }> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const pipeline = [
       { $match: { year: { $exists: true, $ne: null }, visible: true } },
       { $project: { year: 1, language: { $ifNull: ['$language', 'Unknown'] } } },

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Metadata } from 'next';
 import { ArrowLeft } from 'lucide-react';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -39,7 +39,7 @@ interface TraditionCollection {
 async function getTraditions(): Promise<{ traditions: TraditionCollection[]; totalBooks: number }> {
   try {
   const db = await Promise.race([
-    getDb(),
+    getReadDb(),
     new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 10000)),
   ]);
 

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 
 async function getStats() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     // Use fast queries: estimatedDocumentCount + dashboard_snapshot (avoid distinct + countDocuments)
     const [snapshot, totalPages, galleryCount] = await Promise.all([
       db.collection('system_config').findOne({ _id: 'dashboard_snapshot' as unknown as import('mongodb').ObjectId }),
@@ -40,7 +40,7 @@ async function getStats() {
 
 async function getGalleryImages() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const images = await db.collection('gallery_images')
       .find(
         { gallery_quality: { $gte: 0.8 }, book_rank: { $lte: 1 } },

--- a/src/app/contribute/wikipedia/page.tsx
+++ b/src/app/contribute/wikipedia/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { WikipediaPlaybook, TalkPagePost } from './WikipediaPlaybook';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const metadata: Metadata = {
   title: 'Wikipedia Contributions - Source Library',
@@ -169,7 +169,7 @@ const FEATURED_BOOKS: {
 ];
 
 async function getBookStats() {
-  const db = await getDb();
+  const db = await getReadDb();
   const slugs = FEATURED_BOOKS.map(b => b.slug);
 
   const books = await db.collection('books').find(

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/SiteHeader';
@@ -51,7 +51,7 @@ function getHeroImage(col: CuratedCollection): string | undefined {
 }
 
 async function fetchCuratedCollections() {
-  const db = await getDb();
+  const db = await getReadDb();
   const docs = await db
     .collection('collections')
     .find({ type: 'curated' })

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import { CenturyChart } from './DataCharts';
 
@@ -104,7 +104,7 @@ const EMPTY_DATA: LibraryData = {
  * Never runs heavy aggregations inline — that's done by POST /api/admin/data-snapshot.
  */
 async function fetchLibraryData(): Promise<LibraryData> {
-  const db = await getDb();
+  const db = await getReadDb();
   const config = db.collection('system_config');
 
   // Try dedicated data page snapshot first

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
 export const revalidate = false;
@@ -24,7 +24,7 @@ function formatNumber(n: number): string {
 }
 
 async function fetchDatasetStats() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   try {
     const books = db.collection('books');

--- a/src/app/design-options/page.tsx
+++ b/src/app/design-options/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
@@ -57,7 +57,7 @@ function bookTitle(book: { display_title?: string; title: string }): string {
 }
 
 async function getFeaturedCollection(): Promise<FeaturedCollectionItem | null> {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Get a well-populated collection
   const collections = await db
@@ -181,7 +181,7 @@ async function getFeaturedCollection(): Promise<FeaturedCollectionItem | null> {
 }
 
 async function getMultipleFeaturedCollections(): Promise<FeaturedCollectionItem[]> {
-  const db = await getDb();
+  const db = await getReadDb();
 
   const collections = await db
     .collection('collections')
@@ -241,7 +241,7 @@ async function getMultipleFeaturedCollections(): Promise<FeaturedCollectionItem[
 }
 
 async function getCollectionSummaries(): Promise<CollectionSummary[]> {
-  const db = await getDb();
+  const db = await getReadDb();
   const docs = await db.collection('collections').find(
     { parent: { $exists: false }, type: { $ne: 'curated' }, visible: true, book_count: { $gte: 5 } },
     { projection: { _id: 0, slug: 1, name: 1, subtitle: 1, book_count: 1, featured_images: 1, languages: 1 } }

--- a/src/app/developers/pipeline/page.tsx
+++ b/src/app/developers/pipeline/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import PipelineDiagram, { type StageData } from '@/components/pipeline/PipelineDiagram';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const metadata: Metadata = {
   title: 'Pipeline Architecture | Source Library',
@@ -42,7 +42,7 @@ const STATUS_TO_STAGE: Record<string, string> = {
 
 async function getPipelineStats() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const books = db.collection('books');
 
     const maxTimeMS = 45000;

--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -1,6 +1,6 @@
 import { cache } from 'react';
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import EntitySchema from '@/components/seo/EntitySchema';
 
@@ -25,7 +25,7 @@ export interface SharedConnection {
 // Shared books data — which related entities appear in which of the same books
 export const getSharedBooks = cache(async (name: string): Promise<SharedConnection[] | null> => {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const entity = await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },
       { sort: { book_count: -1 } }
@@ -73,7 +73,7 @@ export const getSharedBooks = cache(async (name: string): Promise<SharedConnecti
 // Shared cached fetch — used by both layout (metadata/schema) and page (rendering)
 export const getEntity = cache(async (name: string) => {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const entity = await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },
       { sort: { book_count: -1 } }

--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import BookMapLoader from '@/components/explore/BookMapLoader';
 import type { BookLocation } from '@/components/explore/BookMap';
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 };
 
 async function fetchMapData() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Read pre-computed map data from system_config (fast single-doc read)
   const cached = await db

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -4,7 +4,7 @@ import ExploreStats from '@/components/explore/ExploreStats';
 import CenturyHeatmap from '@/components/explore/CenturyHeatmap';
 import ExploreNav from '@/components/explore/ExploreNav';
 import DataSources from '@/components/explore/DataSources';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const revalidate = 86400;
 export const maxDuration = 30;
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 
 async function fetchExploreStats() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Use estimatedDocumentCount (instant, uses collection metadata)
     // and a single aggregation for all entity stats to avoid multiple slow scans

--- a/src/app/explore/timeline/page.tsx
+++ b/src/app/explore/timeline/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import TimelineLoader from '@/components/explore/TimelineLoader';
 
 // ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
@@ -45,7 +45,7 @@ function languageToTradition(lang: string | undefined | null): string | null {
 }
 
 async function fetchTimelineData() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Fetch entities with their book_ids for tradition lookup
   const entities = await db

--- a/src/app/ficino-society/members/page.tsx
+++ b/src/app/ficino-society/members/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
@@ -17,7 +17,7 @@ interface MemberProfile {
 }
 
 async function getMembers(): Promise<MemberProfile[]> {
-  const db = await getDb();
+  const db = await getReadDb();
   const members = await db.collection('users').find(
     {
       $or: [

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { cache } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import CollectionImageCard, { CollectionImageProps } from './CollectionImageCard';
 
 export const revalidate = 86400;
@@ -14,7 +14,7 @@ interface PageProps {
 
 const getCollectionData = cache(async (slug: string) => {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const collection = await db.collection('gallery_collections').findOne(
       { slug },
       { projection: { title: 1, description: 1, image_ids: 1 } }

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Image as ImageIcon, Layers } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const revalidate = 86400;
 
@@ -33,7 +33,7 @@ interface CollectionListItem {
 
 async function getCollections(): Promise<CollectionListItem[]> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     const collections = await db
       .collection('gallery_collections')

--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -8,7 +8,7 @@
 
 import { cache } from 'react';
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import GalleryImageSchema from '@/components/seo/GalleryImageSchema';
 
 interface PageWithBook {
@@ -68,7 +68,7 @@ const getImageData = cache(async (id: string): Promise<{ page: PageWithBook; det
     const [, pageId, indexStr] = match;
     const index = parseInt(indexStr, 10);
 
-    const db = await getDb();
+    const db = await getReadDb();
     const pages = await db.collection('pages').aggregate([
       { $match: { id: pageId } },
       {

--- a/src/app/gallery/image/[id]/opengraph-image.tsx
+++ b/src/app/gallery/image/[id]/opengraph-image.tsx
@@ -13,7 +13,7 @@
  */
 
 import { ImageResponse } from 'next/og';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { getPageImageUrl } from '@/lib/utils';
 
 export const alt = 'Image from Source Library';
@@ -61,7 +61,7 @@ async function getImageData(id: string): Promise<{ page: PageWithBook; detection
     const [, pageId, indexStr] = match;
     const index = parseInt(indexStr, 10);
 
-    const db = await getDb();
+    const db = await getReadDb();
     const pages = await db.collection('pages').aggregate([
       { $match: { id: pageId } },
       {

--- a/src/app/gallery/opengraph-image.tsx
+++ b/src/app/gallery/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from 'next/og';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const alt = 'Image Gallery - Source Library';
@@ -16,7 +16,7 @@ export const contentType = 'image/png';
  */
 async function getFeaturedImages(): Promise<string[]> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const results = await db.collection('pages').aggregate([
       {
         $match: {

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import GalleryClient from '@/components/gallery/GalleryClient';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import type { GalleryResponse } from '@/lib/api-client/types/gallery';
@@ -47,7 +47,7 @@ export default async function GalleryPage() {
  */
 async function fetchInitialGalleryData(): Promise<GalleryResponse> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const limit = 24;
     const minQuality = 0.7;
     const maxPerBook = 3;
@@ -152,7 +152,7 @@ async function fetchInitialGalleryData(): Promise<GalleryResponse> {
  */
 async function fetchBookCollections() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const collections = await db.collection('collections')
       .find({ book_count: { $gte: 1 } })
       .sort({ parent: 1, order: 1, name: 1 })
@@ -170,7 +170,7 @@ async function fetchBookCollections() {
  */
 async function fetchFeaturedCollections() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const collections = await db.collection('gallery_collections')
       .find({})
       .sort({ featured: -1, sort_order: 1 })

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, Images } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { browseBooks, countBooks } from '@/lib/books-catalog';
 import { notFound } from 'next/navigation';
 import CollectionBookCard from '@/components/CollectionBookCard';
@@ -135,7 +135,7 @@ async function fetchLanguageData(langName: string, sort: string, offset: number,
   let galleryImages: unknown[] = [];
   if (sampleBookIds.length > 0) {
     try {
-      const db = await getDb();
+      const db = await getReadDb();
       galleryImages = await db.collection('gallery_images').aggregate([
         { $match: {
           book_id: { $in: sampleBookIds },

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, ExternalLink, Images, Library } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
 import { notFound } from 'next/navigation';
@@ -100,7 +100,7 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
   let galleryImages: unknown[] = [];
   if (sampleBookIds.length > 0) {
     try {
-      const db = await getDb();
+      const db = await getReadDb();
       galleryImages = await db.collection('gallery_images').aggregate([
         { $match: {
           book_id: { $in: sampleBookIds },
@@ -154,7 +154,7 @@ async function fetchLibraryData(providerKey: string, sort: string, language: str
 /** Build a UBN → { id, slug } map for BPH books on Source Library */
 async function fetchBphDigitizedMap(): Promise<Record<string, { id: string; slug: string }>> {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const bphBooks = await db.collection('books').find(
       { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true } },
       { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 15_000 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { Book } from '@/lib/types';
 import { type CollectionForGrid } from '@/components/book/BookLibrary';
@@ -40,7 +40,7 @@ const BOOK_PROJECTION = {
 // ---------- Data fetching ----------
 
 async function getFeaturedCollections() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // Pick 1 random collection with enough books for the editorial spread
   const collections = await db.collection('collections').aggregate([
@@ -153,7 +153,7 @@ async function getFeaturedCollections() {
 }
 
 async function getRemainingCollections(): Promise<CollectionForGrid[]> {
-  const db = await getDb();
+  const db = await getReadDb();
   const docs = await db.collection('collections').find({ parent: { $exists: false }, type: { $ne: 'curated' }, visible: true, 'highlighted_books.0': { $exists: true } }).toArray();
 
   const result = docs.map(({ _id, ...rest }) => {
@@ -231,7 +231,7 @@ async function getRemainingCollections(): Promise<CollectionForGrid[]> {
 }
 
 async function getDiscoverBooks(): Promise<Book[]> {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // $sample FIRST so MongoDB uses fast random cursor (O(1) when size < 5% of collection).
   // $match after $sample filters the random sample down.
@@ -247,7 +247,7 @@ async function getDiscoverBooks(): Promise<Book[]> {
 }
 
 async function getCollectionShowcase() {
-  const db = await getDb();
+  const db = await getReadDb();
 
   // $sample FIRST (before $match) so MongoDB uses fast random cursor algorithm.
   // When $sample is after $match, Mongo scans all matching docs first → 22s on 77k docs.
@@ -341,7 +341,7 @@ async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglis
       let authorCount = FALLBACK_COUNTS.authorCount;
       let languageCount = FALLBACK_COUNTS.languageCount;
       try {
-        const db = await getDb();
+        const db = await getReadDb();
         const cached = await db.collection('system_config').findOne(
           { _id: 'homepage_stats' } as any,
           { maxTimeMS: 2000 }
@@ -362,7 +362,7 @@ async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglis
 
   // 2. Fallback: MongoDB system_config cache
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const cached = await db.collection('system_config').findOne(
       { _id: 'homepage_stats' } as any,
       { maxTimeMS: 2000 }

--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { decodeShortlink } from '@/lib/shortlinks';
 import { Page } from '@/lib/types';
 
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const { bookId, pageNumber } = decodeShortlink(code);
 
     // Look up the page to get its ID
-    const db = await getDb();
+    const db = await getReadDb();
     const page = await db.collection('pages').findOne({
       book_id: bookId,
       page_number: pageNumber,

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout from '@/components/layout/ContentPageLayout';
 import { SubPageHeader } from '@/components/layout/ContentPageLayout';
 import ConversationView from '@/components/research/ConversationView';
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { id } = await params;
   let session;
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     session = await db.collection('curator_sessions').findOne(
       { id },
       { projection: { title: 1, themes: 1, date: 1 } }
@@ -51,7 +51,7 @@ const TYPE_LABELS: Record<string, string> = {
 
 export default async function ResearchSessionPage({ params }: PageProps) {
   const { id } = await params;
-  const db = await getDb();
+  const db = await getReadDb();
   const doc = await db.collection('curator_sessions').findOne({ id });
 
   if (!doc) notFound();

--- a/src/app/research/page.tsx
+++ b/src/app/research/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import ResearchClient from '@/components/research/ResearchClient';
 import type { CuratorSessionListItem } from '@/lib/api-client/types/research';
@@ -40,7 +40,7 @@ export default async function ResearchPage() {
 
 async function fetchInitialData() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const collection = db.collection('curator_sessions');
 
     const [sessions, total, themesAgg, typesAgg] = await Promise.all([

--- a/src/app/research/translation-lag/page.tsx
+++ b/src/app/research/translation-lag/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import TranslationLagViz from '@/components/research/TranslationLagViz';
 
@@ -26,7 +26,7 @@ interface LagDataPoint {
 }
 
 async function fetchLagData(): Promise<LagDataPoint[]> {
-  const db = await getDb();
+  const db = await getReadDb();
   const books = await db.collection('books').find(
     {
       visible: true,

--- a/src/app/shwep/shwep-data.ts
+++ b/src/app/shwep/shwep-data.ts
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { SHWEP_PERIODS } from '@/data/shwep-episodes';
 import { EPISODE_DESCRIPTIONS } from '@/data/shwep-descriptions';
@@ -142,7 +142,7 @@ function enrichEpisodes(bookMap: Map<string, MatchedBook>) {
 }
 
 export async function getShwepIndexData(): Promise<ShwepIndexData> {
-  const db = await getDb();
+  const db = await getReadDb();
   const bookMap = await fetchMatchedBooks(db);
   const enrichedPeriods = enrichEpisodes(bookMap);
 
@@ -221,7 +221,7 @@ export async function getEpisodeData(episodeNumber: number): Promise<EnrichedEpi
 
   let books: MatchedBook[] = [];
   if (bookIds && bookIds.length > 0) {
-    const db = await getDb();
+    const db = await getReadDb();
     const objectIds = bookIds.map(id => {
       try { return new ObjectId(id); } catch { return null; }
     }).filter((id): id is ObjectId => id !== null);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 // Next.js metadata files (sitemap.ts) are statically generated at build time.
 // Each DB query is independently wrapped so a single timeout doesn't kill the whole sitemap.
@@ -183,11 +183,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Helper: run a DB query with independent error handling
   async function safeQuery<T>(
     label: string,
-    fn: (db: Awaited<ReturnType<typeof getDb>>) => Promise<T>,
+    fn: (db: Awaited<ReturnType<typeof getReadDb>>) => Promise<T>,
     fallback: T,
   ): Promise<T> {
     try {
-      const dbPromise = getDb();
+      const dbPromise = getReadDb();
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error(`${label}: DB connection timeout`)), 20000)
       );

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 
 export const revalidate = 600;
 export const maxDuration = 60;
@@ -60,7 +60,7 @@ function formatStat(n: number): string {
 
 async function fetchStats() {
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const books = db.collection('books');
     const match = { visible: true, pages_count: { $gt: 0 } };
 

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import TimelineClient from './TimelineClient';
 import type { Metadata } from 'next';
@@ -21,7 +21,7 @@ async function fetchTimelineData(): Promise<TimelineOverview> {
   };
 
   try {
-    const db = await getDb();
+    const db = await getReadDb();
 
     // Try pre-computed cache first (seeded by scripts/seed-timeline-filters.mjs)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Metadata } from 'next';
@@ -79,7 +79,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // Fall back to old cluster slug
   let match;
   try {
-    const db = await getDb();
+    const db = await getReadDb();
     const allClusters = await db.collection('books').aggregate([
       { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
       { $group: { _id: '$taxonomy.cluster' } },
@@ -105,7 +105,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 // ─── Data fetching ───────────────────────────────────────────────
 
 async function fetchFacetData(facetId: string, valueId: string) {
-  const db = await getDb();
+  const db = await getReadDb();
   const facet = FACETS.find((f) => f.id === facetId)!;
   const value = facet.values.find((v) => v.id === valueId)!;
 
@@ -201,7 +201,7 @@ async function fetchFacetData(facetId: string, valueId: string) {
 }
 
 async function fetchClusterData(slug: string) {
-  const db = await getDb();
+  const db = await getReadDb();
 
   const allClusters = await db.collection('books').aggregate([
     { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
@@ -33,7 +33,7 @@ interface TopicSummary {
 }
 
 async function fetchTopics(): Promise<{ topics: TopicSummary[]; totalBooks: number }> {
-  const db = await getDb();
+  const db = await getReadDb();
 
   const pipeline = [
     {

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -1,4 +1,4 @@
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
@@ -35,7 +35,7 @@ interface FacetGroup {
 }
 
 async function fetchFacetCounts(): Promise<{ groups: FacetGroup[]; totalBooks: number }> {
-  const db = await getDb();
+  const db = await getReadDb();
   const maxTimeMS = 30000;
   const baseMatch = { faceted_tags: { $exists: true }, visible: true };
 
@@ -78,7 +78,7 @@ async function fetchFacetCounts(): Promise<{ groups: FacetGroup[]; totalBooks: n
 
 /** Single aggregation: all domain co-occurrences in one pass */
 async function fetchDomainCrossTab(): Promise<Map<string, SubDomain[]>> {
-  const db = await getDb();
+  const db = await getReadDb();
   // Efficient: project array as two copies, unwind both, filter out self-pairs
   const results = await db.collection('books').aggregate([
     { $match: { 'faceted_tags.knowledge_domain.1': { $exists: true }, visible: true } },

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getDb } from '@/lib/mongodb';
+import { getReadDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import type { Book } from '@/lib/types';
@@ -16,7 +16,7 @@ interface PageProps {
 }
 
 async function getWorkEditions(workId: string) {
-  const db = await getDb();
+  const db = await getReadDb();
   const editions = await db.collection('books').find(
     { work_id: workId, visible: true },
     {


### PR DESCRIPTION
## Summary
- Migrates 112 read-only routes from `getDb()` to `getReadDb()` (`readPreference: secondaryPreferred`)
- 41 page components (book detail, gallery, collections, browse, etc.)
- 71 API routes (search, IIIF, feeds, catalog, analytics, etc.)
- User reads get their own WiredTiger cache on a replica node, isolated from pipeline write pressure

## Context
Atlas M30 was hitting 3K IOPS ceiling at 400 updates/s from pipeline writes (batch collector, translate worker). Nirmal flagged disk IOPS maxed out. This is the structural fix from #567 — separate reads from writes.

`getReadDb()` was already implemented but only used by 7 files. Now 119 files use it (7 existing + 112 new).

## What stays on primary (`getDb()`)
- All `/api/admin/*` routes
- All `/api/cron/*` and pipeline routes  
- Import, processing, mutation endpoints
- Lambda workers

## Risk
- Secondary reads have 1-5s replication lag. A just-translated page might show stale data briefly. Acceptable for browse/search; book detail ISR cache (24h) masks this anyway.
- Writes through `getReadDb()` connections still go to primary (MongoDB driver behavior). The few fire-and-forget cache writes (author portraits) are safe.

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (done locally, only pre-existing MCP errors)
- [ ] Spot-check homepage, book detail, gallery, search, collections render correctly
- [ ] Monitor Atlas replica lag after deploy

Ref: #567

Generated with [Claude Code](https://claude.com/claude-code)