### PR TITLE
Add art/images view mode to timeline

### DIFF
--- a/src/app/api/books/timeline/route.ts
+++ b/src/app/api/books/timeline/route.ts
@@ -21,16 +21,78 @@ export async function GET(request: NextRequest) {
     if (language) baseMatch.language = language;
     if (collection) baseMatch.categories = collection;
 
-    // Drill-down mode: return books for a specific decade
+    // Drill-down mode: return books or art for a specific decade
     if (decade) {
       const decadeNum = parseInt(decade);
       if (isNaN(decadeNum)) {
         return NextResponse.json({ error: 'Invalid decade' }, { status: 400 });
       }
 
+      const mode = searchParams.get('mode') || 'books';
       const limit = Math.min(parseInt(searchParams.get('limit') || '30'), 100);
       const offset = Math.max(parseInt(searchParams.get('offset') || '0'), 0);
 
+      // Art mode: one best image per author from gallery_images
+      if (mode === 'art') {
+        const artMatch: Record<string, unknown> = {
+          book_year: { $gte: decadeNum, $lt: decadeNum + 10 },
+          book_visible: true,
+          gallery_quality: { $gte: 0.6 },
+        };
+
+        // Aggregate: group by author, pick the best image per author
+        const artPipeline = [
+          { $match: artMatch },
+          { $sort: { gallery_quality: -1 as const } },
+          {
+            $group: {
+              _id: '$book_author',
+              doc: { $first: '$$ROOT' },
+            },
+          },
+          { $replaceRoot: { newRoot: '$doc' } },
+          { $sort: { book_year: 1 as const, gallery_quality: -1 as const } },
+          { $skip: offset },
+          { $limit: limit },
+        ];
+
+        const countPipeline = [
+          { $match: artMatch },
+          { $group: { _id: '$book_author' } },
+          { $count: 'total' },
+        ];
+
+        const [artItems, countResult] = await Promise.all([
+          db.collection('gallery_images').aggregate(artPipeline, { maxTimeMS: 10000 }).toArray(),
+          db.collection('gallery_images').aggregate(countPipeline, { maxTimeMS: 10000 }).toArray(),
+        ]);
+
+        const total = countResult[0]?.total || 0;
+
+        const mapped = artItems.map(item => ({
+          id: item.id || `${item.page_id}-${item.detection_index}`,
+          imageUrl: item.image_url,
+          thumbnailUrl: item.thumbnail_url,
+          extractedUrl: item.extracted_url,
+          description: item.description,
+          museumDescription: item.museum_description,
+          type: item.type,
+          author: item.book_author || 'Unknown',
+          bookTitle: item.book_title,
+          bookId: item.book_id,
+          bookSlug: item.book_slug,
+          year: item.book_year,
+          pageId: item.page_id,
+          detectionIndex: item.detection_index,
+          galleryQuality: item.gallery_quality,
+        }));
+
+        return NextResponse.json({ decade: decadeNum, art: mapped, total, offset, mode: 'art' }, {
+          headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+        });
+      }
+
+      // Books mode (default)
       const decadeMatch = {
         ...baseMatch,
         year: { $gte: decadeNum, $lt: decadeNum + 10 },

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -2,10 +2,13 @@
 
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ChevronDown, X } from 'lucide-react';
+import { ChevronDown, X, BookOpen, Image as ImageIcon } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
 import { BookLoader } from '@/components/ui/BookLoader';
 import CollectionBookCard from '@/components/CollectionBookCard';
-import type { TimelineOverview, TimelineBook, DecadeBucket } from '@/lib/api-client/types/timeline';
+import { formatAuthor } from '@/lib/utils';
+import type { TimelineOverview, TimelineBook, TimelineArtItem, DecadeBucket } from '@/lib/api-client/types/timeline';
 
 /* ── Historical eras ── */
 interface Era {
@@ -105,8 +108,10 @@ export default function TimelineClient({ initialData }: Props) {
   const offset = parseInt(searchParams.get('offset') || '0');
 
   const [books, setBooks] = useState<TimelineBook[]>([]);
+  const [artItems, setArtItems] = useState<TimelineArtItem[]>([]);
   const [booksTotal, setBooksTotal] = useState(0);
   const [loadingBooks, setLoadingBooks] = useState(false);
+  const [viewMode, setViewMode] = useState<'books' | 'art'>('books');
 
   const detailRef = useRef<HTMLDivElement>(null);
 
@@ -155,10 +160,11 @@ export default function TimelineClient({ initialData }: Props) {
     };
   }, [filteredDecades]);
 
-  // Fetch books when decade selected
+  // Fetch books or art when decade selected
   useEffect(() => {
     if (selectedDecade === null) {
       setBooks([]);
+      setArtItems([]);
       setBooksTotal(0);
       return;
     }
@@ -170,19 +176,26 @@ export default function TimelineClient({ initialData }: Props) {
       offset: String(offset),
     });
     if (language) qs.set('language', language);
+    if (viewMode === 'art') qs.set('mode', 'art');
 
     fetch(`/api/books/timeline?${qs}`)
       .then(r => r.json())
       .then(d => {
         if (!cancelled) {
-          setBooks(d.books || []);
+          if (viewMode === 'art') {
+            setArtItems(d.art || []);
+            setBooks([]);
+          } else {
+            setBooks(d.books || []);
+            setArtItems([]);
+          }
           setBooksTotal(d.total || 0);
         }
       })
       .finally(() => { if (!cancelled) setLoadingBooks(false); });
 
     return () => { cancelled = true; };
-  }, [selectedDecade, offset, language]);
+  }, [selectedDecade, offset, language, viewMode]);
 
   // Scroll to detail panel when books load
   useEffect(() => {
@@ -405,24 +418,53 @@ export default function TimelineClient({ initialData }: Props) {
         </div>
       </div>
 
-      {/* ── Book detail panel ── */}
+      {/* ── Detail panel ── */}
       {selectedDecade !== null && (
         <div ref={detailRef} className="pt-2">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-2xl font-serif text-stone-900">
-              {formatDecadeLabel(selectedDecade)}
-              {selectedEra && (
-                <span
-                  className="ml-3 text-sm font-sans font-normal"
-                  style={{ color: selectedEra.color }}
-                >
-                  {selectedEra.label}
+            <div className="flex items-center gap-4">
+              <h2 className="text-2xl font-serif text-stone-900">
+                {formatDecadeLabel(selectedDecade)}
+                {selectedEra && (
+                  <span
+                    className="ml-3 text-sm font-sans font-normal"
+                    style={{ color: selectedEra.color }}
+                  >
+                    {selectedEra.label}
+                  </span>
+                )}
+                <span className="ml-3 text-base font-sans font-normal text-stone-500">
+                  {booksTotal.toLocaleString()} {viewMode === 'art' ? (booksTotal === 1 ? 'artist' : 'artists') : (booksTotal === 1 ? 'text' : 'texts')}
                 </span>
-              )}
-              <span className="ml-3 text-base font-sans font-normal text-stone-500">
-                {booksTotal.toLocaleString()} {booksTotal === 1 ? 'text' : 'texts'}
-              </span>
-            </h2>
+              </h2>
+
+              {/* Books / Art toggle */}
+              <div className="flex rounded-lg border border-stone-200 overflow-hidden text-sm">
+                <button
+                  onClick={() => { setViewMode('books'); updateParams({ offset: null }); }}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${
+                    viewMode === 'books'
+                      ? 'bg-stone-800 text-white'
+                      : 'bg-white text-stone-500 hover:text-stone-700 hover:bg-stone-50'
+                  }`}
+                >
+                  <BookOpen className="w-3.5 h-3.5" />
+                  Books
+                </button>
+                <button
+                  onClick={() => { setViewMode('art'); updateParams({ offset: null }); }}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${
+                    viewMode === 'art'
+                      ? 'bg-stone-800 text-white'
+                      : 'bg-white text-stone-500 hover:text-stone-700 hover:bg-stone-50'
+                  }`}
+                >
+                  <ImageIcon className="w-3.5 h-3.5" />
+                  Art
+                </button>
+              </div>
+            </div>
+
             <button
               onClick={() => updateParams({ decade: null, offset: null })}
               className="text-stone-400 hover:text-stone-600 p-1"
@@ -436,6 +478,40 @@ export default function TimelineClient({ initialData }: Props) {
             <div className="flex justify-center py-16">
               <BookLoader size="sm" />
             </div>
+          ) : viewMode === 'art' ? (
+            artItems.length === 0 ? (
+              <p className="text-center py-12 text-stone-500 font-body">No illustrations found for this decade.</p>
+            ) : (
+              <>
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                  {artItems.map((item, i) => (
+                    <TimelineArtCard key={item.id} item={item} priority={i < 5} />
+                  ))}
+                </div>
+
+                {booksTotal > PER_PAGE && (
+                  <div className="flex items-center justify-center gap-4 mt-8">
+                    <button
+                      onClick={() => updateParams({ offset: String(Math.max(0, offset - PER_PAGE)) })}
+                      disabled={offset === 0}
+                      className="px-4 py-2 text-sm border border-stone-200 rounded-lg disabled:opacity-40 hover:bg-stone-50 transition-colors"
+                    >
+                      Previous
+                    </button>
+                    <span className="text-sm text-stone-500 font-body">
+                      {offset + 1}&ndash;{Math.min(offset + PER_PAGE, booksTotal)} of {booksTotal}
+                    </span>
+                    <button
+                      onClick={() => updateParams({ offset: String(offset + PER_PAGE) })}
+                      disabled={offset + PER_PAGE >= booksTotal}
+                      className="px-4 py-2 text-sm border border-stone-200 rounded-lg disabled:opacity-40 hover:bg-stone-50 transition-colors"
+                    >
+                      Next
+                    </button>
+                  </div>
+                )}
+              </>
+            )
           ) : books.length === 0 ? (
             <p className="text-center py-12 text-stone-500 font-body">No texts found for this decade.</p>
           ) : (
@@ -597,6 +673,60 @@ function FilterDropdown({
         ))}
       </select>
       <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" />
+    </div>
+  );
+}
+
+function TimelineArtCard({ item, priority = false }: { item: TimelineArtItem; priority?: boolean }) {
+  const [imageError, setImageError] = useState(false);
+  const displayUrl = item.thumbnailUrl || item.extractedUrl || item.imageUrl;
+  const galleryImageId = `${item.pageId}-${item.detectionIndex}`;
+  const authorDisplay = item.author && item.author !== 'Unknown' && item.author !== 'Various'
+    ? formatAuthor(item.author).name
+    : null;
+
+  return (
+    <div className="group rounded-lg overflow-hidden bg-white border border-stone-200/60 hover:shadow-md transition-all hover:-translate-y-0.5">
+      <Link href={`/gallery/image/${galleryImageId}`} className="block relative aspect-square bg-stone-100">
+        {!imageError ? (
+          <Image
+            src={displayUrl}
+            alt={item.description}
+            fill
+            quality={85}
+            className="object-cover group-hover:scale-105 transition-transform duration-300"
+            sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 20vw"
+            onError={() => setImageError(true)}
+            unoptimized={!item.thumbnailUrl && !item.extractedUrl}
+            priority={priority}
+            loading={priority ? 'eager' : 'lazy'}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-stone-300">
+            <ImageIcon className="w-8 h-8" />
+          </div>
+        )}
+
+        {item.type && (
+          <span className="absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[10px] bg-black/60 text-white capitalize">
+            {item.type}
+          </span>
+        )}
+      </Link>
+
+      <div className="p-2.5">
+        {authorDisplay && (
+          <p className="text-sm font-serif text-stone-900 truncate">{authorDisplay}</p>
+        )}
+        <p className="text-xs text-stone-500 truncate mt-0.5">
+          {item.bookTitle}{item.year ? `, ${item.year}` : ''}
+        </p>
+        {item.description && (
+          <p className="text-xs text-stone-400 line-clamp-2 mt-1 leading-relaxed">
+            {item.description}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/api-client/types/timeline.ts
+++ b/src/lib/api-client/types/timeline.ts
@@ -35,3 +35,21 @@ export interface TimelineDrilldown {
   total: number;
   offset: number;
 }
+
+export interface TimelineArtItem {
+  id: string;
+  imageUrl: string;
+  thumbnailUrl?: string;
+  extractedUrl?: string;
+  description: string;
+  museumDescription?: string;
+  type?: string;
+  author: string;
+  bookTitle: string;
+  bookId: string;
+  bookSlug?: string;
+  year?: number;
+  pageId: string;
+  detectionIndex: number;
+  galleryQuality?: number;
+}


### PR DESCRIPTION
## Summary
- Adds a Books/Art toggle when viewing a decade on the timeline page
- Art mode queries `gallery_images` collection, picks the best illustration per author (by `gallery_quality`), showing one image per artist for the selected decade
- New `TimelineArtCard` component renders gallery images with author name, book title, description, and image type badge
- New `TimelineArtItem` type and `mode=art` API param on `/api/books/timeline`

## Test plan
- [ ] Click a decade on `/timeline`, verify the Books/Art toggle appears
- [ ] Switch to Art mode — verify illustrations load, one per author
- [ ] Verify pagination works in art mode
- [ ] Verify decades with no gallery images show empty state message
- [ ] Check that clicking an art card links to `/gallery/image/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)