### PR TITLE
Add layout-aligned loading skeletons for gallery and collection pages

### DIFF
--- a/src/app/collections/loading.tsx
+++ b/src/app/collections/loading.tsx
@@ -2,30 +2,23 @@ import SiteHeader from '@/components/layout/SiteHeader';
 
 export default function CollectionsIndexLoading() {
   return (
-    <div className="min-h-screen bg-cream">
+    <div className="min-h-screen bg-stone-50">
       <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="relative overflow-hidden text-white py-16 md:py-20">
         <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
-        <div className="relative max-w-7xl mx-auto px-6">
-          <div className="h-12 w-64 bg-white/15 rounded-lg animate-pulse mb-3" />
-          <div className="h-6 w-96 bg-white/10 rounded animate-pulse" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-64 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
         </div>
       </div>
 
       {/* Collection grid */}
-      <div className="max-w-7xl mx-auto px-6 py-12">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12">
+        <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
           {Array.from({ length: 12 }).map((_, i) => (
-            <div key={i} className="rounded-lg overflow-hidden">
-              <div className="aspect-[16/9] bg-stone-200 animate-pulse" />
-              <div className="p-4 space-y-2">
-                <div className="h-5 w-3/4 bg-stone-200 rounded animate-pulse" />
-                <div className="h-3 w-full bg-stone-100 rounded animate-pulse" />
-                <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
-              </div>
-            </div>
+            <div key={i} className="rounded-lg overflow-hidden aspect-[4/3] bg-stone-200 animate-pulse" />
           ))}
         </div>
       </div>

--- a/src/app/gallery/collections/[slug]/loading.tsx
+++ b/src/app/gallery/collections/[slug]/loading.tsx
@@ -1,0 +1,26 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function GalleryCollectionDetailLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Description skeleton */}
+        <div className="mb-8 max-w-3xl space-y-2">
+          <div className="h-4 w-full bg-stone-200 rounded animate-pulse" />
+          <div className="h-4 w-4/5 bg-stone-200 rounded animate-pulse" />
+        </div>
+
+        {/* Image grid skeleton */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          {Array.from({ length: 15 }).map((_, i) => (
+            <div key={i} className="rounded-lg overflow-hidden">
+              <div className="aspect-square bg-stone-200 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gallery/collections/loading.tsx
+++ b/src/app/gallery/collections/loading.tsx
@@ -1,0 +1,24 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function GalleryCollectionsLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Intro skeleton */}
+        <div className="text-center mb-10">
+          <div className="h-7 w-64 bg-stone-200 rounded animate-pulse mx-auto mb-3" />
+          <div className="h-4 w-96 max-w-full bg-stone-100 rounded animate-pulse mx-auto" />
+        </div>
+
+        {/* Collection cards skeleton */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="rounded-xl overflow-hidden aspect-[4/3] bg-stone-200 animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gallery/loading.tsx
+++ b/src/app/gallery/loading.tsx
@@ -1,9 +1,47 @@
-import { BookLoader } from '@/components/ui/BookLoader';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export default function GalleryLoading() {
   return (
-    <div className="min-h-screen bg-cream flex items-center justify-center">
-      <BookLoader size="lg" />
+    <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="dark" sticky breadcrumbs={[{ label: 'Image Gallery', href: '/gallery' }]} />
+
+      <div className="px-4 sm:px-6 lg:px-8 py-6">
+        {/* Search & filter bar skeleton */}
+        <div className="flex flex-col sm:flex-row flex-wrap items-stretch sm:items-center gap-3 mb-6">
+          <div className="flex-1 min-w-0 sm:min-w-[200px] max-w-md h-9 bg-stone-200 rounded-lg animate-pulse" />
+          <div className="min-w-0 sm:min-w-[200px] max-w-sm flex-1 h-9 bg-stone-200 rounded-lg animate-pulse" />
+          <div className="h-9 w-24 bg-stone-200 rounded-lg animate-pulse" />
+        </div>
+
+        {/* Featured collections skeleton */}
+        <div className="mb-8">
+          <div className="h-6 w-48 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex gap-4 overflow-hidden">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex-shrink-0 w-56 rounded-xl overflow-hidden">
+                <div className="aspect-[4/3] bg-stone-200 animate-pulse" />
+                <div className="p-3 space-y-1.5">
+                  <div className="h-4 w-3/4 bg-stone-200 rounded animate-pulse" />
+                  <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Image grid skeleton */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+          {Array.from({ length: 24 }).map((_, i) => (
+            <div key={i} className="rounded-lg overflow-hidden">
+              <div className="aspect-square bg-stone-200 animate-pulse" />
+              <div className="p-2 space-y-1.5">
+                <div className="h-3 w-full bg-stone-200 rounded animate-pulse" />
+                <div className="h-3 w-2/3 bg-stone-100 rounded animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the gallery page's generic spinner with a skeleton matching the actual layout (search bar + featured collections row + image grid)
- Add new loading skeletons for `/gallery/collections` (index) and `/gallery/collections/[slug]` (detail) — previously had none
- Fix collections index skeleton to match the real page: `grid-cols-2 lg:grid-cols-4` with `aspect-[4/3]` cards and correct container width

Clicking any of these pages now shows an instant skeleton that matches the incoming layout, so nothing feels broken or unresponsive.

## Test plan
- [ ] Navigate to `/gallery` — skeleton shows search bar + grid of square image placeholders
- [ ] Navigate to `/gallery/collections` — skeleton shows centered title + 4:3 collection card grid
- [ ] Navigate to `/gallery/collections/[slug]` — skeleton shows description lines + square image grid
- [ ] Navigate to `/collections` — skeleton shows hero + 2×4 grid of 4:3 cards
- [ ] Navigate to `/collections/[id]` — existing skeleton unchanged, dark hero + book grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)