### PR TITLE
Agentic Librarian: tool-calling, source cards, conversation history

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -3,7 +3,7 @@ import { after } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
-import { generateLibrarianResponse, streamLibrarianResponse } from '@/lib/embassy/librarian';
+import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/lib/embassy/librarian';
 import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
@@ -24,9 +24,18 @@ const chatRequestSchema = z.object({
 
 /**
  * POST /api/embassy/chat — Send a message to the Librarian.
- * Creates or continues a thread. Returns the AI response.
- * Supports streaming via SSE when stream=true.
- * Auth required.
+ * Creates or continues a thread. Returns the AI response as structured SSE events.
+ *
+ * SSE event types:
+ *   threadId   — thread identifier (sent first)
+ *   thinking   — Librarian's reasoning before searching
+ *   tool_call  — search step starting (name + query)
+ *   tool_result — search step completed (name + summary + found count)
+ *   choices    — branching options for the user to select
+ *   chunk      — response text chunk
+ *   sources    — source cards array
+ *   done       — stream complete
+ *   error      — something went wrong
  */
 export async function POST(request: NextRequest) {
   const session = await auth();
@@ -67,7 +76,6 @@ export async function POST(request: NextRequest) {
     }
     activeThreadId = threadId;
 
-    // Save user message
     await db.collection('embassy_messages').insertOne({
       threadId: new ObjectId(threadId),
       authorType: 'human',
@@ -91,7 +99,6 @@ export async function POST(request: NextRequest) {
     });
     activeThreadId = result.insertedId.toString();
 
-    // Save user message
     await db.collection('embassy_messages').insertOne({
       threadId: result.insertedId,
       authorType: 'human',
@@ -102,119 +109,109 @@ export async function POST(request: NextRequest) {
     });
   }
 
-  // Streaming response via TransformStream (flush-friendly on Vercel)
-  if (stream) {
-    const encoder = new TextEncoder();
-    const { readable, writable } = new TransformStream();
-    const writer = writable.getWriter();
+  // Always stream — the agentic response is inherently step-by-step
+  const encoder = new TextEncoder();
+  const { readable, writable } = new TransformStream();
+  const writer = writable.getWriter();
 
-    // Start piping immediately — search + stream happen in background
-    const pipePromise = (async () => {
-      try {
-        // Send threadId immediately so client knows the connection is live
-        await writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'threadId', threadId: activeThreadId })}\n\n`));
-        // Send a status event so the UI can show "Searching..."
-        await writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'status', text: 'Searching the collection...' })}\n\n`));
+  const send = (event: Record<string, unknown>) =>
+    writer.write(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
 
-        // Now do the slow search + Gemini init
-        const { stream: textStream, sources, getFullText } = await streamLibrarianResponse(message, history);
+  // Collect full text + sources for DB write
+  let fullText = '';
+  let allSources: SourceCard[] = [];
 
-        for await (const chunk of textStream) {
-          await writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'chunk', text: chunk })}\n\n`));
+  const pipePromise = (async () => {
+    try {
+      await send({ type: 'threadId', threadId: activeThreadId });
+
+      for await (const step of streamAgenticResponse(message, history)) {
+        switch (step.type) {
+          case 'thinking':
+            await send({ type: 'thinking', text: step.text });
+            break;
+
+          case 'tool_call':
+            await send({ type: 'tool_call', name: step.name, query: step.query });
+            break;
+
+          case 'tool_result':
+            await send({
+              type: 'tool_result',
+              name: step.name,
+              query: step.query,
+              summary: step.summary,
+              found: step.found,
+            });
+            break;
+
+          case 'choices':
+            await send({ type: 'choices', text: step.text, options: step.options });
+            break;
+
+          case 'text':
+            // Send as 'chunk' for backward compat with the existing UI
+            fullText += step.text || '';
+            await send({ type: 'chunk', text: step.text });
+            break;
+
+          case 'sources':
+            allSources = step.sources || [];
+            await send({ type: 'sources', sources: step.sources });
+            break;
         }
-
-        await writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'done' })}\n\n`));
-        await writer.close();
-
-        // Return data needed for after() DB writes
-        return { getFullText, sources };
-      } catch (err) {
-        console.error('[Embassy] Stream error:', err);
-        try {
-          await writer.write(encoder.encode(`data: ${JSON.stringify({ type: 'error', message: 'The Librarian was interrupted. Please try again.' })}\n\n`));
-          await writer.close();
-        } catch { /* already closed */ }
-        return null;
       }
-    })();
 
-      // Defer DB writes to after the response is sent
-      after(async () => {
-        const result = await pipePromise;
-        if (!result) return; // Stream errored
-        const fullText = result.getFullText();
-        const sources = result.sources;
-        const aiMessageTime = new Date();
+      await send({ type: 'done' });
+      await writer.close();
+    } catch (err) {
+      console.error('[Embassy] Agentic stream error:', err);
+      try {
+        await send({ type: 'error', message: 'The Librarian was interrupted. Please try again.' });
+        await writer.close();
+      } catch { /* already closed */ }
+    }
+  })();
 
-        try {
-          await db.collection('embassy_messages').insertOne({
-            threadId: new ObjectId(activeThreadId),
-            authorType: 'ai',
-            authorName: 'The Librarian',
-            content: fullText,
-            sources: sources.map(s => ({
-              bookId: s.book_id,
-              bookTitle: s.bookTitle,
-              bookAuthor: s.bookAuthor,
-              pageNumber: s.page_number,
-              bookSlug: s.bookSlug,
-            })),
-            createdAt: aiMessageTime,
-          });
-
-          await db.collection('embassy_threads').updateOne(
-            { _id: new ObjectId(activeThreadId) },
-            { $set: { lastMessageAt: aiMessageTime }, $inc: { messageCount: 2 } },
-          );
-        } catch (err) {
-          console.error('[Embassy] Failed to save AI response:', err);
-        }
-      });
-
-    return new Response(readable, {
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache, no-transform',
-        'Connection': 'keep-alive',
-        'X-Accel-Buffering': 'no',
-      },
-    });
-  }
-
-  // Non-streaming response (fallback)
-  try {
-    const { content: aiResponse, sources } = await generateLibrarianResponse(message, history);
+  // Defer DB writes
+  after(async () => {
+    await pipePromise;
+    if (!fullText && allSources.length === 0) return;
     const aiMessageTime = new Date();
 
-    await db.collection('embassy_messages').insertOne({
-      threadId: new ObjectId(activeThreadId),
-      authorType: 'ai',
-      authorName: 'The Librarian',
-      content: aiResponse,
-      sources: sources.map(s => ({
-        bookId: s.book_id,
-        bookTitle: s.bookTitle,
-        bookAuthor: s.bookAuthor,
-        pageNumber: s.page_number,
-        bookSlug: s.bookSlug,
-      })),
-      createdAt: aiMessageTime,
-    });
+    try {
+      await db.collection('embassy_messages').insertOne({
+        threadId: new ObjectId(activeThreadId),
+        authorType: 'ai',
+        authorName: 'The Librarian',
+        content: fullText,
+        sources: allSources.map(s => ({
+          bookId: s.book_id,
+          bookTitle: s.bookTitle,
+          bookAuthor: s.bookAuthor,
+          pageNumber: s.pageNumber,
+          bookSlug: s.bookSlug,
+          snippet: s.snippet,
+          inCollection: s.inCollection,
+        })),
+        createdAt: aiMessageTime,
+      });
 
-    await db.collection('embassy_threads').updateOne(
-      { _id: new ObjectId(activeThreadId) },
-      { $set: { lastMessageAt: aiMessageTime }, $inc: { messageCount: 2 } },
-    );
+      await db.collection('embassy_threads').updateOne(
+        { _id: new ObjectId(activeThreadId) },
+        { $set: { lastMessageAt: aiMessageTime }, $inc: { messageCount: 2 } },
+      );
+    } catch (err) {
+      console.error('[Embassy] Failed to save AI response:', err);
+    }
+  });
 
-    return NextResponse.json({
-      threadId: activeThreadId,
-      message: { role: 'assistant', content: aiResponse },
-    });
-  } catch (error) {
-    console.error('[Embassy] Librarian error:', error);
-    return NextResponse.json(
-      { error: 'The Librarian is momentarily away. Please try again.' },
-      { status: 500 },
-    );
-  }
+  return new Response(readable, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
 }

--- a/src/app/api/embassy/threads/route.ts
+++ b/src/app/api/embassy/threads/route.ts
@@ -1,19 +1,33 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { auth } from '@/lib/auth';
 
 /**
- * GET /api/embassy/threads — List public Embassy threads (activity feed).
- * No auth required — public threads are visible to everyone.
+ * GET /api/embassy/threads — List Embassy threads.
+ * ?mine=true — list the current user's threads (auth required)
+ * Default — list public threads (no auth required)
  */
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const limit = Math.min(parseInt(url.searchParams.get('limit') || '20'), 50);
   const offset = parseInt(url.searchParams.get('offset') || '0');
+  const mine = url.searchParams.get('mine') === 'true';
 
   const db = await getReadDb();
 
+  let filter: Record<string, unknown>;
+  if (mine) {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ threads: [] });
+    }
+    filter = { creatorId: session.user.id, messageCount: { $gte: 2 } };
+  } else {
+    filter = { visibility: 'public', messageCount: { $gte: 2 } };
+  }
+
   const threads = await db.collection('embassy_threads')
-    .find({ visibility: 'public', messageCount: { $gte: 2 } }) // Only show threads with at least one exchange
+    .find(filter)
     .sort({ lastMessageAt: -1 })
     .skip(offset)
     .limit(limit)

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -1,15 +1,46 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import SiteHeader from '@/components/layout/SiteHeader';
 
