### PR TITLE
Replace page view spinner with layout-aligned reader skeleton

### DIFF
--- a/src/app/book/[id]/page/[pageId]/loading.tsx
+++ b/src/app/book/[id]/page/[pageId]/loading.tsx
@@ -1,9 +1,66 @@
-import { BookLoader } from '@/components/ui/BookLoader';
-
 export default function PageEditorLoading() {
   return (
-    <div className="min-h-screen bg-cream flex items-center justify-center">
-      <BookLoader size="lg" />
+    <div className="h-screen flex flex-col" style={{ background: 'var(--bg-warm)' }}>
+      {/* Header */}
+      <header className="px-3 sm:px-6 py-2 sm:py-4" style={{ background: 'var(--bg-white)', borderBottom: '1px solid var(--border-light)' }}>
+        {/* Row 1: Logo / Title / Navigation */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+            <div className="w-7 h-7 bg-stone-200 rounded animate-pulse flex-shrink-0" />
+            <span className="text-sm" style={{ color: 'var(--text-muted)' }}>/</span>
+            <div className="h-5 sm:h-6 w-48 bg-stone-200 rounded animate-pulse" />
+          </div>
+          <div className="flex items-center gap-1 rounded-lg p-1 shrink-0" style={{ background: 'var(--bg-warm)' }}>
+            <div className="w-8 h-8 bg-stone-200 rounded-md animate-pulse" />
+            <div className="w-12 h-5 bg-stone-200 rounded animate-pulse mx-1" />
+            <div className="w-8 h-8 bg-stone-200 rounded-md animate-pulse" />
+          </div>
+        </div>
+
+        {/* Row 2: Panel toggles */}
+        <div className="flex items-center justify-between mt-2 sm:mt-3">
+          <div className="flex items-center gap-1 p-1 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
+            <div className="w-16 sm:w-20 h-7 bg-stone-200 rounded-md animate-pulse" />
+            <div className="w-16 sm:w-20 h-7 bg-stone-200 rounded-md animate-pulse" />
+            <div className="w-16 sm:w-20 h-7 bg-stone-200 rounded-md animate-pulse" />
+          </div>
+          <div className="flex items-center gap-1 p-1 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
+            <div className="w-16 sm:w-20 h-7 bg-stone-200 rounded-md animate-pulse" />
+            <div className="w-16 sm:w-20 h-7 bg-stone-200 rounded-md animate-pulse" />
+          </div>
+        </div>
+      </header>
+
+      {/* Panels */}
+      <div className="flex-1 flex flex-col lg:flex-row overflow-hidden">
+        {/* Source image panel */}
+        <div className="w-full min-h-[50vh] lg:min-h-0 lg:flex-1 flex flex-col" style={{ background: 'var(--bg-cream)', borderRight: '1px solid var(--border-light)' }}>
+          <div className="px-3 sm:px-4 py-2 sm:py-3 flex items-center gap-2" style={{ borderBottom: '1px solid var(--border-light)' }}>
+            <div className="h-4 w-12 bg-stone-200 rounded animate-pulse" />
+            <div className="h-5 w-10 bg-violet-100 rounded animate-pulse" />
+          </div>
+          <div className="flex-1 flex items-center justify-center">
+            <div className="w-3/4 aspect-[3/4] max-h-[80%] bg-stone-200 rounded animate-pulse" />
+          </div>
+        </div>
+
+        {/* Translation panel */}
+        <div className="w-full min-h-[50vh] lg:min-h-0 lg:flex-1 flex flex-col" style={{ background: 'var(--bg-white)' }}>
+          <div className="px-3 sm:px-4 py-2 sm:py-3 flex items-center gap-2" style={{ borderBottom: '1px solid var(--border-light)' }}>
+            <div className="h-4 w-20 bg-stone-200 rounded animate-pulse" />
+            <div className="h-5 w-14 bg-stone-100 rounded animate-pulse" />
+          </div>
+          <div className="flex-1 p-4 sm:p-6 space-y-3">
+            <div className="h-4 w-full bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-full bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-5/6 bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-full bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-4/6 bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-full bg-stone-100 rounded animate-pulse" />
+            <div className="h-4 w-3/4 bg-stone-100 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/browse/loading.tsx
+++ b/src/app/browse/loading.tsx
@@ -5,27 +5,48 @@ export default function BrowseLoading() {
     <div className="min-h-screen bg-cream">
       <SiteHeader variant="light" />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-        <div className="h-10 w-48 bg-stone-200 rounded animate-pulse mb-6" />
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-12 md:py-20">
+        <div className="h-10 w-48 bg-stone-200 rounded animate-pulse mb-2" />
+        <div className="h-5 w-80 bg-stone-100 rounded animate-pulse mb-12" />
 
-        {/* Letter nav */}
-        <div className="flex gap-2 flex-wrap mb-8">
-          {Array.from({ length: 26 }).map((_, i) => (
-            <div key={i} className="h-8 w-8 bg-stone-200 rounded animate-pulse" />
-          ))}
+        {/* By Title section */}
+        <div className="mb-10">
+          <div className="h-6 w-24 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: 26 }).map((_, i) => (
+              <div key={i} className="h-8 w-8 bg-stone-200 rounded animate-pulse" />
+            ))}
+          </div>
         </div>
 
-        {/* Book list */}
-        <div className="space-y-3">
-          {Array.from({ length: 20 }).map((_, i) => (
-            <div key={i} className="flex gap-4 items-center">
-              <div className="h-12 w-9 bg-stone-200 rounded animate-pulse flex-shrink-0" />
-              <div className="flex-1 space-y-1">
-                <div className="h-4 w-2/3 bg-stone-200 rounded animate-pulse" />
-                <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
-              </div>
-            </div>
-          ))}
+        {/* By Author section */}
+        <div className="mb-10">
+          <div className="h-6 w-28 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: 26 }).map((_, i) => (
+              <div key={i} className="h-8 w-8 bg-stone-200 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+
+        {/* By Artist section */}
+        <div className="mb-10">
+          <div className="h-6 w-24 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: 26 }).map((_, i) => (
+              <div key={i} className="h-8 w-8 bg-stone-200 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+
+        {/* By Period section */}
+        <div>
+          <div className="h-6 w-28 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="h-16 bg-stone-200 rounded-lg animate-pulse" />
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/collections/loading.tsx
+++ b/src/app/collections/loading.tsx
@@ -2,30 +2,23 @@ import SiteHeader from '@/components/layout/SiteHeader';
 
 export default function CollectionsIndexLoading() {
   return (
-    <div className="min-h-screen bg-cream">
+    <div className="min-h-screen bg-stone-50">
       <SiteHeader variant="light" />
 
       {/* Hero */}
       <div className="relative overflow-hidden text-white py-16 md:py-20">
         <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
-        <div className="relative max-w-7xl mx-auto px-6">
-          <div className="h-12 w-64 bg-white/15 rounded-lg animate-pulse mb-3" />
-          <div className="h-6 w-96 bg-white/10 rounded animate-pulse" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-64 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
         </div>
       </div>
 
       {/* Collection grid */}
-      <div className="max-w-7xl mx-auto px-6 py-12">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12">
+        <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
           {Array.from({ length: 12 }).map((_, i) => (
-            <div key={i} className="rounded-lg overflow-hidden">
-              <div className="aspect-[16/9] bg-stone-200 animate-pulse" />
-              <div className="p-4 space-y-2">
-                <div className="h-5 w-3/4 bg-stone-200 rounded animate-pulse" />
-                <div className="h-3 w-full bg-stone-100 rounded animate-pulse" />
-                <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
-              </div>
-            </div>
+            <div key={i} className="rounded-lg overflow-hidden aspect-[4/3] bg-stone-200 animate-pulse" />
           ))}
         </div>
       </div>

--- a/src/app/curated/loading.tsx
+++ b/src/app/curated/loading.tsx
@@ -1,0 +1,26 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function CuratedLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="bg-warm border-b border-border-light">
+        <div className="max-w-7xl mx-auto px-6 pt-8 pb-10 sm:pb-12">
+          <div className="h-14 sm:h-16 w-72 bg-stone-300/30 rounded-lg animate-pulse mb-3" />
+          <div className="h-5 w-96 max-w-full bg-stone-300/20 rounded animate-pulse" />
+        </div>
+      </div>
+
+      {/* Collection cards */}
+      <div className="max-w-7xl mx-auto px-6 py-10">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-xl overflow-hidden aspect-[3/2] bg-stone-200 animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/explore/loading.tsx
+++ b/src/app/explore/loading.tsx
@@ -2,24 +2,50 @@ import SiteHeader from '@/components/layout/SiteHeader';
 
 export default function ExploreLoading() {
   return (
-    <div className="min-h-screen bg-cream">
+    <div className="min-h-screen bg-stone-50">
       <SiteHeader variant="light" />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
-        <div className="h-10 w-48 bg-stone-200 rounded animate-pulse mb-2" />
-        <div className="h-5 w-96 bg-stone-100 rounded animate-pulse mb-8" />
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-16 md:py-20">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-48 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
 
-        {/* Cards grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="rounded-lg overflow-hidden border border-stone-200">
-              <div className="aspect-[4/3] bg-stone-200 animate-pulse" />
-              <div className="p-4 space-y-2">
-                <div className="h-5 w-2/3 bg-stone-200 rounded animate-pulse" />
-                <div className="h-3 w-full bg-stone-100 rounded animate-pulse" />
-              </div>
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12 space-y-12">
+        {/* Stats row */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-lg border border-stone-200 bg-white p-5">
+              <div className="h-8 w-20 bg-stone-200 rounded animate-pulse mb-2" />
+              <div className="h-4 w-16 bg-stone-100 rounded animate-pulse" />
             </div>
           ))}
+        </div>
+
+        {/* Nav tabs */}
+        <div className="flex gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-9 w-28 bg-stone-200 rounded-lg animate-pulse" />
+          ))}
+        </div>
+
+        {/* Century heatmap placeholder */}
+        <div>
+          <div className="h-7 w-40 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="h-48 bg-stone-100 rounded-lg animate-pulse" />
+        </div>
+
+        {/* Data sources */}
+        <div>
+          <div className="h-7 w-32 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-24 bg-stone-100 rounded-lg animate-pulse" />
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/gallery/collections/[slug]/loading.tsx
+++ b/src/app/gallery/collections/[slug]/loading.tsx
@@ -1,0 +1,26 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function GalleryCollectionDetailLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Description skeleton */}
+        <div className="mb-8 max-w-3xl space-y-2">
+          <div className="h-4 w-full bg-stone-200 rounded animate-pulse" />
+          <div className="h-4 w-4/5 bg-stone-200 rounded animate-pulse" />
+        </div>
+
+        {/* Image grid skeleton */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          {Array.from({ length: 15 }).map((_, i) => (
+            <div key={i} className="rounded-lg overflow-hidden">
+              <div className="aspect-square bg-stone-200 animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gallery/collections/loading.tsx
+++ b/src/app/gallery/collections/loading.tsx
@@ -1,0 +1,24 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function GalleryCollectionsLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="dark" breadcrumbs={[{ label: 'Gallery', href: '/gallery' }]} />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Intro skeleton */}
+        <div className="text-center mb-10">
+          <div className="h-7 w-64 bg-stone-200 rounded animate-pulse mx-auto mb-3" />
+          <div className="h-4 w-96 max-w-full bg-stone-100 rounded animate-pulse mx-auto" />
+        </div>
+
+        {/* Collection cards skeleton */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="rounded-xl overflow-hidden aspect-[4/3] bg-stone-200 animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gallery/loading.tsx
+++ b/src/app/gallery/loading.tsx
@@ -1,9 +1,47 @@
-import { BookLoader } from '@/components/ui/BookLoader';
+import SiteHeader from '@/components/layout/SiteHeader';
 
 export default function GalleryLoading() {
   return (
-    <div className="min-h-screen bg-cream flex items-center justify-center">
-      <BookLoader size="lg" />
+    <div className="min-h-screen bg-gradient-to-b from-[#f6f3ee] to-[#f3ede6]">
+      <SiteHeader variant="dark" sticky breadcrumbs={[{ label: 'Image Gallery', href: '/gallery' }]} />
+
+      <div className="px-4 sm:px-6 lg:px-8 py-6">
+        {/* Search & filter bar skeleton */}
+        <div className="flex flex-col sm:flex-row flex-wrap items-stretch sm:items-center gap-3 mb-6">
+          <div className="flex-1 min-w-0 sm:min-w-[200px] max-w-md h-9 bg-stone-200 rounded-lg animate-pulse" />
+          <div className="min-w-0 sm:min-w-[200px] max-w-sm flex-1 h-9 bg-stone-200 rounded-lg animate-pulse" />
+          <div className="h-9 w-24 bg-stone-200 rounded-lg animate-pulse" />
+        </div>
+
+        {/* Featured collections skeleton */}
+        <div className="mb-8">
+          <div className="h-6 w-48 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex gap-4 overflow-hidden">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex-shrink-0 w-56 rounded-xl overflow-hidden">
+                <div className="aspect-[4/3] bg-stone-200 animate-pulse" />
+                <div className="p-3 space-y-1.5">
+                  <div className="h-4 w-3/4 bg-stone-200 rounded animate-pulse" />
+                  <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Image grid skeleton */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+          {Array.from({ length: 24 }).map((_, i) => (
+            <div key={i} className="rounded-lg overflow-hidden">
+              <div className="aspect-square bg-stone-200 animate-pulse" />
+              <div className="p-2 space-y-1.5">
+                <div className="h-3 w-full bg-stone-200 rounded animate-pulse" />
+                <div className="h-3 w-2/3 bg-stone-100 rounded animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/languages/[code]/loading.tsx
+++ b/src/app/languages/[code]/loading.tsx
@@ -1,0 +1,44 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function LanguageDetailLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="bg-dark overflow-hidden">
+        <div className="bg-gradient-to-b from-black/70 via-black/40 to-transparent">
+          <div className="max-w-7xl mx-auto px-6 pt-8 pb-12 sm:pb-16">
+            <div className="h-4 w-24 bg-white/10 rounded animate-pulse mb-6" />
+            <div className="h-14 sm:h-16 w-48 bg-white/15 rounded-lg animate-pulse mb-3" />
+            <div className="h-5 w-32 bg-white/10 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+
+      {/* Gallery strip */}
+      <div className="bg-warm border-b border-border-light">
+        <div className="max-w-7xl mx-auto px-6 py-6">
+          <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="aspect-square bg-stone-200 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Book grid */}
+      <div className="max-w-7xl mx-auto px-6 py-10">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="aspect-[3/4] bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-3/4 bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-1/2 bg-stone-100 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/languages/loading.tsx
+++ b/src/app/languages/loading.tsx
@@ -1,0 +1,37 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function LanguagesLoading() {
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-16 md:py-20">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-48 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12">
+        {/* Major languages grid */}
+        <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="aspect-[4/3] bg-stone-200 rounded-xl animate-pulse" />
+          ))}
+        </div>
+
+        {/* Other languages chips */}
+        <div className="mt-10">
+          <div className="h-6 w-36 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <div key={i} className="h-7 w-20 bg-stone-200 rounded-full animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/libraries/[slug]/loading.tsx
+++ b/src/app/libraries/[slug]/loading.tsx
@@ -1,0 +1,44 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function LibraryDetailLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="bg-dark overflow-hidden">
+        <div className="bg-gradient-to-b from-black/70 via-black/40 to-transparent">
+          <div className="max-w-7xl mx-auto px-6 pt-8 pb-12 sm:pb-16">
+            <div className="h-4 w-20 bg-white/10 rounded animate-pulse mb-6" />
+            <div className="h-14 sm:h-16 w-2/3 bg-white/15 rounded-lg animate-pulse mb-3" />
+            <div className="h-5 w-48 bg-white/10 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+
+      {/* Gallery strip */}
+      <div className="bg-warm border-b border-border-light">
+        <div className="max-w-7xl mx-auto px-6 py-6">
+          <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="aspect-square bg-stone-200 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Book grid */}
+      <div className="max-w-7xl mx-auto px-6 py-10">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="aspect-[3/4] bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-3/4 bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-1/2 bg-stone-100 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/libraries/loading.tsx
+++ b/src/app/libraries/loading.tsx
@@ -1,0 +1,36 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function LibrariesLoading() {
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-16 md:py-20">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
+          <div className="h-12 w-64 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      <div className="max-w-[var(--container-wide)] mx-auto px-6 py-12 space-y-8">
+        {/* Hero library card */}
+        <div className="aspect-[21/9] md:aspect-[3/1] bg-stone-200 rounded-xl animate-pulse" />
+
+        {/* Featured card */}
+        <div className="aspect-[21/9] bg-stone-200 rounded-xl animate-pulse" />
+
+        {/* Digital sources grid */}
+        <div>
+          <div className="h-7 w-40 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="grid gap-5 grid-cols-1 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="aspect-[4/3] bg-stone-200 rounded-xl animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/[slug]/loading.tsx
+++ b/src/app/topics/[slug]/loading.tsx
@@ -1,0 +1,47 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function TopicDetailLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-12">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-5xl mx-auto px-6">
+          <div className="h-4 w-20 bg-white/10 rounded animate-pulse mb-6" />
+          <div className="h-10 sm:h-12 w-2/3 bg-white/15 rounded-lg animate-pulse mb-3" />
+          <div className="h-5 w-32 bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content with sidebar */}
+      <div className="max-w-5xl mx-auto px-6 py-10">
+        <div className="flex flex-col lg:flex-row gap-8">
+          {/* Main content */}
+          <div className="flex-1">
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex gap-3 p-3 rounded-lg">
+                  <div className="w-12 h-16 bg-stone-200 rounded animate-pulse flex-shrink-0" />
+                  <div className="flex-1 space-y-1.5">
+                    <div className="h-4 w-3/4 bg-stone-200 rounded animate-pulse" />
+                    <div className="h-3 w-1/2 bg-stone-100 rounded animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Sidebar */}
+          <div className="lg:w-64 space-y-3">
+            <div className="h-5 w-20 bg-stone-200 rounded animate-pulse mb-2" />
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-4 w-full bg-stone-100 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/loading.tsx
+++ b/src/app/topics/loading.tsx
@@ -1,0 +1,36 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function TopicsLoading() {
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-16 md:py-20">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-48 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12 space-y-12">
+        {/* Facet sections */}
+        {Array.from({ length: 3 }).map((_, s) => (
+          <div key={s}>
+            <div className="h-7 w-40 bg-stone-200 rounded animate-pulse mb-2" />
+            <div className="h-4 w-64 bg-stone-100 rounded animate-pulse mb-4" />
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="rounded-lg border border-stone-200 bg-white p-4">
+                  <div className="h-5 w-3/4 bg-stone-200 rounded animate-pulse mb-2" />
+                  <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The page reader (`/book/[id]/page/[pageId]`) is the most clicked dynamic page on the site — every page thumbnail tap goes here
- Previously showed a generic centered spinner (BookLoader)
- Now shows a skeleton matching the actual TranslationEditor layout: header bar (logo / book title / page navigation), toolbar row (Image/OCR/Read/Edit toggles), and side-by-side panels (source image placeholder + translation text lines)

## Test plan
- [ ] Click any page thumbnail from a book detail page — skeleton should show the reader layout instantly
- [ ] On mobile: panels should stack vertically with min-height
- [ ] On desktop: panels should be side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)