### PR TITLE
Add grid/list view toggle to all browse pages

### DIFF
--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -6,6 +6,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { notFound, redirect } from 'next/navigation';
 import { bookUrl, authorSlug, artistUrl } from '@/lib/slugify';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import AuthorBibliography from '@/components/browse/AuthorBibliography';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId, type Db } from 'mongodb';
 
@@ -442,83 +443,14 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         );
       })()}
 
-      {/* Content — bibliography table */}
+      {/* Content — bibliography with grid/list toggle */}
       <main className="max-w-6xl mx-auto px-6 md:px-12 py-8 md:py-12">
-        <div className="overflow-x-auto">
-          <table className="w-full text-left">
-            <thead>
-              <tr className="border-b text-xs uppercase tracking-wide" style={{ borderColor: 'var(--border-medium)', color: 'var(--text-muted)' }}>
-                <th className="pb-3 pr-4 font-medium">Title</th>
-                <th className="pb-3 pr-4 font-medium w-16">Year</th>
-                <th className="pb-3 pr-4 font-medium hidden md:table-cell w-24">Language</th>
-                <th className="pb-3 pr-4 font-medium hidden lg:table-cell">Publisher</th>
-                <th className="pb-3 font-medium hidden sm:table-cell w-20 text-right">Pages</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
-              {books.map(book => {
-                const pct = book.translation_percent ?? 0;
-                const hasOriginalTitle = book.display_title && book.title !== book.display_title;
-                const publisher = book.publisher?.split('|')[0]?.trim();
-                const place = book.place_of_publication;
-
-                return (
-                  <tr key={book.id} className="group hover:bg-warm/50 transition-colors">
-                    <td className="py-3 pr-4">
-                      <Link href={bookUrl(book)} className="block">
-                        <span
-                          className="text-sm font-medium line-clamp-1"
-                          style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-serif)' }}
-                        >
-                          {book.display_title || book.title}
-                        </span>
-                        {book.is_first_translation && (
-                          <span className="inline-block ml-2 bg-accent-gold/15 text-[10px] px-1.5 py-0.5 rounded-full font-medium align-middle" style={{ color: 'var(--accent-gold-dark)' }}>
-                            {firstTranslationBadge(book.ft_disposition, book.language)}
-                          </span>
-                        )}
-                        {hasOriginalTitle && (
-                          <span className="block text-xs mt-0.5 line-clamp-1 italic" style={{ color: 'var(--text-faint)' }}>
-                            {book.title}
-                          </span>
-                        )}
-                      </Link>
-                    </td>
-                    <td className="py-3 pr-4 text-sm tabular-nums" style={{ color: 'var(--text-muted)' }}>
-                      <Link href={bookUrl(book)} className="block">
-                        {book.year || book.published || '—'}
-                      </Link>
-                    </td>
-                    <td className="py-3 pr-4 hidden md:table-cell">
-                      <Link href={bookUrl(book)} className="block">
-                        <span className="text-xs px-2 py-0.5 rounded" style={{ color: 'var(--text-muted)', background: 'var(--bg-warm)' }}>
-                          {book.language || '—'}
-                        </span>
-                      </Link>
-                    </td>
-                    <td className="py-3 pr-4 hidden lg:table-cell">
-                      <Link href={bookUrl(book)} className="block text-xs line-clamp-1" style={{ color: 'var(--text-faint)' }}>
-                        {publisher || '—'}
-                        {place && publisher && <span className="text-[10px]"> ({place})</span>}
-                      </Link>
-                    </td>
-                    <td className="py-3 hidden sm:table-cell text-right">
-                      <Link href={bookUrl(book)} className="block text-sm tabular-nums" style={{ color: 'var(--text-muted)' }}>
-                        {book.pages_count || '—'}
-                        {pct > 0 && pct < 95 && (
-                          <span className="text-[10px] ml-1" style={{ color: 'var(--accent-gold-dark)' }}>{pct}%</span>
-                        )}
-                        {pct >= 95 && (
-                          <span className="text-[10px] ml-1" style={{ color: 'var(--status-success)' }}>done</span>
-                        )}
-                      </Link>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <AuthorBibliography books={books.map(b => ({
+          ...b,
+          display_title: b.display_title || undefined,
+          thumbnail: b.thumbnail_blob || b.thumbnail || undefined,
+          thumbnail_blob: b.thumbnail_blob || undefined,
+        }))} />
       </main>
     </div>
   );

--- a/src/app/browse/titles/[letter]/page.tsx
+++ b/src/app/browse/titles/[letter]/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { browseBooks } from '@/lib/books-catalog';
-import { bookUrl } from '@/lib/slugify';
 import { notFound } from 'next/navigation';
+import BrowseViewToggle from '@/components/browse/BrowseViewToggle';
 
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
@@ -30,22 +30,27 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-interface BrowseBook {
-  id: string;
-  slug?: string;
-  title: string;
-  display_title?: string;
-  author: string;
-  language: string;
-  published: string;
-}
-
 export default async function BrowseTitlesPage({ params }: PageProps) {
   const { letter } = await params;
   const l = letter.toUpperCase();
   if (l.length !== 1 || !/[A-Z]/.test(l)) notFound();
 
-  let books: BrowseBook[] = [];
+  let books: Array<{
+    id: string;
+    slug?: string;
+    title: string;
+    display_title?: string;
+    author: string;
+    language: string;
+    published: string;
+    year: number;
+    pages_count: number;
+    pages_translated: number;
+    thumbnail: string | null;
+    thumbnail_blob: string | null;
+    is_first_translation: boolean;
+    ft_disposition?: string;
+  }> = [];
   try {
     const result = await browseBooks({
       titlePrefix: l,
@@ -61,6 +66,13 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
       author: b.author || '',
       language: b.language || '',
       published: b.published || '',
+      year: b.year || 0,
+      pages_count: b.pages_count || 0,
+      pages_translated: b.pages_translated || 0,
+      thumbnail: b.thumbnail,
+      thumbnail_blob: b.thumbnail_blob,
+      is_first_translation: b.is_first_translation || false,
+      ft_disposition: undefined,
     }));
   } catch {
     // Supabase error — render empty page
@@ -69,7 +81,7 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
   return (
     <>
       <SiteHeader variant="light" breadcrumbs={[{ label: 'Browse', href: '/browse' }]} />
-      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <div className="max-w-6xl mx-auto px-6 md:px-12 py-12 md:py-20">
       <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
         Titles: {l}
       </h1>
@@ -96,27 +108,9 @@ export default async function BrowseTitlesPage({ params }: PageProps) {
         ))}
       </div>
 
-      {/* Book list */}
-      <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
-        {books.map(book => (
-          <Link
-            key={book.id}
-            href={bookUrl(book)}
-            className="block py-3 hover:opacity-70 transition-opacity"
-          >
-            <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
-              {book.display_title || book.title}
-            </p>
-            <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
-              {book.author}
-              {book.published ? ` · ${book.published}` : ''}
-              {book.language ? ` · ${book.language}` : ''}
-            </p>
-          </Link>
-        ))}
-      </div>
-
-      {books.length === 0 && (
+      {books.length > 0 ? (
+        <BrowseViewToggle books={books} />
+      ) : (
         <p className="py-12 text-center" style={{ color: 'var(--text-muted)' }}>
           No books found starting with {l}.
         </p>

--- a/src/app/browse/years/[period]/page.tsx
+++ b/src/app/browse/years/[period]/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { browseBooks } from '@/lib/books-catalog';
-import { bookUrl } from '@/lib/slugify';
 import { notFound } from 'next/navigation';
+import BrowseViewToggle from '@/components/browse/BrowseViewToggle';
 
 const PERIODS: Record<string, { label: string; min: number; max: number }> = {
   ancient:   { label: 'Ancient (before 500 CE)', min: -9999, max: 499 },
@@ -42,23 +42,26 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-interface BrowseBook {
-  id: string;
-  slug?: string;
-  title: string;
-  display_title?: string;
-  author: string;
-  language: string;
-  published: string;
-  _pub_year: number;
-}
-
 export default async function BrowseYearsPage({ params }: PageProps) {
   const { period } = await params;
   const p = PERIODS[period];
   if (!p) notFound();
 
-  let books: BrowseBook[] = [];
+  let books: Array<{
+    id: string;
+    slug?: string;
+    title: string;
+    display_title?: string;
+    author: string;
+    language: string;
+    published: string;
+    year: number;
+    pages_count: number;
+    pages_translated: number;
+    thumbnail: string | null;
+    thumbnail_blob: string | null;
+    is_first_translation: boolean;
+  }> = [];
   try {
     const result = await browseBooks({
       yearMin: p.min,
@@ -75,7 +78,12 @@ export default async function BrowseYearsPage({ params }: PageProps) {
       author: b.author || '',
       language: b.language || '',
       published: b.published || '',
-      _pub_year: b.year || 0,
+      year: b.year || 0,
+      pages_count: b.pages_count || 0,
+      pages_translated: b.pages_translated || 0,
+      thumbnail: b.thumbnail,
+      thumbnail_blob: b.thumbnail_blob,
+      is_first_translation: b.is_first_translation || false,
     }));
   } catch {
     // Supabase error — render empty page
@@ -84,7 +92,7 @@ export default async function BrowseYearsPage({ params }: PageProps) {
   return (
     <>
       <SiteHeader variant="light" breadcrumbs={[{ label: 'Browse', href: '/browse' }]} />
-      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+      <div className="max-w-6xl mx-auto px-6 md:px-12 py-12 md:py-20">
       <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
         {p.label}
       </h1>
@@ -111,27 +119,9 @@ export default async function BrowseYearsPage({ params }: PageProps) {
         ))}
       </div>
 
-      {/* Book list */}
-      <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
-        {books.map(book => (
-          <Link
-            key={book.id}
-            href={bookUrl(book)}
-            className="block py-3 hover:opacity-70 transition-opacity"
-          >
-            <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
-              {book.display_title || book.title}
-            </p>
-            <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
-              {book.author}
-              {book.published ? ` · ${book.published}` : ''}
-              {book.language ? ` · ${book.language}` : ''}
-            </p>
-          </Link>
-        ))}
-      </div>
-
-      {books.length === 0 && (
+      {books.length > 0 ? (
+        <BrowseViewToggle books={books} />
+      ) : (
         <p className="py-12 text-center" style={{ color: 'var(--text-muted)' }}>
           No books found for this period.
         </p>

--- a/src/components/browse/AuthorBibliography.tsx
+++ b/src/components/browse/AuthorBibliography.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { LayoutGrid, List } from 'lucide-react';
+import CollectionBookCard from '@/components/CollectionBookCard';
+import { bookUrl } from '@/lib/slugify';
+import { firstTranslationBadge } from '@/lib/first-translation-labels';
+
+type ViewMode = 'grid' | 'list';
+
+const STORAGE_KEY = 'sl-browse-view';
+
+interface AuthorBook {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  language: string;
+  published: string;
+  year?: number;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+  pages_count?: number;
+  pages_translated?: number;
+  pages_ocr?: number;
+  pages_blank?: number;
+  translation_percent?: number;
+  is_first_translation?: boolean;
+  ft_disposition?: string;
+  publisher?: string;
+  place_of_publication?: string;
+}
+
+export default function AuthorBibliography({ books }: { books: AuthorBook[] }) {
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!initialized.current) {
+      const stored = localStorage.getItem(STORAGE_KEY) as ViewMode | null;
+      if (stored === 'grid' || stored === 'list') setViewMode(stored);
+      initialized.current = true;
+    }
+  }, []);
+
+  const handleToggle = (mode: ViewMode) => {
+    setViewMode(mode);
+    localStorage.setItem(STORAGE_KEY, mode);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xs uppercase tracking-wide font-medium" style={{ color: 'var(--text-muted)' }}>
+          Bibliography
+        </h2>
+        <div className="flex items-center border rounded-lg overflow-hidden" style={{ borderColor: 'var(--border-light)' }}>
+          <button
+            onClick={() => handleToggle('grid')}
+            className={`p-2 transition-colors ${
+              viewMode === 'grid'
+                ? 'bg-[var(--accent-rust)]/10 text-[var(--accent-rust)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+            }`}
+            aria-label="Grid view"
+          >
+            <LayoutGrid className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => handleToggle('list')}
+            className={`p-2 transition-colors ${
+              viewMode === 'list'
+                ? 'bg-[var(--accent-rust)]/10 text-[var(--accent-rust)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+            }`}
+            aria-label="List view"
+          >
+            <List className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {viewMode === 'grid' ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {books.map((book, i) => (
+            <CollectionBookCard
+              key={book.id}
+              book={{
+                bookId: book.id,
+                id: book.id,
+                slug: book.slug,
+                title: book.display_title || book.title,
+                author: book.author || '',
+                year: book.year || 0,
+                pages_count: book.pages_count,
+                pages_translated: book.pages_translated,
+                thumbnail: book.thumbnail_blob || book.thumbnail || undefined,
+                language: book.language || undefined,
+                is_first_translation: book.is_first_translation,
+                ft_disposition: book.ft_disposition || undefined,
+              }}
+              priority={i < 10}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b text-xs uppercase tracking-wide" style={{ borderColor: 'var(--border-medium)', color: 'var(--text-muted)' }}>
+                <th className="pb-3 pr-4 font-medium">Title</th>
+                <th className="pb-3 pr-4 font-medium w-16">Year</th>
+                <th className="pb-3 pr-4 font-medium hidden md:table-cell w-24">Language</th>
+                <th className="pb-3 pr-4 font-medium hidden lg:table-cell">Publisher</th>
+                <th className="pb-3 font-medium hidden sm:table-cell w-20 text-right">Pages</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+              {books.map(book => {
+                const pct = book.translation_percent ?? 0;
+                const hasOriginalTitle = book.display_title && book.title !== book.display_title;
+                const publisher = book.publisher?.split('|')[0]?.trim();
+                const place = book.place_of_publication;
+
+                return (
+                  <tr key={book.id} className="group hover:bg-warm/50 transition-colors">
+                    <td className="py-3 pr-4">
+                      <Link href={bookUrl(book)} className="block">
+                        <span
+                          className="text-sm font-medium line-clamp-1"
+                          style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-serif)' }}
+                        >
+                          {book.display_title || book.title}
+                        </span>
+                        {book.is_first_translation && (
+                          <span className="inline-block ml-2 bg-accent-gold/15 text-[10px] px-1.5 py-0.5 rounded-full font-medium align-middle" style={{ color: 'var(--accent-gold-dark)' }}>
+                            {firstTranslationBadge(book.ft_disposition, book.language)}
+                          </span>
+                        )}
+                        {hasOriginalTitle && (
+                          <span className="block text-xs mt-0.5 line-clamp-1 italic" style={{ color: 'var(--text-faint)' }}>
+                            {book.title}
+                          </span>
+                        )}
+                      </Link>
+                    </td>
+                    <td className="py-3 pr-4 text-sm tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                      <Link href={bookUrl(book)} className="block">
+                        {book.year || book.published || '—'}
+                      </Link>
+                    </td>
+                    <td className="py-3 pr-4 hidden md:table-cell">
+                      <Link href={bookUrl(book)} className="block">
+                        <span className="text-xs px-2 py-0.5 rounded" style={{ color: 'var(--text-muted)', background: 'var(--bg-warm)' }}>
+                          {book.language || '—'}
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="py-3 pr-4 hidden lg:table-cell">
+                      <Link href={bookUrl(book)} className="block text-xs line-clamp-1" style={{ color: 'var(--text-faint)' }}>
+                        {publisher || '—'}
+                        {place && publisher && <span className="text-[10px]"> ({place})</span>}
+                      </Link>
+                    </td>
+                    <td className="py-3 hidden sm:table-cell text-right">
+                      <Link href={bookUrl(book)} className="block text-sm tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                        {book.pages_count || '—'}
+                        {pct > 0 && pct < 95 && (
+                          <span className="text-[10px] ml-1" style={{ color: 'var(--accent-gold-dark)' }}>{pct}%</span>
+                        )}
+                        {pct >= 95 && (
+                          <span className="text-[10px] ml-1" style={{ color: 'var(--status-success)' }}>done</span>
+                        )}
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/browse/BrowseViewToggle.tsx
+++ b/src/components/browse/BrowseViewToggle.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { LayoutGrid, List } from 'lucide-react';
+import CollectionBookCard from '@/components/CollectionBookCard';
+import { bookUrl } from '@/lib/slugify';
+import Link from 'next/link';
+
+type ViewMode = 'grid' | 'list';
+
+const STORAGE_KEY = 'sl-browse-view';
+
+interface BrowseBook {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string | null;
+  author?: string | null;
+  year?: number | null;
+  language?: string | null;
+  published?: string | null;
+  pages_count?: number;
+  pages_translated?: number;
+  thumbnail?: string | null;
+  thumbnail_blob?: string | null;
+  is_first_translation?: boolean;
+  ft_disposition?: string | null;
+}
+
+interface BrowseViewToggleProps {
+  books: BrowseBook[];
+  /** Render function for the list view. If not provided, uses a default list. */
+  renderListItem?: (book: BrowseBook) => React.ReactNode;
+}
+
+export function ViewToggleButtons({ viewMode, onChange }: { viewMode: ViewMode; onChange: (v: ViewMode) => void }) {
+  return (
+    <div className="flex items-center border rounded-lg overflow-hidden" style={{ borderColor: 'var(--border-light)' }}>
+      <button
+        onClick={() => onChange('grid')}
+        className={`p-2 transition-colors ${
+          viewMode === 'grid'
+            ? 'bg-[var(--accent-rust)]/10 text-[var(--accent-rust)]'
+            : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+        }`}
+        aria-label="Grid view"
+      >
+        <LayoutGrid className="w-4 h-4" />
+      </button>
+      <button
+        onClick={() => onChange('list')}
+        className={`p-2 transition-colors ${
+          viewMode === 'list'
+            ? 'bg-[var(--accent-rust)]/10 text-[var(--accent-rust)]'
+            : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]'
+        }`}
+        aria-label="List view"
+      >
+        <List className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}
+
+export default function BrowseViewToggle({ books, renderListItem }: BrowseViewToggleProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!initialized.current) {
+      const stored = localStorage.getItem(STORAGE_KEY) as ViewMode | null;
+      if (stored === 'grid' || stored === 'list') setViewMode(stored);
+      initialized.current = true;
+    }
+  }, []);
+
+  const handleToggle = (mode: ViewMode) => {
+    setViewMode(mode);
+    localStorage.setItem(STORAGE_KEY, mode);
+  };
+
+  const defaultListItem = (book: BrowseBook) => (
+    <Link
+      key={book.id}
+      href={bookUrl(book)}
+      className="block py-3 hover:opacity-70 transition-opacity"
+    >
+      <p className="font-medium text-sm" style={{ color: 'var(--text-primary)' }}>
+        {book.display_title || book.title}
+      </p>
+      <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        {book.author || ''}
+        {book.published ? ` · ${book.published}` : ''}
+        {book.language ? ` · ${book.language}` : ''}
+      </p>
+    </Link>
+  );
+
+  return (
+    <div>
+      <div className="flex items-center justify-end mb-4">
+        <ViewToggleButtons viewMode={viewMode} onChange={handleToggle} />
+      </div>
+
+      {viewMode === 'grid' ? (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {books.map((book, i) => (
+            <CollectionBookCard
+              key={book.id}
+              book={{
+                bookId: book.id,
+                id: book.id,
+                slug: book.slug,
+                title: book.display_title || book.title,
+                author: book.author || '',
+                year: book.year || 0,
+                pages_count: book.pages_count,
+                pages_translated: book.pages_translated,
+                thumbnail: book.thumbnail_blob || book.thumbnail || undefined,
+                language: book.language || undefined,
+                is_first_translation: book.is_first_translation,
+                ft_disposition: book.ft_disposition || undefined,
+              }}
+              priority={i < 10}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="divide-y" style={{ borderColor: 'var(--border-light)' }}>
+          {books.map(book => (
+            <div key={book.id}>
+              {renderListItem ? renderListItem(book) : defaultListItem(book)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a cover image grid view (CollectionBookCard) as an alternative to list/table views on browse pages
- Toggle persists via localStorage (`sl-browse-view` key), shared across all browse pages
- Wider containers (`max-w-6xl`) on titles and years pages to accommodate the 5-column grid

**Pages updated:**
- `/browse/titles/[letter]` — grid/list toggle
- `/browse/years/[period]` — grid/list toggle  
- `/author/[name]` — grid/list toggle on bibliography section (replaces inline table)

**New components:**
- `BrowseViewToggle` — shared toggle for simple browse pages
- `AuthorBibliography` — toggle with full bibliography table preserved as list view

## Test plan
- [ ] Visit `/browse/titles/A` — toggle between list and grid, verify covers load
- [ ] Visit `/browse/years/1500s` — same toggle test
- [ ] Visit an author page (e.g. `/author/paracelsus`) — verify bibliography table still works, grid view shows covers
- [ ] Toggle preference persists across page navigations
- [ ] Mobile responsive — grid should collapse to 2 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)