### PR TITLE
Librarian: present plan before searching

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -109,7 +109,7 @@ const TOOL_DECLARATIONS: FunctionDeclaration[] = [
   },
   {
     name: 'present_choices',
-    description: 'Present the user with 2-4 interpretation options before searching. Use when the question is ambiguous and could mean different things. The user will select one to guide your search. Each option should be a short phrase (under 60 chars).',
+    description: 'Present the user with 2-4 research directions before searching. Use this as your FIRST tool call for broad or exploratory questions — share your hypothesis about what the user might mean, and let them steer. The preamble should show your knowledge ("Mushrooms appear in early modern texts as..."). Each option should be a short phrase (under 60 chars). The user will click one or type their own direction.',
     parameters: {
       type: Type.OBJECT,
       properties: {
@@ -494,13 +494,20 @@ You are a research librarian. When a user asks a question:
 
 5. **Cite precisely.** Every claim grounded in the collection must include the full URL: https://sourcelibrary.org/book/{slug}/page/{N}. Use the format: "quoted text" — *Title* by Author, [Page N](url).
 
-## When to use present_choices
+## IMPORTANT: Present a plan before searching
 
-If the user's question is genuinely ambiguous and could lead to very different searches, use present_choices to offer 2-4 interpretations. For example:
-- "What is the philosopher's stone?" → search directly (not ambiguous)
-- "Tell me about resonance" → present choices: sympathetic magic, musical cosmology, acoustic experiments
+For broad or exploratory questions, ALWAYS use present_choices FIRST to share your thinking and let the user steer. This should happen fast — within your first response, before any search tools. Examples:
 
-Only present choices when the ambiguity would lead to materially different search strategies. Most questions should just be answered directly.
+- "Are there books about magic mushrooms?" → present_choices with preamble like "Interesting — mushrooms show up in early modern texts under different guises" and options like: "Psychoactive plants in herbals (Porta, Mattioli)", "Flying ointments & witchcraft", "Alchemical symbolism of fungi", "Entheogenic theories (Wasson, Allegro)"
+- "What books explore resonance as magic?" → present_choices: "Sympathetic magic & occult virtues (Agrippa)", "Musical cosmology & spiritus (Ficino)", "Acoustic experiments (Kircher)"
+- "Tell me about the Emerald Tablet" → present_choices: "History and transmission of the text", "Alchemical interpretations", "Hermetic philosophy and context"
+
+Only skip present_choices for questions that are specific and unambiguous:
+- "What did Agrippa write about planetary seals?" → search directly
+- "Who was Marsilio Ficino?" → search directly
+- "Find me the passage about the vulture in Ficino's De Voluptate" → search directly
+
+When in doubt, present choices. It's better to pause and let the user steer than to search in the wrong direction. The user can always click a choice to proceed or type something different.
 
 ## The collection
 


### PR DESCRIPTION
For broad/exploratory questions, the Librarian now presents its hypothesis as clickable choice chips BEFORE executing any searches. The user steers, then searches happen.

- "Magic mushrooms?" → choices: "Psychoactive plants in herbals", "Flying ointments & witchcraft", "Alchemical symbolism", "Entheogenic theories"
- "Resonance as magic?" → choices: "Sympathetic magic (Agrippa)", "Musical cosmology (Ficino)", "Acoustic experiments (Kircher)"
- "What did Agrippa write about planetary seals?" → searches directly (specific, no ambiguity)

Tested with live Gemini API — `present_choices` fires as the first tool call for exploratory questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)