### PR TITLE
Switch batch pipeline to @google/genai SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-s3": "^3.1009.0",
         "@aws-sdk/client-sqs": "^3.982.0",
         "@cornerstonejs/codec-openjpeg": "^1.3.0",
-        "@google/genai": "^1.34.0",
+        "@google/genai": "^1.49.0",
         "@google/generative-ai": "^0.24.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/rest": "^22.0.1",
@@ -2073,24 +2073,56 @@
       "license": "MIT"
     },
     "node_modules/@google/genai": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.34.0.tgz",
-      "integrity": "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.49.0.tgz",
+      "integrity": "sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
         "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.24.0"
+        "@modelcontextprotocol/sdk": "^1.25.2"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@google/genai/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@google/genai/node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -4979,6 +5011,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
@@ -13464,6 +13502,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/client-s3": "^3.1009.0",
     "@aws-sdk/client-sqs": "^3.982.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@google/genai": "^1.34.0",
+    "@google/genai": "^1.49.0",
     "@google/generative-ai": "^0.24.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/rest": "^22.0.1",

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -18,6 +18,7 @@
 
 import { MongoClient } from 'mongodb';
 import { randomBytes } from 'crypto';
+import { GoogleGenAI } from '@google/genai';
 import { logUsageAsync } from './lib/supabase-usage-logger.mjs';
 
 /**
@@ -65,6 +66,9 @@ const ALL_KEYS = [
   ...Array.from({ length: 9 }, (_, i) => process.env[`GEMINI_API_KEY_${i + 2}`]),
   process.env.GEMINI_API_KEY_TIER3,
 ].filter(Boolean);
+
+// SDK clients — one per unique key for batch job inspection
+const SDK_CLIENTS = [...new Set(ALL_KEYS)].map(key => new GoogleGenAI({ apiKey: key }));
 
 if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 if (ALL_KEYS.length === 0) { console.error('No GEMINI_API_KEY* set'); process.exit(1); }
@@ -204,6 +208,8 @@ function parseMultiPageOcr(text) {
 // ── Gemini API ──
 
 async function getJobData(jobName) {
+  // Use raw REST — the response format is relied upon by extractResults() downstream.
+  // SDK is used for list/cancel operations only.
   for (const key of ALL_KEYS) {
     try {
       const url = `${GEMINI_API_BASE}/${jobName}?key=${key}`;
@@ -584,10 +590,12 @@ async function processOneJob(db, job) {
     if (state === 'JOB_STATE_PENDING' && jobAge > STALE_HOURS) {
       console.log(`  Stale PENDING job (${jobAge.toFixed(1)}h old): ${job.job_name || job.gemini_job_name} — cancelling`);
       if (!DRY_RUN) {
-        // Cancel the Gemini job
+        // Cancel the Gemini job via SDK
         try {
-          const cancelUrl = `${GEMINI_API_BASE}/${job.job_name || job.gemini_job_name}:cancel?key=${ALL_KEYS[0]}`;
-          await fetch(cancelUrl, { method: 'POST' });
+          const jobName = job.job_name || job.gemini_job_name;
+          for (const client of SDK_CLIENTS) {
+            try { await client.batches.cancel({ name: jobName }); break; } catch (_) { /* try next key */ }
+          }
         } catch (_) { /* best effort */ }
 
         await db.collection('batch_jobs').updateOne(

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -24,6 +24,7 @@ import { MongoClient, ObjectId } from 'mongodb';
 import { nanoid } from 'nanoid';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { GoogleGenAI } from '@google/genai';
 import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -1007,6 +1008,9 @@ const GEMINI_BATCH_KEYS = [...new Set([
 ].filter(k => !!k))];
 console.log(`  Batch API: ${GEMINI_BATCH_KEYS.length} unique keys`);
 
+// SDK clients — one per GCP project key for proper rate limit isolation
+const GEMINI_SDK_CLIENTS = GEMINI_BATCH_KEYS.map(key => new GoogleGenAI({ apiKey: key }));
+
 let _batchKeyCounter = 0;
 function getGeminiApiKey(keyIndex) {
   if (keyIndex !== undefined) {
@@ -1021,9 +1025,47 @@ function getGeminiApiKey(keyIndex) {
   return key;
 }
 
+function getSdkClient(keyIndex) {
+  if (keyIndex !== undefined) return GEMINI_SDK_CLIENTS[keyIndex] || GEMINI_SDK_CLIENTS[0];
+  return GEMINI_SDK_CLIENTS[_batchKeyCounter % GEMINI_SDK_CLIENTS.length];
+}
+
 // Get next key index for round-robin upload+create pairing
 function nextBatchKeyIndex() {
   return _batchKeyCounter % GEMINI_BATCH_KEYS.length;
+}
+
+/**
+ * Count active batch jobs across all Gemini projects using SDK batches.list().
+ * Returns the real Gemini-side count, not our DB's potentially stale count.
+ * Jobs are key-scoped, so we must query each key separately.
+ *
+ * Note: batches.list() returns ALL historical jobs (newest first). We page through
+ * until we've seen enough non-active jobs to be confident we've counted all active ones.
+ * Active jobs (PENDING/RUNNING) are typically at the front of the list.
+ */
+async function getActiveGeminiJobCount() {
+  let total = 0;
+  const activeStates = new Set(['JOB_STATE_PENDING', 'JOB_STATE_RUNNING']);
+  for (let i = 0; i < GEMINI_SDK_CLIENTS.length; i++) {
+    try {
+      const pager = await GEMINI_SDK_CLIENTS[i].batches.list({ config: { pageSize: 100 } });
+      let consecutiveInactive = 0;
+      for await (const job of pager) {
+        if (activeStates.has(job.state)) {
+          total++;
+          consecutiveInactive = 0;
+        } else {
+          consecutiveInactive++;
+          // If we've seen 50 consecutive non-active jobs, all active ones are likely counted
+          if (consecutiveInactive >= 50) break;
+        }
+      }
+    } catch (err) {
+      console.log(`    Warning: batches.list failed for key ${i}: ${err.message?.substring(0, 100)}`);
+    }
+  }
+  return total;
 }
 
 function getPageImageUrl(page) {
@@ -1070,38 +1112,37 @@ async function downloadImagesParallel(pages, concurrency) {
 }
 
 async function createBatchJobInline(model, requests, displayName) {
+  // Convert raw REST request format to SDK InlinedRequest format
+  const sdkRequests = requests.map(r => ({
+    contents: r.request.contents,
+    config: {
+      safetySettings: r.request.safetySettings,
+      temperature: r.request.generationConfig?.temperature,
+      maxOutputTokens: r.request.generationConfig?.maxOutputTokens,
+      thinkingConfig: r.request.generationConfig?.thinkingConfig,
+    },
+    metadata: r.metadata,
+  }));
+
   // Round-robin start key, try each on quota exhaustion (429)
   const startKey = nextBatchKeyIndex();
-  for (let attempt = 0; attempt < GEMINI_BATCH_KEYS.length; attempt++) {
-    const ki = (startKey + attempt) % GEMINI_BATCH_KEYS.length;
-    const apiKey = getGeminiApiKey(ki);
-    const response = await fetch(
-      `${GEMINI_API_BASE}/models/${model}:batchGenerateContent?key=${apiKey}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          batch: {
-            display_name: displayName,
-            input_config: {
-              requests: { requests },
-            },
-          },
-        }),
+  for (let attempt = 0; attempt < GEMINI_SDK_CLIENTS.length; attempt++) {
+    const ki = (startKey + attempt) % GEMINI_SDK_CLIENTS.length;
+    try {
+      const batchJob = await GEMINI_SDK_CLIENTS[ki].batches.create({
+        model,
+        src: sdkRequests,
+        config: { displayName },
+      });
+      return { name: batchJob.name, state: batchJob.state || 'JOB_STATE_PENDING', keyIndex: ki };
+    } catch (err) {
+      const msg = err.message || '';
+      console.log(`    Key ${ki} failed: ${msg.substring(0, 150)}`);
+      if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
+        continue;
       }
-    );
-
-    if (response.ok) {
-      const result = await response.json();
-      return { name: result.name, state: result.state || 'JOB_STATE_PENDING' };
+      throw err;
     }
-
-    const errorText = await response.text();
-    console.log(`    Key ${ki} failed (${response.status}): ${errorText.substring(0, 100)}`);
-    if (response.status === 429) {
-      continue;
-    }
-    throw new Error(`Batch create failed (${response.status}): ${errorText.substring(0, 200)}`);
   }
   throw new Error('ALL_KEYS_QUOTA_EXHAUSTED');
 }
@@ -1128,97 +1169,33 @@ function buildJsonlFile(chunk, requestBuilder) {
 }
 
 /**
- * Upload a file to Gemini File API for file-based batch submission.
- * Uses resumable upload protocol with file streaming (no full-file buffer).
- * Accepts either a file path (string) or content string for backwards compat.
+ * Upload a file to Gemini File API using SDK.
+ * Accepts a file path (string). Returns { name, uri }.
  */
-async function uploadBatchFile(filePathOrContent, displayName, apiKey) {
-  const isFilePath = typeof filePathOrContent === 'string' && fs.existsSync(filePathOrContent);
-  const contentLength = isFilePath
-    ? fs.statSync(filePathOrContent).size
-    : Buffer.byteLength(filePathOrContent);
-
-  // Step 1: Start resumable upload (text/plain as workaround for Gemini JSONL bug)
-  const startResponse = await fetch(
-    `https://generativelanguage.googleapis.com/upload/v1beta/files?key=${apiKey}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Goog-Upload-Protocol': 'resumable',
-        'X-Goog-Upload-Command': 'start',
-        'X-Goog-Upload-Header-Content-Length': contentLength.toString(),
-        'X-Goog-Upload-Header-Content-Type': 'text/plain',
-      },
-      body: JSON.stringify({ file: { displayName } }),
-    }
-  );
-
-  if (!startResponse.ok) {
-    const error = await startResponse.text();
-    throw new Error(`File upload start failed: ${error.substring(0, 200)}`);
-  }
-
-  const uploadUrl = startResponse.headers.get('X-Goog-Upload-URL');
-  if (!uploadUrl) throw new Error('No upload URL returned from File API');
-
-  // Step 2: Upload — stream from file or send string directly
-  const body = isFilePath ? fs.createReadStream(filePathOrContent) : filePathOrContent;
-  const uploadResponse = await fetch(uploadUrl, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'text/plain',
-      'X-Goog-Upload-Command': 'upload, finalize',
-      'X-Goog-Upload-Offset': '0',
-    },
-    body,
-    duplex: 'half', // Required for streaming request bodies in Node 18+
+async function uploadBatchFile(filePath, displayName, keyIndex) {
+  const client = getSdkClient(keyIndex);
+  const file = await client.files.upload({
+    file: filePath,
+    config: { mimeType: 'text/plain', displayName },
   });
-
-  if (!uploadResponse.ok) {
-    const error = await uploadResponse.text();
-    throw new Error(`File upload failed: ${error.substring(0, 200)}`);
+  if (!file?.name) {
+    throw new Error(`File upload response missing 'name': ${JSON.stringify(file).substring(0, 200)}`);
   }
-
-  const fileInfo = await uploadResponse.json();
-  if (!fileInfo.file?.name) {
-    throw new Error(`File upload response missing 'file.name': ${JSON.stringify(fileInfo).substring(0, 200)}`);
-  }
-
-  return { name: fileInfo.file.name, uri: fileInfo.file.uri };
+  return { name: file.name, uri: file.uri };
 }
 
 /**
- * Create a batch job from an uploaded JSONL file.
- * Tries all API keys on quota exhaustion (429).
+ * Create a batch job from an uploaded JSONL file using SDK.
+ * IMPORTANT: Only use the key that uploaded the file. Other keys can't see it (404).
  */
 async function createBatchJobFromFile(model, fileName, displayName, preferredKeyIndex = 0) {
-  // IMPORTANT: Only use the key that uploaded the file. Other keys can't see it (404).
-  // If this key hits 429, throw so the caller can re-upload with a different key.
-  const apiKey = getGeminiApiKey(preferredKeyIndex);
-  const response = await fetch(
-    `${GEMINI_API_BASE}/models/${model}:batchGenerateContent?key=${apiKey}`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        batch: {
-          display_name: displayName,
-          input_config: { file_name: fileName },
-        },
-      }),
-    }
-  );
-
-  if (response.ok) {
-    const result = await response.json();
-    return { name: result.name, state: result.state || 'JOB_STATE_PENDING', keyIndex: preferredKeyIndex };
-  }
-
-  const errorText = await response.text();
-  console.log(`    Key ${preferredKeyIndex} failed for file batch (${response.status}): ${errorText.substring(0, 100)}`);
-  // Throw on any error — caller must re-upload with a different key on 429
-  throw new Error(`File batch create failed (${response.status}): ${errorText.substring(0, 200)}`);
+  const client = getSdkClient(preferredKeyIndex);
+  const batchJob = await client.batches.create({
+    model,
+    src: { fileName },
+    config: { displayName },
+  });
+  return { name: batchJob.name, state: batchJob.state || 'JOB_STATE_PENDING', keyIndex: preferredKeyIndex };
 }
 
 async function getOcrPromptFromDb(db) {
@@ -1421,14 +1398,14 @@ Output structure:
       const startKey = nextBatchKeyIndex();
       for (let attempt = 0; attempt < GEMINI_BATCH_KEYS.length; attempt++) {
         const uki = (startKey + attempt) % GEMINI_BATCH_KEYS.length;
-        const uploadKey = getGeminiApiKey(uki);
         let fileResult;
         try {
-          fileResult = await uploadBatchFile(jsonlFile, displayName, uploadKey);
+          fileResult = await uploadBatchFile(jsonlFile, displayName, uki);
           uploadKeyIndex = uki;
           console.log(`    Uploaded file: ${fileResult.name} (key ${uki})`);
         } catch (uploadErr) {
-          if (uploadErr.message.includes('429') || uploadErr.message.includes('quota')) {
+          const msg = uploadErr.message || '';
+          if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
             console.log(`    Upload key ${uki} FILE API quota exhausted, trying next...`);
             continue;
           }
@@ -1438,15 +1415,14 @@ Output structure:
         try {
           batchJob = await createBatchJobFromFile(ocrModel, fileResult.name, displayName, uploadKeyIndex);
           // Clean up uploaded file — Gemini copies it into the batch job
-          try {
-            await fetch(`https://generativelanguage.googleapis.com/v1beta/${fileResult.name}?key=${uploadKey}`, { method: 'DELETE' });
-          } catch (cleanupErr) {
+          try { await getSdkClient(uki).files.delete({ name: fileResult.name }); } catch (cleanupErr) {
             console.log(`    Warning: file cleanup failed: ${cleanupErr.message}`);
           }
           break; // success
         } catch (batchErr) {
-          try { await fetch(`https://generativelanguage.googleapis.com/v1beta/${fileResult.name}?key=${uploadKey}`, { method: 'DELETE' }); } catch (_) {}
-          if (batchErr.message.includes('429') || batchErr.message.includes('quota')) {
+          try { await getSdkClient(uki).files.delete({ name: fileResult.name }); } catch (_) {}
+          const msg = batchErr.message || '';
+          if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
             console.log(`    Batch create key ${uki} BATCH CREATION quota exhausted, re-uploading with next key...`);
             continue;
           }
@@ -1691,14 +1667,14 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
       const imgStartKey = nextBatchKeyIndex();
       for (let attempt = 0; attempt < GEMINI_BATCH_KEYS.length; attempt++) {
         const uki = (imgStartKey + attempt) % GEMINI_BATCH_KEYS.length;
-        const uploadKey = getGeminiApiKey(uki);
         let fileResult;
         try {
-          fileResult = await uploadBatchFile(jsonlFile, displayName, uploadKey);
+          fileResult = await uploadBatchFile(jsonlFile, displayName, uki);
           uploadKeyIndex = uki;
           console.log(`    Uploaded file: ${fileResult.name} (key ${uki})`);
         } catch (uploadErr) {
-          if (uploadErr.message.includes('429') || uploadErr.message.includes('quota')) {
+          const msg = uploadErr.message || '';
+          if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
             console.log(`    Upload key ${uki} FILE API quota exhausted, trying next...`);
             continue;
           }
@@ -1707,15 +1683,14 @@ async function submitImageExtractionBatch(db, book, candidatePages) {
 
         try {
           batchJob = await createBatchJobFromFile(IMAGE_EXTRACTION_MODEL, fileResult.name, displayName, uploadKeyIndex);
-          try {
-            await fetch(`https://generativelanguage.googleapis.com/v1beta/${fileResult.name}?key=${uploadKey}`, { method: 'DELETE' });
-          } catch (cleanupErr) {
+          try { await getSdkClient(uki).files.delete({ name: fileResult.name }); } catch (cleanupErr) {
             console.log(`    Warning: file cleanup failed: ${cleanupErr.message}`);
           }
           break;
         } catch (batchErr) {
-          try { await fetch(`https://generativelanguage.googleapis.com/v1beta/${fileResult.name}?key=${uploadKey}`, { method: 'DELETE' }); } catch (_) {}
-          if (batchErr.message.includes('429') || batchErr.message.includes('quota')) {
+          try { await getSdkClient(uki).files.delete({ name: fileResult.name }); } catch (_) {}
+          const msg = batchErr.message || '';
+          if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
             console.log(`    Batch create key ${uki} BATCH CREATION quota exhausted, re-uploading with next key...`);
             continue;
           }
@@ -1917,13 +1892,13 @@ async function submitCrossBookImageBatches(db, bookItems) {
     const imgStartKey = nextBatchKeyIndex();
     for (let attempt = 0; attempt < GEMINI_BATCH_KEYS.length; attempt++) {
       const uki = (imgStartKey + attempt) % GEMINI_BATCH_KEYS.length;
-      const uploadKey = getGeminiApiKey(uki);
       let fileResult;
       try {
-        fileResult = await uploadBatchFile(jsonlFile, displayName, uploadKey);
+        fileResult = await uploadBatchFile(jsonlFile, displayName, uki);
         console.log(`    Uploaded file: ${fileResult.name} (key ${uki})`);
       } catch (uploadErr) {
-        if (uploadErr.message.includes('429') || uploadErr.message.includes('quota')) {
+        const msg = uploadErr.message || '';
+        if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
           console.log(`    Upload key ${uki} quota exhausted, trying next...`);
           continue;
         }
@@ -1932,15 +1907,14 @@ async function submitCrossBookImageBatches(db, bookItems) {
 
       try {
         batchJob = await createBatchJobFromFile(IMAGE_EXTRACTION_MODEL, fileResult.name, displayName, uki);
-        try {
-          await fetch(`https://generativelanguage.googleapis.com/v1beta/${fileResult.name}?key=${uploadKey}`, { method: 'DELETE' });
-        } catch (cleanupErr) {
+        try { await getSdkClient(uki).files.delete({ name: fileResult.name }); } catch (cleanupErr) {
           console.log(`    Warning: file cleanup failed: ${cleanupErr.message}`);
         }
         break;
       } catch (batchErr) {
-        try { await fetch(`https://generativelanguage.googleapis.com/v1beta/${fileResult.name}?key=${uploadKey}`, { method: 'DELETE' }); } catch (_) {}
-        if (batchErr.message.includes('429') || batchErr.message.includes('quota')) {
+        try { await getSdkClient(uki).files.delete({ name: fileResult.name }); } catch (_) {}
+        const msg = batchErr.message || '';
+        if (msg.includes('429') || msg.includes('quota') || msg.includes('RESOURCE_EXHAUSTED')) {
           console.log(`    Batch create key ${uki} quota exhausted, re-uploading with next key...`);
           continue;
         }
@@ -2913,6 +2887,9 @@ Rules:
       console.log(`  AI metadata classified: ${metadataEnriched} books`);
     }
 
+    // Shared Gemini active job count — queried once, reused by OCR (Phase 2) and image extraction (Phase 5)
+    let geminiActiveJobs = null;
+
     // ── Phase 2: Submit OCR via Gemini Batch API (archive_complete -> ocr_submitted) ──
     // Two-pass strategy:
     //   Pass 1 ("preview"): First 25 pages of first-translation books — gives readers content fast
@@ -2920,13 +2897,17 @@ Rules:
     if (shouldRun(2)) {
       console.log('\n--- Phase 2: OCR submission ---');
 
+      // Check real Gemini-side active job count (not just DB) to enforce hard limit
+      geminiActiveJobs = await getActiveGeminiJobCount();
       const activeBatchOcr = await db.collection('batch_jobs').countDocuments({
         type: 'ocr',
         status: { $in: ['pending', 'processing', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] },
       });
-      console.log(`  Active OCR batch jobs: ${activeBatchOcr}/${MAX_ACTIVE_BATCH_OCR}`);
+      console.log(`  Active Gemini jobs (real): ${geminiActiveJobs}/80 | DB OCR jobs: ${activeBatchOcr}/${MAX_ACTIVE_BATCH_OCR}`);
 
-      const ocrLimit = activeBatchOcr >= MAX_ACTIVE_BATCH_OCR ? 0 : OCR_SUBMIT_LIMIT;
+      // Use the HIGHER of DB count and Gemini count to be safe — either limit can block
+      const effectiveActive = Math.max(geminiActiveJobs, activeBatchOcr);
+      const ocrLimit = effectiveActive >= MAX_ACTIVE_BATCH_OCR ? 0 : OCR_SUBMIT_LIMIT;
 
       const ENGLISH_VARIANTS_P2 = ['english', 'eng', 'en'];
       const PREVIEW_PAGES = 25;
@@ -3828,13 +3809,15 @@ Rules:
 
       if (USE_BATCH) {
         // ── Batch API path: submit via Gemini Batch API (same as OCR) ──
+        // Re-use geminiActiveJobs if available from Phase 2, otherwise query fresh
+        const geminiJobsForImages = geminiActiveJobs !== null ? geminiActiveJobs : await getActiveGeminiJobCount();
         const activeBatchImageJobs = await db.collection('batch_jobs').countDocuments({
           type: 'image_extraction',
           status: { $in: ['pending', 'processing', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] },
         });
-        console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS}`);
+        console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS} | Gemini total: ${geminiJobsForImages}/80`);
 
-        if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS) {
+        if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS && geminiJobsForImages < 80) {
           const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed'];
 
           const readyForImages = await db.collection('books')


### PR DESCRIPTION
## Summary
- **Root cause found and fixed:** 337 orphan Gemini batch jobs (cancelled in our DB but never on Gemini) were clogging the 100-per-project concurrent limit across all 3 GCP projects. This is why the pipeline has been frozen with zero completions.
- Migrated `pipeline-orchestrator.mjs` and `batch-collector.mjs` from raw REST to `@google/genai` SDK for all batch operations (create, upload, list, cancel, delete)
- Added `getActiveGeminiJobCount()` — queries real Gemini-side state via `batches.list()` instead of trusting our potentially stale DB count
- Enforces hard concurrent limit against actual Gemini state before submitting new jobs

## What changed
- `createBatchJobInline()` → SDK `batches.create()` with inline requests
- `uploadBatchFile()` → SDK `files.upload()` + `files.delete()`
- `createBatchJobFromFile()` → SDK `batches.create()` with `{ fileName }`
- Batch-collector stale job cancellation → SDK `batches.cancel()`
- Phase 2 (OCR) and Phase 5 (images) both check real Gemini job count before submitting

## Emergency cleanup done
- Cancelled 92 zombie DB jobs (created but never submitted)
- Cancelled 337 stale Gemini-side jobs across 3 projects
- Pipeline is clear and ready to process again

## Test plan
- [x] Both files parse without syntax/import errors
- [x] `npx tsc --noEmit` passes
- [x] SDK `batches.list()` returns correct job counts from all 3 keys
- [x] SDK `batches.cancel()` successfully cancels stale jobs
- [ ] Deploy to Hetzner and verify next orchestrator run submits+completes jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)