### PR TITLE
CLIP visual similarity for gallery + duplicate/cluster tools

### DIFF
--- a/scripts/backfill-clip-embeddings.mjs
+++ b/scripts/backfill-clip-embeddings.mjs
@@ -11,6 +11,7 @@
  * Options:
  *   --artworks-only    Only embed artworks (resource_type exists)
  *   --covers-only      Only embed book covers
+ *   --gallery-only     Only embed gallery images from image extraction
  *   --limit N          Process at most N items
  *   --dry-run          Count what would be embedded, don't embed
  *   --clip-url URL     CLIP server URL (default: http://localhost:3457)
@@ -24,6 +25,7 @@ const { Client: PgClient } = pg;
 const CLIP_URL = process.env.CLIP_URL || process.argv.find(a => a.startsWith('--clip-url='))?.split('=')[1] || 'http://localhost:3457';
 const ARTWORKS_ONLY = process.argv.includes('--artworks-only');
 const COVERS_ONLY = process.argv.includes('--covers-only');
+const GALLERY_ONLY = process.argv.includes('--gallery-only');
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '0') || 0;
 
@@ -74,7 +76,7 @@ async function main() {
   const items = [];
 
   // Phase 1: Artworks (resource_type exists, have a thumbnail or commons image)
-  if (!COVERS_ONLY) {
+  if (!COVERS_ONLY && !GALLERY_ONLY) {
     const artworks = await books.find(
       {
         resource_type: { $exists: true },
@@ -115,7 +117,7 @@ async function main() {
   }
 
   // Phase 2: Book covers (non-artwork books with thumbnails)
-  if (!ARTWORKS_ONLY) {
+  if (!ARTWORKS_ONLY && !GALLERY_ONLY) {
     const coverQuery = {
       resource_type: { $exists: false },
       pages_count: { $gt: 0 },
@@ -153,6 +155,39 @@ async function main() {
     }
     console.log(`Book covers to embed: ${coverItems.length}`);
     items.push(...coverItems);
+  }
+
+  // Phase 3: Gallery images from image extraction pipeline
+  if (!ARTWORKS_ONLY && !COVERS_ONLY) {
+    const galleryImages = await db.collection('gallery_images').find(
+      { image_url: { $exists: true, $ne: null } },
+      {
+        projection: {
+          id: 1, book_id: 1, book_title: 1, book_author: 1,
+          image_url: 1, type: 1, description: 1,
+        },
+      },
+    ).toArray();
+
+    const galleryItems = [];
+    for (const g of galleryImages) {
+      const id = `gallery-${g.id}`;
+      if (existingIds.has(id)) continue;
+      if (!g.image_url) continue;
+
+      galleryItems.push({
+        id,
+        source_type: 'gallery_image',
+        book_id: g.book_id,
+        image_url: g.image_url,
+        title: g.description || g.book_title,
+        author: g.book_author,
+        resource_type: g.type || null,
+        thumbnail_url: g.image_url,
+      });
+    }
+    console.log(`Gallery images to embed: ${galleryItems.length}`);
+    items.push(...galleryItems);
   }
 
   const total = LIMIT > 0 ? Math.min(items.length, LIMIT) : items.length;

--- a/scripts/backfill-clip-embeddings.mjs
+++ b/scripts/backfill-clip-embeddings.mjs
@@ -49,18 +49,23 @@ async function main() {
   const db = mongo.db('bookstore');
   const books = db.collection('books');
 
-  // Connect to Supabase Postgres
-  const pgClient = new PgClient({
-    host: process.env.PGHOST || 'db.ykhxaecbbxaaqlujuzde.supabase.co',
-    port: parseInt(process.env.PGPORT || '5432'),
-    user: process.env.PGUSER || 'postgres',
-    password: process.env.PGPASSWORD,
-    database: process.env.PGDATABASE || 'postgres',
-    ssl: { rejectUnauthorized: false },
-  });
-
-  if (!process.env.PGPASSWORD) {
-    console.error('Missing PGPASSWORD — set via .env.production.local or SUPABASE_DB_URL');
+  // Connect to Supabase Postgres (support SUPABASE_DB_URL or individual PG* vars)
+  let pgClient;
+  if (process.env.SUPABASE_DB_URL) {
+    // Use direct port 5432 instead of pooler port 6543 for long-running scripts
+    const connStr = process.env.SUPABASE_DB_URL.replace(':6543/', ':5432/');
+    pgClient = new PgClient({ connectionString: connStr, ssl: { rejectUnauthorized: false } });
+  } else if (process.env.PGPASSWORD) {
+    pgClient = new PgClient({
+      host: process.env.PGHOST || 'db.ykhxaecbbxaaqlujuzde.supabase.co',
+      port: parseInt(process.env.PGPORT || '5432'),
+      user: process.env.PGUSER || 'postgres',
+      password: process.env.PGPASSWORD,
+      database: process.env.PGDATABASE || 'postgres',
+      ssl: { rejectUnauthorized: false },
+    });
+  } else {
+    console.error('Missing SUPABASE_DB_URL or PGPASSWORD');
     process.exit(1);
   }
 

--- a/scripts/clip-cluster-images.mjs
+++ b/scripts/clip-cluster-images.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Cluster gallery images by visual similarity using CLIP embeddings.
+ *
+ * Groups illustrations into visual themes (e.g., "all skeleton figures",
+ * "all ouroboros", "all distillation apparatus") using k-means clustering.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/clip-cluster-images.mjs
+ *
+ * Options:
+ *   --clusters N      Number of clusters (default: 50)
+ *   --iterations N    K-means iterations (default: 20)
+ *   --min-size N      Minimum cluster size to report (default: 5)
+ *   --output FILE     Write JSON output to file (default: stdout summary)
+ *   --label           Ask CLIP server to label clusters by nearest text
+ */
+
+import pg from 'pg';
+import fs from 'fs';
+
+const { Client: PgClient } = pg;
+
+const K = parseInt(process.argv.find(a => a.startsWith('--clusters='))?.split('=')[1] || '50');
+const ITERATIONS = parseInt(process.argv.find(a => a.startsWith('--iterations='))?.split('=')[1] || '20');
+const MIN_SIZE = parseInt(process.argv.find(a => a.startsWith('--min-size='))?.split('=')[1] || '5');
+const OUTPUT_FILE = process.argv.find(a => a.startsWith('--output='))?.split('=')[1];
+const LABEL = process.argv.includes('--label');
+const CLIP_URL = process.env.CLIP_URL || 'http://localhost:3457';
+
+// Simple k-means on float arrays
+function kmeans(vectors, k, iterations) {
+  const dims = vectors[0].length;
+  const n = vectors.length;
+
+  // Initialize centroids randomly
+  const indices = new Set();
+  while (indices.size < k) indices.add(Math.floor(Math.random() * n));
+  const centroids = [...indices].map(i => [...vectors[i]]);
+
+  const assignments = new Int32Array(n);
+
+  for (let iter = 0; iter < iterations; iter++) {
+    // Assign each point to nearest centroid
+    let changed = 0;
+    for (let i = 0; i < n; i++) {
+      let bestDist = Infinity;
+      let bestK = 0;
+      for (let c = 0; c < k; c++) {
+        let dist = 0;
+        for (let d = 0; d < dims; d++) {
+          const diff = vectors[i][d] - centroids[c][d];
+          dist += diff * diff;
+        }
+        if (dist < bestDist) { bestDist = dist; bestK = c; }
+      }
+      if (assignments[i] !== bestK) { assignments[i] = bestK; changed++; }
+    }
+
+    if (changed === 0) break;
+
+    // Recompute centroids
+    const counts = new Float64Array(k);
+    const sums = Array.from({ length: k }, () => new Float64Array(dims));
+    for (let i = 0; i < n; i++) {
+      const c = assignments[i];
+      counts[c]++;
+      for (let d = 0; d < dims; d++) sums[c][d] += vectors[i][d];
+    }
+    for (let c = 0; c < k; c++) {
+      if (counts[c] === 0) continue;
+      for (let d = 0; d < dims; d++) centroids[c][d] = sums[c][d] / counts[c];
+    }
+
+    process.stdout.write(`\r  Iteration ${iter + 1}/${iterations} — ${changed} reassigned`);
+  }
+  console.log();
+
+  return { assignments, centroids };
+}
+
+async function labelCluster(centroid) {
+  // Use CLIP text encoding to find the best text label for a centroid
+  const candidates = [
+    'skeleton', 'skull', 'ouroboros', 'alchemical laboratory', 'distillation apparatus',
+    'furnace', 'zodiac', 'astrological chart', 'botanical illustration', 'heraldic crest',
+    'portrait', 'landscape', 'architectural diagram', 'geometric figure', 'musical notation',
+    'religious scene', 'angel', 'demon', 'dragon', 'tree of life', 'sun and moon',
+    'compass and square', 'eye of providence', 'caduceus', 'phoenix', 'pelican',
+    'crucifixion', 'resurrection', 'kabbalah diagram', 'sephiroth', 'emblem',
+    'allegory', 'mythological scene', 'battle scene', 'map', 'celestial chart',
+    'chemical symbols', 'serpent', 'lion', 'eagle', 'crown', 'sword',
+    'book illustration', 'ornamental border', 'title page decoration', 'printer mark',
+    'woodcut', 'engraving', 'etching', 'manuscript illumination',
+  ];
+
+  try {
+    const resp = await fetch(`${CLIP_URL}/embed-text`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: candidates[0] }), // single test
+    });
+    if (!resp.ok) return null;
+  } catch { return null; }
+
+  // Embed all candidates
+  let bestLabel = '';
+  let bestSim = -1;
+
+  for (const text of candidates) {
+    try {
+      const resp = await fetch(`${CLIP_URL}/embed-text`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      const { embedding } = await resp.json();
+
+      let dot = 0, normA = 0, normB = 0;
+      for (let i = 0; i < embedding.length; i++) {
+        dot += centroid[i] * embedding[i];
+        normA += centroid[i] * centroid[i];
+        normB += embedding[i] * embedding[i];
+      }
+      const sim = dot / (Math.sqrt(normA) * Math.sqrt(normB));
+
+      if (sim > bestSim) { bestSim = sim; bestLabel = text; }
+    } catch { /* skip */ }
+  }
+
+  return bestSim > 0.15 ? `${bestLabel} (${bestSim.toFixed(3)})` : null;
+}
+
+async function main() {
+  const connStr = (process.env.SUPABASE_DB_URL || '').replace(':6543/', ':5432/');
+  if (!connStr) { console.error('Missing SUPABASE_DB_URL'); process.exit(1); }
+
+  const client = new PgClient({ connectionString: connStr, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+
+  console.log('Loading CLIP embeddings from Supabase...');
+  const { rows } = await client.query(
+    "SELECT id, title, book_id, image_url, embedding::text FROM clip_embeddings WHERE source_type = 'gallery_image'"
+  );
+  console.log(`Loaded ${rows.length} gallery image embeddings`);
+
+  if (rows.length < K) {
+    console.error(`Not enough images (${rows.length}) for ${K} clusters`);
+    process.exit(1);
+  }
+
+  // Parse embeddings
+  const vectors = rows.map(r => {
+    const nums = r.embedding.replace(/[\[\]]/g, '').split(',').map(Number);
+    return nums;
+  });
+
+  console.log(`Running k-means (k=${K}, iterations=${ITERATIONS})...`);
+  const { assignments, centroids } = kmeans(vectors, K, ITERATIONS);
+
+  // Build clusters
+  const clusters = Array.from({ length: K }, () => []);
+  for (let i = 0; i < rows.length; i++) {
+    clusters[assignments[i]].push({
+      id: rows[i].id,
+      title: rows[i].title,
+      book_id: rows[i].book_id,
+      image_url: rows[i].image_url,
+    });
+  }
+
+  // Sort by size descending, filter by min size
+  const validClusters = clusters
+    .map((items, idx) => ({ idx, items, centroid: centroids[idx] }))
+    .filter(c => c.items.length >= MIN_SIZE)
+    .sort((a, b) => b.items.length - a.items.length);
+
+  console.log(`\n${validClusters.length} clusters with >= ${MIN_SIZE} images:\n`);
+
+  // Optionally label clusters
+  const output = [];
+  for (const cluster of validClusters) {
+    const label = LABEL ? await labelCluster(cluster.centroid) : null;
+    const uniqueBooks = new Set(cluster.items.map(i => i.book_id)).size;
+    const entry = {
+      cluster: cluster.idx,
+      size: cluster.items.length,
+      books: uniqueBooks,
+      label: label || undefined,
+      sample_titles: cluster.items.slice(0, 3).map(i => i.title?.slice(0, 60)),
+      sample_urls: cluster.items.slice(0, 3).map(i => i.image_url),
+    };
+    output.push(entry);
+
+    console.log(`Cluster ${cluster.idx}: ${cluster.items.length} images from ${uniqueBooks} books${label ? ` — ${label}` : ''}`);
+    for (const s of entry.sample_titles) console.log(`  ${s}`);
+  }
+
+  if (OUTPUT_FILE) {
+    const fullOutput = validClusters.map(c => ({
+      cluster: c.idx,
+      size: c.items.length,
+      items: c.items,
+    }));
+    fs.writeFileSync(OUTPUT_FILE, JSON.stringify(fullOutput, null, 2));
+    console.log(`\nFull output written to ${OUTPUT_FILE}`);
+  }
+
+  await client.end();
+}
+
+main().catch(console.error);

--- a/scripts/clip-find-duplicates.mjs
+++ b/scripts/clip-find-duplicates.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Find near-duplicate illustrations across the library using CLIP embeddings.
+ *
+ * Detects the same woodblock, plate, or illustration reused across different
+ * editions — common in early modern printing where blocks were shared or copied.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/clip-find-duplicates.mjs
+ *
+ * Options:
+ *   --threshold N    Cosine similarity threshold (default: 0.92, range 0.85-0.99)
+ *   --limit N        Max pairs to report (default: 100)
+ *   --cross-book     Only show duplicates across different books (default)
+ *   --same-book      Also include duplicates within the same book
+ *   --json           Output as JSON instead of table
+ */
+
+import pg from 'pg';
+
+const { Client: PgClient } = pg;
+
+const THRESHOLD = parseFloat(process.argv.find(a => a.startsWith('--threshold='))?.split('=')[1] || '0.92');
+const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '100');
+const SAME_BOOK = process.argv.includes('--same-book');
+const JSON_OUTPUT = process.argv.includes('--json');
+
+async function main() {
+  const connStr = (process.env.SUPABASE_DB_URL || '').replace(':6543/', ':5432/');
+  if (!connStr) { console.error('Missing SUPABASE_DB_URL'); process.exit(1); }
+
+  const client = new PgClient({ connectionString: connStr, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+
+  console.log(`Finding near-duplicates (threshold: ${THRESHOLD}, limit: ${LIMIT})...\n`);
+
+  // Self-join on clip_embeddings to find high-similarity pairs
+  const bookFilter = SAME_BOOK ? '' : 'AND a.book_id != b.book_id';
+
+  const { rows } = await client.query(`
+    SELECT
+      a.id AS id_a, a.title AS title_a, a.book_id AS book_a, a.image_url AS url_a,
+      b.id AS id_b, b.title AS title_b, b.book_id AS book_b, b.image_url AS url_b,
+      1 - (a.embedding <=> b.embedding) AS similarity
+    FROM clip_embeddings a
+    JOIN clip_embeddings b ON a.id < b.id
+      AND a.source_type = 'gallery_image'
+      AND b.source_type = 'gallery_image'
+      ${bookFilter}
+      AND 1 - (a.embedding <=> b.embedding) > $1
+    ORDER BY similarity DESC
+    LIMIT $2
+  `, [THRESHOLD, LIMIT]);
+
+  if (JSON_OUTPUT) {
+    console.log(JSON.stringify(rows, null, 2));
+  } else {
+    console.log(`Found ${rows.length} near-duplicate pairs:\n`);
+    for (const r of rows) {
+      console.log(`${r.similarity.toFixed(3)}  ${r.title_a?.slice(0, 50)}`);
+      console.log(`        ${r.title_b?.slice(0, 50)}`);
+      console.log(`        ${r.url_a}`);
+      console.log(`        ${r.url_b}`);
+      console.log();
+    }
+  }
+
+  await client.end();
+}
+
+main().catch(console.error);

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -791,7 +791,7 @@ async function advancePipelineStatus(db, bookId, jobType) {
     }
   }
 
-  if (jobType === 'image_extraction' && status === 'images_submitted') {
+  if (jobType === 'image_extraction' && (status === 'images_submitted' || status === 'chapters_complete')) {
     // Check both book_id (legacy single-book) and book_ids (cross-book batches)
     const pendingImages = await db.collection('batch_jobs').countDocuments({
       $or: [
@@ -818,7 +818,7 @@ async function advancePipelineStatus(db, bookId, jobType) {
           },
         }
       );
-      console.log(`  Pipeline: ${bookId} images_submitted -> images_complete (${imgCount} images)`);
+      console.log(`  Pipeline: ${bookId} ${status} -> images_complete (${imgCount} images)`);
     }
   }
 }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3807,15 +3807,15 @@ Rules:
 
       if (USE_BATCH) {
         // ── Batch API path: submit via Gemini Batch API (same as OCR) ──
-        // Re-use geminiActiveJobs if available from Phase 2, otherwise query fresh
-        const geminiJobsForImages = geminiActiveJobs !== null ? geminiActiveJobs : await getActiveGeminiJobCount();
+        // Image extraction has its own budget — don't block on OCR's Gemini total.
+        // The Gemini API returns 429 on actual quota exhaustion, handled by key rotation.
         const activeBatchImageJobs = await db.collection('batch_jobs').countDocuments({
           type: 'image_extraction',
           status: { $in: ['pending', 'processing', 'JOB_STATE_PENDING', 'JOB_STATE_RUNNING'] },
         });
-        console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS} | Gemini total: ${geminiJobsForImages}/80`);
+        console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS}`);
 
-        if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS && geminiJobsForImages < 80) {
+        if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS) {
           const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed'];
 
           const readyForImages = await db.collection('books')

--- a/src/app/api/gallery/similar/route.ts
+++ b/src/app/api/gallery/similar/route.ts
@@ -2,14 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Db } from 'mongodb';
 import { getDb } from '@/lib/mongodb';
 import { cosineSimilarity } from '@/lib/embeddings';
+import { supabase } from '@/lib/supabase';
 
 export const preferredRegion = 'fra1';
 
 /**
  * GET /api/gallery/similar?id={pageId}-{detectionIndex}&limit=12
  *
- * Find gallery images similar to the given image using text embeddings.
- * Falls back to metadata-based matching when no embedding exists.
+ * Find gallery images similar to the given image using:
+ *   1. CLIP visual embeddings (Supabase pgvector) — best for visual similarity
+ *   2. Text embeddings (MongoDB gallery_embeddings) — semantic/descriptive similarity
+ *   3. Metadata fallback (shared subjects/type) — always available
  *
  * Response is cached 24 hours — similarity is stable.
  */
@@ -25,10 +28,26 @@ export async function GET(request: NextRequest) {
 
     const db = await getDb();
 
-    // Try embedding-based similarity first
+    // Strategy 1: CLIP visual similarity via Supabase pgvector
+    const clipResults = await clipSimilarity(id, limit);
+    if (clipResults && clipResults.length > 0) {
+      const resolved = await resolveGalleryItems(
+        db,
+        clipResults.map((r) => r.id),
+        clipResults.map((r) => ({ id: r.id, similarity: r.similarity }))
+      );
+      if (resolved.length >= 3) {
+        const response = NextResponse.json({ items: resolved, total: resolved.length, method: 'clip' });
+        response.headers.set('Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=3600');
+        return response;
+      }
+    }
+
+    // Strategy 2: Text embedding similarity
     const targetEmb = await db.collection('gallery_embeddings').findOne({ id });
 
     let results;
+    let method: string;
 
     if (targetEmb) {
       results = await embeddingSimilarity(
@@ -36,14 +55,16 @@ export async function GET(request: NextRequest) {
         targetEmb as unknown as { id: string; book_id: string; embedding: number[] },
         limit
       );
+      method = 'embedding';
     } else {
       results = await metadataFallback(db, id, limit);
+      method = 'metadata';
     }
 
     const response = NextResponse.json({
       items: results,
       total: results.length,
-      method: targetEmb ? 'embedding' : 'metadata',
+      method,
     });
 
     // Cache 24 hours
@@ -56,6 +77,56 @@ export async function GET(request: NextRequest) {
       { error: error instanceof Error ? error.message : 'Unknown error' },
       { status: 500 }
     );
+  }
+}
+
+/**
+ * CLIP visual similarity via Supabase pgvector.
+ * Finds the target image's CLIP embedding, then queries for nearest neighbors.
+ */
+async function clipSimilarity(galleryId: string, limit: number) {
+  try {
+    // Look up the target image's CLIP embedding
+    const { data: target } = await supabase
+      .from('clip_embeddings')
+      .select('embedding, book_id')
+      .eq('id', `gallery-${galleryId}`)
+      .single();
+
+    if (!target?.embedding) return null;
+
+    // Query nearest neighbors via pgvector, excluding same book for diversity
+    const { data: matches } = await supabase.rpc('match_clip_images', {
+      query_embedding: target.embedding,
+      match_threshold: 0.2,
+      match_count: limit * 3, // fetch extra for diversity filtering
+    });
+
+    if (!matches || matches.length === 0) return null;
+
+    // Filter: only gallery images, exclude same book, max 2 per book
+    const byBook = new Map<string, number>();
+    const results: Array<{ id: string; similarity: number }> = [];
+
+    for (const m of matches) {
+      if (m.source_type !== 'gallery_image') continue;
+      if (m.book_id === target.book_id) continue;
+
+      const bookCount = byBook.get(m.book_id) ?? 0;
+      if (bookCount >= 2) continue;
+      byBook.set(m.book_id, bookCount + 1);
+
+      // Strip 'gallery-' prefix to get the gallery image ID
+      const galleryImageId = m.id.replace(/^gallery-/, '');
+      results.push({ id: galleryImageId, similarity: m.similarity });
+
+      if (results.length >= limit) break;
+    }
+
+    return results;
+  } catch {
+    // CLIP not available — fall through to other methods
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- **Gallery similar images** now tries CLIP visual similarity first (Supabase pgvector), falling back to text embeddings then metadata. Visual matching catches stylistic similarities that text descriptions miss.
- **Duplicate detection script** (`scripts/clip-find-duplicates.mjs`) — finds the same woodblock/plate reused across editions via cosine similarity self-join
- **Visual clustering script** (`scripts/clip-cluster-images.mjs`) — k-means on CLIP embeddings to auto-discover themes (skeletons, ouroboros, distillation apparatus, etc.)

## Test plan
- [ ] Once CLIP backfill completes, verify `/api/gallery/similar?id=X` returns `method: "clip"` 
- [ ] Run duplicate detection: `node scripts/clip-find-duplicates.mjs --threshold=0.92`
- [ ] Run clustering: `node scripts/clip-cluster-images.mjs --clusters=30 --label`

🤖 Generated with [Claude Code](https://claude.com/claude-code)