### PR TITLE
Replace translated excerpt with Chapters & Sections dropdown

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { getBookDetail } from '@/lib/books-catalog';
-import { Calendar, Globe, FileText, BookText, BookMarked, Images } from 'lucide-react';
+import { Calendar, Globe, FileText, BookMarked, Images } from 'lucide-react';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
 import SearchPanel from '@/components/search/SearchPanel';
 import BookPagesSection from '@/components/book/BookPagesSection';
@@ -14,6 +14,7 @@ import EarlyAccessGate from '@/components/book/EarlyAccessGate';
 import BookDedication from '@/components/book/BookDedication';
 import BookHistory from '@/components/book/BookHistory';
 import BookIndex from '@/components/book/BookIndex';
+import ChaptersDropdown from '@/components/book/ChaptersDropdown';
 import BookAnalytics from '@/components/book/BookAnalytics';
 import CoverImagePicker from '@/components/book/CoverImagePicker';
 import DownloadButton from '@/components/ui/DownloadButton';
@@ -90,7 +91,6 @@ const getCachedBookLookup = cache(async (id: string): Promise<{
     new Promise<never>((_, reject) => setTimeout(() => reject(new Error('DB timeout')), 15000)),
   ]);
   const result = await findBookByIdOrSlug(db, id, {
-    chapters: 0,
     reading_sections: 0,
     pipeline: 0,
     pipeline_auto: 0,
@@ -204,7 +204,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 interface GalleryImagePreview { id: string; extracted_url?: string; thumbnail_url?: string; image_url?: string; description?: string; type?: string; page_number?: number; gallery_quality?: number }
 interface BookCollectionPreview { slug: string; name: string; subtitle?: string; color?: string; book_count?: number; featured_images?: Array<{ extracted_url?: string; thumbnail_url?: string; image_url?: string }> }
 
-async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; translatedExcerpt: string | null; excerptPageNumber: number | null; matchedBySlug: boolean } | null> {
+async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean } | null> {
   // Reuse the cached book lookup (shared with generateMetadata — saves a full DB round trip)
   // When Supabase serves the lookup (<50ms), we get the bookId instantly and can start
   // ALL Atlas queries in parallel — including a full book refetch for fields not in the catalog.
@@ -224,7 +224,6 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
   // This runs in parallel with pages/gallery/collections — no sequential bottleneck.
   const fullBookPromise = fromCatalog
     ? findBookByIdOrSlug(db, bookId, {
-        chapters: 0,
         reading_sections: 0,
         pipeline: 0,
         pipeline_auto: 0,
@@ -238,7 +237,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
     : Promise.resolve(null); // Already have full book from Atlas
 
   // All queries have maxTimeMS to fail fast during DB degradation
-  const [fullBookResult, pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw, excerptPageRaw] = await Promise.all([
+  const [fullBookResult, pagesRaw, totalBooks, galleryImagesRaw, galleryImageCount, bookCollectionsRaw] = await Promise.all([
     fullBookPromise,
     // Drop $ne filter — it prevents use of the {book_id,page_number} compound
     // index and forces a collection scan. Filter digitizer-inserts in JS instead.
@@ -297,13 +296,6 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
           .toArray()
           .catch(() => [])
       : Promise.resolve([]),
-    // First non-blank translated page for excerpt preview
-    db.collection('pages')
-      .findOne(
-        { book_id: bookId, 'translation.data': { $exists: true, $ne: '' } },
-        { sort: { page_number: 1 }, projection: { _id: 0, 'translation.data': 1, page_number: 1 }, maxTimeMS: 3000 },
-      )
-      .catch(() => null),
   ]);
 
   // Use the full Atlas book when available (has editions, translation_verification, etc.)
@@ -327,30 +319,7 @@ async function getBook(id: string): Promise<{ book: Book; pages: Page[]; totalBo
   const galleryImages = JSON.parse(JSON.stringify(galleryImagesRaw)) as GalleryImagePreview[];
   const bookCollections = JSON.parse(JSON.stringify(bookCollectionsRaw)) as BookCollectionPreview[];
 
-  // Extract and truncate translated excerpt at a sentence boundary
-  let translatedExcerpt: string | null = null;
-  let excerptPageNumber: number | null = null;
-  if (excerptPageRaw?.translation?.data) {
-    const raw = excerptPageRaw.translation.data as string;
-    // Strip XML/HTML tags that translation data may contain
-    const cleaned = raw.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
-    if (cleaned.length > 0) {
-      excerptPageNumber = excerptPageRaw.page_number ?? null;
-      if (cleaned.length <= 300) {
-        translatedExcerpt = cleaned;
-      } else {
-        // Find the last sentence boundary before 300 chars
-        const truncated = cleaned.slice(0, 350);
-        const lastPeriod = truncated.lastIndexOf('. ', 300);
-        const lastQuestion = truncated.lastIndexOf('? ', 300);
-        const lastExclaim = truncated.lastIndexOf('! ', 300);
-        const boundary = Math.max(lastPeriod, lastQuestion, lastExclaim);
-        translatedExcerpt = boundary > 80 ? truncated.slice(0, boundary + 1) : cleaned.slice(0, 300) + '...';
-      }
-    }
-  }
-
-  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, translatedExcerpt, excerptPageNumber, matchedBySlug };
+  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, matchedBySlug };
 }
 
 // Skeleton for book info while loading
@@ -413,7 +382,7 @@ async function BookInfo({ id }: { id: string }) {
     notFound();
   }
 
-  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, translatedExcerpt, excerptPageNumber } = data;
+  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections } = data;
 
   // Empty shell books (0 pages from failed imports) should 404
   // But visual art (paintings, prints, etc.) legitimately has no page documents
@@ -796,24 +765,13 @@ async function BookInfo({ id }: { id: string }) {
               )}
             </div>
 
-            {/* Translated Excerpt */}
-            {translatedExcerpt && (
-              <div className="card p-6 mt-6">
-                <h2 className="text-lg font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>
-                  <BookText className="w-4 h-4 inline-block mr-2 -mt-0.5 opacity-60" />
-                  From the Translation
-                </h2>
-                <blockquote className="border-l-3 border-accent-gold/40 pl-4 italic text-secondary leading-relaxed">
-                  {translatedExcerpt}
-                </blockquote>
-                <Link
-                  href={`/book/${book.slug || book.id}${excerptPageNumber ? `/page-number/${excerptPageNumber}` : ''}`}
-                  className="inline-block mt-3 text-sm text-accent-rust hover:text-accent-gold-dark transition-colors"
-                >
-                  Continue reading &rarr;
-                </Link>
-              </div>
-            )}
+            {/* Chapters & Sections */}
+            {book.chapters?.length ? (
+              <ChaptersDropdown
+                chapters={book.chapters as { title: string; titleEn?: string; pageNumber: number; level: number }[]}
+                bookSlug={book.slug || book.id}
+              />
+            ) : null}
 
             {/* Editions Panel */}
             {book.editions?.length ? (

--- a/src/components/book/ChaptersDropdown.tsx
+++ b/src/components/book/ChaptersDropdown.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ChevronDown, List } from 'lucide-react';
+
+interface Chapter {
+  title: string;
+  titleEn?: string;
+  pageNumber: number;
+  level: number;
+}
+
+export default function ChaptersDropdown({ chapters, bookSlug }: { chapters: Chapter[]; bookSlug: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="card mt-6 overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between p-5 text-left hover:bg-stone-50 dark:hover:bg-stone-800/50 transition-colors"
+      >
+        <span className="flex items-center gap-2 text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+          <List className="w-4 h-4 opacity-60" />
+          Chapters &amp; Sections
+        </span>
+        <ChevronDown className={`w-5 h-5 opacity-40 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+      {open && (
+        <div className="px-5 pb-5 border-t border-stone-200 dark:border-stone-700">
+          <nav className="mt-3 space-y-0.5">
+            {chapters.map((ch, i) => (
+              <Link
+                key={i}
+                href={`/book/${bookSlug}/page-number/${ch.pageNumber}`}
+                className="flex items-baseline gap-2 py-1.5 px-2 -mx-2 rounded hover:bg-stone-100 dark:hover:bg-stone-800/50 transition-colors group"
+                style={{ paddingLeft: `${(ch.level - 1) * 1.25 + 0.5}rem` }}
+              >
+                <span className="text-sm text-secondary flex-1" style={{ color: 'var(--text-primary)' }}>
+                  {ch.titleEn || ch.title}
+                </span>
+                <span className="text-xs text-stone-400 opacity-0 group-hover:opacity-100 transition-opacity tabular-nums">
+                  p.{ch.pageNumber}
+                </span>
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Remove the "From the Translation" excerpt block — it consistently picked up e-rara digital cover sheets and other non-content pages
- Replace with a collapsible **Chapters & Sections** dropdown that links to each chapter's start page
- Include chapter data in the book query (was previously excluded with `chapters: 0`)
- Remove the extra `pages.findOne` query that fetched the excerpt (one fewer DB call per book page load)

## Test plan
- [ ] Visit a book with chapters data — verify dropdown appears and expands
- [ ] Verify chapter links navigate to correct page numbers
- [ ] Visit a book without chapters — verify no dropdown appears (clean fallback)
- [ ] Check e-rara books no longer show cover sheet text

🤖 Generated with [Claude Code](https://claude.com/claude-code)