### PR TITLE
Standardize book thumbnail URLs to correct R2 variant

### DIFF
--- a/.claude/docs/image-variants.md
+++ b/.claude/docs/image-variants.md
@@ -1,0 +1,82 @@
+# Image Variant System
+
+Source Library stores multiple resolution variants of every page image on R2.
+Understanding which variant to use where is critical for both performance and visual quality.
+
+## R2 Path Convention
+
+All page images live under `images.sourcelibrary.org/pages/{bookId}/`:
+
+| Variant | Path | Size | Quality | Use case |
+|---------|------|------|---------|----------|
+| **Full** | `{num}-full.jpg` | Original resolution | Lossless | OCR input, zoom, download |
+| **Display** | `{num}.jpg` | 1200px wide | 85 | Browser display, cards, grids, heroes |
+| **Thumb** | `{num}-thumb.jpg` | 150px wide | 60 | Tiny previews, search dropdowns |
+
+Gallery images follow the same convention under `gallery/{bookId}/{imageId}`:
+- `{id}-full.jpg` — full extracted crop
+- `{id}.jpg` — 1200px display
+- `{id}-thumb.jpg` — 300px thumbnail (gallery thumbs are larger than page thumbs)
+
+Legacy images under `archived/{bookId}/{num}.jpg` are full-res originals (pre-convention).
+
+## Path Helpers
+
+`src/lib/storage.ts` exports deterministic path builders:
+
+```ts
+pagePaths(bookId, pageNumber)   // → { full, display, thumb }
+galleryPaths(bookId, imageId)   // → { full, display, thumb }
+```
+
+## Choosing the Right Variant in UI Code
+
+Use `getBookThumbnailUrl()` from `src/lib/utils.ts`:
+
+```ts
+// Card grids, collection pages, heroes — anything >100px display size
+getBookThumbnailUrl(book)               // → 1200px display variant (default)
+getBookThumbnailUrl(book, 'display')    // → same, explicit
+
+// Search dropdown previews, tiny list thumbnails — anything <100px
+getBookThumbnailUrl(book, 'thumb')      // → 150px thumb variant
+```
+
+The function:
+1. Takes `thumbnail_blob` or `thumbnail` from the book object
+2. If it's an R2 `/pages/` URL, rewrites the suffix to the requested variant
+3. For non-R2 URLs (Internet Archive, external), returns as-is
+
+**Never use `thumbnail_blob || thumbnail` directly in UI code.** Always go through `getBookThumbnailUrl()`.
+
+## Database Fields
+
+Books have two thumbnail URL fields:
+
+| Field | Typical content | Notes |
+|-------|----------------|-------|
+| `thumbnail` | Full-res or display R2 URL, or external hotlink | Set during archiving |
+| `thumbnail_blob` | Usually the `-thumb.jpg` variant | Set during archiving |
+
+These fields are not standardized — the same field might contain a `-full.jpg`, `.jpg`, or `-thumb.jpg` URL
+depending on when and how the book was archived. That's why `getBookThumbnailUrl()` normalizes at runtime.
+
+## Provenance Marks
+
+~10% of display variants have subtle provenance marks baked in:
+- 16x16 icon watermark in a random corner
+- `sourcelibrary.org` attribution in bottom-right
+- CC BY-SA 4.0 text at top edge (nearly invisible)
+- EXIF metadata (Copyright, Artist, ImageDescription)
+
+Applied by `scripts/workers/lib/display-image.mjs` during archiving.
+
+## Generation Pipeline
+
+Variants are created by archive workers (`scripts/workers/archive-*.mjs`):
+1. Download source image (IIIF, JP2, PDF page)
+2. Upload original as `-full.jpg`
+3. Resize to 1200px → apply provenance marks (10% chance) → upload as `.jpg`
+4. Resize to 150px → upload as `-thumb.jpg`
+
+The shared function `uploadPageVariants()` in `scripts/workers/lib/display-image.mjs` handles all three.

--- a/src/app/artist/[name]/page.tsx
+++ b/src/app/artist/[name]/page.tsx
@@ -7,6 +7,7 @@ import { notFound, redirect } from 'next/navigation';
 import { bookUrl, authorSlug, authorUrl } from '@/lib/slugify';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId, type Db } from 'mongodb';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 export const revalidate = 86400;
 export const dynamicParams = true;
