### PR TITLE
Add donation intention form with email follow-up

### DIFF
--- a/scripts/migration/create-donation-intentions.sql
+++ b/scripts/migration/create-donation-intentions.sql
@@ -1,0 +1,26 @@
+-- Supabase table for donation intentions
+-- Run this in the Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS donation_intentions (
+  id          BIGSERIAL PRIMARY KEY,
+  name        TEXT NOT NULL,
+  email       TEXT NOT NULL,
+  route       TEXT NOT NULL CHECK (route IN ('naf', 'efm', 'undecided')),
+  amount_range TEXT,          -- e.g. 'under-100', '100-500', '500-1000', '1000-5000', '5000-plus'
+  message     TEXT,
+  referrer    TEXT,           -- how they found us
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- RLS: service role can read/write, anon can insert only
+ALTER TABLE donation_intentions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON donation_intentions
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Anon can insert" ON donation_intentions
+  FOR INSERT WITH CHECK (true);
+
+-- Index for admin queries
+CREATE INDEX idx_donation_intentions_created ON donation_intentions (created_at DESC);
+CREATE INDEX idx_donation_intentions_email ON donation_intentions (email);

--- a/src/app/api/donate/route.ts
+++ b/src/app/api/donate/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase';
+import { Resend } from 'resend';
+
+const VALID_ROUTES = ['naf', 'efm', 'undecided'] as const;
+const VALID_AMOUNTS = ['under-100', '100-500', '500-1000', '1000-5000', '5000-plus', ''] as const;
+
+interface DonationIntention {
+  name: string;
+  email: string;
+  route: (typeof VALID_ROUTES)[number];
+  amount_range?: string;
+  message?: string;
+  referrer?: string;
+}
+
+function buildDonorEmail(firstName: string, route: string): string {
+  const routeInfo =
+    route === 'naf'
+      ? `Since you indicated interest in donating via the <strong>Netherland-America Foundation</strong> (NAF),
+         your gift will be tax-deductible under US law as a 501(c)(3) contribution.`
+      : route === 'efm'
+        ? `Your contribution will go directly to the <strong>Embassy of the Free Mind</strong> in Amsterdam,
+           earmarked for the Source Library project.`
+        : `We'll help you find the best donation route for your situation.`;
+
+  return `
+    <div style="font-family: Georgia, 'Times New Roman', serif; max-width: 520px; margin: 0 auto; padding: 40px 24px; color: #1a1612;">
+      <div style="text-align: center; margin-bottom: 32px;">
+        <img src="https://sourcelibrary.org/brand/svg/icon-only--black-on-white.svg" alt="Source Library" width="48" height="48" style="margin-bottom: 16px;" />
+        <h1 style="font-size: 24px; font-weight: 400; margin: 0; letter-spacing: -0.01em;">
+          Source Library
+        </h1>
+      </div>
+
+      <div style="line-height: 1.8; font-size: 15px; color: #1a1612;">
+        <p>Dear ${firstName},</p>
+        <p>
+          Thank you for your interest in supporting Source Library. Every contribution
+          moves us closer to making these extraordinary texts freely available to the world.
+        </p>
+        <p>${routeInfo}</p>
+      </div>
+
+      <div style="background: #f5f0e8; border-radius: 8px; padding: 20px 24px; margin: 24px 0; line-height: 1.8; font-size: 14px; color: #1a1612;">
+        <strong>Your point of contact:</strong><br>
+        Derek Lomas, Project Director<br>
+        <a href="mailto:derek@sourcelibrary.org" style="color: #9e4a3a; text-decoration: none;">derek@sourcelibrary.org</a><br><br>
+        Derek can walk you through the donation process, answer questions about the project,
+        or help with wire transfers and larger gifts. Don't hesitate to reach out directly.
+      </div>
+
+      <div style="line-height: 1.8; font-size: 15px; color: #1a1612;">
+        <p>
+          Source Library is an initiative of the Embassy of the Free Mind in Amsterdam,
+          home to one of the world's most important collections of Hermetic, alchemical,
+          and esoteric manuscripts. We are digitizing and translating these texts &mdash;
+          many for the first time &mdash; and publishing them freely online.
+        </p>
+        <p>
+          We'll be in touch soon. In the meantime, feel free to explore the library at
+          <a href="https://sourcelibrary.org" style="color: #9e4a3a; text-decoration: none;">sourcelibrary.org</a>.
+        </p>
+      </div>
+
+      <div style="margin-top: 36px; padding-top: 20px; border-top: 1px solid #e8e4dc; line-height: 1.7; font-size: 14px; color: #8a8480;">
+        <p style="margin: 0;">With gratitude,</p>
+        <p style="margin: 4px 0 0; color: #1a1612;">The Source Library team</p>
+        <p style="margin: 16px 0 0; font-size: 12px;">
+          <a href="https://sourcelibrary.org" style="color: #8a8480;">sourcelibrary.org</a>
+          &nbsp;&middot;&nbsp;
+          Embassy of the Free Mind, Amsterdam
+        </p>
+      </div>
+    </div>
+  `;
+}
+
+function buildNotificationEmail(intention: DonationIntention): string {
+  const routeLabel = intention.route === 'naf' ? 'NAF (US tax-deductible)' : intention.route === 'efm' ? 'Direct via EFM' : 'Undecided';
+  const amountLabel = intention.amount_range
+    ? intention.amount_range.replace('under-', 'Under $').replace('plus', '+').replace(/-/g, ' - $').replace(/^(\d)/, '$$$1')
+    : 'Not specified';
+
+  return `
+    <div style="font-family: -apple-system, sans-serif; max-width: 520px; margin: 0 auto; padding: 24px; color: #1a1612;">
+      <h2 style="font-size: 18px; margin: 0 0 16px;">New Donation Interest</h2>
+      <table style="width: 100%; border-collapse: collapse; font-size: 14px;">
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600; width: 120px;">Name</td><td style="padding: 8px 12px;">${intention.name}</td></tr>
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Email</td><td style="padding: 8px 12px;"><a href="mailto:${intention.email}">${intention.email}</a></td></tr>
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Route</td><td style="padding: 8px 12px;">${routeLabel}</td></tr>
+        <tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Amount</td><td style="padding: 8px 12px;">${amountLabel}</td></tr>
+        ${intention.message ? `<tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600; vertical-align: top;">Message</td><td style="padding: 8px 12px;">${intention.message}</td></tr>` : ''}
+        ${intention.referrer ? `<tr><td style="padding: 8px 12px; background: #f5f0e8; font-weight: 600;">Referrer</td><td style="padding: 8px 12px;">${intention.referrer}</td></tr>` : ''}
+      </table>
+      <p style="margin-top: 16px; font-size: 13px; color: #8a8480;">
+        Reply directly to this email to reach the donor at ${intention.email}.
+      </p>
+    </div>
+  `;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, email, route, amount_range, message, referrer } = body;
+
+    // Validate required fields
+    if (!name?.trim() || !email?.trim() || !route) {
+      return NextResponse.json({ error: 'Name, email, and donation route are required' }, { status: 400 });
+    }
+
+    if (!VALID_ROUTES.includes(route)) {
+      return NextResponse.json({ error: 'Invalid donation route' }, { status: 400 });
+    }
+
+    if (amount_range && !VALID_AMOUNTS.includes(amount_range)) {
+      return NextResponse.json({ error: 'Invalid amount range' }, { status: 400 });
+    }
+
+    // Basic email validation
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+      return NextResponse.json({ error: 'Invalid email address' }, { status: 400 });
+    }
+
+    const intention: DonationIntention = {
+      name: name.trim(),
+      email: email.trim(),
+      route,
+      amount_range: amount_range || undefined,
+      message: message?.trim() || undefined,
+      referrer: referrer?.trim() || undefined,
+    };
+
+    // Save to Supabase
+    if (supabaseAdmin) {
+      const { error: dbError } = await supabaseAdmin.from('donation_intentions').insert({
+        name: intention.name,
+        email: intention.email,
+        route: intention.route,
+        amount_range: intention.amount_range || null,
+        message: intention.message || null,
+        referrer: intention.referrer || null,
+      });
+
+      if (dbError) {
+        console.error('Failed to save donation intention:', dbError);
+        // Don't fail the request — still send emails
+      }
+    }
+
+    // Send emails
+    if (process.env.RESEND_API_KEY) {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const from = process.env.EMAIL_FROM || 'Source Library <noreply@sourcelibrary.org>';
+      const firstName = intention.name.split(' ')[0] || 'friend';
+
+      // Email to donor
+      await resend.emails.send({
+        from,
+        to: intention.email,
+        subject: 'Thank you for your interest in Source Library',
+        replyTo: 'derek@sourcelibrary.org',
+        html: buildDonorEmail(firstName, intention.route),
+      });
+
+      // Notification to Derek
+      await resend.emails.send({
+        from,
+        to: 'derek@sourcelibrary.org',
+        replyTo: intention.email,
+        subject: `Donation interest: ${intention.name}`,
+        html: buildNotificationEmail(intention),
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('Donation intention error:', err);
+    return NextResponse.json({ error: 'Something went wrong' }, { status: 500 });
+  }
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Metadata } from 'next';
 import SiteHeader from '@/components/layout/SiteHeader';
+import DonationIntentionForm from '@/components/donate/DonationIntentionForm';
 import { getReadDb } from '@/lib/mongodb';
 
 export const revalidate = 600;
@@ -217,96 +218,70 @@ export default async function SupportPage() {
         </div>
       </section>
 
-      {/* How to Donate — Two Routes */}
+      {/* Donation Intention Form */}
       <section className="bg-white py-16 md:py-24">
         <div className="px-6 md:px-12 max-w-5xl mx-auto">
-          <h2 className="text-3xl md:text-4xl text-stone-900 mb-4 leading-tight font-display">
-            How to Donate
-          </h2>
-          <p className="text-lg text-stone-600 mb-12 max-w-3xl">
-            There are two ways to support Source Library, depending on your location and needs.
-          </p>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-start">
+            <div>
+              <h2 className="text-3xl md:text-4xl text-stone-900 mb-4 leading-tight font-display">
+                Support This Work
+              </h2>
+              <p className="text-lg text-stone-600 leading-relaxed mb-6">
+                Tell us a little about yourself and we'll personally guide you through the donation process. Every gift — of any size — makes a difference.
+              </p>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {/* US Donors — NAF */}
-            <div className="bg-[#faf8f5] rounded-2xl border border-stone-200 p-8 flex flex-col">
-              <div className="flex items-center gap-3 mb-4">
-                <span className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-stone-200 text-stone-600 text-lg font-semibold shrink-0">
-                  US
-                </span>
-                <h3 className="text-xl font-semibold text-stone-900">
-                  US Tax-Deductible Donation
-                </h3>
+              <div className="space-y-6 text-stone-600 text-sm leading-relaxed">
+                <div className="flex gap-3">
+                  <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-stone-100 text-stone-500 text-xs font-semibold shrink-0 mt-0.5">US</span>
+                  <div>
+                    <strong className="text-stone-900">US donors</strong> can give tax-deductibly through the{' '}
+                    <strong>Netherland-America Foundation</strong> (NAF), a 501(c)(3) public charity.
+                  </div>
+                </div>
+                <div className="flex gap-3">
+                  <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-stone-100 text-stone-500 text-xs font-semibold shrink-0 mt-0.5">EU</span>
+                  <div>
+                    <strong className="text-stone-900">European and international donors</strong> can contribute directly to the Embassy of the Free Mind (ANBI-registered).
+                  </div>
+                </div>
               </div>
-              <p className="text-stone-600 text-sm leading-relaxed mb-4">
-                For US-based donors and companies seeking tax benefits. Donations are processed through the{' '}
-                <strong>Netherland-America Foundation</strong> (NAF), a 501(c)(3) public charity (EIN: 13-2989216).
-              </p>
-              <p className="text-stone-500 text-xs leading-relaxed mb-6">
-                Tax-deductible to the full extent permitted by US law. Please write &ldquo;Source Library&rdquo; in the comments field.
-              </p>
-              <div className="mt-auto">
+
+              <div className="mt-8 bg-[#faf8f5] rounded-xl border border-stone-200 p-5">
+                <h3 className="text-sm font-semibold text-stone-900 mb-2">Tax Benefits</h3>
+                <p className="text-stone-600 text-xs leading-relaxed">
+                  EFM is a registered non-profit (ANBI, Netherlands). US donors giving through the NAF receive full 501(c)(3) tax benefits. Donation receipts are available upon request or automatically via Stripe.
+                </p>
+              </div>
+
+              <div className="mt-6 flex flex-wrap gap-4 text-sm">
+                <span className="text-stone-400">Or donate directly:</span>
                 <a
                   href={DONORPERFECT_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="block w-full text-center bg-stone-900 text-white py-3 px-6 rounded-full hover:bg-stone-800 transition-colors text-base font-medium"
+                  className="text-accent-rust hover:text-accent-gold-dark underline"
                 >
-                  Donate via NAF
+                  NAF (US)
                 </a>
-              </div>
-            </div>
-
-            {/* International Donors — EFM / Mollie */}
-            <div className="bg-[#faf8f5] rounded-2xl border border-stone-200 p-8 flex flex-col">
-              <div className="flex items-center gap-3 mb-4">
-                <span className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-stone-200 text-stone-600 text-lg font-semibold shrink-0">
-                  EU
-                </span>
-                <h3 className="text-xl font-semibold text-stone-900">
-                  Direct Donation via EFM
-                </h3>
-              </div>
-              <p className="text-stone-600 text-sm leading-relaxed mb-4">
-                For European and international donors. Your contribution goes directly to the Embassy of the Free Mind, earmarked for Source Library.
-              </p>
-              <p className="text-stone-500 text-xs leading-relaxed mb-2">
-                Please include <strong>&ldquo;Source Library&rdquo;</strong> in the description of your donation so we can allocate your contribution correctly.
-              </p>
-              <p className="text-stone-500 text-xs leading-relaxed mb-6">
-                Donation confirmations and receipts are available upon request.
-              </p>
-              <div className="mt-auto">
                 <a
                   href={MOLLIE_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="block w-full text-center bg-stone-900 text-white py-3 px-6 rounded-full hover:bg-stone-800 transition-colors text-base font-medium"
+                  className="text-accent-rust hover:text-accent-gold-dark underline"
                 >
-                  Donate via EFM
+                  EFM (International)
+                </a>
+                <a
+                  href={`mailto:${CONTACT_EMAIL}?subject=Source%20Library%20%E2%80%94%20Donation%20Inquiry`}
+                  className="text-accent-rust hover:text-accent-gold-dark underline"
+                >
+                  Wire / Large Gifts
                 </a>
               </div>
             </div>
-          </div>
 
-          {/* Tax Benefits */}
-          <div className="mt-10 bg-[#faf8f5] rounded-xl border border-stone-200 p-6">
-            <h3 className="text-base font-semibold text-stone-900 mb-2">Tax Benefits</h3>
-            <p className="text-stone-600 text-sm leading-relaxed">
-              The Embassy of the Free Mind is a registered non-profit organization (ANBI-registered in the Netherlands). Your donation may be tax-deductible depending on your country of residence. US donors giving through the Netherland-America Foundation receive full 501(c)(3) tax benefits.
-            </p>
+            <DonationIntentionForm />
           </div>
-
-          {/* Large gifts */}
-          <p className="text-stone-500 text-sm mt-8 text-center">
-            For wire transfers, stock gifts, or donations over $10,000,{' '}
-            <a
-              href={`mailto:${CONTACT_EMAIL}?subject=Source%20Library%20%E2%80%94%20Large%20Gift%20Inquiry`}
-              className="text-accent-rust hover:text-accent-gold-dark underline"
-            >
-              contact us directly
-            </a>.
-          </p>
         </div>
       </section>
 

--- a/src/components/donate/DonationIntentionForm.tsx
+++ b/src/components/donate/DonationIntentionForm.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+
+const AMOUNT_OPTIONS = [
+  { value: 'under-100', label: 'Under $100' },
+  { value: '100-500', label: '$100 - $500' },
+  { value: '500-1000', label: '$500 - $1,000' },
+  { value: '1000-5000', label: '$1,000 - $5,000' },
+  { value: '5000-plus', label: '$5,000+' },
+];
+
+const ROUTE_OPTIONS = [
+  {
+    value: 'naf',
+    label: 'US Tax-Deductible (NAF)',
+    description: 'Via the Netherland-America Foundation, a 501(c)(3) public charity.',
+  },
+  {
+    value: 'efm',
+    label: 'Direct to Embassy of the Free Mind',
+    description: 'For European and international donors. ANBI-registered in the Netherlands.',
+  },
+  {
+    value: 'undecided',
+    label: "I'm not sure yet",
+    description: "We'll help you find the best option for your situation.",
+  },
+];
+
+type FormState = 'idle' | 'submitting' | 'success' | 'error';
+
+export default function DonationIntentionForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [route, setRoute] = useState('');
+  const [amountRange, setAmountRange] = useState('');
+  const [message, setMessage] = useState('');
+  const [state, setState] = useState<FormState>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || !email.trim() || !route) return;
+
+    setState('submitting');
+    setErrorMsg('');
+
+    try {
+      const res = await fetch('/api/donate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          route,
+          amount_range: amountRange || undefined,
+          message: message.trim() || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Something went wrong');
+      }
+
+      setState('success');
+    } catch (err) {
+      setState('error');
+      setErrorMsg(err instanceof Error ? err.message : 'Something went wrong');
+    }
+  }
+
+  if (state === 'success') {
+    return (
+      <div className="bg-[#faf8f5] rounded-2xl border border-stone-200 p-8 md:p-12 text-center">
+        <div className="w-16 h-16 rounded-full bg-emerald-50 flex items-center justify-center mx-auto mb-6">
+          <svg className="w-8 h-8 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h3 className="text-2xl font-display text-stone-900 mb-3">Thank you, {name.split(' ')[0]}</h3>
+        <p className="text-stone-600 text-lg leading-relaxed max-w-md mx-auto mb-4">
+          We've sent you an email with next steps and a personal introduction to Derek Lomas, our Project Director, who can help with anything you need.
+        </p>
+        <p className="text-stone-500 text-sm">
+          Check your inbox at <strong>{email}</strong>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-[#faf8f5] rounded-2xl border border-stone-200 p-8 md:p-10">
+      <div className="mb-8">
+        <h3 className="text-2xl font-display text-stone-900 mb-2">Express Your Interest</h3>
+        <p className="text-stone-600 text-sm leading-relaxed">
+          Tell us a bit about yourself and we'll follow up personally to help make your contribution as easy as possible.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        {/* Name + Email */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="donor-name" className="block text-sm font-medium text-stone-700 mb-1.5">
+              Your name
+            </label>
+            <input
+              id="donor-name"
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-4 py-2.5 rounded-lg border border-stone-300 bg-white text-stone-900 text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust transition-colors"
+              placeholder="Full name"
+            />
+          </div>
+          <div>
+            <label htmlFor="donor-email" className="block text-sm font-medium text-stone-700 mb-1.5">
+              Email
+            </label>
+            <input
+              id="donor-email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-4 py-2.5 rounded-lg border border-stone-300 bg-white text-stone-900 text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust transition-colors"
+              placeholder="you@example.com"
+            />
+          </div>
+        </div>
+
+        {/* Donation Route */}
+        <fieldset>
+          <legend className="block text-sm font-medium text-stone-700 mb-3">
+            How would you like to donate?
+          </legend>
+          <div className="space-y-3">
+            {ROUTE_OPTIONS.map((opt) => (
+              <label
+                key={opt.value}
+                className={`flex items-start gap-3 p-4 rounded-lg border cursor-pointer transition-all ${
+                  route === opt.value
+                    ? 'border-accent-rust bg-white shadow-sm'
+                    : 'border-stone-200 bg-white/50 hover:border-stone-300'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="route"
+                  value={opt.value}
+                  checked={route === opt.value}
+                  onChange={(e) => setRoute(e.target.value)}
+                  className="mt-0.5 accent-accent-rust"
+                  required
+                />
+                <div>
+                  <div className="text-sm font-medium text-stone-900">{opt.label}</div>
+                  <div className="text-xs text-stone-500 mt-0.5">{opt.description}</div>
+                </div>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {/* Amount Range */}
+        <div>
+          <label htmlFor="donor-amount" className="block text-sm font-medium text-stone-700 mb-1.5">
+            Approximate amount <span className="font-normal text-stone-400">(optional)</span>
+          </label>
+          <select
+            id="donor-amount"
+            value={amountRange}
+            onChange={(e) => setAmountRange(e.target.value)}
+            className="w-full px-4 py-2.5 rounded-lg border border-stone-300 bg-white text-stone-900 text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust transition-colors"
+          >
+            <option value="">Prefer not to say</option>
+            {AMOUNT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Message */}
+        <div>
+          <label htmlFor="donor-message" className="block text-sm font-medium text-stone-700 mb-1.5">
+            Anything you'd like us to know? <span className="font-normal text-stone-400">(optional)</span>
+          </label>
+          <textarea
+            id="donor-message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={3}
+            className="w-full px-4 py-2.5 rounded-lg border border-stone-300 bg-white text-stone-900 text-sm focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust transition-colors resize-none"
+            placeholder="What draws you to this work, how you found us, or anything else..."
+          />
+        </div>
+
+        {/* Error */}
+        {state === 'error' && (
+          <div className="bg-red-50 text-red-700 text-sm rounded-lg px-4 py-3">
+            {errorMsg || 'Something went wrong. Please try again or email derek@sourcelibrary.org directly.'}
+          </div>
+        )}
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={state === 'submitting' || !name.trim() || !email.trim() || !route}
+          className="w-full bg-stone-900 text-white py-3.5 px-6 rounded-full hover:bg-stone-800 transition-colors text-base font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {state === 'submitting' ? 'Sending...' : 'Get in Touch'}
+        </button>
+
+        <p className="text-xs text-stone-400 text-center leading-relaxed">
+          We'll respond personally within one business day. Your information is never shared.
+        </p>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a donation intention form to `/support` that captures donor info (name, email, preferred route, amount range, optional message)
- Saves to Supabase `donation_intentions` table for CRM tracking
- Sends personalized thank-you email to donor introducing Derek as point of contact
- Sends notification email to Derek with donor details (reply-to set to donor's email)
- Direct payment links (NAF, Mollie, wire/large gifts) remain accessible below the form

## Setup required before merge
Run the SQL in `scripts/migration/create-donation-intentions.sql` in the Supabase SQL editor to create the `donation_intentions` table.

## Test plan
- [ ] Create `donation_intentions` table in Supabase
- [ ] Submit the form on the preview deploy
- [ ] Verify Supabase row is created
- [ ] Verify donor receives thank-you email
- [ ] Verify Derek receives notification email
- [ ] Test validation (empty fields, bad email)
- [ ] Test graceful degradation (emails still send if Supabase is down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)