### PR TITLE
Fix dot-notation crash on null translation field

### DIFF
--- a/scripts/migration/backfill-blank-page-markers.mjs
+++ b/scripts/migration/backfill-blank-page-markers.mjs
@@ -71,10 +71,12 @@ async function main() {
         filter: { _id: page._id },
         update: {
           $set: {
-            'translation.data': marker,
-            'translation.language': 'English',
-            'translation.source': 'system',
-            'translation.updated_at': new Date(),
+            translation: {
+              data: marker,
+              language: 'English',
+              source: 'system',
+              updated_at: new Date(),
+            },
             updated_at: new Date(),
           },
         },

--- a/src/workers/translation-processor-logic.ts
+++ b/src/workers/translation-processor-logic.ts
@@ -143,10 +143,12 @@ export async function processTranslationPage(message: PageProcessingMessage) {
     await retryDbWrite(() => pages.updateOne(
       { id: pageId },
       { $set: {
-        'translation.data': marker,
-        'translation.language': 'English',
-        'translation.source': 'system',
-        'translation.updated_at': new Date(),
+        translation: {
+          data: marker,
+          language: 'English',
+          source: 'system',
+          updated_at: new Date(),
+        },
         updated_at: new Date(),
       }}
     ), `write blank marker for page ${pageId}`, 3, '[TRANS]');


### PR DESCRIPTION
## Summary
- When `translation` is `null` (not missing), MongoDB throws `Cannot create field 'data' in element {translation: null}` with dot-notation `$set`
- Fix: set the entire `translation` object instead of using dot-notation paths
- Applies to both the translation worker and the backfill script

Follow-up to #979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)