### PR TITLE
Unblock batch image extraction from shared Gemini quota

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -791,7 +791,7 @@ async function advancePipelineStatus(db, bookId, jobType) {
     }
   }
 
-  if (jobType === 'image_extraction' && status === 'images_submitted') {
+  if (jobType === 'image_extraction' && (status === 'images_submitted' || status === 'chapters_complete')) {
     // Check both book_id (legacy single-book) and book_ids (cross-book batches)
     const pendingImages = await db.collection('batch_jobs').countDocuments({
       $or: [
@@ -818,7 +818,7 @@ async function advancePipelineStatus(db, bookId, jobType) {
           },
         }
       );
-      console.log(`  Pipeline: ${bookId} images_submitted -> images_complete (${imgCount} images)`);
+      console.log(`  Pipeline: ${bookId} ${status} -> images_complete (${imgCount} images)`);
     }
   }
 }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3807,15 +3807,15 @@ Rules:
 
       if (USE_BATCH) {
         // ── Batch API path: submit via Gemini Batch API (same as OCR) ──
-        // Re-use geminiActiveJobs if available from Phase 2, otherwise query fresh
-        const geminiJobsForImages = geminiActiveJobs !== null ? geminiActiveJobs : await getActiveGeminiJobCount();
+        // Image extraction has its own budget — don't block on OCR's Gemini total.
+        // The Gemini API returns 429 on actual quota exhaustion, handled by key rotation.
         const activeBatchImageJobs = await db.collection('batch_jobs').countDocuments({
           type: 'image_extraction',
           status: { $in: ['pending', 'processing', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] },
         });
-        console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS} | Gemini total: ${geminiJobsForImages}/80`);
+        console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS}`);
 
-        if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS && geminiJobsForImages < 80) {
+        if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS) {
           const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed'];
 
           const readyForImages = await db.collection('books')


### PR DESCRIPTION
## Summary
- Image extraction Phase 8 was completely blocked because it shared the total Gemini active job count with OCR (143 OCR jobs > 80 limit gate). Removed the shared gate — image extraction now uses only its own per-type budget (`MAX_ACTIVE_IMAGE_JOBS=50`), relying on Gemini 429 + key rotation for actual quota enforcement.
- Fixed batch collector to advance books from `chapters_complete` → `images_complete` (not just `images_submitted`), handling cases where batch jobs were submitted outside the orchestrator pipeline.

## Impact
- 2,916 books stuck at `chapters_complete` can now proceed through image extraction
- 2,760 already-collected image extraction jobs can now advance their books' pipeline status

## Test plan
- [ ] Deploy to Hetzner, verify Phase 8 logs show submission instead of quota block
- [ ] Verify batch collector advances books after image extraction results are collected
- [ ] Monitor Gemini API for 429 errors (key rotation should handle gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)