@@ -382,9 +383,9 @@ export default async function ArtistPage({ params }: ArtistPageProps) {
           {books.map(book => (
             <Link key={book.id} href={bookUrl(book)} className="group">
               <div className="aspect-[3/4] relative rounded overflow-hidden bg-stone-200">
-                {(book.thumbnail_blob || book.thumbnail) ? (
+                {getBookThumbnailUrl(book) ? (
                   <Image
-                    src={(book.thumbnail_blob || book.thumbnail)!}
+                    src={getBookThumbnailUrl(book)!}
                     alt={book.display_title || book.title}
                     fill
                     className="object-cover group-hover:scale-105 transition-transform duration-300"

--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -9,6 +9,7 @@ import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import AuthorBibliography from '@/components/browse/AuthorBibliography';
 import { VISUAL_RESOURCE_TYPES } from '@/lib/books-catalog';
 import { ObjectId, type Db } from 'mongodb';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 // ISR: 24h background revalidation (survives deploys better than revalidate=false)
 export const revalidate = 86400;
@@ -414,7 +415,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
 
       {/* Title page gallery */}
       {(() => {
-        const thumbBooks = books.filter(b => b.thumbnail_blob || b.thumbnail);
+        const thumbBooks = books.filter(b => getBookThumbnailUrl(b));
         if (thumbBooks.length === 0) return null;
         const shown = thumbBooks.slice(0, 8);
         return (
@@ -425,7 +426,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
                   <Link key={book.id} href={bookUrl(book)} className="shrink-0 group">
                     <div className="w-24 h-32 relative rounded overflow-hidden bg-stone-200">
                       <Image
-                        src={(book.thumbnail_blob || book.thumbnail)!}
+                        src={getBookThumbnailUrl(book)!}
                         alt={book.display_title || book.title}
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-300"
@@ -448,7 +449,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         <AuthorBibliography books={books.map(b => ({
           ...b,
           display_title: b.display_title || undefined,
-          thumbnail: b.thumbnail_blob || b.thumbnail || undefined,
+          thumbnail: getBookThumbnailUrl(b) || undefined,
           thumbnail_blob: b.thumbnail_blob || undefined,
         }))} />
       </main>

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -8,6 +8,7 @@ import { LIBRARY_CATEGORIES } from '@/app/api/categories/route';
 import { notFound } from 'next/navigation';
 import CategorySchema from '@/components/seo/CategorySchema';
 import { bookUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 interface Book {
   id: string;
@@ -148,9 +149,9 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
                 >
                   {/* Thumbnail */}
                   <div className="aspect-[3/2] bg-stone-100 relative overflow-hidden">
-                    {(book.thumbnail_blob || book.thumbnail) ? (
+                    {getBookThumbnailUrl(book) ? (
                       <Image
-                        src={(book.thumbnail_blob || book.thumbnail)!}
+                        src={getBookThumbnailUrl(book)!}
                         alt={book.title}
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-300"

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -13,6 +13,7 @@ import ExhibitionLayout from '@/components/collections/ExhibitionLayout';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { bookUrl } from '@/lib/slugify';
 import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-utils';
+import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { browseBooks } from '@/lib/books-catalog';
 
@@ -552,7 +553,7 @@ export default async function CollectionDetailPage({ params }: Props) {
   type ArtPreview = { id: string; slug?: string; title: string; display_title?: string; author?: string; thumbnail?: string; thumbnail_blob?: string; resource_type?: string; enrichment?: { subject?: string }; commons_width?: number; commons_height?: number };
   let artworkPreviewImages: ArtPreview[] = [];
   if (isArtCollection && diverseGalleryImages.length === 0) {
-    const artPool = (books as ArtPreview[]).filter(a => sanitizeThumbnail(a.thumbnail_blob || a.thumbnail || ''));
+    const artPool = (books as ArtPreview[]).filter(a => getBookThumbnailUrl(a));
     // Shuffle for variety on each ISR build
     for (let i = artPool.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -618,7 +619,7 @@ export default async function CollectionDetailPage({ params }: Props) {
         ) : artworkPreviewImages.length > 0 ? (
           <div className="absolute inset-0 grid grid-cols-3 sm:grid-cols-6 opacity-30">
             {artworkPreviewImages.slice(0, 6).map((art) => {
-              const src = sanitizeThumbnail(art.thumbnail_blob || art.thumbnail || '');
+              const src = getBookThumbnailUrl(art);
               if (!src) return null;
               return (
                 <div key={art.id} className="relative overflow-hidden">
@@ -740,9 +741,9 @@ export default async function CollectionDetailPage({ params }: Props) {
               >
                 <div className="w-40 sm:w-48 flex-shrink-0 mx-auto sm:mx-0">
                   <div className="aspect-[3/4] relative rounded-lg overflow-hidden bg-white shadow-lg group-hover:shadow-xl transition-shadow">
-                    {(featured.thumbnail_blob || featured.thumbnail) ? (
+                    {getBookThumbnailUrl(featured) ? (
                       <Image
-                        src={(featured.thumbnail_blob || featured.thumbnail)!}
+                        src={getBookThumbnailUrl(featured)!}
                         alt={featured.title || ''}
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-500"
@@ -871,7 +872,7 @@ export default async function CollectionDetailPage({ params }: Props) {
             </p>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4">
               {artworkPreviewImages.map((art) => {
-                const thumb = sanitizeThumbnail(art.thumbnail_blob || art.thumbnail || '');
+                const thumb = getBookThumbnailUrl(art);
                 return (
                   <Link
                     key={art.id}
@@ -942,7 +943,7 @@ export default async function CollectionDetailPage({ params }: Props) {
             </p>
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
               {artworks.slice(0, 15).map((art: { id: string; slug?: string; title: string; display_title?: string; author?: string; published?: string; resource_type?: string; medium?: string; thumbnail?: string; thumbnail_blob?: string; enrichment?: { subject?: string; genre?: string }; commons_width?: number; commons_height?: number }) => {
-                const thumb = sanitizeThumbnail(art.thumbnail_blob || art.thumbnail || '');
+                const thumb = getBookThumbnailUrl(art);
                 const isPortrait = (art.commons_height || 0) > (art.commons_width || 0);
                 return (
                   <Link

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -7,6 +7,7 @@ import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp } from 
 import SiteHeader from '@/components/layout/SiteHeader';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { likes } from '@/lib/api-client';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 const VISITOR_ID_KEY = 'sl_visitor_id';
 
@@ -260,7 +261,7 @@ export default function FavoritesPage() {
           <div className="grid gap-5 grid-cols-1 sm:grid-cols-2">
             {books.map((book, i) => {
               const imgs = book.featured_images || [];
-              const heroUrl = imgs[0]?.url || book.thumbnail_blob || book.thumbnail;
+              const heroUrl = imgs[0]?.url || getBookThumbnailUrl(book);
 
               return (
                 <Link

--- a/src/app/gallery/image/[id]/page.tsx
+++ b/src/app/gallery/image/[id]/page.tsx
@@ -32,6 +32,7 @@ import ImageWithMagnifier from '@/components/ui/ImageWithMagnifier';
 import LikeButton from '@/components/ui/LikeButton';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { gallery } from '@/lib/api-client';
+import { getBookThumbnailUrl } from '@/lib/utils';
 import type { GalleryImageDetail, GalleryItem, ImageMetadata } from '@/lib/api-client';
 import SimilarImages from '@/components/gallery/SimilarImages';
 import { useSession } from 'next-auth/react';
@@ -1104,9 +1105,9 @@ export default function ImageDetailPage({
               <div className="space-y-5 min-w-0">
                 <div className="bg-stone-800 rounded-lg overflow-hidden">
                   <Link href={data.readUrl} className="block group">
-                    {(data.book.thumbnail_blob || data.book.thumbnail) && (
+                    {getBookThumbnailUrl(data.book) && (
                       <div className="relative w-full aspect-[3/4] bg-stone-900">
-                        <Image src={(data.book.thumbnail_blob || data.book.thumbnail)!} alt={data.book.title} fill sizes="(max-width: 768px) 90vw, 300px" className="object-cover group-hover:opacity-90 transition-opacity" unoptimized />
+                        <Image src={getBookThumbnailUrl(data.book)!} alt={data.book.title} fill sizes="(max-width: 768px) 90vw, 300px" className="object-cover group-hover:opacity-90 transition-opacity" unoptimized />
                       </div>
                     )}
                     <div className="p-5">

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -12,6 +12,7 @@ import CollectionBookCard from '@/components/CollectionBookCard';
 import CollectionFilters from '@/components/collections/CollectionFilters';
 import { bookTitle } from '@/lib/collections-utils';
 import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 const PER_PAGE = 60;
 
@@ -388,7 +389,7 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
                     pages_count: book.pages_count,
                     pages_ocr: book.pages_ocr,
                     pages_translated: book.pages_translated,
-                    thumbnail: book.thumbnail_blob || book.thumbnail || book.photo,
+                    thumbnail: getBookThumbnailUrl(book) || book.photo || undefined,
                     thumbnail_blob: book.thumbnail_blob,
                     language: book.language,
                     published: book.published,
@@ -474,7 +475,7 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
                         pages_count: book.pages_count,
                         pages_ocr: book.pages_ocr,
                         pages_translated: book.pages_translated,
-                        thumbnail: book.thumbnail_blob || book.thumbnail || book.photo,
+                        thumbnail: getBookThumbnailUrl(book) || book.photo || undefined,
                         thumbnail_blob: book.thumbnail_blob,
                         language: book.language,
                         published: book.published,

--- a/src/app/reading-history/page.tsx
+++ b/src/app/reading-history/page.tsx
@@ -8,6 +8,7 @@ import SiteHeader from '@/components/layout/SiteHeader';
 import { readingHistory, type ReadingHistoryEntry } from '@/lib/api-client';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { bookUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 function timeAgo(dateStr: string): string {
   const now = Date.now();
@@ -221,9 +222,9 @@ function ReadingHistoryCard({
       >
         {/* Cover */}
         <div className="relative w-14 h-[72px] flex-shrink-0 bg-stone-100 rounded overflow-hidden">
-          {(book.thumbnail_blob || book.thumbnail) && !imageError ? (
+          {getBookThumbnailUrl(book, 'thumb') && !imageError ? (
             <Image
-              src={(book.thumbnail_blob || book.thumbnail)!}
+              src={getBookThumbnailUrl(book, 'thumb')!}
               alt={displayTitle}
               fill
               className="object-cover opacity-90 group-hover:opacity-100 transition-opacity"

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -29,6 +29,7 @@ import { SEARCH_TYPE_STYLES, type SearchIndexType } from '@/lib/style-constants'
 import { BookLoader } from '@/components/ui/BookLoader';
 import { LIBRARY_PARTNERS } from '@/lib/library-partners';
 import BookCard from '@/components/book/BookCard';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 // How many results to show in unified view per section
 const PREVIEW_BOOKS = 5;
@@ -943,7 +944,7 @@ export default function SearchPage() {
           <div className="space-y-3">
             <p className="text-sm text-muted">Related results from AI-expanded search:</p>
             {aiResults.map(result => {
-              const cover = result.thumbnail || (result as any).thumbnail_blob;
+              const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
               const text = result.snippet || result.summary;
               return (
                 <Link
@@ -1116,7 +1117,7 @@ export default function SearchPage() {
             <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-4">Related in the Library</h2>
             <div className="space-y-3">
               {aiResults.map(result => {
-                const cover = result.thumbnail || (result as any).thumbnail_blob;
+                const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
                 const text = result.snippet || result.summary;
                 return (
                   <Link
@@ -1154,7 +1155,7 @@ export default function SearchPage() {
 // ==================== RESULT CARDS ====================
 
 function BookResultCard({ result, query }: { result: SearchResult; query: string }) {
-  const cover = result.thumbnail || (result as any).thumbnail_blob;
+  const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
   const text = result.snippet || result.summary;
   const [imgError, setImgError] = useState(false);
 

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -7,6 +7,7 @@ import SiteHeader from '@/components/layout/SiteHeader';
 import { notFound } from 'next/navigation';
 import { bookUrl } from '@/lib/slugify';
 import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 export const revalidate = false;
 
@@ -259,7 +260,7 @@ async function fetchClusterData(slug: string) {
 
 function BookCard({ book }: { book: BookItem }) {
   const title = book.display_title || book.title;
-  const thumb = book.thumbnail_blob || (book.thumbnail?.startsWith('http') ? book.thumbnail : null);
+  const thumb = getBookThumbnailUrl(book);
   const pagesOcr = book.pages_ocr || book.pages_count || 0;
   const denom = Math.max(pagesOcr - (book.pages_blank || 0), 1);
   const translationPercent =

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import type { Book } from '@/lib/types';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 export const revalidate = false;
 export const dynamicParams = true;
@@ -103,7 +104,7 @@ export default async function WorkPage({ params }: PageProps) {
         <div className="grid gap-4">
           {editions.map((book) => {
             const provider = (book as unknown as { image_source?: { provider_name?: string } }).image_source?.provider_name;
-            const thumb = book.thumbnail_blob || book.thumbnail;
+            const thumb = getBookThumbnailUrl(book);
             const displayTitle = book.display_title || book.title;
             const pagesOcr = book.pages_ocr || 0;
             const pagesTranslated = book.pages_translated || 0;

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, Calendar, FileText } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn, getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import AuthorName from '@/components/AuthorName';
 
@@ -41,19 +41,8 @@ export default function CollectionBookCard({ book, priority = false }: Collectio
   const [useFallback, setUseFallback] = useState(false);
 
   const pageCount = book.pages_count || book.pages || 0;
-
-  // For card-sized display, use the 1200px display variant instead of -thumb (150px).
-  // R2 convention: pages/{bookId}/{num}-thumb.jpg → pages/{bookId}/{num}.jpg (display)
-  //                pages/{bookId}/{num}-full.jpg → pages/{bookId}/{num}.jpg (display)
-  const toDisplayUrl = (url?: string | null): string | null => {
-    if (!url || !url.includes('images.sourcelibrary.org/pages/')) return url || null;
-    return url.replace(/-thumb\.jpg$/, '.jpg').replace(/-full\.jpg$/, '.jpg');
-  };
-
-  const bestUrl = toDisplayUrl(book.thumbnail) || toDisplayUrl(book.thumbnail_blob);
-  const primaryUrl = bestUrl || book.thumbnail || book.thumbnail_blob || null;
-  const fallbackUrl = book.thumbnail_blob && book.thumbnail_blob !== primaryUrl
-    ? book.thumbnail_blob : (book.thumbnail !== primaryUrl ? book.thumbnail : null);
+  const primaryUrl = getBookThumbnailUrl(book, 'display');
+  const fallbackUrl = getBookThumbnailUrl(book, 'thumb');
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
 
   return (

--- a/src/components/book/AuthorCrossReference.tsx
+++ b/src/components/book/AuthorCrossReference.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { BookOpen, Paintbrush } from 'lucide-react';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 import { authorUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 export interface CrossRefItem {
   slug: string;
@@ -59,7 +60,7 @@ export default function AuthorCrossReference({ author, crossRef, context }: Prop
         <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
           {items.map((a) => {
             const isPortrait = (a.commons_width || 1) < (a.commons_height || 1);
-            const thumb = sanitizeThumbnail(a.thumbnail_blob || a.thumbnail || '');
+            const thumb = getBookThumbnailUrl(a);
             return (
               <Link key={a.slug} href={`/artwork/${a.slug}`} className="group block">
                 <div className={`relative overflow-hidden rounded-sm bg-stone-100 ${isPortrait ? 'aspect-[3/4]' : 'aspect-[4/3]'}`}>
@@ -107,7 +108,7 @@ export default function AuthorCrossReference({ author, crossRef, context }: Prop
       </div>
       <div className="space-y-3">
         {items.map((b) => {
-          const thumb = sanitizeThumbnail(b.thumbnail_blob || b.thumbnail || '');
+          const thumb = getBookThumbnailUrl(b);
           return (
             <Link
               key={b.slug}

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -39,10 +39,9 @@ export default function BookCard({ book, priority = false }: BookCardProps) {
     };
   }, []);
 
-  // Prefer R2 (thumbnail_blob) over external hotlinks, with fallback on error
-  const primaryUrl = getBookThumbnailUrl(book);
-  const fallbackUrl = book.thumbnail && book.thumbnail_blob && book.thumbnail !== book.thumbnail_blob
-    ? book.thumbnail : null;
+  // Use 1200px display variant for card-sized display, fall back to thumb
+  const primaryUrl = getBookThumbnailUrl(book, 'display');
+  const fallbackUrl = getBookThumbnailUrl(book, 'thumb');
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
 
   // Determine image source type for analytics

--- a/src/components/book/BookLibrary.tsx
+++ b/src/components/book/BookLibrary.tsx
@@ -9,6 +9,7 @@ import { Book } from '@/lib/types';
 import { bookUrl } from '@/lib/slugify';
 import { LIBRARY_PARTNERS } from '@/lib/library-partners';
 import AuthorName from '@/components/AuthorName';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 import { Search, Loader2, ExternalLink, BookOpen, Plus, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { catalog, importBooks, type CatalogResult } from '@/lib/api-client';
@@ -682,10 +683,10 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
             >
               {/* Thumbnail */}
               <div className="w-16 h-20 bg-stone-100 rounded overflow-hidden flex-shrink-0">
-                {(book.thumbnail_blob || book.thumbnail) ? (
+                {getBookThumbnailUrl(book, 'thumb') ? (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
-                    src={book.thumbnail_blob || book.thumbnail}
+                    src={getBookThumbnailUrl(book, 'thumb')!}
                     alt={book.title || ''}
                     loading="lazy"
                     decoding="async"

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -7,6 +7,7 @@ import CollectionBookCard from '@/components/CollectionBookCard';
 import CollectionListView from '@/components/collections/CollectionListView';
 import CatalogPagination from '@/components/collections/CatalogPagination';
 import { bookTitle } from '@/lib/collections-utils';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 const PER_PAGE = 60;
 
@@ -356,7 +357,7 @@ export default function CollectionAllBooks({
                 pages_count: book.pages_count,
                 pages_ocr: book.pages_ocr,
                 pages_translated: book.pages_translated,
-                thumbnail: book.thumbnail_blob || book.thumbnail || book.photo,
+                thumbnail: getBookThumbnailUrl(book) || book.photo || undefined,
                 thumbnail_blob: book.thumbnail_blob,
                 language: book.language,
                 published: book.published,
@@ -379,10 +380,10 @@ export default function CollectionAllBooks({
                 <div className="absolute top-0 left-0 right-0 flex">
                   {compactBooks.slice(0, 5).map((b) => (
                     <div key={b.id} className="flex-1 aspect-square relative opacity-15 group-hover:opacity-25 transition-opacity">
-                      {(b.thumbnail || b.thumbnail_blob) && (
+                      {getBookThumbnailUrl(b) && (
                         // eslint-disable-next-line @next/next/no-img-element
                         <img
-                          src={b.thumbnail || b.thumbnail_blob || ''}
+                          src={getBookThumbnailUrl(b)!}
                           alt=""
                           className="absolute inset-0 w-full h-full object-cover"
                         />

--- a/src/components/collections/ExhibitionLayout.tsx
+++ b/src/components/collections/ExhibitionLayout.tsx
@@ -7,6 +7,7 @@ import { BookOpen, ArrowRight, Quote, Clock, Users, Sparkles } from 'lucide-reac
 import { bookUrl } from '@/lib/slugify';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import AuthorName from '@/components/AuthorName';
+import { getBookThumbnailUrl } from '@/lib/utils';
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -197,9 +198,9 @@ function SectionsBlock({ sections, books }: {
                 >
                   <div className="w-16 sm:w-20 flex-shrink-0">
                     <div className="aspect-[3/4] relative rounded-lg overflow-hidden bg-warm">
-                      {(book.thumbnail_blob || book.thumbnail) ? (
+                      {getBookThumbnailUrl(book) ? (
                         <Image
-                          src={(book.thumbnail_blob || book.thumbnail)!}
+                          src={getBookThumbnailUrl(book)!}
                           alt={bookTitle(book)}
                           fill
                           className="object-cover group-hover:scale-105 transition-transform duration-300"

--- a/src/components/search/UnifiedSearch.tsx
+++ b/src/components/search/UnifiedSearch.tsx
@@ -9,6 +9,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { search as searchApi } from '@/lib/api-client';
 import { bookUrl } from '@/lib/slugify';
 import type { UnifiedSearchResponse } from '@/lib/api-client';
+import { getBookThumbnailUrl } from '@/lib/utils';
 import HighlightedText from './HighlightedText';
 import { ENTITY_TYPE_STYLES, type EntityType } from '@/lib/style-constants';
 
@@ -375,10 +376,10 @@ export default function UnifiedSearch() {
                           className={`flex items-center gap-3 px-2 py-2 rounded-lg transition-colors ${activeIndex === itemIndex ? 'bg-accent-gold/8' : 'hover:bg-accent-gold/8'
                             }`}
                         >
-                          {book.thumbnail_blob || book.thumbnail ? (
+                          {getBookThumbnailUrl(book, 'thumb') ? (
                             <div className="w-8 h-10 rounded overflow-hidden flex-shrink-0 bg-stone-100">
                               <Image
-                                src={book.thumbnail_blob || book.thumbnail!}
+                                src={getBookThumbnailUrl(book, 'thumb')!}
                                 alt={book.display_title || book.title}
                                 width={32}
                                 height={40}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,9 +26,40 @@ export function isUsableImageUrl(url: string | undefined | null): url is string 
   return !!url && (url.startsWith('http://') || url.startsWith('https://'));
 }
 
-/** Return the best book thumbnail URL, preferring R2 (thumbnail_blob) over external hotlinks. */
-export function getBookThumbnailUrl(book: { thumbnail?: string | null; thumbnail_blob?: string | null }): string | null {
-  return book.thumbnail_blob || book.thumbnail || null;
+/**
+ * Return the best book image URL for the given display context.
+ *
+ * R2 image variants (see src/lib/storage.ts for path helpers):
+ *   - `-full.jpg`  — original resolution (OCR, zoom, download)
+ *   - `.jpg`       — 1200px display variant (browser display, cards)
+ *   - `-thumb.jpg` — 150px thumbnail (tiny previews, search dropdowns)
+ *
+ * @param size 'display' (default, 1200px) | 'thumb' (150px)
+ *   - Use 'display' for any UI element >100px (book cards, grids, heroes)
+ *   - Use 'thumb' for tiny previews (<100px, search results, list rows)
+ */
+export function getBookThumbnailUrl(
+  book: { thumbnail?: string | null; thumbnail_blob?: string | null },
+  size: 'display' | 'thumb' = 'display'
+): string | null {
+  const raw = book.thumbnail_blob || book.thumbnail || null;
+  if (!raw) return null;
+
+  // Only rewrite R2 /pages/ URLs where we know the variant convention exists
+  if (!raw.includes('images.sourcelibrary.org/pages/')) return raw;
+
+  if (size === 'display') {
+    // Rewrite -thumb.jpg or -full.jpg → .jpg (1200px display variant)
+    return raw.replace(/-thumb\.jpg$/, '.jpg').replace(/-full\.jpg$/, '.jpg');
+  }
+  // size === 'thumb': ensure we get the -thumb variant
+  if (raw.endsWith('-thumb.jpg')) return raw;
+  if (raw.endsWith('-full.jpg')) return raw.replace(/-full\.jpg$/, '-thumb.jpg');
+  // bare .jpg (display) → -thumb.jpg
+  if (raw.endsWith('.jpg') && !raw.endsWith('-thumb.jpg')) {
+    return raw.replace(/\.jpg$/, '-thumb.jpg');
+  }
+  return raw;
 }
 
 export function isArchiveFailed(photo: string | undefined | null): boolean {


### PR DESCRIPTION
## Summary
- `getBookThumbnailUrl()` now rewrites R2 URLs to the correct size variant: `display` (1200px, default) or `thumb` (150px)
- Updated 18 components/pages that were using raw `thumbnail_blob || thumbnail` inline
- Added `.claude/docs/image-variants.md` documenting the three-variant system (`-full.jpg`, `.jpg`, `-thumb.jpg`)

**Before:** Most UI code resolved to the 150px thumb, making cards/grids blurry
**After:** Cards, grids, heroes get the 1200px display variant; tiny previews get 150px thumb

## Files changed
- `src/lib/utils.ts` — `getBookThumbnailUrl()` now accepts `size` param, rewrites R2 URLs
- `src/components/CollectionBookCard.tsx`, `BookCard.tsx` — use centralized function
- 14 page/component files — migrated from inline patterns
- `.claude/docs/image-variants.md` — new documentation

## Test plan
- [ ] `/browse/titles/A` grid view — sharp 1200px covers
- [ ] `/timeline?decade=1580` — sharp covers
- [ ] `/author/paracelsus` grid view — sharp covers
- [ ] `/search?q=alchemy` — search results use display variant
- [ ] Search dropdown (type in header) — uses 150px thumb (fast)
- [ ] `/reading-history` — uses 150px thumb (small previews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)