### PR TITLE
Upgrade cache-probe to full site warmth score

### DIFF
--- a/src/app/api/admin/cache-probe/route.ts
+++ b/src/app/api/admin/cache-probe/route.ts
@@ -3,23 +3,25 @@ import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 30;
+export const maxDuration = 120;
 
-const PROBE_PATHS = [
+const STATIC_PAGES = [
   '/',
   '/collections',
   '/browse',
-  '/book/the-man-in-the-moone-godwin',
-  '/book/utriusque-cosmi-historia-fludd',
-  '/book/de-revolutionibus-orbium-coelestium-copernicus',
-  '/book/the-anatomy-of-melancholy-burton',
-  '/book/novum-organum-bacon',
-  '/book/monas-hieroglyphica-dee',
-  '/book/atalanta-fugiens-maier',
-  '/book/corpus-hermeticum',
-  '/book/de-occulta-philosophia-agrippa',
-  '/book/chemical-wedding-of-christian-rosenkreutz',
   '/gallery',
+  '/libraries',
+  '/languages',
+  '/search',
+  '/about',
+  '/reading-room',
+  '/blog',
+  '/artwork',
+  '/encyclopedia',
+  '/explore',
+  '/categories',
+  '/topics',
+  '/timeline',
   '/browse/authors',
   '/taxonomy',
 ];
@@ -34,39 +36,26 @@ interface ProbeResult {
   error?: string;
 }
 
-/**
- * POST /api/admin/cache-probe — Run a fresh cache probe
- * GET /api/admin/cache-probe — Return latest stored results
- */
-export const GET = withAdminAuth(async () => {
-  const db = await getDb();
-  const stored = await db.collection('system_config').findOne(
-    { _id: 'cache_probe' as any },
-    { maxTimeMS: 5000 }
-  );
-  if (!stored) {
-    return NextResponse.json({ error: 'No probe results yet. POST to run a probe.' }, { status: 404 });
-  }
-  return NextResponse.json(stored.data);
-});
+interface CategoryStats {
+  hit: number;
+  miss: number;
+  stale: number;
+  total: number;
+}
 
-export const POST = withAdminAuth(async () => {
+async function probePaths(paths: string[]): Promise<ProbeResult[]> {
   const results: ProbeResult[] = [];
-
-  // Probe pages in parallel (batches of 5 to avoid self-DoS)
-  for (let i = 0; i < PROBE_PATHS.length; i += 5) {
-    const batch = PROBE_PATHS.slice(i, i + 5);
+  // Batches of 8 to balance speed vs self-DoS
+  for (let i = 0; i < paths.length; i += 8) {
+    const batch = paths.slice(i, i + 8);
     const batchResults = await Promise.all(
       batch.map(async (path) => {
-        const url = `${BASE_URL}${path}`;
         const t = Date.now();
         try {
-          const res = await fetch(url, {
+          const res = await fetch(`${BASE_URL}${path}`, {
             method: 'HEAD',
-            headers: {
-              'User-Agent': 'SourceLibrary-CacheProbe/1.0',
-            },
-            signal: AbortSignal.timeout(8000),
+            headers: { 'User-Agent': 'SourceLibrary-CacheProbe/1.0' },
+            signal: AbortSignal.timeout(10_000),
           });
           return {
             path,
@@ -87,27 +76,125 @@ export const POST = withAdminAuth(async () => {
     );
     results.push(...batchResults);
   }
+  return results;
+}
 
-  // Compute summary
-  const hits = results.filter(r => r.cache === 'HIT').length;
-  const misses = results.filter(r => r.cache === 'MISS').length;
-  const stale = results.filter(r => r.cache === 'STALE').length;
-  const revalidated = results.filter(r => r.cache === 'REVALIDATED').length;
-  const total = results.length;
+function summarizeCategory(results: ProbeResult[]): CategoryStats {
+  return {
+    hit: results.filter(r => r.cache === 'HIT').length,
+    miss: results.filter(r => r.cache === 'MISS' || r.cache === 'PRERENDER' || !r.cache).length,
+    stale: results.filter(r => r.cache === 'STALE' || r.cache === 'REVALIDATED').length,
+    total: results.length,
+  };
+}
+
+/**
+ * GET /api/admin/cache-probe — Return latest stored results
+ * POST /api/admin/cache-probe — Run a fresh probe across the whole site
+ *
+ * Returns a warmth score (0-100) measuring ISR cache coverage.
+ */
+export const GET = withAdminAuth(async () => {
+  const db = await getDb();
+  const stored = await db.collection('system_config').findOne(
+    { _id: 'cache_probe' as any },
+    { maxTimeMS: 5000 }
+  );
+  if (!stored) {
+    return NextResponse.json({ error: 'No probe results yet. POST to run a probe.' }, { status: 404 });
+  }
+  return NextResponse.json(stored.data);
+});
+
+export const POST = withAdminAuth(async () => {
+  const db = await getDb();
+  const started = Date.now();
+
+  // 1. Static pages
+  const staticResults = await probePaths(STATIC_PAGES);
+
+  // 2. All visible collections
+  let collectionSlugs: string[] = [];
+  try {
+    const collections = await db.collection('collections')
+      .find(
+        { visible: { $ne: false }, parent: { $exists: false } },
+        { projection: { slug: 1 }, maxTimeMS: 5000 }
+      )
+      .toArray();
+    collectionSlugs = collections.map(c => c.slug as string).filter(Boolean);
+  } catch { /* skip on DB failure */ }
+  const collectionResults = await probePaths(
+    collectionSlugs.map(s => `/collections/${s}`)
+  );
+
+  // 3. All visible sub-collections
+  let subSlugs: string[] = [];
+  try {
+    const subs = await db.collection('collections')
+      .find(
+        { visible: { $ne: false }, parent: { $exists: true } },
+        { projection: { slug: 1 }, maxTimeMS: 5000 }
+      )
+      .toArray();
+    subSlugs = subs.map(c => c.slug as string).filter(Boolean);
+  } catch { /* skip */ }
+  const subResults = await probePaths(
+    subSlugs.map(s => `/collections/${s}`)
+  );
+
+  // 4. Top 25 books by translation completeness
+  let bookResults: ProbeResult[] = [];
+  try {
+    const topBooks = await db.collection('books').find(
+      {
+        hidden: { $ne: true },
+        pages_count: { $gt: 0 },
+        pages_translated: { $gt: 0 },
+      },
+      {
+        projection: { slug: 1, id: 1 },
+        sort: { pages_translated: -1 },
+        limit: 25,
+        maxTimeMS: 10000,
+      }
+    ).toArray();
+    const bookPaths = topBooks.map(b => `/book/${b.slug || b.id}`);
+    bookResults = await probePaths(bookPaths);
+  } catch { /* skip */ }
+
+  // Aggregate
+  const allResults = [...staticResults, ...collectionResults, ...subResults, ...bookResults];
+  const hits = allResults.filter(r => r.cache === 'HIT').length;
+  const total = allResults.length;
+  const warmth = total > 0 ? Math.round((hits / total) * 100) : 0;
 
   const data = {
     probed_at: new Date().toISOString(),
+    warmth,
     total,
     hits,
-    misses,
-    stale,
-    revalidated,
-    hit_rate: total > 0 ? Math.round((hits / total) * 100) / 100 : 0,
-    pages: results,
+    misses: allResults.filter(r => r.cache === 'MISS' || r.cache === 'PRERENDER' || !r.cache).length,
+    stale: allResults.filter(r => r.cache === 'STALE' || r.cache === 'REVALIDATED').length,
+    errors: allResults.filter(r => r.status === 0 || r.status >= 400).length,
+    by_category: {
+      static: summarizeCategory(staticResults),
+      collections: summarizeCategory(collectionResults),
+      subcollections: summarizeCategory(subResults),
+      books_top25: summarizeCategory(bookResults),
+    },
+    slowest: allResults
+      .filter(r => !r.error)
+      .sort((a, b) => b.latency_ms - a.latency_ms)
+      .slice(0, 10)
+      .map(r => ({ path: r.path, ms: r.latency_ms, cache: r.cache })),
+    failed: allResults
+      .filter(r => r.status === 0 || r.status >= 400)
+      .map(r => ({ path: r.path, status: r.status, error: r.error })),
+    duration_ms: Date.now() - started,
   };
 
-  // Store in system_config
-  const db = await getDb();
+  // Store for GET retrieval
   await db.collection('system_config').updateOne(
     { _id: 'cache_probe' as any },
     { $set: { data, updated_at: new Date() } },


### PR DESCRIPTION
## Summary
Closes #965

- Expands `/api/admin/cache-probe` from 15 hardcoded paths to probing **all visible collections, sub-collections, top 25 books, and static pages**
- Returns a `warmth` score (0-100) measuring ISR cache HIT rate across the whole site
- Per-category breakdown (static, collections, subcollections, books)
- Top 10 slowest pages and failure list
- Stores results in `system_config` for quick GET retrieval
- `maxDuration` bumped to 120s to accommodate full-site probe

## Test plan
- [ ] POST `/api/admin/cache-probe` returns warmth score with category breakdown
- [ ] GET returns stored results after a POST
- [ ] Warmth increases after running deploy-warm
- [ ] No timeouts on full probe (~250+ pages in ~60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)