### PR TITLE
Cover scoring, digitizer detection, and language prompt migration

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -36,6 +36,16 @@ function extractPageType(text) {
   return match ? match[1].toLowerCase().trim() : null;
 }
 
+/** Detect Google Books, IA, or other digitizer notice pages from OCR text (pages 1-3 only). */
+function isDigitizerNotice(text) {
+  if (!text) return false;
+  const start = text.substring(0, 1500);
+  return /google\s+logo|digitized\s+by\s+google|scanned\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(start) ||
+    /preserved\s+for\s+generations\s+on\s+library\s+shelves/i.test(start) ||
+    /inserted\s+by\s+the\s+internet|internet\s+archive|digitization\s+(credit|notice)/i.test(start) ||
+    /not\s+part\s+of\s+the\s+original\s+book|scanner\s+barcode/i.test(start);
+}
+
 function extractColumns(text) {
   const match = text.match(/<columns>\s*(\d+)\s*<\/columns>/i);
   if (!match) return null;
@@ -223,7 +233,13 @@ async function processOneJob(db, job) {
           updated_at: now,
         };
         if (isMultiPage) setObj['ocr.pages_per_request'] = job.pages_per_request;
-        if (pageType) setObj.page_type = pageType;
+        // Auto-detect digitizer notice pages (Google Books, IA inserts)
+        if (isDigitizerNotice(text)) {
+          setObj.page_type = 'digitizer-insert';
+          setObj.hidden = true;
+        } else if (pageType) {
+          setObj.page_type = pageType;
+        }
         if (columns) setObj.columns = columns;
         if (detectedImages.length > 0) setObj.detected_images = detectedImages;
 

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -185,6 +185,15 @@ function extractPageType(text) {
   return match ? match[1].toLowerCase().trim() : null;
 }
 
+function isDigitizerNotice(text) {
+  if (!text) return false;
+  const start = text.substring(0, 1500);
+  return /google\s+logo|digitized\s+by\s+google|scanned\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(start) ||
+    /preserved\s+for\s+generations\s+on\s+library\s+shelves/i.test(start) ||
+    /inserted\s+by\s+the\s+internet|internet\s+archive|digitization\s+(credit|notice)/i.test(start) ||
+    /not\s+part\s+of\s+the\s+original\s+book|scanner\s+barcode/i.test(start);
+}
+
 function extractColumns(text) {
   const match = text.match(/<columns>\s*(\d+)\s*<\/columns>/i);
   if (!match) return null;
@@ -256,7 +265,7 @@ async function processPage(page, promptText, db) {
             source: 'ai',
             prompt_version: TARGET_PROMPT,
           },
-          ...(pageType && { page_type: pageType }),
+          ...(isDigitizerNotice(result.text) ? { page_type: 'digitizer-insert', hidden: true } : pageType ? { page_type: pageType } : {}),
           ...(columns && { columns }),
           ...(detectedImages.length > 0 && { detected_images: detectedImages }),
           updated_at: new Date(),

--- a/scripts/lib/cover-scoring.mjs
+++ b/scripts/lib/cover-scoring.mjs
@@ -1,0 +1,174 @@
+/**
+ * Shared cover page scoring logic.
+ *
+ * Used by:
+ *   - pipeline-orchestrator.mjs (Phase 3 + Phase 8.9)
+ *   - smart-cover-selection.mjs (batch re-evaluation)
+ *
+ * Scores a page as a potential book cover using OCR content analysis.
+ * Parses <page-type> tags from OCR text when page.page_type is null.
+ * Detects binding photos, digitizer inserts, bookplates (incl. BPH pelican),
+ * and prefers decorated title pages with woodcuts/borders/printer's marks.
+ */
+
+/**
+ * Extract page type from <page-type> tags in OCR text.
+ * Returns null if no tag found.
+ */
+export function parsePageTypeFromOcr(ocrText) {
+  if (!ocrText) return null;
+  const match = ocrText.match(/<page-type>([^<]+)<\/page-type>/);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Score a page as a potential book cover.
+ *
+ * @param {Object} page - Page document with page_number, page_type, ocr.data, hidden
+ * @param {Object} [options]
+ * @param {string} [options.bookTitle] - Book title for title-match bonus
+ * @returns {{ score: number, reason: string }}
+ */
+export function scorePageForCover(page, options = {}) {
+  const ocrRaw = page.ocr?.data || page.ocr_text || '';
+  const ocr = ocrRaw.substring(0, 1200).toLowerCase();
+  const pageNum = page.page_number;
+
+  // Resolve page type: explicit field → parsed from OCR tags → null
+  const pageType = page.page_type || parsePageTypeFromOcr(ocrRaw);
+
+  let score = 0;
+  let reason = pageType || 'unknown';
+
+  // Skip hidden pages
+  if (page.hidden) return { score: -200, reason: 'hidden' };
+
+  // === NEGATIVE signals ===
+
+  if (pageType === 'blank') return { score: -100, reason: 'blank' };
+  if (pageType === 'digitizer-notice' || pageType === 'digitizer-insert') {
+    return { score: -90, reason: 'digitizer-notice' };
+  }
+
+  // Physical binding / cover photos
+  if (ocr.includes('front cover') || (ocr.includes('external') && ocr.includes('cover')) ||
+      (ocr.includes('binding') && ocr.includes('spine')) || ocr.includes('fore-edge') ||
+      ocr.includes('closed book') || ocr.includes('book block') ||
+      ocr.includes('leather-bound') || ocr.includes('leather bound') ||
+      ((ocr.includes('blind-stamp') || ocr.includes('blind stamp')) && ocr.includes('cover')) ||
+      ocr.includes('textured surface') || ocr.includes('inside cover') ||
+      ocr.includes('endpaper') || (ocr.includes('marbled') && pageNum <= 3)) {
+    return { score: -80, reason: 'physical book photo' };
+  }
+
+  // Digitizer inserts and portal pages
+  if (ocr.includes('digitized by') || (ocr.includes('google') && ocr.includes('logo')) ||
+      ocr.includes('google books') || ocr.includes('scanned by google') ||
+      (ocr.includes('internet archive') && ocr.includes('logo')) ||
+      ocr.includes('proquest') || ocr.includes('early european books') ||
+      ocr.includes('hathitrust') || ocr.includes('scan sheet') ||
+      ocr.includes('e-rara.ch') || ocr.includes('www.e-rara') ||
+      ocr.includes('gallica.bnf') || ocr.includes('mdz-nbn') ||
+      ocr.includes('digital.staatsbibliothek') || ocr.includes('daten.digitale-sammlungen')) {
+    return { score: -70, reason: 'digitizer insert' };
+  }
+
+  // BPH pelican bookplate
+  const isBphBookplate =
+    (ocr.includes('pelican') && (ocr.includes('piety') || ocr.includes('nest') || ocr.includes('young') || ocr.includes('hermetica'))) ||
+    ocr.includes('philosophia hermetica') || ocr.includes('philosophica hermetica');
+  if (isBphBookplate && pageType !== 'title-page') {
+    return { score: -65, reason: 'BPH pelican bookplate' };
+  }
+
+  // Ex-libris / bookplates (but allow on actual title pages with small inscriptions)
+  const hasExLibris = ocr.includes('ex-libris') || ocr.includes('exlibris') || ocr.includes('ex libris') ||
+      ocr.includes('bookplate') || (ocr.includes('ownership') && ocr.includes('stamp')) ||
+      ocr.includes('library stamp') || ocr.includes('library sticker') ||
+      (ocr.includes('library of') && pageNum <= 5) ||
+      (ocr.includes('botanical garden') && pageNum <= 5) ||
+      (ocr.includes('book fund') && pageNum <= 5);
+  if (hasExLibris && pageType !== 'title-page') {
+    return { score: -60, reason: 'ex-libris/bookplate' };
+  }
+
+  // Bleed-through / ghosting
+  if (ocr.includes('bleed-through') || ocr.includes('ghosting') || ocr.includes('mirrored impression')) {
+    return { score: -50, reason: 'bleed-through' };
+  }
+
+  if (pageType === 'toc' || pageType === 'index') return { score: -20, reason: pageType };
+  if (pageType === 'colophon') return { score: -10, reason: 'colophon' };
+
+  // === POSITIVE signals ===
+
+  const hasHeadings = (ocr.match(/^#+ .+/gm) || []).length;
+  const isTitlePage = pageType === 'title-page';
+  const looksLikeTitlePage = !pageType && hasHeadings >= 3;
+
+  if (isTitlePage) { score += 80; reason = 'title-page'; }
+  else if (looksLikeTitlePage) { score += 70; reason = 'likely title-page'; }
+
+  if (isTitlePage || looksLikeTitlePage) {
+    // Publisher imprint bonus (Latin publishing terms)
+    if (ocr.includes('excudebat') || ocr.includes('typis') || ocr.includes('apud') ||
+        ocr.includes('impensis') || ocr.includes('sumptibus') || ocr.includes('officina') ||
+        ocr.includes('printed by') || ocr.includes('published by') || ocr.includes('printed for')) {
+      score += 15;
+      reason = (isTitlePage ? 'title-page' : 'likely title-page') + ' with imprint';
+    }
+    // Decorative elements bonus
+    if (ocr.includes('decorative') || ocr.includes('ornamental') || ocr.includes('border') ||
+        ocr.includes('frame') || ocr.includes('vignette') || ocr.includes('woodcut') ||
+        ocr.includes('architectural') || ocr.includes("printer's mark") ||
+        ocr.includes("printer's device")) {
+      score += 20;
+      reason = 'decorated title-page';
+    }
+  }
+
+  // Title-match bonus: boost pages whose OCR contains the book's actual title
+  if (options.bookTitle && (isTitlePage || looksLikeTitlePage)) {
+    const titleWords = options.bookTitle.toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .split(/\s+/)
+      .filter(w => w.length > 3);
+    if (titleWords.length > 0) {
+      const matchCount = titleWords.filter(w => ocr.includes(w)).length;
+      const matchRatio = matchCount / titleWords.length;
+      if (matchRatio >= 0.5) {
+        score += 10;
+        reason += ' (title match)';
+      }
+    }
+  }
+
+  // Frontispieces — but not binding photos mislabeled as frontispiece
+  if (pageType === 'frontispiece') {
+    if (ocr.includes('cover') && (ocr.includes('leather') || ocr.includes('binding') || ocr.includes('marbled'))) {
+      return { score: -80, reason: 'binding photo (mislabeled frontispiece)' };
+    }
+    score += 90; reason = 'frontispiece';
+    if (ocr.includes('engrav') || ocr.includes('allegor') || ocr.includes('portrait') ||
+        ocr.includes('emblem') || ocr.includes('woodcut')) {
+      score += 15; reason = 'frontispiece with engraving';
+    }
+  }
+
+  if (pageType === 'illustration') {
+    if (ocr.includes('photograph') && (ocr.includes('fore-edge') || (ocr.includes('book') && ocr.includes('closed')))) {
+      return { score: -80, reason: 'physical book photo' };
+    }
+    score += 60; reason = 'illustration';
+  }
+
+  if (pageType === 'dedication') { score += 15; reason = 'dedication'; }
+  if (pageType === 'text' && score === 0) { score += 5; reason = 'text'; }
+
+  // Position bonus — covers are usually in first 10 pages
+  if (pageNum <= 5) score += 5;
+  else if (pageNum <= 10) score += 3;
+  else if (pageNum > 15) score -= 3;
+
+  return { score, reason };
+}

--- a/scripts/maintenance/backfill-digitizer-pages.mjs
+++ b/scripts/maintenance/backfill-digitizer-pages.mjs
@@ -1,0 +1,171 @@
+/**
+ * Backfill: detect and tag Google Books / IA digitizer notice pages.
+ *
+ * Scans pages 1-3 (and last 3) of all books, checks OCR text for digitizer
+ * patterns, and sets page_type: 'digitizer-insert' + hidden: true.
+ *
+ * The UI already filters these (page_type !== 'digitizer-insert').
+ * The pipeline (Phase 8.9) now detects them going forward — this script
+ * catches existing books that were imported before detection was added.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-digitizer-pages.mjs
+ *   --dry-run       Preview without writing
+ *   --limit N       Process first N books
+ *   --book-id ID    Process single book
+ */
+
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const LIMIT = (() => {
+  const idx = process.argv.indexOf('--limit');
+  return idx !== -1 ? parseInt(process.argv[idx + 1]) : 0;
+})();
+const BOOK_ID = (() => {
+  const idx = process.argv.indexOf('--book-id');
+  return idx !== -1 ? process.argv[idx + 1] : null;
+})();
+
+const BATCH_SIZE = 100;
+
+function isDigitizerNotice(text) {
+  if (!text) return false;
+  const start = text.substring(0, 1500);
+  return /google\s+logo|digitized\s+by\s+google|scanned\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(start) ||
+    /preserved\s+for\s+generations\s+on\s+library\s+shelves/i.test(start) ||
+    /inserted\s+by\s+the\s+internet|internet\s+archive|digitization\s+(credit|notice)/i.test(start) ||
+    /not\s+part\s+of\s+the\s+original\s+book|scanner\s+barcode/i.test(start);
+}
+
+const client = new MongoClient(process.env.MONGODB_URI, {
+  serverSelectionTimeoutMS: 30000, connectTimeoutMS: 30000, socketTimeoutMS: 60000,
+});
+await client.connect();
+const db = client.db('bookstore');
+
+console.log(`\n=== Backfill Digitizer Page Detection ===`);
+console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+
+const bookQuery = BOOK_ID
+  ? { id: BOOK_ID }
+  : { pages_count: { $gt: 0 } };
+
+const booksCursor = db.collection('books')
+  .find(bookQuery, { projection: { id: 1, title: 1, pages_count: 1, _id: 0 } })
+  .sort({ _id: -1 });
+
+let booksChecked = 0, pagesTagged = 0, booksAffected = 0;
+const affected = [];
+let batch = [];
+
+for await (const book of booksCursor) {
+  if (LIMIT && booksChecked >= LIMIT) break;
+  batch.push(book);
+
+  if (batch.length >= BATCH_SIZE) {
+    await processBatch(batch);
+    batch = [];
+  }
+}
+if (batch.length > 0) await processBatch(batch);
+
+async function processBatch(books) {
+  const bookIds = books.map(b => b.id);
+  const bookMap = new Map(books.map(b => [b.id, b]));
+
+  // Fetch edge pages (first 3 + last 3) that haven't already been tagged
+  const pages = await db.collection('pages')
+    .find(
+      {
+        book_id: { $in: bookIds },
+        page_type: { $nin: ['digitizer-notice', 'digitizer-insert'] },
+        $or: [
+          { page_number: { $lte: 3 } },
+          // We check last 3 via a secondary pass per-book below
+        ],
+      },
+      { projection: { id: 1, book_id: 1, page_number: 1, 'ocr.data': 1, _id: 0 } }
+    )
+    .toArray();
+
+  // Also fetch last-3 pages for books with many pages
+  const lastPageQueries = books
+    .filter(b => b.pages_count > 6)
+    .map(b => ({
+      book_id: b.id,
+      page_number: { $gte: b.pages_count - 2 },
+      page_type: { $nin: ['digitizer-notice', 'digitizer-insert'] },
+    }));
+
+  if (lastPageQueries.length > 0) {
+    const lastPages = await db.collection('pages')
+      .find(
+        { $or: lastPageQueries },
+        { projection: { id: 1, book_id: 1, page_number: 1, 'ocr.data': 1, _id: 0 } }
+      )
+      .toArray();
+    pages.push(...lastPages);
+  }
+
+  const bulkOps = [];
+  const booksHit = new Set();
+
+  for (const page of pages) {
+    booksChecked; // just for counting
+    if (isDigitizerNotice(page.ocr?.data)) {
+      booksHit.add(page.book_id);
+      pagesTagged++;
+      if (!DRY_RUN) {
+        bulkOps.push({
+          updateOne: {
+            filter: { id: page.id },
+            update: {
+              $set: {
+                page_type: 'digitizer-insert',
+                hidden: true,
+                updated_at: new Date(),
+                'field_provenance.page_type': {
+                  source: 'backfill', method: 'digitizer-pattern-match',
+                  confidence: 0.95, date: new Date(),
+                },
+              },
+            },
+          },
+        });
+      }
+    }
+  }
+
+  if (bulkOps.length > 0) {
+    await db.collection('pages').bulkWrite(bulkOps, { ordered: false });
+  }
+
+  for (const bookId of booksHit) {
+    const book = bookMap.get(bookId);
+    booksAffected++;
+    affected.push({ id: bookId, title: (book?.title || '').substring(0, 60) });
+  }
+
+  booksChecked += books.length;
+  process.stdout.write(`  Checked ${booksChecked} books, tagged ${pagesTagged} pages\r`);
+}
+
+console.log(`\n\n=== Results ===`);
+console.log(`Books checked: ${booksChecked}`);
+console.log(`Books with digitizer pages: ${booksAffected}`);
+console.log(`Pages ${DRY_RUN ? 'would tag' : 'tagged'}: ${pagesTagged}`);
+
+if (affected.length > 0) {
+  console.log(`\n--- Affected books ---`);
+  for (const b of affected.slice(0, 50)) {
+    console.log(`  ${b.title} (${b.id})`);
+  }
+  if (affected.length > 50) console.log(`  ... and ${affected.length - 50} more`);
+}
+
+if (DRY_RUN && pagesTagged > 0) {
+  console.log(`\nRun without --dry-run to apply.`);
+}
+
+await client.close();

--- a/scripts/maintenance/smart-cover-selection.mjs
+++ b/scripts/maintenance/smart-cover-selection.mjs
@@ -3,6 +3,7 @@
  *
  * Picks the best cover by analyzing OCR text content — not just page_type,
  * but the actual descriptions, meta tags, and transcribed text.
+ * Parses <page-type> tags from OCR when page_type field is null.
  *
  * Cost: FREE
  *
@@ -16,6 +17,7 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { scorePageForCover } from '../lib/cover-scoring.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const SKIP_MANUAL = process.argv.includes('--skip-manual');
@@ -35,160 +37,13 @@ const PROVIDER = (() => {
 })();
 
 const SCAN_PAGES = 20;
-const BATCH_SIZE = 50; // smaller batches since we fetch more OCR data
+const BATCH_SIZE = 50;
 
 const client = new MongoClient(process.env.MONGODB_URI, {
   serverSelectionTimeoutMS: 30000, connectTimeoutMS: 30000, socketTimeoutMS: 60000,
 });
 await client.connect();
 const db = client.db('bookstore');
-
-/**
- * Score a page as a potential cover based on OCR content analysis.
- * Returns { score, reason }.
- */
-function scorePage(page) {
-  const ocr = (page.ocr_text || '').toLowerCase();
-  const pageType = page.page_type;
-  const pageNum = page.page_number;
-  let score = 0;
-  let reason = pageType || 'unknown';
-
-  // === NEGATIVE signals: things that make terrible covers ===
-
-  // Blank pages
-  if (pageType === 'blank' && !ocr.includes('title')) return { score: -100, reason: 'blank' };
-
-  // Book binding / cover photos (external shots of the physical book)
-  if (ocr.includes('front cover') || ocr.includes('external') && ocr.includes('cover') ||
-      ocr.includes('binding') && ocr.includes('spine') || ocr.includes('fore-edge') ||
-      ocr.includes('closed book') || ocr.includes('book block') ||
-      ocr.includes('leather-bound') || ocr.includes('leather bound') ||
-      (ocr.includes('blind-stamp') || ocr.includes('blind stamp')) && ocr.includes('cover')) {
-    return { score: -80, reason: 'physical book photo' };
-  }
-
-  // Digitizer inserts and digital portal pages
-  if (ocr.includes('digitized by') || ocr.includes('google books') ||
-      ocr.includes('internet archive') && ocr.includes('logo') ||
-      ocr.includes('proquest') || ocr.includes('early european books') ||
-      ocr.includes('hathitrust') || ocr.includes('scan sheet') ||
-      ocr.includes('e-rara.ch') || ocr.includes('www.e-rara') ||
-      ocr.includes('gallica.bnf') || ocr.includes('mdz-nbn') ||
-      ocr.includes('digital.staatsbibliothek') || ocr.includes('daten.digitale-sammlungen')) {
-    return { score: -70, reason: 'digitizer insert' };
-  }
-
-  // BPH pelican bookplate (Embassy of the Free Mind / Bibliotheca Philosophica Hermetica)
-  const isBphBookplate = (ocr.includes('pelican') && (ocr.includes('piety') || ocr.includes('nest') || ocr.includes('young') || ocr.includes('hermetica'))) ||
-      ocr.includes('philosophia hermetica') || ocr.includes('philosophica hermetica');
-  if (isBphBookplate && pageType !== 'title-page') {
-    return { score: -65, reason: 'BPH pelican bookplate' };
-  }
-
-  // Ex-libris / bookplates — but only if the page is PRIMARILY a bookplate,
-  // not a title page that happens to have a small ownership inscription
-  const hasExLibris = ocr.includes('ex-libris') || ocr.includes('exlibris') || ocr.includes('ex libris') ||
-      ocr.includes('bookplate') || (ocr.includes('ownership') && ocr.includes('stamp')) ||
-      ocr.includes('library stamp') || ocr.includes('library sticker');
-  if (hasExLibris && pageType !== 'title-page') {
-    return { score: -60, reason: 'ex-libris/bookplate' };
-  }
-
-  // Bleed-through / ghosting pages
-  if (ocr.includes('bleed-through') || ocr.includes('ghosting') ||
-      ocr.includes('mirrored impression')) {
-    return { score: -50, reason: 'bleed-through' };
-  }
-
-  // Tables of contents, indices
-  if (pageType === 'toc' || pageType === 'index') return { score: -20, reason: pageType };
-
-  // Colophon
-  if (pageType === 'colophon') return { score: -10, reason: 'colophon' };
-
-  // === POSITIVE signals: things that make great covers ===
-
-  // Title pages with actual title text (centered headings in OCR)
-  const hasHeadings = (ocr.match(/^#+ .+/gm) || []).length;
-  const isTitlePage = pageType === 'title-page';
-  const looksLikeTitlePage = !pageType && hasHeadings >= 3;
-
-  if (isTitlePage) {
-    score += 80;
-    reason = 'title-page';
-  } else if (looksLikeTitlePage) {
-    score += 70;
-    reason = 'likely title-page (headings)';
-  }
-
-  if (isTitlePage || looksLikeTitlePage) {
-    // Bonus: publisher marks / imprints (Latin publishing terms)
-    if (ocr.includes('excudebat') || ocr.includes('typis') || ocr.includes('apud') ||
-        ocr.includes('impensis') || ocr.includes('sumptibus') || ocr.includes('officina') ||
-        ocr.includes('printed by') || ocr.includes('published by') || ocr.includes('printed for')) {
-      score += 15;
-      reason = (isTitlePage ? 'title-page' : 'likely title-page') + ' with imprint';
-    }
-
-    // Bonus: decorative elements described in OCR
-    if (ocr.includes('decorative') || ocr.includes('ornamental') || ocr.includes('border') ||
-        ocr.includes('frame') || ocr.includes('vignette') || ocr.includes('woodcut') ||
-        ocr.includes('architectural') || ocr.includes('printer\'s mark') ||
-        ocr.includes('printer\'s device') || ocr.includes('colophon device')) {
-      score += 20;
-      reason = 'decorated title-page';
-    }
-  }
-
-  // Frontispieces — but distinguish real frontispieces from binding photos
-  if (pageType === 'frontispiece') {
-    // Check if it's actually a physical cover photo mislabeled as frontispiece
-    if (ocr.includes('cover') && (ocr.includes('leather') || ocr.includes('binding') || ocr.includes('marbled'))) {
-      return { score: -80, reason: 'binding photo (mislabeled frontispiece)' };
-    }
-
-    score += 90;
-    reason = 'frontispiece';
-
-    // Bonus for engravings / allegorical imagery
-    if (ocr.includes('engrav') || ocr.includes('allegor') || ocr.includes('portrait') ||
-        ocr.includes('emblem') || ocr.includes('woodcut')) {
-      score += 15;
-      reason = 'frontispiece with engraving';
-    }
-  }
-
-  // Illustrations
-  if (pageType === 'illustration') {
-    // Skip if it's a photo of the physical book
-    if (ocr.includes('photograph') && (ocr.includes('fore-edge') || ocr.includes('book') && ocr.includes('closed'))) {
-      return { score: -80, reason: 'physical book photo' };
-    }
-    score += 60;
-    reason = 'illustration';
-  }
-
-  // Dedication pages — sometimes nice but not ideal
-  if (pageType === 'dedication') {
-    score += 15;
-    reason = 'dedication';
-  }
-
-  // Plain text — lowest priority
-  if (pageType === 'text' && score === 0) {
-    score += 5;
-    reason = 'text';
-  }
-
-  // === Position bonuses ===
-  // Slight preference for earlier pages (covers are usually in first 10)
-  if (pageNum <= 5) score += 5;
-  else if (pageNum <= 10) score += 3;
-  else if (pageNum > 15) score -= 3;
-
-  return { score, reason };
-}
 
 function getPageImageUrl(page) {
   const isUsable = (u) => u && (u.startsWith('http://') || u.startsWith('https://'));
@@ -249,11 +104,9 @@ for (let i = 0; i < allBooks.length; i += BATCH_SIZE) {
     .sort({ book_id: 1, page_number: 1 })
     .toArray();
 
-  // Extract OCR text (first 800 chars for scoring) and group by book
+  // Group by book — keep ocr.data intact for the shared scorer
   const pagesByBook = new Map();
   for (const p of allPages) {
-    p.ocr_text = (p.ocr?.data || '').substring(0, 800);
-    delete p.ocr;
     if (!pagesByBook.has(p.book_id)) pagesByBook.set(p.book_id, []);
     pagesByBook.get(p.book_id).push(p);
   }
@@ -265,10 +118,10 @@ for (let i = 0; i < allBooks.length; i += BATCH_SIZE) {
     if (!pages || pages.length === 0) { noData++; continue; }
     checked++;
 
-    // Score all pages
+    // Score all pages using shared scoring module
     const scored = pages
       .map(p => {
-        const { score, reason } = scorePage(p);
+        const { score, reason } = scorePageForCover(p, { bookTitle: book.title });
         return { page: p, score, reason };
       })
       .sort((a, b) => b.score - a.score);

--- a/scripts/migration/seed-language-prompts.mjs
+++ b/scripts/migration/seed-language-prompts.mjs
@@ -1,0 +1,108 @@
+/**
+ * Seed language-specific OCR and translation prompts into the DB.
+ *
+ * Imports Arabic, Hebrew, Latin, and German prompts from the TypeScript
+ * source files into the `prompts` collection with proper versioning.
+ * Creates new versions if content has changed; skips if identical.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/migration/seed-language-prompts.mjs
+ *   --dry-run    Preview without writing
+ */
+
+import { MongoClient } from 'mongodb';
+import { createHash } from 'crypto';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function contentHash(text) {
+  return createHash('md5').update(text).digest('hex');
+}
+
+// Import prompts dynamically (TS files compiled to JS by node --loader)
+// We inline the prompt names and import from the compiled source
+const { ARABIC_PROMPTS } = await import('../../src/lib/types/prompts/arabic.ts');
+const { HEBREW_PROMPTS } = await import('../../src/lib/types/prompts/hebrew.ts');
+const { LATIN_PROMPTS } = await import('../../src/lib/types/prompts/latin.ts');
+const { GERMAN_PROMPTS } = await import('../../src/lib/types/prompts/german.ts');
+
+const PROMPTS_TO_SEED = [
+  { name: 'Arabic OCR', type: 'ocr', content: ARABIC_PROMPTS.ocr, description: 'Arabic manuscript/printed book OCR with script identification' },
+  { name: 'Arabic Translation', type: 'translation', content: ARABIC_PROMPTS.translation, description: 'Arabic to English translation for Islamic/esoteric texts' },
+  { name: 'Hebrew OCR', type: 'ocr', content: HEBREW_PROMPTS.ocr, description: 'Hebrew manuscript/printed book OCR with nikud and Rashi script' },
+  { name: 'Hebrew Translation', type: 'translation', content: HEBREW_PROMPTS.translation, description: 'Hebrew/Aramaic to English translation for Kabbalistic/mystical texts' },
+  { name: 'Latin OCR (Neo-Latin)', type: 'ocr', content: LATIN_PROMPTS.ocr, description: 'Neo-Latin OCR (1450-1700) with abbreviation expansion' },
+  { name: 'Latin Translation (Neo-Latin)', type: 'translation', content: LATIN_PROMPTS.translation, description: 'Neo-Latin to English scholarly accessible translation' },
+  { name: 'German OCR (Fraktur)', type: 'ocr', content: GERMAN_PROMPTS.ocr, description: 'German/Fraktur OCR (1450-1800) with historical spelling' },
+  { name: 'German Translation (Early Modern)', type: 'translation', content: GERMAN_PROMPTS.translation, description: 'Early modern German to English translation' },
+];
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+const collection = db.collection('prompts');
+
+console.log(`\n=== Seed Language-Specific Prompts ===`);
+console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}\n`);
+
+let created = 0, skipped = 0, updated = 0;
+
+for (const prompt of PROMPTS_TO_SEED) {
+  const latest = await collection.findOne(
+    { name: prompt.name },
+    { sort: { version: -1 } }
+  );
+
+  const hash = contentHash(prompt.content);
+
+  if (latest && latest.content_hash === hash) {
+    console.log(`  SKIP  ${prompt.name} v${latest.version} (content unchanged)`);
+    skipped++;
+    continue;
+  }
+
+  const newVersion = (latest?.version || 0) + 1;
+  const action = latest ? 'UPDATE' : 'CREATE';
+
+  console.log(`  ${action} ${prompt.name} v${newVersion} (${prompt.type})`);
+
+  if (!DRY_RUN) {
+    // If updating, remove is_default from old versions
+    if (latest?.is_default) {
+      await collection.updateMany(
+        { name: prompt.name },
+        { $set: { is_default: false } }
+      );
+    }
+
+    await collection.insertOne({
+      name: prompt.name,
+      type: prompt.type,
+      version: newVersion,
+      content: prompt.content,
+      content_hash: hash,
+      variables: [],
+      description: prompt.description,
+      is_default: false, // Language prompts are NOT default — they're selected by language
+      created_at: new Date(),
+      migration_note: 'Seeded from TypeScript source (#384)',
+    });
+
+    if (action === 'CREATE') created++;
+    else updated++;
+  } else {
+    if (action === 'CREATE') created++;
+    else updated++;
+  }
+}
+
+console.log(`\n=== Results ===`);
+console.log(`Created: ${created}`);
+console.log(`Updated: ${updated}`);
+console.log(`Skipped (unchanged): ${skipped}`);
+
+if (DRY_RUN && (created + updated) > 0) {
+  console.log(`\nRun without --dry-run to apply.`);
+}
+
+await client.close();

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -342,128 +342,8 @@ function isDigitizerOcr(ocrData) {
     /ex[\s\-.]?libris|bookplate|library\s+stamp/i.test(start);
 }
 
-/**
- * Score a page as a potential book cover using OCR content analysis.
- * Detects binding photos, digitizer inserts, bookplates (incl. BPH pelican),
- * and prefers decorated title pages with woodcuts/borders/printer's marks.
- *
- * @param {Object} page - Page document with page_number, page_type, ocr.data
- * @returns {{ score: number, reason: string }}
- */
-function scorePageForCover(page) {
-  const ocr = (page.ocr?.data || '').substring(0, 800).toLowerCase();
-  const pageType = page.page_type;
-  const pageNum = page.page_number;
-  let score = 0;
-  let reason = pageType || 'unknown';
-
-  // Skip hidden pages
-  if (page.hidden) return { score: -200, reason: 'hidden' };
-
-  // --- NEGATIVE signals ---
-
-  if (pageType === 'blank') return { score: -100, reason: 'blank' };
-  if (pageType === 'digitizer-notice') return { score: -90, reason: 'digitizer-notice' };
-
-  // Book binding / cover photos
-  if (ocr.includes('front cover') || (ocr.includes('external') && ocr.includes('cover')) ||
-      (ocr.includes('binding') && ocr.includes('spine')) || ocr.includes('fore-edge') ||
-      ocr.includes('closed book') || ocr.includes('book block') ||
-      ocr.includes('leather-bound') || ocr.includes('leather bound') ||
-      ((ocr.includes('blind-stamp') || ocr.includes('blind stamp')) && ocr.includes('cover'))) {
-    return { score: -80, reason: 'physical book photo' };
-  }
-
-  // Digitizer inserts and portal pages
-  if (ocr.includes('digitized by') || (ocr.includes('google') && ocr.includes('logo')) ||
-      (ocr.includes('internet archive') && ocr.includes('logo')) ||
-      ocr.includes('proquest') || ocr.includes('early european books') ||
-      ocr.includes('hathitrust') || ocr.includes('scan sheet') ||
-      ocr.includes('e-rara.ch') || ocr.includes('www.e-rara') ||
-      ocr.includes('gallica.bnf') || ocr.includes('mdz-nbn') ||
-      ocr.includes('digital.staatsbibliothek') || ocr.includes('daten.digitale-sammlungen')) {
-    return { score: -70, reason: 'digitizer insert' };
-  }
-
-  // BPH pelican bookplate
-  const isBphBookplate = (ocr.includes('pelican') && (ocr.includes('piety') || ocr.includes('nest') || ocr.includes('young') || ocr.includes('hermetica'))) ||
-      ocr.includes('philosophia hermetica') || ocr.includes('philosophica hermetica');
-  if (isBphBookplate && pageType !== 'title-page') {
-    return { score: -65, reason: 'BPH pelican bookplate' };
-  }
-
-  // Ex-libris / bookplates (but allow on title pages with small inscriptions)
-  const hasExLibris = ocr.includes('ex-libris') || ocr.includes('exlibris') || ocr.includes('ex libris') ||
-      ocr.includes('bookplate') || (ocr.includes('ownership') && ocr.includes('stamp')) ||
-      ocr.includes('library stamp') || ocr.includes('library sticker');
-  if (hasExLibris && pageType !== 'title-page') {
-    return { score: -60, reason: 'ex-libris/bookplate' };
-  }
-
-  // Bleed-through / ghosting
-  if (ocr.includes('bleed-through') || ocr.includes('ghosting') || ocr.includes('mirrored impression')) {
-    return { score: -50, reason: 'bleed-through' };
-  }
-
-  if (pageType === 'toc' || pageType === 'index') return { score: -20, reason: pageType };
-  if (pageType === 'colophon') return { score: -10, reason: 'colophon' };
-
-  // --- POSITIVE signals ---
-
-  const hasHeadings = (ocr.match(/^#+ .+/gm) || []).length;
-  const isTitlePage = pageType === 'title-page';
-  const looksLikeTitlePage = !pageType && hasHeadings >= 3;
-
-  if (isTitlePage) { score += 80; reason = 'title-page'; }
-  else if (looksLikeTitlePage) { score += 70; reason = 'likely title-page'; }
-
-  if (isTitlePage || looksLikeTitlePage) {
-    // Publisher imprint bonus
-    if (ocr.includes('excudebat') || ocr.includes('typis') || ocr.includes('apud') ||
-        ocr.includes('impensis') || ocr.includes('sumptibus') || ocr.includes('officina') ||
-        ocr.includes('printed by') || ocr.includes('published by') || ocr.includes('printed for')) {
-      score += 15;
-      reason = (isTitlePage ? 'title-page' : 'likely title-page') + ' with imprint';
-    }
-    // Decorative elements bonus
-    if (ocr.includes('decorative') || ocr.includes('ornamental') || ocr.includes('border') ||
-        ocr.includes('frame') || ocr.includes('vignette') || ocr.includes('woodcut') ||
-        ocr.includes('architectural') || ocr.includes("printer's mark") ||
-        ocr.includes("printer's device")) {
-      score += 20;
-      reason = 'decorated title-page';
-    }
-  }
-
-  // Frontispieces — but not binding photos mislabeled as frontispiece
-  if (pageType === 'frontispiece') {
-    if (ocr.includes('cover') && (ocr.includes('leather') || ocr.includes('binding') || ocr.includes('marbled'))) {
-      return { score: -80, reason: 'binding photo (mislabeled frontispiece)' };
-    }
-    score += 90; reason = 'frontispiece';
-    if (ocr.includes('engrav') || ocr.includes('allegor') || ocr.includes('portrait') ||
-        ocr.includes('emblem') || ocr.includes('woodcut')) {
-      score += 15; reason = 'frontispiece with engraving';
-    }
-  }
-
-  if (pageType === 'illustration') {
-    if (ocr.includes('photograph') && (ocr.includes('fore-edge') || (ocr.includes('book') && ocr.includes('closed')))) {
-      return { score: -80, reason: 'physical book photo' };
-    }
-    score += 60; reason = 'illustration';
-  }
-
-  if (pageType === 'dedication') { score += 15; reason = 'dedication'; }
-  if (pageType === 'text' && score === 0) { score += 5; reason = 'text'; }
-
-  // Position bonus
-  if (pageNum <= 5) score += 5;
-  else if (pageNum <= 10) score += 3;
-  else if (pageNum > 15) score -= 3;
-
-  return { score, reason };
-}
+// Cover scoring — imported from shared module
+import { scorePageForCover } from '../lib/cover-scoring.mjs';
 
 /**
  * Select the best cover page for a book from its first N pages.
@@ -474,7 +354,7 @@ function scorePageForCover(page) {
  * @param {number} maxPages - Max pages to consider (default 20)
  * @returns {Promise<{page: Object, score: number, reason: string} | null>}
  */
-async function selectBestCoverPage(db, bookId, maxPages = 20) {
+async function selectBestCoverPage(db, bookId, maxPages = 20, bookTitle = null) {
   const pages = await db.collection('pages').find(
     { book_id: bookId, page_number: { $lte: maxPages } },
     { projection: {
@@ -487,7 +367,7 @@ async function selectBestCoverPage(db, bookId, maxPages = 20) {
   if (!pages.length) return null;
 
   const scored = pages
-    .map(p => ({ page: p, ...scorePageForCover(p) }))
+    .map(p => ({ page: p, ...scorePageForCover(p, { bookTitle }) }))
     .sort((a, b) => b.score - a.score);
 
   const best = scored[0];
@@ -3207,7 +3087,7 @@ Rules:
               // cover immediately instead of waiting for the full pipeline to complete.
               if (book.thumbnail_source !== 'manual') {
                 try {
-                  const coverResult = await selectBestCoverPage(db, book.id);
+                  const coverResult = await selectBestCoverPage(db, book.id, 20, book.title);
                   if (coverResult) {
                     await db.collection('books').updateOne(
                       { id: book.id },
@@ -4271,7 +4151,7 @@ Rules:
           }
 
           // Smart OCR-based cover selection
-          const coverResult = await selectBestCoverPage(db, book.id);
+          const coverResult = await selectBestCoverPage(db, book.id, 20, book.title);
           if (coverResult && coverResult.url !== book.thumbnail) {
             await db.collection('books').updateOne(
               { id: book.id },

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -336,7 +336,8 @@ function isNonLatin(language) {
 function isDigitizerOcr(ocrData) {
   if (!ocrData) return false;
   const start = ocrData.substring(0, 1500);
-  return /google\s+logo|digitized\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(start) ||
+  return /google\s+logo|digitized\s+by\s+google|scanned\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(start) ||
+    /preserved\s+for\s+generations\s+on\s+library\s+shelves/i.test(start) ||
     /inserted\s+by\s+the\s+internet|internet\s+archive|digitization\s+(credit|notice)/i.test(start) ||
     /not\s+part\s+of\s+the\s+original\s+book|scanner\s+barcode/i.test(start) ||
     /ex[\s\-.]?libris|bookplate|library\s+stamp/i.test(start);
@@ -4120,17 +4121,11 @@ Rules:
           ).sort({ page_number: 1 }).toArray();
 
           for (const page of edgePages) {
-            const ocr = (page.ocr?.data || '').substring(0, 1500);
-            const isDigitizerPage =
-              /google\s+logo|digitized\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(ocr) ||
-              /inserted\s+by\s+the\s+internet|internet\s+archive|digitization\s+(credit|notice)/i.test(ocr) ||
-              /not\s+part\s+of\s+the\s+original\s+book|scanner\s+barcode/i.test(ocr);
-
-            if (isDigitizerPage && page.page_type !== 'digitizer-notice') {
+            if (isDigitizerOcr(page.ocr?.data) && page.page_type !== 'digitizer-insert') {
               await db.collection('pages').updateOne(
                 { id: page.id },
                 { $set: {
-                  page_type: 'digitizer-notice',
+                  page_type: 'digitizer-insert',
                   hidden: true,
                   updated_at: new Date(),
                   'field_provenance.page_type': {

--- a/src/app/api/admin/migrate-prompts/route.ts
+++ b/src/app/api/admin/migrate-prompts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { DEFAULT_PROMPTS, LATIN_PROMPTS, GERMAN_PROMPTS } from '@/lib/types';
+import { DEFAULT_PROMPTS, LATIN_PROMPTS, GERMAN_PROMPTS, ARABIC_PROMPTS, HEBREW_PROMPTS } from '@/lib/types';
 import { withAdminAuth } from '@/lib/auth-helpers';
 import { promptContentHash } from '@/lib/prompts';
 
@@ -67,6 +67,30 @@ export const POST = withAdminAuth(async (request, session) => {
         type: 'translation',
         content: GERMAN_PROMPTS.translation,
         description: 'German translation with XML annotations (v2)',
+      },
+      {
+        name: 'Arabic OCR',
+        type: 'ocr',
+        content: ARABIC_PROMPTS.ocr,
+        description: 'Arabic manuscript/printed book OCR with script identification',
+      },
+      {
+        name: 'Arabic Translation',
+        type: 'translation',
+        content: ARABIC_PROMPTS.translation,
+        description: 'Arabic to English translation for Islamic/esoteric texts',
+      },
+      {
+        name: 'Hebrew OCR',
+        type: 'ocr',
+        content: HEBREW_PROMPTS.ocr,
+        description: 'Hebrew manuscript/printed book OCR with nikud and Rashi script',
+      },
+      {
+        name: 'Hebrew Translation',
+        type: 'translation',
+        content: HEBREW_PROMPTS.translation,
+        description: 'Hebrew/Aramaic to English translation for Kabbalistic/mystical texts',
       },
     ];
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -110,13 +110,44 @@ export async function getPrompt(
 }
 
 /**
+ * Map of book languages to their DB prompt names.
+ * When a book's language matches, we look up the language-specific OCR prompt.
+ * Falls back to the default Standard OCR prompt if no match or not found.
+ */
+const LANGUAGE_OCR_PROMPT_NAMES: Record<string, string> = {
+  arabic: 'Arabic OCR',
+  hebrew: 'Hebrew OCR',
+  latin: 'Latin OCR (Neo-Latin)',
+  german: 'German OCR (Fraktur)',
+};
+
+/**
  * Get OCR prompt from DB (or hardcoded fallback).
  * Always uses auto-detect for language — Gemini 3 Flash detects reliably,
  * and the language hint was propagating bad metadata (e.g. "Unknown").
+ *
+ * If `language` is provided, looks up a language-specific prompt from DB first.
+ * Falls back to the default Standard OCR prompt if no language match or not found.
  */
 export async function getOcrPrompt(
-  options?: { name?: string; id?: string; customText?: string }
+  options?: { name?: string; id?: string; customText?: string; language?: string }
 ): Promise<PromptLookupResult> {
+  // Try language-specific prompt if language is provided (and no explicit name/id/custom)
+  if (options?.language && !options.name && !options.id && !options.customText) {
+    const langKey = options.language.toLowerCase();
+    const promptName = LANGUAGE_OCR_PROMPT_NAMES[langKey];
+    if (promptName) {
+      const langResult = await getPrompt('ocr', { name: promptName });
+      // Only use if we found a real DB prompt (not hardcoded fallback)
+      if (langResult.reference.id !== 'hardcoded') {
+        return {
+          text: langResult.text,
+          reference: langResult.reference,
+        };
+      }
+    }
+  }
+
   const result = await getPrompt('ocr', options);
   const languageInstruction = `**Source language:** Detect the primary language from the text. Pages may contain multiple languages — transcribe all of them. Report the primary language in the <language> tag (e.g. <language>Latin</language>).`;
   return {
@@ -128,7 +159,19 @@ export async function getOcrPrompt(
 }
 
 /**
- * Get translation prompt with language variables replaced
+ * Map of book languages to their DB translation prompt names.
+ */
+const LANGUAGE_TRANSLATION_PROMPT_NAMES: Record<string, string> = {
+  arabic: 'Arabic Translation',
+  hebrew: 'Hebrew Translation',
+  latin: 'Latin Translation (Neo-Latin)',
+  german: 'German Translation (Early Modern)',
+};
+
+/**
+ * Get translation prompt with language variables replaced.
+ * If sourceLanguage matches a language-specific prompt in DB, uses that instead
+ * of the default Standard Translation prompt.
  */
 export async function getTranslationPrompt(
   sourceLanguage: string,
@@ -147,6 +190,21 @@ export async function getTranslationPrompt(
         version: 0,
       },
     };
+  }
+
+  // Try language-specific prompt if no explicit name/id/custom
+  if (!options?.name && !options?.id && !options?.customText) {
+    const langKey = sourceLanguage.toLowerCase();
+    const promptName = LANGUAGE_TRANSLATION_PROMPT_NAMES[langKey];
+    if (promptName) {
+      const langResult = await getPrompt('translation', { name: promptName });
+      if (langResult.reference.id !== 'hardcoded') {
+        return {
+          text: langResult.text,
+          reference: langResult.reference,
+        };
+      }
+    }
   }
 
   const result = await getPrompt('translation', options);

--- a/tests/integration/embassy-api.test.ts
+++ b/tests/integration/embassy-api.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/lib/mongodb', async () => {
   const { getTestDb } = await import('../setup');
   return {
     getDb: vi.fn().mockImplementation(async () => getTestDb()),
+    getReadDb: vi.fn().mockImplementation(async () => getTestDb()),
     connectToDatabase: vi.fn(),
     isConnectionError: vi.fn().mockReturnValue(false),
   };


### PR DESCRIPTION
## Summary

Three issues resolved in one PR:

- **#977 — Smart cover picker: parse OCR page-type tags.** Extracts shared cover scoring module (`scripts/lib/cover-scoring.mjs`) used by both the pipeline orchestrator and maintenance script. Now parses `<page-type>` tags from OCR text when `page.page_type` is null (most pages). Adds bookplate detection ("library of", "botanical garden"), endpaper detection ("textured surface", "marbled"), and a title-match bonus.

- **#919 — Clean up Google Books digitization notice pages.** Adds post-OCR digitizer detection to batch-collector and realtime-ocr (auto-tags as `digitizer-insert` + hidden). Fixes inconsistency where pipeline used `digitizer-notice` but UI/prompts used `digitizer-insert`. Includes backfill script for existing books.

- **#384 — Migrate hardcoded language prompts to DB.** Arabic and Hebrew OCR/translation prompts now available in DB versioning alongside Latin and German. `getOcrPrompt()` and `getTranslationPrompt()` accept a `language` parameter to auto-select language-specific prompts. Migration script included.

## Post-merge steps

1. Run digitizer page backfill: `set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-digitizer-pages.mjs --dry-run`
2. Seed language prompts: `set -a; source .env.production.local; set +a; node scripts/migration/seed-language-prompts.mjs`
3. Deploy Hetzner: `git pull` on orchestrator

## Test plan

- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Cover scoring unit tests (inline in commit: tested parsePageTypeFromOcr, bookplate, endpaper, Google detection)
- [ ] Backfill digitizer pages dry-run on production DB
- [ ] Seed language prompts dry-run
- [ ] Verify Vercel preview deploys without errors

Closes #977, closes #919, closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)