-interface Message {
-  role: 'user' | 'assistant';
+// ── Types ─────────────────────────────────────────────────────────────
+
+interface SourceCard {
+  bookId: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookSlug?: string;
+  pageNumber?: number;
+  snippet?: string;
+  inCollection: boolean;
+}
+
+interface SearchStep {
+  name: string;
+  query: string;
+  summary?: string;
+  found?: number;
+  status: 'searching' | 'done';
+}
+
+interface AssistantMessage {
+  role: 'assistant';
+  thinking?: string;
+  steps: SearchStep[];
+  content: string;
+  sources: SourceCard[];
+  choices?: { text: string; options: string[] };
+}
+
+interface UserMessage {
+  role: 'user';
   content: string;
 }
+
+type Message = UserMessage | AssistantMessage;
 
 interface ThreadPreview {
   id: string;
@@ -18,10 +49,7 @@ interface ThreadPreview {
   messageCount: number;
   createdAt: string;
   lastMessageAt: string;
-  preview: {
-    question: string;
-    answer: string;
-  };
+  preview: { question: string; answer: string };
 }
 
 interface FeaturedPassage {
@@ -51,6 +79,88 @@ function timeAgo(dateStr: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
+const TOOL_LABELS: Record<string, string> = {
+  search_collection: 'Searching the collection',
+  search_semantic: 'Semantic search',
+  search_wikipedia: 'Checking Wikipedia',
+  get_book_page: 'Reading a page',
+  present_choices: 'Thinking...',
+};
+
+// ── Source Card Component ─────────────────────────────────────────────
+
+function SourceCardRow({ sources }: { sources: SourceCard[] }) {
+  if (sources.length === 0) return null;
+  return (
+    <div className="mt-3 flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+      {sources.map((s, i) => {
+        const url = s.bookSlug
+          ? `/book/${s.bookSlug}${s.pageNumber ? `?page=${s.pageNumber}` : ''}`
+          : `/book/${s.bookId}${s.pageNumber ? `?page=${s.pageNumber}` : ''}`;
+        return (
+          <Link
+            key={`${s.bookId}-${s.pageNumber}-${i}`}
+            href={url}
+            className={`flex-shrink-0 w-[200px] rounded-lg border p-2.5 transition-colors ${
+              s.inCollection
+                ? 'border-[#e8e4dc] bg-white hover:border-[#c9a86c] hover:bg-[#faf8f4]'
+                : 'border-dashed border-[#d4d0c8] bg-[#f9f7f3] opacity-60'
+            }`}
+          >
+            <p className="text-[12px] font-body text-[#1a1612] font-medium leading-tight line-clamp-2">
+              {s.bookTitle}
+            </p>
+            <p className="text-[10px] text-[#8a8480] font-body mt-0.5">
+              {s.bookAuthor}
+              {s.pageNumber ? ` · p. ${s.pageNumber}` : ''}
+            </p>
+            {s.snippet && (
+              <p className="text-[10px] text-[#6b6560] font-body mt-1 line-clamp-2 italic leading-relaxed">
+                {s.snippet}
+              </p>
+            )}
+            {!s.inCollection && (
+              <p className="text-[9px] text-[#b0a89c] font-sans mt-1">Not yet in collection</p>
+            )}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Search Steps Component ────────────────────────────────────────────
+
+function SearchSteps({ steps }: { steps: SearchStep[] }) {
+  if (steps.length === 0) return null;
+  return (
+    <div className="space-y-1 mb-2">
+      {steps.map((step, i) => (
+        <div key={i} className="flex items-center gap-2 text-[12px] font-sans text-[#8a8480]">
+          <span className={`inline-block w-3.5 text-center ${step.status === 'done' ? (step.found && step.found > 0 ? 'text-[#6b8f5e]' : 'text-[#b0a89c]') : 'text-[#c9a86c]'}`}>
+            {step.status === 'searching' ? (
+              <span className="inline-block animate-pulse">...</span>
+            ) : step.found && step.found > 0 ? (
+              <span>&#x2713;</span>
+            ) : (
+              <span>&#x2717;</span>
+            )}
+          </span>
+          <span>
+            {TOOL_LABELS[step.name] || step.name}
+            {step.query && <span className="text-[#b0a89c]"> &ldquo;{step.query.slice(0, 50)}{step.query.length > 50 ? '...' : ''}&rdquo;</span>}
+            {step.status === 'done' && step.summary && (
+              <span className="text-[#6b6560]"> &mdash; {step.summary}</span>
+            )}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main Component ────────────────────────────────────────────────────
+
 export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClientProps) {
   const { data: session, status } = useSession();
   const [messages, setMessages] = useState<Message[]>([]);
@@ -58,11 +168,15 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
   const [sending, setSending] = useState(false);
   const [threadId, setThreadId] = useState<string | null>(null);
   const [threads, setThreads] = useState<ThreadPreview[]>([]);
+  const [myThreads, setMyThreads] = useState<ThreadPreview[]>([]);
+  const [sidebarTab, setSidebarTab] = useState<'recent' | 'mine'>('recent');
   const [visibility, setVisibility] = useState<'public' | 'private'>('public');
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [showThinking, setShowThinking] = useState(false);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
+  // Fetch public threads
   useEffect(() => {
     fetch('/api/embassy/threads?limit=10')
       .then(r => r.json())
@@ -70,15 +184,22 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
       .catch(() => {});
   }, []);
 
-  // Auto-scroll chat container to bottom on new content (including streaming chunks)
+  // Fetch user's own threads when signed in
+  useEffect(() => {
+    if (status === 'authenticated') {
+      fetch('/api/embassy/threads?mine=true&limit=20')
+        .then(r => r.json())
+        .then(data => { if (data.threads) setMyThreads(data.threads); })
+        .catch(() => {});
+    }
+  }, [status]);
+
+  // Auto-scroll
   useEffect(() => {
     const container = chatContainerRef.current;
     if (!container) return;
-    // Only auto-scroll if user is near the bottom (not scrolled up to read history)
     const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 150;
-    if (isNearBottom) {
-      container.scrollTop = container.scrollHeight;
-    }
+    if (isNearBottom) container.scrollTop = container.scrollHeight;
   }, [messages]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -87,19 +208,39 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
     e.target.style.height = Math.min(e.target.scrollHeight, 200) + 'px';
   };
 
+  // Update the last assistant message immutably
+  const updateLastAssistant = useCallback((updater: (msg: AssistantMessage) => AssistantMessage) => {
+    setMessages(prev => {
+      const updated = [...prev];
+      const last = updated[updated.length - 1];
+      if (last?.role === 'assistant') {
+        updated[updated.length - 1] = updater(last as AssistantMessage);
+      }
+      return updated;
+    });
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = input.trim();
     if (!trimmed || sending) return;
 
-    const userMessage: Message = { role: 'user', content: trimmed };
-    setMessages(prev => [...prev, userMessage]);
+    setMessages(prev => [...prev, { role: 'user', content: trimmed }]);
     setInput('');
     setSending(true);
+    if (inputRef.current) inputRef.current.style.height = 'auto';
 
-    if (inputRef.current) {
-      inputRef.current.style.height = 'auto';
-    }
+    // Create empty assistant message
+    const emptyAssistant: AssistantMessage = {
+      role: 'assistant',
+      steps: [],
+      content: '',
+      sources: [],
+    };
+    setMessages(prev => [...prev, emptyAssistant]);
+
+    const abort = new AbortController();
+    abortRef.current = abort;
 
     try {
       const res = await fetch('/api/embassy/chat', {
@@ -108,101 +249,146 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
         body: JSON.stringify({
           threadId,
           message: trimmed,
-          history: messages,
+          history: messages.map(m => ({
+            role: m.role,
+            content: m.role === 'user' ? m.content : (m as AssistantMessage).content,
+          })),
           visibility,
           stream: true,
         }),
+        signal: abort.signal,
       });
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         if (res.status === 401) {
-          setMessages(prev => [...prev, {
-            role: 'assistant',
+          updateLastAssistant(m => ({
+            ...m,
             content: 'Please [sign in](/auth/signin?callbackUrl=/reading-room) to talk with the Librarian. It\'s free — just create an account or sign in with Google.',
-          }]);
+          }));
         } else {
-          setMessages(prev => [...prev, {
-            role: 'assistant',
-            content: err.error || 'Something went wrong. Please try again.',
-          }]);
+          updateLastAssistant(m => ({ ...m, content: err.error || 'Something went wrong. Please try again.' }));
         }
         setSending(false);
         return;
       }
 
-      if (res.headers.get('content-type')?.includes('text/event-stream')) {
-        setMessages(prev => [...prev, { role: 'assistant', content: '' }]);
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
 
-        const reader = res.body?.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
 
-        if (reader) {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
 
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split('\n');
-            buffer = lines.pop() || '';
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            try {
+              const event = JSON.parse(line.slice(6));
 
-            for (const line of lines) {
-              if (!line.startsWith('data: ')) continue;
-              try {
-                const event = JSON.parse(line.slice(6));
-                if (event.type === 'threadId' && !threadId) {
-                  setThreadId(event.threadId);
-                } else if (event.type === 'status') {
-                  // Show status text (e.g. "Searching the collection...") as a temporary assistant message
-                  setMessages(prev => {
-                    const updated = [...prev];
-                    const last = updated[updated.length - 1];
-                    if (last?.role === 'assistant' && !last.content) {
-                      updated[updated.length - 1] = { ...last, content: `*${event.text}*` };
-                    }
-                    return updated;
-                  });
-                } else if (event.type === 'chunk') {
-                  setMessages(prev => {
-                    const updated = [...prev];
-                    const last = updated[updated.length - 1];
-                    if (last?.role === 'assistant') {
-                      // Replace status text on first real chunk
-                      const isStatus = last.content.startsWith('*') && last.content.endsWith('*');
-                      const newContent = isStatus ? event.text : last.content + event.text;
-                      updated[updated.length - 1] = { ...last, content: newContent };
-                    }
-                    return updated;
-                  });
-                } else if (event.type === 'error') {
-                  setMessages(prev => {
-                    const updated = [...prev];
-                    updated[updated.length - 1] = { role: 'assistant', content: event.message };
-                    return updated;
-                  });
-                }
-              } catch {
-                // Skip malformed events
+              switch (event.type) {
+                case 'threadId':
+                  if (!threadId) setThreadId(event.threadId);
+                  break;
+
+                case 'thinking':
+                  updateLastAssistant(m => ({
+                    ...m,
+                    thinking: (m.thinking || '') + (event.text || ''),
+                  }));
+                  break;
+
+                case 'tool_call':
+                  updateLastAssistant(m => ({
+                    ...m,
+                    steps: [...m.steps, {
+                      name: event.name,
+                      query: event.query || '',
+                      status: 'searching' as const,
+                    }],
+                  }));
+                  break;
+
+                case 'tool_result':
+                  updateLastAssistant(m => ({
+                    ...m,
+                    steps: m.steps.map((s, i) =>
+                      i === m.steps.length - 1 && s.status === 'searching'
+                        ? { ...s, status: 'done' as const, summary: event.summary, found: event.found }
+                        : s
+                    ),
+                  }));
+                  break;
+
+                case 'choices':
+                  updateLastAssistant(m => ({
+                    ...m,
+                    choices: { text: event.text, options: event.options },
+                  }));
+                  break;
+
+                case 'chunk':
+                  updateLastAssistant(m => ({
+                    ...m,
+                    content: m.content + (event.text || ''),
+                  }));
+                  break;
+
+                case 'sources':
+                  updateLastAssistant(m => ({
+                    ...m,
+                    sources: (event.sources || []).map((s: Record<string, unknown>) => ({
+                      bookId: s.book_id,
+                      bookTitle: s.bookTitle,
+                      bookAuthor: s.bookAuthor,
+                      bookSlug: s.bookSlug,
+                      pageNumber: s.pageNumber,
+                      snippet: s.snippet,
+                      inCollection: s.inCollection !== false,
+                    })),
+                  }));
+                  break;
+
+                case 'error':
+                  updateLastAssistant(m => ({ ...m, content: event.message || 'Something went wrong.' }));
+                  break;
               }
-            }
+            } catch { /* skip malformed */ }
           }
         }
-      } else {
-        const data = await res.json();
-        if (data.threadId && !threadId) {
-          setThreadId(data.threadId);
-        }
-        setMessages(prev => [...prev, { role: 'assistant', content: data.message.content }]);
       }
-    } catch {
-      setMessages(prev => [...prev, {
-        role: 'assistant',
-        content: 'The Librarian seems to be away. Please try again in a moment.',
-      }]);
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        updateLastAssistant(m => ({
+          ...m,
+          content: 'The Librarian seems to be away. Please try again in a moment.',
+        }));
+      }
     }
 
+    abortRef.current = null;
     setSending(false);
+  };
+
+  const handleStop = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setSending(false);
+  };
+
+  const handleChoiceClick = (choice: string) => {
+    setInput(choice);
+    inputRef.current?.focus();
+    // Auto-submit
+    setTimeout(() => {
+      const form = inputRef.current?.closest('form');
+      if (form) form.requestSubmit();
+    }, 50);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -223,7 +409,7 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
   return (
     <div className="min-h-screen bg-[#f5f0e8]">
       <SiteHeader variant="dark" />
-      {/* Hero with reading room painting */}
+      {/* Hero */}
       <div className="relative bg-[#0e0c0a] overflow-hidden min-h-[360px] sm:min-h-[420px]">
         <div className="absolute inset-0">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -238,10 +424,7 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
         <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#0e0c0a]/90" />
 
         <div className="relative max-w-[1200px] mx-auto px-6 md:px-12 pt-14 sm:pt-20 pb-14">
-          <h1
-            className="text-4xl sm:text-5xl md:text-6xl text-white font-display mb-3 drop-shadow-lg"
-            style={{ fontWeight: 500 }}
-          >
+          <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-display mb-3 drop-shadow-lg" style={{ fontWeight: 500 }}>
             The Reading Room
           </h1>
           <p className="text-white/80 text-base sm:text-lg font-body leading-relaxed max-w-[480px] drop-shadow-sm">
@@ -249,16 +432,12 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
             Kabbalah, astrology, natural philosophy.
           </p>
 
-          {/* Featured passage */}
           {featuredPassage && (
             <div className="mt-8 max-w-[560px]">
               <p className="text-[11px] text-white/40 tracking-[0.15em] uppercase font-sans mb-2">
                 The Librarian is reading
               </p>
-              <Link
-                href={`/book/${featuredPassage.bookSlug}?page=${featuredPassage.pageNumber}`}
-                className="block group"
-              >
+              <Link href={`/book/${featuredPassage.bookSlug}?page=${featuredPassage.pageNumber}`} className="block group">
                 <blockquote className="text-white/70 text-[15px] font-body leading-relaxed italic border-l-2 border-[#c9a86c]/40 pl-4">
                   &ldquo;{featuredPassage.text}&rdquo;
                 </blockquote>
@@ -273,204 +452,269 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
         </div>
       </div>
 
-      {/* Main content — painting continues as background */}
+      {/* Main content */}
       <div className="relative">
         <div className="absolute inset-0">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="https://images.sourcelibrary.org/artwork/reading-room-hero.png"
-            alt=""
-            className="absolute inset-0 w-full h-full object-cover opacity-[0.06]"
-          />
+          <img src="https://images.sourcelibrary.org/artwork/reading-room-hero.png" alt="" className="absolute inset-0 w-full h-full object-cover opacity-[0.06]" />
         </div>
         <div className="relative max-w-[1200px] mx-auto px-6 md:px-12 py-8 md:py-12">
-        <div className="flex flex-col lg:flex-row gap-8 lg:gap-12">
+          <div className="flex flex-col lg:flex-row gap-8 lg:gap-12">
 
-          {/* Chat area */}
-          <div className="flex-1 min-w-0">
-            <div className="border border-[#e8e4dc] rounded-lg bg-white overflow-hidden shadow-sm">
-              {/* Messages */}
-              <div ref={chatContainerRef} className="min-h-[300px] max-h-[600px] overflow-y-auto p-6 space-y-6">
-                {messages.length === 0 && (
-                  <div className="text-center py-8">
-                    <div className="text-[#c9a86c] text-3xl mb-3" style={{ fontFamily: 'serif' }}>
-                      &#x2609;
-                    </div>
-                    <p className="text-[#8a8480] text-sm font-body max-w-[400px] mx-auto leading-relaxed">
-                      The Librarian searches the translated texts in the collection.
-                      Ask about an author, a tradition, a symbol, or a passage.
-                    </p>
-                    <p className="text-[#8a8480]/50 text-xs font-body mt-1.5">
-                      Responses may contain errors &mdash; always verify against the source page.
-                    </p>
-                    <div className="flex flex-wrap justify-center gap-2 mt-5">
-                      {[
-                        'What did Agrippa write about planetary seals?',
-                        'Tell me about the Emerald Tablet',
-                        'Who was Marsilio Ficino?',
-                        'What is the Philosopher\'s Stone?',
-                      ].map((suggestion) => (
-                        <button
-                          key={suggestion}
-                          onClick={() => {
-                            setInput(suggestion);
-                            inputRef.current?.focus();
-                          }}
-                          className="px-3 py-1.5 text-xs text-[#6b6560] border border-[#e8e4dc] rounded-full hover:bg-[#f5f0e8] hover:text-[#444] transition-colors font-sans"
-                        >
-                          {suggestion}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {messages.map((msg, i) => (
-                  <div key={i} className={`flex gap-3 ${msg.role === 'user' ? 'justify-end' : ''}`}>
-                    {msg.role === 'assistant' && (
-                      <div className="flex-shrink-0 w-8 h-8 rounded-full bg-[#f5f0e8] flex items-center justify-center text-[#c9a86c] text-sm" style={{ fontFamily: 'serif' }}>
-                        &#x2609;
+            {/* Chat area */}
+            <div className="flex-1 min-w-0">
+              <div className="border border-[#e8e4dc] rounded-lg bg-white overflow-hidden shadow-sm">
+                {/* Messages */}
+                <div ref={chatContainerRef} className="min-h-[300px] max-h-[600px] overflow-y-auto p-6 space-y-6">
+                  {messages.length === 0 && (
+                    <div className="text-center py-8">
+                      <div className="text-[#c9a86c] text-3xl mb-3" style={{ fontFamily: 'serif' }}>&#x2609;</div>
+                      <p className="text-[#8a8480] text-sm font-body max-w-[400px] mx-auto leading-relaxed">
+                        The Librarian searches the collection, Wikipedia, and semantic search
+                        to find answers in over 5,000 rare books.
+                      </p>
+                      <p className="text-[#8a8480]/50 text-xs font-body mt-1.5">
+                        Responses may contain errors &mdash; always verify against the source page.
+                      </p>
+                      <div className="flex flex-wrap justify-center gap-2 mt-5">
+                        {[
+                          'Are there any books about magic mushrooms?',
+                          'What did Agrippa write about planetary seals?',
+                          'What books explore resonance as magic?',
+                          'Who was Marsilio Ficino?',
+                        ].map((suggestion) => (
+                          <button
+                            key={suggestion}
+                            onClick={() => { setInput(suggestion); inputRef.current?.focus(); }}
+                            className="px-3 py-1.5 text-xs text-[#6b6560] border border-[#e8e4dc] rounded-full hover:bg-[#f5f0e8] hover:text-[#444] transition-colors font-sans"
+                          >
+                            {suggestion}
+                          </button>
+                        ))}
                       </div>
-                    )}
-                    <div
-                      className={`max-w-[85%] ${
-                        msg.role === 'user'
-                          ? 'bg-[#1a1612] text-white rounded-2xl rounded-br-sm px-4 py-3'
-                          : 'bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3'
-                      }`}
-                    >
-                      {msg.role === 'assistant' ? (
-                        <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed prose-a:text-[#9e4a3a] prose-a:no-underline hover:prose-a:underline prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-strong:text-[#1a1612]">
-                          <ReactMarkdown>{msg.content}</ReactMarkdown>
+                    </div>
+                  )}
+
+                  {messages.map((msg, i) => {
+                    if (msg.role === 'user') {
+                      return (
+                        <div key={i} className="flex gap-3 justify-end">
+                          <div className="max-w-[85%] bg-[#1a1612] text-white rounded-2xl rounded-br-sm px-4 py-3">
+                            <p className="text-[15px] font-body leading-relaxed whitespace-pre-wrap">{msg.content}</p>
+                          </div>
                         </div>
-                      ) : (
-                        <p className="text-[15px] font-body leading-relaxed whitespace-pre-wrap">{msg.content}</p>
+                      );
+                    }
+
+                    const assistant = msg as AssistantMessage;
+                    return (
+                      <div key={i} className="flex gap-3">
+                        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-[#f5f0e8] flex items-center justify-center text-[#c9a86c] text-sm" style={{ fontFamily: 'serif' }}>
+                          &#x2609;
+                        </div>
+                        <div className="max-w-[85%] min-w-0">
+                          {/* Thinking (collapsible) */}
+                          {assistant.thinking && (
+                            <div className="mb-2">
+                              <button
+                                onClick={() => setShowThinking(!showThinking)}
+                                className="text-[11px] text-[#b0a89c] hover:text-[#8a8480] font-sans transition-colors"
+                              >
+                                {showThinking ? 'Hide reasoning' : 'Show reasoning'}
+                              </button>
+                              {showThinking && (
+                                <div className="mt-1 text-[13px] text-[#8a8480] font-body italic leading-relaxed bg-[#faf8f4] rounded px-3 py-2 border-l-2 border-[#e8e4dc]">
+                                  <ReactMarkdown>{assistant.thinking}</ReactMarkdown>
+                                </div>
+                              )}
+                            </div>
+                          )}
+
+                          {/* Search steps */}
+                          <SearchSteps steps={assistant.steps} />
+
+                          {/* Response text */}
+                          {assistant.content && (
+                            <div className="bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3">
+                              <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed prose-a:text-[#9e4a3a] prose-a:no-underline hover:prose-a:underline prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-strong:text-[#1a1612]">
+                                <ReactMarkdown>{assistant.content}</ReactMarkdown>
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Choice chips */}
+                          {assistant.choices && (
+                            <div className="mt-3">
+                              {assistant.choices.text && (
+                                <p className="text-[13px] text-[#6b6560] font-body mb-2 italic">{assistant.choices.text}</p>
+                              )}
+                              <div className="flex flex-wrap gap-2">
+                                {assistant.choices.options.map((opt) => (
+                                  <button
+                                    key={opt}
+                                    onClick={() => handleChoiceClick(opt)}
+                                    className="px-3 py-1.5 text-[13px] text-[#1a1612] border border-[#c9a86c] rounded-full hover:bg-[#c9a86c] hover:text-white transition-colors font-body"
+                                  >
+                                    {opt}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Source cards */}
+                          <SourceCardRow sources={assistant.sources} />
+
+                          {/* Loading state: no content yet and still sending */}
+                          {!assistant.content && !assistant.thinking && assistant.steps.length === 0 && sending && i === messages.length - 1 && (
+                            <div className="bg-[#f5f0e8] rounded-2xl rounded-bl-sm px-4 py-3">
+                              <p className="text-[13px] text-[#8a8480] font-body italic animate-pulse">Thinking...</p>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                  <div />
+                </div>
+
+                {/* Input area */}
+                <div className="border-t border-[#e8e4dc] p-4">
+                  <form onSubmit={handleSubmit} className="flex gap-3 items-end">
+                    <textarea
+                      ref={inputRef}
+                      value={input}
+                      onChange={handleInputChange}
+                      onKeyDown={handleKeyDown}
+                      placeholder={isSignedIn ? 'Ask the Librarian...' : 'Sign in to ask the Librarian...'}
+                      disabled={!isSignedIn && status !== 'loading'}
+                      rows={1}
+                      className="flex-1 resize-none border border-[#e8e4dc] rounded-lg px-4 py-2.5 text-[15px] font-body text-[#1a1612] placeholder-[#8a8480] focus:outline-none focus:border-[#c9a86c] transition-colors bg-transparent disabled:opacity-50"
+                    />
+                    {sending ? (
+                      <button
+                        type="button"
+                        onClick={handleStop}
+                        className="flex-shrink-0 px-5 py-2.5 bg-[#9e4a3a] text-white rounded-lg text-sm font-sans hover:bg-[#8b3d30] transition-colors"
+                      >
+                        Stop
+                      </button>
+                    ) : (
+                      <button
+                        type="submit"
+                        disabled={!input.trim() || (!isSignedIn && status !== 'loading')}
+                        className="flex-shrink-0 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] disabled:opacity-30 transition-colors"
+                      >
+                        Send
+                      </button>
+                    )}
+                  </form>
+
+                  <div className="flex items-center justify-between mt-2">
+                    <div className="flex items-center gap-3">
+                      {messages.length > 0 && (
+                        <button onClick={startNewThread} className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans">
+                          New conversation
+                        </button>
                       )}
                     </div>
-                  </div>
-                ))}
-
-                {sending && !(messages.length > 0 && messages[messages.length - 1]?.role === 'assistant') && (
-                  <div className="flex gap-3">
-                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-[#f5f0e8] flex items-center justify-center text-[#c9a86c] text-sm" style={{ fontFamily: 'serif' }}>
-                      &#x2609;
-                    </div>
-                    <div className="bg-[#f5f0e8] rounded-2xl rounded-bl-sm px-4 py-3">
-                      <p className="text-[13px] text-[#8a8480] font-body italic">Searching the collection...</p>
-                    </div>
-                  </div>
-                )}
-
-                <div ref={messagesEndRef} />
-              </div>
-
-              {/* Input area */}
-              <div className="border-t border-[#e8e4dc] p-4">
-                <form onSubmit={handleSubmit} className="flex gap-3 items-end">
-                  <textarea
-                    ref={inputRef}
-                    value={input}
-                    onChange={handleInputChange}
-                    onKeyDown={handleKeyDown}
-                    placeholder={isSignedIn ? 'Ask the Librarian...' : 'Sign in to ask the Librarian...'}
-                    disabled={!isSignedIn && status !== 'loading'}
-                    rows={1}
-                    className="flex-1 resize-none border border-[#e8e4dc] rounded-lg px-4 py-2.5 text-[15px] font-body text-[#1a1612] placeholder-[#8a8480] focus:outline-none focus:border-[#c9a86c] transition-colors bg-transparent disabled:opacity-50"
-                  />
-                  <button
-                    type="submit"
-                    disabled={!input.trim() || sending || (!isSignedIn && status !== 'loading')}
-                    className="flex-shrink-0 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] disabled:opacity-30 transition-colors"
-                  >
-                    Send
-                  </button>
-                </form>
-
-                <div className="flex items-center justify-between mt-2">
-                  <div className="flex items-center gap-3">
-                    {messages.length > 0 && (
+                    {isSignedIn && (
                       <button
-                        onClick={startNewThread}
-                        className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans"
+                        onClick={() => setVisibility(v => v === 'public' ? 'private' : 'public')}
+                        className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans flex items-center gap-1"
                       >
-                        New conversation
+                        <span>{visibility === 'public' ? 'Public' : 'Private'}</span>
+                        <span className="text-[9px]">{visibility === 'public' ? '(visible to others)' : '(only you)'}</span>
                       </button>
                     )}
                   </div>
+
+                  {!isSignedIn && status !== 'loading' && (
+                    <p className="mt-2 text-[12px] text-[#8a8480] font-sans">
+                      <Link href="/auth/signin?callbackUrl=/reading-room" className="text-[#9e4a3a] hover:underline">
+                        Sign in
+                      </Link>
+                      {' '}to talk with the Librarian. Free — no membership required.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Sidebar */}
+            <div className="lg:w-[300px] flex-shrink-0">
+              <div className="lg:sticky lg:top-8">
+                {/* Tab toggle */}
+                <div className="flex gap-4 mb-4">
+                  <button
+                    onClick={() => setSidebarTab('recent')}
+                    className={`text-[11px] tracking-[0.2em] uppercase font-sans transition-colors ${
+                      sidebarTab === 'recent' ? 'text-[#1a1612]' : 'text-[#b0a89c] hover:text-[#8a8480]'
+                    }`}
+                  >
+                    Recent
+                  </button>
                   {isSignedIn && (
                     <button
-                      onClick={() => setVisibility(v => v === 'public' ? 'private' : 'public')}
-                      className="text-[11px] text-[#8a8480] hover:text-[#6b6560] transition-colors font-sans flex items-center gap-1"
+                      onClick={() => setSidebarTab('mine')}
+                      className={`text-[11px] tracking-[0.2em] uppercase font-sans transition-colors ${
+                        sidebarTab === 'mine' ? 'text-[#1a1612]' : 'text-[#b0a89c] hover:text-[#8a8480]'
+                      }`}
                     >
-                      <span>{visibility === 'public' ? 'Public' : 'Private'}</span>
-                      <span className="text-[9px]">{visibility === 'public' ? '(visible to others)' : '(only you)'}</span>
+                      My Conversations
                     </button>
                   )}
                 </div>
 
-                {!isSignedIn && status !== 'loading' && (
-                  <p className="mt-2 text-[12px] text-[#8a8480] font-sans">
-                    <Link href="/auth/signin?callbackUrl=/reading-room" className="text-[#9e4a3a] hover:underline">
-                      Sign in
+                {(() => {
+                  const displayThreads = sidebarTab === 'mine' ? myThreads : threads;
+                  if (displayThreads.length === 0) {
+                    return (
+                      <p className="text-[#8a8480] text-sm font-body">
+                        {sidebarTab === 'mine'
+                          ? 'No conversations yet. Ask the Librarian something!'
+                          : 'No conversations yet. Be the first to ask the Librarian something.'}
+                      </p>
+                    );
+                  }
+                  return (
+                    <div className="space-y-0">
+                      {displayThreads.map((thread) => (
+                        <Link
+                          key={thread.id}
+                          href={`/reading-room/thread/${thread.id}`}
+                          className="block py-3 border-b border-[#e8e4dc] hover:bg-[#f5f0e8]/50 transition-colors -mx-2 px-2 rounded"
+                        >
+                          <p className="text-sm font-body text-[#1a1612] line-clamp-2 leading-snug mb-1">
+                            {thread.preview.question}
+                          </p>
+                          <p className="text-[12px] text-[#8a8480] font-body line-clamp-2 leading-relaxed mb-1">
+                            {thread.preview.answer}
+                          </p>
+                          <p className="text-[10px] text-[#8a8480] font-sans">
+                            {thread.creatorName} &middot; {timeAgo(thread.lastMessageAt)}
+                            {thread.messageCount > 2 && <span> &middot; {thread.messageCount} messages</span>}
+                          </p>
+                        </Link>
+                      ))}
+                    </div>
+                  );
+                })()}
+
+                <div className="mt-8 pt-6 border-t border-[#e8e4dc]">
+                  <div className="space-y-2">
+                    <Link href="/ficino-society" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
+                      The Ficino Society
                     </Link>
-                    {' '}to talk with the Librarian. Free — no membership required.
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* Sidebar */}
-          <div className="lg:w-[300px] flex-shrink-0">
-            <div className="lg:sticky lg:top-8">
-              {/* Recent conversations */}
-              <h2 className="text-[11px] text-[#6b6560] tracking-[0.2em] uppercase font-sans mb-4">
-                Recent Conversations
-              </h2>
-
-              {threads.length === 0 ? (
-                <p className="text-[#8a8480] text-sm font-body">
-                  No conversations yet. Be the first to ask the Librarian something.
-                </p>
-              ) : (
-                <div className="space-y-0">
-                  {threads.map((thread) => (
-                    <Link
-                      key={thread.id}
-                      href={`/reading-room/thread/${thread.id}`}
-                      className="block py-3 border-b border-[#e8e4dc] hover:bg-[#f5f0e8]/50 transition-colors -mx-2 px-2 rounded"
-                    >
-                      <p className="text-sm font-body text-[#1a1612] line-clamp-2 leading-snug mb-1">
-                        {thread.preview.question}
-                      </p>
-                      <p className="text-[12px] text-[#8a8480] font-body line-clamp-2 leading-relaxed mb-1">
-                        {thread.preview.answer}
-                      </p>
-                      <p className="text-[10px] text-[#8a8480] font-sans">
-                        {thread.creatorName} &middot; {timeAgo(thread.lastMessageAt)}
-                        {thread.messageCount > 2 && (
-                          <span> &middot; {thread.messageCount} messages</span>
-                        )}
-                      </p>
+                    <Link href="/collections" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
+                      Browse the Collection
                     </Link>
-                  ))}
-                </div>
-              )}
-
-              {/* Quick links */}
-              <div className="mt-8 pt-6 border-t border-[#e8e4dc]">
-                <div className="space-y-2">
-                  <Link href="/ficino-society" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
-                    The Ficino Society
-                  </Link>
-                  <Link href="/collections" className="block text-sm text-[#444] hover:text-[#9e4a3a] transition-colors font-body">
-                    Browse the Collection
-                  </Link>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
         </div>
       </div>
     </div>

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -1,136 +1,56 @@
 import { getDb } from '@/lib/mongodb';
-import { getGeminiClient } from '@/lib/gemini-client';
+import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
 import { buildBookSearchStage, buildPageSearchStage } from '@/lib/atlas-search';
+import { supabase } from '@/lib/supabase';
 
 /**
- * The Librarian — AI assistant for the Embassy Reading Room.
- * Uses Atlas Search (indexed, fast) for corpus-wide retrieval + Gemini for conversation.
+ * The Librarian — Agentic AI assistant for the Embassy Reading Room.
+ *
+ * Architecture: reason-first, search-second.
+ * Gemini reasons about the user's question, then calls tools iteratively
+ * to search the collection, Wikipedia, and semantic search. Each step is
+ * streamed to the client as a structured event.
+ *
+ * Tools:
+ *   - search_collection: Atlas Search on books + pages (keyword)
+ *   - search_semantic: pgvector hybrid search on Supabase (conceptual)
+ *   - search_wikipedia: Wikipedia REST API for historical/biographical context
+ *   - get_book_page: Read a specific translated page
+ *   - present_choices: Offer the user branching options before searching
  */
 
-interface BookResult {
-  id: string;
-  title: string;
-  display_title?: string;
-  author?: string;
-  year?: number;
-  language?: string;
-  slug?: string;
-}
+const MODEL = 'gemini-3-flash-preview';
+const MAX_ROUNDS = 6;
+const TEMPERATURE = 0.7;
 
-interface PageResult {
+// ── Types ──────────────────────────────────────���──────────────────────
+
+export interface SourceCard {
   book_id: string;
-  page_number: number;
-  text: string;
   bookTitle: string;
   bookAuthor: string;
   bookSlug?: string;
+  pageNumber?: number;
+  snippet?: string;
+  thumbnail?: string;
+  inCollection: boolean; // false = "ghost card"
 }
 
-/**
- * Search the corpus for passages relevant to a query using Atlas Search.
- * Fast — uses the pages_search index, not regex scans.
- */
-export async function searchCorpus(query: string, limit = 8): Promise<PageResult[]> {
-  if (!query.trim()) return [];
-
-  const db = await getDb();
-
-  // Atlas Search on pages — searches translation.data (boosted) and ocr.data
-  const searchStage = buildPageSearchStage(query);
-
-  const pages = await db.collection('pages')
-    .aggregate([
-      searchStage,
-      { $limit: limit * 2 }, // Fetch extra, then deduplicate by book
-      {
-        $project: {
-          book_id: 1,
-          page_number: 1,
-          'translation.data': 1,
-          score: { $meta: 'searchScore' },
-        },
-      },
-    ])
-    .toArray();
-
-  if (pages.length === 0) return [];
-
-  // Deduplicate: max 2 pages per book to get variety across the collection
-  const perBook = new Map<string, number>();
-  const deduped = pages.filter(p => {
-    const count = perBook.get(p.book_id) || 0;
-    if (count >= 2) return false;
-    perBook.set(p.book_id, count + 1);
-    return true;
-  }).slice(0, limit);
-
-  // Enrich with book metadata
-  const bookIds = [...new Set(deduped.map(p => p.book_id))];
-  const books = await db.collection('books')
-    .find({ id: { $in: bookIds } })
-    .project({ id: 1, title: 1, display_title: 1, author: 1, slug: 1 })
-    .toArray();
-
-  const bookMap = new Map(books.map(b => [b.id, b]));
-
-  return deduped.map(page => {
-    const book = bookMap.get(page.book_id);
-    const rawText = page.translation?.data || '';
-    const text = rawText
-      .replace(/\[\[[^\]]+\]\]/g, '')
-      .replace(/^```(?:markdown)?\s*\n?/i, '')
-      .replace(/\n?```\s*$/i, '')
-      .trim()
-      .slice(0, 1500);
-
-    return {
-      book_id: page.book_id,
-      page_number: page.page_number,
-      text,
-      bookTitle: book?.display_title || book?.title || 'Unknown',
-      bookAuthor: book?.author || 'Unknown',
-      bookSlug: book?.slug,
-    };
-  });
-}
-
-/**
- * Search for relevant books by title/author using Atlas Search.
- */
-export async function searchBooks(query: string, limit = 5): Promise<BookResult[]> {
-  if (!query.trim()) return [];
-
-  const db = await getDb();
-
-  const searchStage = buildBookSearchStage(query, { hasTranslation: true }, { fuzzy: true });
-
-  const books = await db.collection('books')
-    .aggregate([
-      searchStage,
-      { $limit: limit },
-      {
-        $project: {
-          id: 1,
-          title: 1,
-          display_title: 1,
-          author: 1,
-          year: 1,
-          language: 1,
-          slug: 1,
-        },
-      },
-    ])
-    .toArray();
-
-  return books.map(b => ({
-    id: b.id,
-    title: b.display_title || b.title,
-    display_title: b.display_title,
-    author: b.author,
-    year: b.year,
-    language: b.language,
-    slug: b.slug,
-  }));
+export interface LibrarianStep {
+  type: 'thinking' | 'tool_call' | 'tool_result' | 'choices' | 'text' | 'sources';
+  // thinking: text is the reasoning
+  // tool_call: name + query describe what's being searched
+  // tool_result: name + summary + found (count)
+  // choices: options array for branching
+  // text: response text chunk
+  // sources: source cards array
+  text?: string;
+  name?: string;
+  query?: string;
+  summary?: string;
+  found?: number;
+  options?: string[];
+  sources?: SourceCard[];
 }
 
 interface ConversationMessage {
@@ -138,250 +58,624 @@ interface ConversationMessage {
   content: string;
 }
 
-interface ReaderActivity {
-  bookTitle: string;
-  bookAuthor: string;
-  bookSlug?: string;
-  readerCount: number;
-  recentReaders: string[];
-}
+// ── Tool Declarations ───────────────────────────��─────────────────────
 
-/**
- * Get recent reading activity — what people are reading in the Embassy.
- * The Librarian uses this to connect people with shared interests.
- */
-export async function getRecentReadingActivity(limit = 10): Promise<ReaderActivity[]> {
+const TOOL_DECLARATIONS: FunctionDeclaration[] = [
+  {
+    name: 'search_collection',
+    description: 'Search Source Library\'s collection of rare books by keyword. Searches translated text (English) and original text (Latin, etc). Returns matching passages with book metadata and page numbers. Use historical/period terms for best results — these are 15th-18th century texts.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        query: { type: Type.STRING, description: 'Search query — use period-appropriate terms (e.g., "sympathetic magic" not "resonance", "flying ointment" not "psychedelics")' },
+        search_books: { type: Type.BOOLEAN, description: 'Also search book titles/authors (default true)' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'search_semantic',
+    description: 'Semantic/conceptual search across translated pages using AI embeddings. Better than keyword search for finding conceptually related passages even when exact terms differ. Use when keyword search misses or when the concept may be described differently in historical texts.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        query: { type: Type.STRING, description: 'Conceptual query — can be modern language, the embedding model handles the mapping' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'search_wikipedia',
+    description: 'Search Wikipedia for historical, biographical, or scholarly context. Use to understand concepts, identify historical terms and synonyms, get biographical details about authors, or find cross-references. Returns a summary and key facts.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        query: { type: Type.STRING, description: 'Wikipedia search query' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'get_book_page',
+    description: 'Read a specific translated page from a book in the collection. Use when you found a promising passage and want to read the full page for context, or to verify a quote.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        book_id: { type: Type.STRING, description: 'Book ID from a previous search result' },
+        page_number: { type: Type.NUMBER, description: 'Page number to read' },
+      },
+      required: ['book_id', 'page_number'],
+    },
+  },
+  {
+    name: 'present_choices',
+    description: 'Present the user with 2-4 interpretation options before searching. Use when the question is ambiguous and could mean different things. The user will select one to guide your search. Each option should be a short phrase (under 60 chars).',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        preamble: { type: Type.STRING, description: 'Brief intro before the choices (1-2 sentences)' },
+        options: {
+          type: Type.ARRAY,
+          items: { type: Type.STRING },
+          description: '2-4 interpretive options for the user to choose from',
+        },
+      },
+      required: ['preamble', 'options'],
+    },
+  },
+];
+
+// ── Tool Execution ────────────────────────────────────────────────────
+
+async function executeSearchCollection(query: string, searchBooks = true): Promise<{
+  passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string }>;
+  books: Array<{ id: string; title: string; author?: string; year?: number; slug?: string }>;
+}> {
   const db = await getDb();
-  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
-  const activity = await db.collection('reading_history')
+  // Search pages via Atlas Search
+  const searchStage = buildPageSearchStage(query);
+  const pages = await db.collection('pages')
     .aggregate([
-      { $match: { started_at: { $gte: oneWeekAgo } } },
-      { $group: {
-        _id: '$book_id',
-        readerIds: { $addToSet: '$user_id' },
-        readerCount: { $sum: 1 },
-        lastRead: { $max: '$updated_at' },
-      }},
-      { $match: { readerCount: { $gte: 1 } } },
-      { $sort: { readerCount: -1, lastRead: -1 } },
-      { $limit: limit },
+      searchStage,
+      { $limit: 16 },
+      { $project: { book_id: 1, page_number: 1, 'translation.data': 1, score: { $meta: 'searchScore' } } },
     ])
     .toArray();
 
-  if (activity.length === 0) return [];
+  // Deduplicate: max 2 pages per book
+  const perBook = new Map<string, number>();
+  const deduped = pages.filter(p => {
+    const count = perBook.get(p.book_id) || 0;
+    if (count >= 2) return false;
+    perBook.set(p.book_id, count + 1);
+    return true;
+  }).slice(0, 8);
 
-  // Get book metadata
-  const bookIds = activity.map(a => a._id);
-  const books = await db.collection('books')
-    .find({ id: { $in: bookIds } })
-    .project({ id: 1, title: 1, display_title: 1, author: 1, slug: 1 })
-    .toArray();
-  const bookMap = new Map(books.map(b => [b.id, b]));
+  // Enrich with book metadata
+  const bookIds = [...new Set(deduped.map(p => p.book_id))];
+  const bookDocs = bookIds.length > 0
+    ? await db.collection('books')
+        .find({ id: { $in: bookIds } })
+        .project({ id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1 })
+        .toArray()
+    : [];
+  const bookMap = new Map(bookDocs.map(b => [b.id, b]));
 
-  // Get reader names (from embassy_profiles or users)
-  const allReaderIds = [...new Set(activity.flatMap(a => a.readerIds))];
-  const profiles = await db.collection('embassy_profiles')
-    .find({ userId: { $in: allReaderIds } })
-    .project({ userId: 1, displayName: 1 })
-    .toArray();
-  const profileMap = new Map(profiles.map(p => [p.userId, p.displayName]));
-
-  return activity.map(a => {
-    const book = bookMap.get(a._id);
+  const passages = deduped.map(page => {
+    const book = bookMap.get(page.book_id);
+    const rawText = page.translation?.data || '';
+    const text = rawText
+      .replace(/\[\[[^\]]+\]\]/g, '')
+      .replace(/^```(?:markdown)?\s*\n?/i, '')
+      .replace(/\n?```\s*$/i, '')
+      .trim()
+      .slice(0, 1200);
     return {
+      book_id: page.book_id,
       bookTitle: book?.display_title || book?.title || 'Unknown',
       bookAuthor: book?.author || 'Unknown',
       bookSlug: book?.slug,
-      readerCount: a.readerIds.length,
-      recentReaders: a.readerIds
-        .slice(0, 3)
-        .map((id: string) => profileMap.get(id) || 'A visitor'),
+      page_number: page.page_number,
+      text,
     };
-  }).filter(a => a.bookTitle !== 'Unknown');
-}
-
-/**
- * Generate a Librarian response using Atlas Search + Gemini.
- */
-export async function generateLibrarianResponse(
-  userMessage: string,
-  history: ConversationMessage[] = [],
-): Promise<{ content: string; sources: PageResult[] }> {
-  // Search the corpus for relevant passages + get community activity (parallel)
-  const [passages, books, readingActivity] = await Promise.all([
-    searchCorpus(userMessage, 8),
-    searchBooks(userMessage, 5),
-    getRecentReadingActivity(8),
-  ]);
-
-  // Build context from search results
-  let context = '';
-
-  if (books.length > 0) {
-    context += '## Relevant Books in the Collection\n';
-    for (const book of books) {
-      context += `- **${book.title}** by ${book.author || 'Unknown'}`;
-      if (book.year) context += ` (${book.year})`;
-      if (book.slug) context += ` — https://sourcelibrary.org/book/${book.slug}`;
-      context += '\n';
-    }
-    context += '\n';
-  }
-
-  if (passages.length > 0) {
-    context += '## Relevant Passages from the Collection\n';
-    for (const p of passages) {
-      const bookUrl = p.bookSlug
-        ? `https://sourcelibrary.org/book/${p.bookSlug}`
-        : `https://sourcelibrary.org/book/${p.book_id}`;
-      context += `\n### ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number}\n`;
-      context += `Source: ${bookUrl}/page/${p.page_number}\n`;
-      context += p.text + '\n';
-    }
-  }
-
-  // Build community context
-  let communityContext = '';
-  if (readingActivity.length > 0) {
-    communityContext = '## Who\'s Reading What This Week\n';
-    for (const activity of readingActivity) {
-      const bookUrl = activity.bookSlug
-        ? `https://sourcelibrary.org/book/${activity.bookSlug}`
-        : '';
-      const readers = activity.recentReaders.join(', ');
-      communityContext += `- **${activity.bookTitle}** by ${activity.bookAuthor}`;
-      if (bookUrl) communityContext += ` — ${bookUrl}`;
-      communityContext += ` (${activity.readerCount} reader${activity.readerCount > 1 ? 's' : ''}: ${readers})\n`;
-    }
-    communityContext += '\n';
-  }
-
-  const systemPrompt = `You are the Librarian of the Embassy of the Free Mind — a digital scholarly institution dedicated to the Western esoteric tradition. You have deep knowledge of alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, and the intellectual history of the Renaissance and early modern period.
-
-You are warm, knowledgeable, and genuinely enthusiastic about these texts. You speak like a learned scholar who loves sharing discoveries, not like a search engine. You are conversational but substantive.
-
-${context ? `## Source Material from the Collection\n\nThe following texts were found in Source Library's collection of over 5,000 rare books, many translated into English for the first time:\n\n${context}` : '## No Source Material Found\n\nNo directly relevant passages were found in the collection for this query. You can still discuss the topic from your general knowledge, but note when you are speaking from general knowledge vs. from specific texts in the collection.'}
-
-${communityContext ? communityContext : ''}## Instructions
-- When citing texts from the collection, use direct quotes with page references and include the full URL so the reader can verify: "quoted text" — *Title* by Author, [Page N](url)
-- Recommend specific books from the collection when relevant, with links
-- If the query is about a topic you know the collection covers but no passages were found, suggest the user try different search terms
-- Be honest about the limits of what's in the collection vs. your general knowledge
-- Keep responses focused and conversational — this is a reading room conversation, not a lecture
-- Use markdown formatting for readability
-- When someone is new, make them feel welcome. The Embassy is a place of open inquiry.
-- When relevant, naturally mention what other Embassy visitors have been reading. Connect people with shared interests — "A few visitors have been reading X this week, you might enjoy comparing notes." Don't force it; only mention when genuinely relevant to the conversation.`;
-
-  const model = getGeminiClient().getGenerativeModel({ model: 'gemini-3-flash-preview' });
-
-  const chatHistory = [
-    { role: 'user' as const, parts: [{ text: systemPrompt }] },
-    { role: 'model' as const, parts: [{ text: 'I understand. I\'m the Librarian of the Embassy, ready to help visitors explore the collection and discuss the Western esoteric tradition.' }] },
-    ...history.map(msg => ({
-      role: (msg.role === 'user' ? 'user' : 'model') as 'user' | 'model',
-      parts: [{ text: msg.content }],
-    })),
-  ];
-
-  const chat = model.startChat({ history: chatHistory });
-  const result = await chat.sendMessage(userMessage);
-  const content = result.response.text();
-
-  return { content, sources: passages };
-}
-
-/**
- * Stream a Librarian response — yields text chunks as they arrive from Gemini.
- * Used by the SSE chat endpoint for a responsive conversational feel.
- */
-export async function streamLibrarianResponse(
-  userMessage: string,
-  history: ConversationMessage[] = [],
-): Promise<{ stream: AsyncIterable<string>; sources: PageResult[]; getFullText: () => string }> {
-  const [passages, books, readingActivity] = await Promise.all([
-    searchCorpus(userMessage, 8),
-    searchBooks(userMessage, 5),
-    getRecentReadingActivity(8),
-  ]);
-
-  // Reuse same context-building logic
-  let context = '';
-  if (books.length > 0) {
-    context += '## Relevant Books in the Collection\n';
-    for (const book of books) {
-      context += `- **${book.title}** by ${book.author || 'Unknown'}`;
-      if (book.year) context += ` (${book.year})`;
-      if (book.slug) context += ` — https://sourcelibrary.org/book/${book.slug}`;
-      context += '\n';
-    }
-    context += '\n';
-  }
-  if (passages.length > 0) {
-    context += '## Relevant Passages from the Collection\n';
-    for (const p of passages) {
-      const bookUrl = p.bookSlug
-        ? `https://sourcelibrary.org/book/${p.bookSlug}`
-        : `https://sourcelibrary.org/book/${p.book_id}`;
-      context += `\n### ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number}\n`;
-      context += `Source: ${bookUrl}/page/${p.page_number}\n`;
-      context += p.text + '\n';
-    }
-  }
-
-  let communityContext = '';
-  if (readingActivity.length > 0) {
-    communityContext = '## Who\'s Reading What This Week\n';
-    for (const activity of readingActivity) {
-      const bookUrl = activity.bookSlug ? `https://sourcelibrary.org/book/${activity.bookSlug}` : '';
-      communityContext += `- **${activity.bookTitle}** by ${activity.bookAuthor}`;
-      if (bookUrl) communityContext += ` — ${bookUrl}`;
-      communityContext += ` (${activity.readerCount} reader${activity.readerCount > 1 ? 's' : ''}: ${activity.recentReaders.join(', ')})\n`;
-    }
-    communityContext += '\n';
-  }
-
-  const systemPrompt = `You are the Librarian of the Embassy of the Free Mind — a digital scholarly institution dedicated to the Western esoteric tradition. You have deep knowledge of alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, and the intellectual history of the Renaissance and early modern period.
-
-You are warm, knowledgeable, and genuinely enthusiastic about these texts. You speak like a learned scholar who loves sharing discoveries, not like a search engine. You are conversational but substantive.
-
-${context ? `## Source Material from the Collection\n\nThe following texts were found in Source Library's collection of over 5,000 rare books, many translated into English for the first time:\n\n${context}` : '## No Source Material Found\n\nNo directly relevant passages were found in the collection for this query. You can still discuss the topic from your general knowledge, but note when you are speaking from general knowledge vs. from specific texts in the collection.'}
-
-${communityContext}## Instructions
-- When citing texts from the collection, use direct quotes with page references and include the full URL so the reader can verify: "quoted text" — *Title* by Author, [Page N](url)
-- Recommend specific books from the collection when relevant, with links
-- Keep responses focused and conversational — this is a reading room conversation, not a lecture
-- Use markdown formatting for readability
-- When relevant, naturally mention what other visitors have been reading.`;
-
-  const model = getGeminiClient().getGenerativeModel({ model: 'gemini-3-flash-preview' });
-  const chatSession = model.startChat({
-    history: [
-      { role: 'user' as const, parts: [{ text: systemPrompt }] },
-      { role: 'model' as const, parts: [{ text: 'I understand. I\'m the Librarian of the Embassy, ready to help visitors explore the collection.' }] },
-      ...history.map(msg => ({
-        role: (msg.role === 'user' ? 'user' : 'model') as 'user' | 'model',
-        parts: [{ text: msg.content }],
-      })),
-    ],
   });
 
-  const result = await chatSession.sendMessageStream(userMessage);
-  let fullText = '';
+  // Search books by title/author
+  let books: Array<{ id: string; title: string; author?: string; year?: number; slug?: string }> = [];
+  if (searchBooks) {
+    const bookSearchStage = buildBookSearchStage(query, { hasTranslation: true }, { fuzzy: true });
+    const bookResults = await db.collection('books')
+      .aggregate([
+        bookSearchStage,
+        { $limit: 5 },
+        { $project: { id: 1, title: 1, display_title: 1, author: 1, year: 1, slug: 1 } },
+      ])
+      .toArray();
+    books = bookResults.map(b => ({
+      id: b.id,
+      title: b.display_title || b.title,
+      author: b.author,
+      year: b.year,
+      slug: b.slug,
+    }));
+  }
 
-  const textStream = {
-    async *[Symbol.asyncIterator]() {
-      for await (const chunk of result.stream) {
-        const text = chunk.text();
-        fullText += text;
-        yield text;
-      }
-    },
-  };
+  return { passages, books };
+}
+
+async function executeSearchSemantic(query: string): Promise<
+  Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>
+> {
+  // Generate embedding via Hetzner
+  const embedUrl = process.env.EMBED_URL || 'http://46.224.122.120:3456';
+  let queryEmbedding: number[] | null = null;
+  try {
+    const res = await fetch(`${embedUrl}/embed`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ texts: [query], task: 'query' }),
+      signal: AbortSignal.timeout(3000),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      queryEmbedding = data?.embeddings?.[0] || null;
+    }
+  } catch { /* embedding server unavailable */ }
+
+  if (!queryEmbedding) {
+    // Fall back to keyword search on Supabase
+    const { data } = await supabase
+      .from('page_translations')
+      .select('page_id, book_id, page_number, translation, book_title, book_author')
+      .textSearch('tsv', query, { type: 'websearch' })
+      .limit(8);
+
+    return (data || []).map(r => ({
+      book_id: r.book_id,
+      bookTitle: r.book_title || 'Unknown',
+      bookAuthor: r.book_author || 'Unknown',
+      page_number: r.page_number,
+      snippet: (r.translation || '').slice(0, 500),
+      score: 1,
+    }));
+  }
+
+  const { data } = await supabase.rpc('hybrid_search', {
+    query_text: query,
+    query_embedding: JSON.stringify(queryEmbedding),
+    match_count: 8,
+    keyword_weight: 0.3,
+    semantic_weight: 0.7,
+  });
+
+  return (data || []).map((r: Record<string, unknown>) => ({
+    book_id: r.book_id as string,
+    bookTitle: (r.book_title as string) || 'Unknown',
+    bookAuthor: (r.book_author as string) || 'Unknown',
+    bookSlug: undefined, // Supabase doesn't have slug, we'll resolve later
+    page_number: r.page_number as number,
+    snippet: ((r.translation as string) || '').slice(0, 500),
+    score: Number(r.score) || 0,
+  }));
+}
+
+async function executeSearchWikipedia(query: string): Promise<{ title: string; summary: string; url: string } | null> {
+  try {
+    const searchUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(query)}`;
+    const res = await fetch(searchUrl, {
+      headers: { 'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org)' },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      return {
+        title: data.title,
+        summary: data.extract?.slice(0, 1500) || '',
+        url: data.content_urls?.desktop?.page || '',
+      };
+    }
+
+    // If direct lookup fails, try search
+    const searchApiUrl = `https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=${encodeURIComponent(query)}&srlimit=3&format=json&origin=*`;
+    const searchRes = await fetch(searchApiUrl, {
+      headers: { 'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org)' },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!searchRes.ok) return null;
+    const searchData = await searchRes.json();
+    const firstResult = searchData?.query?.search?.[0];
+    if (!firstResult) return null;
+
+    // Fetch summary for the first result
+    const summaryRes = await fetch(
+      `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(firstResult.title)}`,
+      {
+        headers: { 'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org)' },
+        signal: AbortSignal.timeout(5000),
+      },
+    );
+    if (!summaryRes.ok) return null;
+    const summaryData = await summaryRes.json();
+    return {
+      title: summaryData.title,
+      summary: summaryData.extract?.slice(0, 1500) || '',
+      url: summaryData.content_urls?.desktop?.page || '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function executeGetBookPage(bookId: string, pageNumber: number): Promise<{
+  text: string;
+  originalText?: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookSlug?: string;
+} | null> {
+  const db = await getDb();
+  const page = await db.collection('pages').findOne(
+    { book_id: bookId, page_number: pageNumber },
+    { projection: { 'translation.data': 1, 'ocr.data': 1, book_id: 1, page_number: 1 } },
+  );
+  if (!page) return null;
+
+  const book = await db.collection('books').findOne(
+    { id: bookId },
+    { projection: { title: 1, display_title: 1, author: 1, slug: 1 } },
+  );
 
   return {
-    stream: textStream,
-    sources: passages,
-    getFullText: () => fullText,
+    text: page.translation?.data || '',
+    originalText: page.ocr?.data?.slice(0, 800),
+    bookTitle: book?.display_title || book?.title || 'Unknown',
+    bookAuthor: book?.author || 'Unknown',
+    bookSlug: book?.slug,
   };
+}
+
+// ── Tool Router ───────────────────────────────────────────────────────
+
+async function executeTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ result: unknown; step: LibrarianStep }> {
+  switch (name) {
+    case 'search_collection': {
+      const query = args.query as string;
+      const searchBooks = args.search_books !== false;
+      const data = await executeSearchCollection(query, searchBooks);
+      const totalFound = data.passages.length + data.books.length;
+
+      // Build context for Gemini
+      let context = '';
+      if (data.books.length > 0) {
+        context += 'Books found:\n';
+        for (const b of data.books) {
+          context += `- "${b.title}" by ${b.author || 'Unknown'}${b.year ? ` (${b.year})` : ''} — https://sourcelibrary.org/book/${b.slug || b.id}\n`;
+        }
+      }
+      if (data.passages.length > 0) {
+        context += '\nPassages found:\n';
+        for (const p of data.passages) {
+          const url = `https://sourcelibrary.org/book/${p.bookSlug || p.book_id}/page/${p.page_number}`;
+          context += `\n--- ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number} (${url}) ---\n${p.text}\n`;
+        }
+      }
+      if (totalFound === 0) {
+        context = 'No results found for this query.';
+      }
+
+      return {
+        result: { found: totalFound, context },
+        step: {
+          type: 'tool_result',
+          name: 'search_collection',
+          query,
+          found: totalFound,
+          summary: totalFound > 0
+            ? `Found ${data.passages.length} passages across ${data.books.length} books`
+            : 'No results',
+        },
+      };
+    }
+
+    case 'search_semantic': {
+      const query = args.query as string;
+      const results = await executeSearchSemantic(query);
+
+      let context = '';
+      if (results.length > 0) {
+        context = 'Semantic search results:\n';
+        for (const r of results) {
+          context += `\n--- ${r.bookTitle} by ${r.bookAuthor}, Page ${r.page_number} (score: ${r.score.toFixed(2)}) ---\n${r.snippet}\n`;
+        }
+      } else {
+        context = 'No semantic matches found.';
+      }
+
+      return {
+        result: { found: results.length, context },
+        step: {
+          type: 'tool_result',
+          name: 'search_semantic',
+          query,
+          found: results.length,
+          summary: results.length > 0
+            ? `Found ${results.length} conceptually related passages`
+            : 'No semantic matches',
+        },
+      };
+    }
+
+    case 'search_wikipedia': {
+      const query = args.query as string;
+      const result = await executeSearchWikipedia(query);
+
+      return {
+        result: result
+          ? { found: 1, title: result.title, summary: result.summary, url: result.url }
+          : { found: 0, summary: 'No Wikipedia article found.' },
+        step: {
+          type: 'tool_result',
+          name: 'search_wikipedia',
+          query,
+          found: result ? 1 : 0,
+          summary: result
+            ? `Found: ${result.title}`
+            : 'No article found',
+        },
+      };
+    }
+
+    case 'get_book_page': {
+      const bookId = args.book_id as string;
+      const pageNumber = args.page_number as number;
+      const result = await executeGetBookPage(bookId, pageNumber);
+
+      return {
+        result: result
+          ? { found: 1, text: result.text, originalText: result.originalText, bookTitle: result.bookTitle }
+          : { found: 0, text: 'Page not found.' },
+        step: {
+          type: 'tool_result',
+          name: 'get_book_page',
+          query: `${bookId} p.${pageNumber}`,
+          found: result ? 1 : 0,
+          summary: result
+            ? `Read page ${pageNumber} of ${result.bookTitle}`
+            : 'Page not found',
+        },
+      };
+    }
+
+    case 'present_choices': {
+      const preamble = args.preamble as string;
+      const options = args.options as string[];
+      return {
+        result: { status: 'choices_presented', note: 'The user will select an option. Wait for their response.' },
+        step: {
+          type: 'choices',
+          text: preamble,
+          options,
+        },
+      };
+    }
+
+    default:
+      return {
+        result: { error: `Unknown tool: ${name}` },
+        step: { type: 'tool_result', name, summary: 'Unknown tool', found: 0 },
+      };
+  }
+}
+
+// ── System Prompt ─���────────────────────���──────────────────────────────
+
+function buildSystemPrompt(): string {
+  return `You are the Librarian of the Embassy of the Free Mind — a digital scholarly institution dedicated to the Western esoteric tradition. You have deep knowledge of alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, and the intellectual history of the Renaissance and early modern period.
+
+You are warm, knowledgeable, and genuinely enthusiastic about these texts. You speak like a learned scholar who loves sharing discoveries.
+
+## Your approach
+
+You are a research librarian. When a user asks a question:
+
+1. **Think first.** Use your training knowledge to reason about what the user is really asking. What historical concepts, authors, or traditions are relevant? What terms would appear in 15th-18th century texts?
+
+2. **Hypothesize.** Form specific hypotheses about what might be in the collection. "Porta probably discussed psychoactive plants." "Agrippa covered planetary correspondences." Some hypotheses will be wrong — that's fine.
+
+3. **Search strategically.** Call tools to validate your hypotheses. Use period-appropriate terms for search_collection (these are historical texts). Use modern language for search_semantic (the embedding model handles the mapping). Use search_wikipedia for biographical context or to discover historical terminology.
+
+4. **Be honest about what you find and what you don't.** If a hypothesis doesn't pan out, say so. If a relevant book isn't in the collection, mention it as a gap. "We don't have Ficino's De Vita yet, but Agrippa covers similar ground."
+
+5. **Cite precisely.** Every claim grounded in the collection must include the full URL: https://sourcelibrary.org/book/{slug}/page/{N}. Use the format: "quoted text" — *Title* by Author, [Page N](url).
+
+## When to use present_choices
+
+If the user's question is genuinely ambiguous and could lead to very different searches, use present_choices to offer 2-4 interpretations. For example:
+- "What is the philosopher's stone?" → search directly (not ambiguous)
+- "Tell me about resonance" → present choices: sympathetic magic, musical cosmology, acoustic experiments
+
+Only present choices when the ambiguity would lead to materially different search strategies. Most questions should just be answered directly.
+
+## The collection
+
+Source Library has over 5,000 rare books from the 15th-18th centuries, many translated into English for the first time. Topics include alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, demonology, and related traditions. The collection is growing.
+
+## Style
+
+- Conversational but substantive — reading room conversation, not a lecture
+- Use markdown for readability
+- Keep responses focused — cite 2-4 key passages rather than dumping everything
+- When you're speaking from general knowledge vs. from specific texts, make it clear`;
+}
+
+// ── Agentic Streaming ────────────���────────────────────────────────────
+
+/**
+ * Stream an agentic Librarian response.
+ * Yields LibrarianStep events as the Librarian thinks, searches, and responds.
+ */
+export async function* streamAgenticResponse(
+  userMessage: string,
+  history: ConversationMessage[] = [],
+): AsyncGenerator<LibrarianStep> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('GEMINI_API_KEY not set');
+
+  const ai = new GoogleGenAI({ apiKey });
+  const systemPrompt = buildSystemPrompt();
+
+  // Build conversation history for Gemini
+  const contents: Array<{ role: string; parts: Array<Record<string, unknown>> }> = [
+    { role: 'user', parts: [{ text: systemPrompt }] },
+    { role: 'model', parts: [{ text: 'I understand. I\'m the Librarian, ready to help visitors explore the collection using my tools and knowledge.' }] },
+    // Prior conversation turns
+    ...history.map(msg => ({
+      role: msg.role === 'user' ? 'user' : 'model',
+      parts: [{ text: msg.content }],
+    })),
+    // Current message
+    { role: 'user', parts: [{ text: userMessage }] },
+  ];
+
+  const allSources: SourceCard[] = [];
+  // Cache search results to avoid double-execution for source cards
+  const searchCache = new Map<string, { passages: Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; text: string }>; books: Array<{ id: string; title: string; author?: string; year?: number; slug?: string }> }>();
+  const semanticCache = new Map<string, Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>>();
+
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    const response = await ai.models.generateContent({
+      model: MODEL,
+      contents,
+      config: {
+        tools: [{ functionDeclarations: TOOL_DECLARATIONS }],
+        temperature: TEMPERATURE,
+      },
+    });
+
+    const candidate = response.candidates?.[0];
+    if (!candidate?.content?.parts) break;
+
+    // Add model response to conversation
+    contents.push({
+      role: 'model',
+      parts: candidate.content.parts as Array<Record<string, unknown>>,
+    });
+
+    // Process parts: text chunks and function calls
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const functionCalls = candidate.content.parts.filter((p: any) => p.functionCall);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const textParts = candidate.content.parts.filter((p: any) => p.text);
+
+    // Emit any thinking/text from this round
+    for (const part of textParts) {
+      const text = (part as { text: string }).text;
+      if (text.trim()) {
+        if (functionCalls.length > 0) {
+          yield { type: 'thinking', text };
+        } else {
+          yield { type: 'text', text };
+        }
+      }
+    }
+
+    // No function calls = final response, we're done
+    if (functionCalls.length === 0) break;
+
+    // Execute tools and stream results
+    const responseParts: Array<Record<string, unknown>> = [];
+
+    for (const part of functionCalls) {
+      const fc = (part as { functionCall: { name: string; args: Record<string, unknown> } }).functionCall;
+
+      // Emit tool_call event (what's being searched)
+      yield {
+        type: 'tool_call',
+        name: fc.name,
+        query: (fc.args?.query as string) || (fc.args?.preamble as string) || '',
+      };
+
+      // Execute the tool
+      const { result, step } = await executeTool(fc.name, fc.args || {});
+
+      // Emit the result
+      yield step;
+
+      // If it's present_choices, stop and wait for user
+      if (fc.name === 'present_choices') {
+        if (allSources.length > 0) {
+          yield { type: 'sources', sources: allSources };
+        }
+        responseParts.push({ functionResponse: { name: fc.name, response: result } });
+        contents.push({ role: 'user', parts: responseParts });
+        return;
+      }
+
+      // Collect source cards from search results
+      if (fc.name === 'search_collection') {
+        const cacheKey = fc.args?.query as string;
+        // The executeTool already ran the search — extract structured data from the result
+        const data = searchCache.get(cacheKey) || await executeSearchCollection(cacheKey, fc.args?.search_books !== false);
+        searchCache.set(cacheKey, data);
+        for (const p of data.passages) {
+          if (!allSources.some(s => s.book_id === p.book_id && s.pageNumber === p.page_number)) {
+            allSources.push({
+              book_id: p.book_id,
+              bookTitle: p.bookTitle,
+              bookAuthor: p.bookAuthor,
+              bookSlug: p.bookSlug,
+              pageNumber: p.page_number,
+              snippet: p.text.slice(0, 200),
+              inCollection: true,
+            });
+          }
+        }
+      }
+
+      if (fc.name === 'search_semantic') {
+        const cacheKey = fc.args?.query as string;
+        const results = semanticCache.get(cacheKey) || await executeSearchSemantic(cacheKey);
+        semanticCache.set(cacheKey, results);
+        for (const r of results) {
+          if (!allSources.some(s => s.book_id === r.book_id && s.pageNumber === r.page_number)) {
+            allSources.push({
+              book_id: r.book_id,
+              bookTitle: r.bookTitle,
+              bookAuthor: r.bookAuthor,
+              bookSlug: r.bookSlug,
+              pageNumber: r.page_number,
+              snippet: r.snippet.slice(0, 200),
+              inCollection: true,
+            });
+          }
+        }
+      }
+
+      responseParts.push({ functionResponse: { name: fc.name, response: result } });
+    }
+
+    // Add tool responses to conversation
+    contents.push({ role: 'user', parts: responseParts });
+  }
+
+  // Emit source cards at the end
+  if (allSources.length > 0) {
+    yield { type: 'sources', sources: deduplicateSources(allSources) };
+  }
+}
+
+function deduplicateSources(sources: SourceCard[]): SourceCard[] {
+  const seen = new Set<string>();
+  return sources.filter(s => {
+    const key = `${s.book_id}:${s.pageNumber || 0}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }


### PR DESCRIPTION
## Summary

Rewrites the Reading Room Librarian from single-shot RAG to an agentic tool-calling architecture.

- **Backend:** Gemini function calling with 5 tools (collection search, semantic search, Wikipedia, page reader, branching choices). The Librarian reasons first using its training knowledge to identify period-appropriate terms, then searches strategically. Up to 6 tool-calling rounds.
- **Frontend:** Structured step stream replaces the single text bubble. Users see: collapsible thinking, search steps with checkmarks/X, response text with citations, and source cards below every response.
- **Source cards:** The `sources` array (already saved but never rendered) now displays as a scrollable row of book cards below each response. Guaranteed provenance.
- **Choice chips:** When the Librarian detects ambiguity, it presents clickable options ("Sympathetic magic", "Musical cosmology", "Acoustic experiments") before searching.
- **Stop button:** Abort the current generation at any point.
- **My Conversations:** Sidebar tab showing the user's own thread history.

Closes #996

## Test plan

- [ ] Ask "are there any books about magic mushrooms?" — should see Wikipedia lookup for historical terms, then collection search with period vocabulary
- [ ] Ask "tell me about resonance" — should present choice chips for disambiguation
- [ ] Ask "what did Agrippa write about planetary seals?" — direct search, no disambiguation
- [ ] Verify source cards appear below responses with working links
- [ ] Verify Stop button aborts generation
- [ ] Verify "My Conversations" tab shows user's threads when signed in
- [ ] Test unsigned user sees sign-in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)