### PR TITLE
Tune pipeline throughput: batch size, parallelism, model routing

### DIFF
--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -70,8 +70,9 @@ const RUN_PHASE_7 = phaseArg === 'all' || phaseArg === '7';
 const RUN_PHASE_7_5 = phaseArg === 'all' || phaseArg === '7.5';
 const RUN_PHASE_7_6 = phaseArg === 'all' || phaseArg === '7.6';
 const limitArg = args.find(a => a.startsWith('--limit='))?.split('=')[1];
-const PHASE_6_LIMIT = limitArg ? parseInt(limitArg) : 100;
-const PHASE_7_LIMIT = limitArg ? parseInt(limitArg) : 100;
+const PHASE_6_LIMIT = limitArg ? parseInt(limitArg) : 200;
+const PHASE_7_LIMIT = limitArg ? parseInt(limitArg) : 200;
+const BOOK_CONCURRENCY = 4; // Process multiple books in parallel within each phase
 const SINGLE_BOOK = args.find(a => a.startsWith('--book='))?.split('=')[1];
 
 // ── Gemini API keys ──
@@ -1144,8 +1145,8 @@ async function extractChaptersForBook(db, bookId) {
     }
   }
 
-  // Call Gemini
-  const modelId = DEFAULT_MODEL;
+  // Call Gemini — flash-lite is sufficient for structured chapter extraction
+  const modelId = LITE_MODEL;
   const model = getClient().getGenerativeModel({ model: modelId });
   const prompt = buildExtractionPrompt(
     book.display_title || book.title,
@@ -1286,27 +1287,32 @@ async function main() {
 
     console.log(`  Books ready: ${books.length}`);
 
-    for (const book of books) {
-      try {
-        if (DRY_RUN) { console.log(`  Would enrich: ${book.title}`); continue; }
-
-        await setPipelineStatus(db, book.id, 'summarizing');
-
-        await enrichBook(db, book);
-
-        await setPipelineStatus(db, book.id, 'summary_indexed', { 'pipeline_auto.retry_count': 0 });
-        revalidateBookPage(book.id).catch(() => {});
-        enriched++;
-      } catch (err) {
-        const retries = book.pipeline_auto?.retry_count || 0;
-        if (retries >= MAX_RETRIES) {
-          await markFailed(db, book.id, `Summary+Index: ${err.message}`, retries);
-        } else {
-          await setPipelineStatus(db, book.id, 'translate_complete', { 'pipeline_auto.retry_count': retries + 1 });
+    if (DRY_RUN) {
+      for (const book of books) console.log(`  Would enrich: ${book.title}`);
+    } else {
+      const queue = [...books];
+      const workers = Array.from({ length: Math.min(BOOK_CONCURRENCY, queue.length) }, async () => {
+        while (queue.length > 0) {
+          const book = queue.shift();
+          try {
+            await setPipelineStatus(db, book.id, 'summarizing');
+            await enrichBook(db, book);
+            await setPipelineStatus(db, book.id, 'summary_indexed', { 'pipeline_auto.retry_count': 0 });
+            revalidateBookPage(book.id).catch(() => {});
+            enriched++;
+          } catch (err) {
+            const retries = book.pipeline_auto?.retry_count || 0;
+            if (retries >= MAX_RETRIES) {
+              await markFailed(db, book.id, `Summary+Index: ${err.message}`, retries);
+            } else {
+              await setPipelineStatus(db, book.id, 'translate_complete', { 'pipeline_auto.retry_count': retries + 1 });
+            }
+            errors.push(`Summary+Index ${book.id}: ${err.message}`);
+            console.error(`  ERROR [${book.title}]:`, err.message);
+          }
         }
-        errors.push(`Summary+Index ${book.id}: ${err.message}`);
-        console.error(`  ERROR [${book.title}]:`, err.message);
-      }
+      });
+      await Promise.all(workers);
     }
     console.log(`  Enriched: ${enriched}`);
   }
@@ -1330,36 +1336,40 @@ async function main() {
 
     console.log(`  Books ready: ${books.length}`);
 
-    for (const book of books) {
-      try {
-        if ((book.pages_count || 0) < 10) {
-          if (!DRY_RUN) await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
-          console.log(`  Skipped (< 10 pages): ${book.title}`);
-          continue;
+    if (DRY_RUN) {
+      for (const book of books) console.log(`  Would extract chapters: ${book.title}`);
+    } else {
+      const chQueue = [...books];
+      const chWorkers = Array.from({ length: Math.min(BOOK_CONCURRENCY, chQueue.length) }, async () => {
+        while (chQueue.length > 0) {
+          const book = chQueue.shift();
+          try {
+            if ((book.pages_count || 0) < 10) {
+              await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
+              console.log(`  Skipped (< 10 pages): ${book.title}`);
+              continue;
+            }
+
+            await setPipelineStatus(db, book.id, 'chapters');
+            await extractChaptersForBook(db, book.id);
+            await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
+            revalidateBookPage(book.id).catch(() => {});
+            chaptersExtracted++;
+          } catch (err) {
+            if (err.message?.includes('429') || err.message?.includes('RESOURCE_EXHAUSTED')) rotateKey();
+
+            const retries = book.pipeline_auto?.retry_count || 0;
+            if (retries >= MAX_RETRIES) {
+              await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
+            } else {
+              await setPipelineStatus(db, book.id, 'summary_indexed', { 'pipeline_auto.retry_count': retries + 1 });
+            }
+            errors.push(`Chapters ${book.id}: ${err.message}`);
+            console.error(`  ERROR [${book.title}]:`, err.message);
+          }
         }
-
-        if (DRY_RUN) { console.log(`  Would extract chapters: ${book.title}`); continue; }
-
-        await setPipelineStatus(db, book.id, 'chapters');
-
-        await extractChaptersForBook(db, book.id);
-
-        await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
-        revalidateBookPage(book.id).catch(() => {});
-        chaptersExtracted++;
-      } catch (err) {
-        if (err.message?.includes('429') || err.message?.includes('RESOURCE_EXHAUSTED')) rotateKey();
-
-        const retries = book.pipeline_auto?.retry_count || 0;
-        if (retries >= MAX_RETRIES) {
-          // Non-critical, skip
-          if (!DRY_RUN) await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
-        } else {
-          if (!DRY_RUN) await setPipelineStatus(db, book.id, 'summary_indexed', { 'pipeline_auto.retry_count': retries + 1 });
-        }
-        errors.push(`Chapters ${book.id}: ${err.message}`);
-        console.error(`  ERROR [${book.title}]:`, err.message);
-      }
+      });
+      await Promise.all(chWorkers);
     }
     console.log(`  Chapters extracted: ${chaptersExtracted}`);
   }

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -7,14 +7,14 @@
  *
  * Architecture:
  * - Picks up books in 'translate_submitted' status that have a job
- * - Translates pages in batches of BATCH_SIZE (default 5) for throughput
+ * - Translates pages in batches of BATCH_SIZE (default 8) for throughput
  * - Falls back to single-page on batch parse failures or errors
  * - Runs multiple books concurrently (up to CONCURRENCY cap)
  * - Writes translations + progress directly to MongoDB
  * - Rotates Gemini API keys on rate limit errors
  *
  * CLI flags:
- *   --batch-size=N   Pages per API call (default 5, set to 1 for single-page)
+ *   --batch-size=N   Pages per API call (default 8, set to 1 for single-page)
  *   --single-page    Force single-page mode (equivalent to --batch-size=1)
  *
  * The orchestrator (Phase 4) creates jobs and sets status to translate_submitted.
@@ -32,9 +32,9 @@ const CONCURRENCY = 40;          // Max books translating simultaneously
 const PAGES_PER_RUN = 8000;      // Global page cap per run (prevent runaway costs)
 const MAX_CONSECUTIVE_ERRORS = 5; // Per-book error threshold before giving up
 const RATE_LIMIT_BACKOFF_MS = 15000;
-const BATCH_SIZE = parseInt(process.argv.find(a => a.startsWith('--batch-size='))?.split('=')[1] || '5', 10);
+const BATCH_SIZE = parseInt(process.argv.find(a => a.startsWith('--batch-size='))?.split('=')[1] || '8', 10);
 const SINGLE_PAGE = process.argv.includes('--single-page');
-const MAX_BATCH_OCR_CHARS = 15000; // If total OCR text exceeds this, reduce batch size
+const MAX_BATCH_OCR_CHARS = 20000; // If total OCR text exceeds this, reduce batch size
 const MODEL_FLASH = 'gemini-3-flash-preview';
 const MODEL_LITE = 'gemini-3.1-flash-lite-preview';
 function getModelForBook(book) {
@@ -390,7 +390,7 @@ async function bulkWritePageTranslations(db, entries, book) {
   }));
   // Throttle writes to avoid IOPS spikes on Atlas M30
   const CHUNK_SIZE = 25;
-  const CHUNK_DELAY_MS = 200;
+  const CHUNK_DELAY_MS = 50;
   for (let i = 0; i < ops.length; i += CHUNK_SIZE) {
     const chunk = ops.slice(i, i + CHUNK_SIZE);
     await db.collection('pages').bulkWrite(chunk, { ordered: false });


### PR DESCRIPTION
## Summary
- **Translation worker:** batch size 5→8, OCR char limit 15K→20K, DB write delay 200→50ms
- **Enrich worker:** parallelize book processing (concurrency=4), limits 100→200, Phase 7 chapters switched to flash-lite (6x cheaper)

Expected impact:
- Translation: ~60% more pages per API call
- Enrichment: 3-4x faster (was sequential, now 4 books in parallel)
- Phase 7 cost: ~6x reduction (flash-lite vs flash)

## Test plan
- [ ] Deploy to Hetzner via `git pull`
- [ ] Monitor translate-worker throughput for 1 hour (target: >600 pages/hr → >1000)
- [ ] Monitor enrich-worker throughput (target: 100 books/90min → 200 books/30min)
- [ ] Watch for Gemini 429 rate limits — if excessive, reduce BOOK_CONCURRENCY to 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)