### PR TITLE
Add /learn page: vocabulary quizzes from translated texts

### DIFF
--- a/src/app/api/learn/route.ts
+++ b/src/app/api/learn/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+
+export const maxDuration = 15;
+export const dynamic = 'force-dynamic';
+
+interface TermEntry {
+  term: string;
+  definition: string;
+  originalContext?: string;
+  bookId: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookDate?: string;
+  bookLanguage?: string;
+  pageNumber: number;
+  slug?: string;
+}
+
+/** Parse <term>...</term> tags, extracting inline definitions when present */
+function extractTerms(translationText: string): Array<{ term: string; definition: string; context: string }> {
+  const results: Array<{ term: string; definition: string; context: string }> = [];
+
+  // Pattern: <term>word</term> optionally followed by <note>definition</note> or <gloss>definition</gloss>
+  // Also handles inline definitions like "word: definition" or "word; definition"
+  const termRegex = /<term>([\s\S]*?)<\/term>\s*(?:<(?:note|gloss)>([\s\S]*?)<\/(?:note|gloss)>)?/g;
+
+  let match;
+  while ((match = termRegex.exec(translationText)) !== null) {
+    const rawTerm = match[1].trim();
+    const noteOrGloss = match[2]?.trim();
+
+    let term: string;
+    let definition: string;
+
+    // Check if the term itself contains a definition (e.g., "spiritus: the breath of life")
+    const inlineSplit = rawTerm.match(/^([^:;]+?)\s*[:;]\s+([\s\S]+)$/);
+    if (inlineSplit) {
+      term = inlineSplit[1].trim().replace(/\*/g, '');
+      definition = inlineSplit[2].trim().replace(/\*/g, '');
+    } else if (noteOrGloss) {
+      term = rawTerm.replace(/\*/g, '');
+      // Clean up note text — remove "original: " prefix and quote marks
+      definition = noteOrGloss
+        .replace(/^original:\s*/i, '')
+        .replace(/^["']|["']$/g, '')
+        .replace(/<[^>]+>/g, '') // strip nested tags
+        .trim();
+    } else {
+      // Term without definition — skip these for quiz purposes
+      continue;
+    }
+
+    // Skip very long terms (they're more like explanations)
+    if (term.length > 60 || definition.length > 300) continue;
+    // Skip very short/generic terms
+    if (term.length < 3) continue;
+
+    // Get surrounding context (sentence containing the term)
+    const termIdx = translationText.indexOf(match[0]);
+    const contextStart = Math.max(0, translationText.lastIndexOf('.', termIdx) + 1);
+    const contextEnd = translationText.indexOf('.', termIdx + match[0].length);
+    const context = translationText
+      .slice(contextStart, contextEnd > 0 ? contextEnd + 1 : contextStart + 200)
+      .replace(/<[^>]+>/g, '') // strip all tags
+      .trim()
+      .substring(0, 200);
+
+    results.push({ term, definition, context });
+  }
+
+  return results;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const count = Math.min(parseInt(searchParams.get('count') || '10'), 50);
+    const language = searchParams.get('language'); // filter by book language
+
+    const db = await getReadDb();
+
+    // Build query — find pages with <term> tags that also have adjacent <note> or <gloss>
+    const query: Record<string, unknown> = {
+      'translation.data': { $regex: '<term>.*?</term>\\s*<(?:note|gloss)>' },
+    };
+
+    // Get pages — we'll fetch more than needed since not all terms parse cleanly
+    const pages = await db.collection('pages')
+      .find(query)
+      .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
+      .limit(count * 5)
+      .maxTimeMS(10000)
+      .toArray();
+
+    // Also try pages with inline definitions (term; definition pattern)
+    if (pages.length < count * 3) {
+      const inlinePages = await db.collection('pages')
+        .find({ 'translation.data': { $regex: '<term>[^<]*[:;][^<]*</term>' } })
+        .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
+        .limit(count * 5)
+        .maxTimeMS(10000)
+        .toArray();
+      const existingIds = new Set(pages.map(p => p._id.toString()));
+      for (const p of inlinePages) {
+        if (!existingIds.has(p._id.toString())) pages.push(p);
+      }
+    }
+
+    // Extract all terms
+    let allTerms: Array<{ term: string; definition: string; context: string; bookId: string; pageNumber: number }> = [];
+    for (const page of pages) {
+      const terms = extractTerms(page.translation?.data || '');
+      for (const t of terms) {
+        allTerms.push({
+          ...t,
+          bookId: page.book_id,
+          pageNumber: page.page_number,
+        });
+      }
+    }
+
+    // Deduplicate by term (keep first occurrence)
+    const seen = new Set<string>();
+    allTerms = allTerms.filter(t => {
+      const key = t.term.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    // Shuffle
+    for (let i = allTerms.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [allTerms[i], allTerms[j]] = [allTerms[j], allTerms[i]];
+    }
+
+    // Take requested count
+    const selected = allTerms.slice(0, count);
+
+    // Enrich with book metadata
+    const bookIds = [...new Set(selected.map(t => t.bookId))];
+    const books = await db.collection('books')
+      .find({ id: { $in: bookIds } })
+      .project({ id: 1, title: 1, author: 1, date: 1, language: 1, slug: 1 })
+      .toArray();
+    const bookMap = new Map(books.map(b => [b.id as string, b]));
+
+    // Filter by language if requested
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let enriched: TermEntry[] = selected.map(t => {
+      const book: any = bookMap.get(t.bookId) || {};
+      return {
+        term: t.term,
+        definition: t.definition,
+        originalContext: t.context,
+        bookId: t.bookId,
+        bookTitle: book.title || 'Unknown',
+        bookAuthor: book.author || 'Unknown',
+        bookDate: book.date,
+        bookLanguage: book.language,
+        pageNumber: t.pageNumber,
+        slug: book.slug,
+      };
+    });
+
+    if (language) {
+      enriched = enriched.filter(t => t.bookLanguage?.toLowerCase() === language.toLowerCase());
+    }
+
+    // Generate wrong answers from other terms' definitions (for multiple choice)
+    const allDefinitions = allTerms.map(t => t.definition);
+
+    const questions = enriched.map(entry => {
+      // Pick 3 random wrong answers from other definitions
+      const wrongs: string[] = [];
+      const shuffledDefs = [...allDefinitions].sort(() => Math.random() - 0.5);
+      for (const d of shuffledDefs) {
+        if (d !== entry.definition && wrongs.length < 3) {
+          wrongs.push(d);
+        }
+      }
+
+      // Shuffle options
+      const options = [entry.definition, ...wrongs].sort(() => Math.random() - 0.5);
+      const correctIndex = options.indexOf(entry.definition);
+
+      return {
+        ...entry,
+        options,
+        correctIndex,
+      };
+    });
+
+    return NextResponse.json({
+      terms: questions,
+      total: allTerms.length,
+    });
+  } catch (error) {
+    console.error('Learn API error:', error);
+    return NextResponse.json({ error: 'Failed to fetch terms' }, { status: 500 });
+  }
+}

--- a/src/app/learn/LearnQuiz.tsx
+++ b/src/app/learn/LearnQuiz.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+
+interface TermQuestion {
+  term: string;
+  definition: string;
+  originalContext?: string;
+  bookId: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookDate?: string;
+  bookLanguage?: string;
+  pageNumber: number;
+  slug?: string;
+  options: string[];
+  correctIndex: number;
+}
+
+type QuizState = 'loading' | 'question' | 'answered' | 'complete';
+
+export default function LearnQuiz() {
+  const [questions, setQuestions] = useState<TermQuestion[]>([]);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [selected, setSelected] = useState<number | null>(null);
+  const [state, setState] = useState<QuizState>('loading');
+  const [score, setScore] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [bestStreak, setBestStreak] = useState(0);
+  const [totalAnswered, setTotalAnswered] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchQuestions = useCallback(async () => {
+    setState('loading');
+    setError(null);
+    try {
+      const res = await fetch('/api/learn?count=10');
+      if (!res.ok) throw new Error('Failed to load');
+      const data = await res.json();
+      if (!data.terms?.length) {
+        setError('No vocabulary terms found. Check back soon.');
+        return;
+      }
+      setQuestions(data.terms);
+      setCurrentIdx(0);
+      setSelected(null);
+      setState('question');
+    } catch {
+      setError('Could not load questions. Please try again.');
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchQuestions();
+    // Load persisted stats
+    const saved = localStorage.getItem('sl-learn-stats');
+    if (saved) {
+      try {
+        const stats = JSON.parse(saved);
+        setTotalAnswered(stats.totalAnswered || 0);
+        setBestStreak(stats.bestStreak || 0);
+      } catch { /* ignore */ }
+    }
+  }, [fetchQuestions]);
+
+  const handleSelect = (idx: number) => {
+    if (state !== 'question') return;
+    setSelected(idx);
+    setState('answered');
+    const correct = idx === questions[currentIdx].correctIndex;
+    const newTotal = totalAnswered + 1;
+    setTotalAnswered(newTotal);
+    if (correct) {
+      setScore(s => s + 1);
+      const newStreak = streak + 1;
+      setStreak(newStreak);
+      if (newStreak > bestStreak) setBestStreak(newStreak);
+      localStorage.setItem('sl-learn-stats', JSON.stringify({
+        totalAnswered: newTotal,
+        bestStreak: Math.max(newStreak, bestStreak),
+      }));
+    } else {
+      setStreak(0);
+      localStorage.setItem('sl-learn-stats', JSON.stringify({
+        totalAnswered: newTotal,
+        bestStreak,
+      }));
+    }
+  };
+
+  const handleNext = () => {
+    if (currentIdx + 1 >= questions.length) {
+      setState('complete');
+    } else {
+      setCurrentIdx(i => i + 1);
+      setSelected(null);
+      setState('question');
+    }
+  };
+
+  const handleNewRound = () => {
+    setScore(0);
+    setStreak(0);
+    fetchQuestions();
+  };
+
+  const q = questions[currentIdx];
+
+  if (error) {
+    return (
+      <div className="max-w-xl mx-auto py-16 text-center">
+        <p className="text-secondary mb-6">{error}</p>
+        <button onClick={fetchQuestions} className="text-accent-rust hover:underline">
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (state === 'loading') {
+    return (
+      <div className="max-w-xl mx-auto py-16">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-stone-200 rounded w-2/3" />
+          <div className="h-4 bg-stone-200 rounded w-full" />
+          <div className="space-y-3 mt-8">
+            {[1, 2, 3, 4].map(i => (
+              <div key={i} className="h-14 bg-stone-200 rounded-lg" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'complete') {
+    return (
+      <div className="max-w-xl mx-auto py-16 text-center">
+        <h2 className="font-serif text-3xl text-primary mb-4">Round Complete</h2>
+        <div className="text-6xl font-serif text-accent-rust mb-2">{score}/{questions.length}</div>
+        <p className="text-secondary mb-8">
+          {score === questions.length
+            ? 'Perfect score.'
+            : score >= questions.length * 0.7
+              ? 'Well done.'
+              : 'Keep studying.'}
+        </p>
+        <div className="flex items-center justify-center gap-6 text-sm text-muted mb-10">
+          <span>Total answered: {totalAnswered}</span>
+          <span>Best streak: {bestStreak}</span>
+        </div>
+        <button
+          onClick={handleNewRound}
+          className="bg-[#1a1612] text-white px-8 py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
+        >
+          New round
+        </button>
+      </div>
+    );
+  }
+
+  if (!q) return null;
+
+  const isCorrect = selected === q.correctIndex;
+  const bookHref = q.slug ? `/book/${q.slug}` : `/book/${q.bookId}`;
+
+  return (
+    <div className="max-w-2xl mx-auto py-8 md:py-12">
+      {/* Progress bar */}
+      <div className="flex items-center gap-3 mb-8">
+        <div className="flex-1 h-1.5 bg-stone-200 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-accent-rust transition-all duration-300 rounded-full"
+            style={{ width: `${((currentIdx + (state === 'answered' ? 1 : 0)) / questions.length) * 100}%` }}
+          />
+        </div>
+        <span className="text-sm text-muted tabular-nums">
+          {currentIdx + 1}/{questions.length}
+        </span>
+        {streak > 1 && (
+          <span className="text-sm text-accent-rust font-medium">{streak} streak</span>
+        )}
+      </div>
+
+      {/* Term */}
+      <div className="mb-8">
+        <p className="text-sm text-muted uppercase tracking-wide mb-2">
+          What does this term mean?
+        </p>
+        <h2 className="font-serif text-3xl md:text-4xl text-primary italic">
+          {q.term}
+        </h2>
+      </div>
+
+      {/* Context (shown before answering as a hint) */}
+      {q.originalContext && (
+        <div className="bg-white border border-border-light rounded-lg p-4 mb-8 text-sm text-secondary font-body leading-relaxed">
+          <span className="text-muted text-xs uppercase tracking-wide block mb-1">Context</span>
+          &ldquo;...{q.originalContext}...&rdquo;
+        </div>
+      )}
+
+      {/* Options */}
+      <div className="space-y-3 mb-8">
+        {q.options.map((option, idx) => {
+          let style = 'bg-white border-border-light hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] cursor-pointer';
+          if (state === 'answered') {
+            if (idx === q.correctIndex) {
+              style = 'bg-emerald-50 border-emerald-300 text-emerald-900';
+            } else if (idx === selected && !isCorrect) {
+              style = 'bg-red-50 border-red-300 text-red-900';
+            } else {
+              style = 'bg-stone-50 border-stone-200 text-muted';
+            }
+          }
+          return (
+            <button
+              key={idx}
+              onClick={() => handleSelect(idx)}
+              disabled={state === 'answered'}
+              className={`w-full text-left p-4 rounded-lg border transition-colors ${style}`}
+            >
+              <span className="font-body text-[15px] leading-relaxed">{option}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Post-answer: source info + next */}
+      {state === 'answered' && (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3 bg-warm rounded-lg p-4 border border-border-light">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-primary truncate">{q.bookTitle}</p>
+              <p className="text-xs text-muted">
+                {q.bookAuthor}{q.bookDate ? `, ${q.bookDate}` : ''}
+                {q.bookLanguage ? ` · ${q.bookLanguage}` : ''}
+                {' · '}p.{q.pageNumber}
+              </p>
+            </div>
+            <Link
+              href={`${bookHref}?page=${q.pageNumber}`}
+              className="text-sm text-accent-rust hover:underline whitespace-nowrap"
+            >
+              Read in context
+            </Link>
+          </div>
+
+          <button
+            onClick={handleNext}
+            className="w-full bg-[#1a1612] text-white py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
+          >
+            {currentIdx + 1 >= questions.length ? 'See results' : 'Next'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,0 +1,27 @@
+import { Metadata } from 'next';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import LearnQuiz from './LearnQuiz';
+
+export const metadata: Metadata = {
+  title: 'Learn - Source Library',
+  description: 'Test your knowledge of historical terminology from Renaissance, Hermetic, and alchemical texts.',
+  alternates: { canonical: '/learn' },
+};
+
+export const revalidate = 86400;
+
+export default function LearnPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Learn"
+          subtitle="Vocabulary from the Western esoteric tradition"
+        />
+      }
+      bg="bg-cream"
+    >
+      <LearnQuiz />
+    </ContentPageLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/learn` page with interactive vocabulary quiz
- Extracts `<term>` + `<note>`/`<gloss>` pairs from XML-tagged translations
- Multiple choice format with 4 options drawn from real definitions across the collection
- Shows original context, book source, and links to the reader after answering
- Tracks score and streak in localStorage
- Museum-quality aesthetic consistent with the rest of the site

## How it works
1. API route `/api/learn` queries pages with `<term>` tags
2. Parses inline definitions (e.g., `spiritus: the breath of life`) and adjacent `<note>`/`<gloss>` tags
3. Deduplicates, shuffles, enriches with book metadata
4. Client component presents one term at a time with multiple choice

## Test plan
- [ ] Visit `/learn` on preview deploy
- [ ] Verify terms load and display correctly
- [ ] Answer questions — check correct/incorrect highlighting
- [ ] Verify "Read in context" links go to the right book/page
- [ ] Check round completion screen and "New round" flow
- [ ] Test on mobile

Refs #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)