### PR TITLE
Learn page: topic picker, source attribution, answer-leak fix

### DIFF
--- a/src/app/api/learn/route.ts
+++ b/src/app/api/learn/route.ts
@@ -56,15 +56,22 @@ function extractTerms(translationText: string): Array<{ term: string; definition
     // Skip very short/generic terms
     if (term.length < 3) continue;
 
-    // Get surrounding context (sentence containing the term)
+    // Get surrounding context (sentence containing the term), stripping the definition
+    // so the context doesn't give away the answer
     const termIdx = translationText.indexOf(match[0]);
     const contextStart = Math.max(0, translationText.lastIndexOf('.', termIdx) + 1);
     const contextEnd = translationText.indexOf('.', termIdx + match[0].length);
-    const context = translationText
+    let context = translationText
       .slice(contextStart, contextEnd > 0 ? contextEnd + 1 : contextStart + 200)
-      .replace(/<[^>]+>/g, '') // strip all tags
+      .replace(/<[^>]+>[^<]*<\/[^>]+>/g, '') // strip tag pairs and their content (definitions)
+      .replace(/<[^>]+>/g, '') // strip remaining tags
+      .replace(/\s{2,}/g, ' ')
       .trim()
       .substring(0, 200);
+    // If the definition text still appears in context, redact it
+    if (definition.length > 10 && context.toLowerCase().includes(definition.toLowerCase().substring(0, 30))) {
+      context = context.replace(new RegExp(definition.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').substring(0, 40), 'i'), '...');
+    }
 
     results.push({ term, definition, context });
   }
@@ -72,18 +79,85 @@ function extractTerms(translationText: string): Array<{ term: string; definition
   return results;
 }
 
+// Topics map to collection slugs in the database
+const TOPICS: Record<string, { label: string; description: string; collections: string[] }> = {
+  alchemy: {
+    label: 'Alchemy',
+    description: 'The art of transformation — prima materia, the philosopher\'s stone, and the Great Work',
+    collections: ['alchemy', 'alchemical-emblems'],
+  },
+  hermetica: {
+    label: 'Hermetica',
+    description: 'The teachings of Hermes Trismegistus and the Hermetic tradition',
+    collections: ['hermetica', 'neoplatonism'],
+  },
+  kabbalah: {
+    label: 'Kabbalah',
+    description: 'Jewish mystical tradition — the sefirot, the Tree of Life, and divine emanation',
+    collections: ['kabbalah', 'christian-kabbalah'],
+  },
+  astrology: {
+    label: 'Astrology & Astronomy',
+    description: 'Celestial influences, planetary spheres, and the music of the heavens',
+    collections: ['astrology', 'astronomy'],
+  },
+  magic: {
+    label: 'Magic & Divination',
+    description: 'Natural magic, ceremonial practice, and the hidden forces of nature',
+    collections: ['magic', 'divination', 'natural-magic'],
+  },
+  medicine: {
+    label: 'Medicine & Natural Philosophy',
+    description: 'Humors, signatures, Paracelsian medicine, and the book of nature',
+    collections: ['medicine', 'natural-philosophy', 'paracelsus'],
+  },
+  philosophy: {
+    label: 'Philosophy',
+    description: 'Neoplatonism, Aristotelian thought, Renaissance humanism',
+    collections: ['philosophy', 'neoplatonism', 'renaissance-philosophy'],
+  },
+  rosicrucianism: {
+    label: 'Rosicrucianism',
+    description: 'The Rosicrucian manifestos and the invisible brotherhood',
+    collections: ['rosicrucianism', 'freemasonry'],
+  },
+};
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const count = Math.min(parseInt(searchParams.get('count') || '10'), 50);
-    const language = searchParams.get('language'); // filter by book language
+    const language = searchParams.get('language');
+    const topic = searchParams.get('topic');
+
+    // If no topic specified and no count, return available topics
+    if (searchParams.get('topics') === 'true') {
+      return NextResponse.json({ topics: Object.entries(TOPICS).map(([id, t]) => ({ id, ...t })) });
+    }
 
     const db = await getReadDb();
+
+    // If topic specified, first get book IDs from that collection
+    let topicBookIds: string[] | null = null;
+    if (topic && TOPICS[topic]) {
+      const collSlugs = TOPICS[topic].collections;
+      const collections = await db.collection('collections')
+        .find({ slug: { $in: collSlugs } })
+        .project({ 'books': 1 })
+        .toArray();
+      topicBookIds = collections.flatMap(c => (c.books || []).map((b: { book_id?: string }) => b.book_id)).filter(Boolean);
+      if (!topicBookIds.length) {
+        return NextResponse.json({ terms: [], total: 0 });
+      }
+    }
 
     // Build query — find pages with <term> tags that also have adjacent <note> or <gloss>
     const query: Record<string, unknown> = {
       'translation.data': { $regex: '<term>.*?</term>\\s*<(?:note|gloss)>' },
     };
+    if (topicBookIds) {
+      query.book_id = { $in: topicBookIds };
+    }
 
     // Get pages — we'll fetch more than needed since not all terms parse cleanly
     const pages = await db.collection('pages')
@@ -95,8 +169,14 @@ export async function GET(request: NextRequest) {
 
     // Also try pages with inline definitions (term; definition pattern)
     if (pages.length < count * 3) {
+      const inlineQuery: Record<string, unknown> = {
+        'translation.data': { $regex: '<term>[^<]*[:;][^<]*</term>' },
+      };
+      if (topicBookIds) {
+        inlineQuery.book_id = { $in: topicBookIds };
+      }
       const inlinePages = await db.collection('pages')
-        .find({ 'translation.data': { $regex: '<term>[^<]*[:;][^<]*</term>' } })
+        .find(inlineQuery)
         .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
         .limit(count * 5)
         .maxTimeMS(10000)

--- a/src/app/learn/LearnQuiz.tsx
+++ b/src/app/learn/LearnQuiz.tsx
@@ -3,6 +3,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 
+interface Topic {
+  id: string;
+  label: string;
+  description: string;
+}
+
 interface TermQuestion {
   term: string;
   definition: string;
@@ -18,28 +24,60 @@ interface TermQuestion {
   correctIndex: number;
 }
 
-type QuizState = 'loading' | 'question' | 'answered' | 'complete';
+type QuizState = 'topics' | 'loading' | 'question' | 'answered' | 'complete';
+
+const FALLBACK_TOPICS: Topic[] = [
+  { id: 'alchemy', label: 'Alchemy', description: 'The art of transformation — prima materia, the philosopher\'s stone, and the Great Work' },
+  { id: 'hermetica', label: 'Hermetica', description: 'The teachings of Hermes Trismegistus and the Hermetic tradition' },
+  { id: 'kabbalah', label: 'Kabbalah', description: 'Jewish mystical tradition — the sefirot, the Tree of Life, and divine emanation' },
+  { id: 'astrology', label: 'Astrology & Astronomy', description: 'Celestial influences, planetary spheres, and the music of the heavens' },
+  { id: 'magic', label: 'Magic & Divination', description: 'Natural magic, ceremonial practice, and the hidden forces of nature' },
+  { id: 'medicine', label: 'Medicine & Natural Philosophy', description: 'Humors, signatures, Paracelsian medicine, and the book of nature' },
+  { id: 'philosophy', label: 'Philosophy', description: 'Neoplatonism, Aristotelian thought, Renaissance humanism' },
+  { id: 'rosicrucianism', label: 'Rosicrucianism', description: 'The Rosicrucian manifestos and the invisible brotherhood' },
+];
 
 export default function LearnQuiz() {
+  const [topics, setTopics] = useState<Topic[]>(FALLBACK_TOPICS);
+  const [activeTopic, setActiveTopic] = useState<string | null>(null);
   const [questions, setQuestions] = useState<TermQuestion[]>([]);
   const [currentIdx, setCurrentIdx] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
-  const [state, setState] = useState<QuizState>('loading');
+  const [state, setState] = useState<QuizState>('topics');
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
   const [bestStreak, setBestStreak] = useState(0);
   const [totalAnswered, setTotalAnswered] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchQuestions = useCallback(async () => {
+  // Load persisted stats on mount
+  useEffect(() => {
+    const saved = localStorage.getItem('sl-learn-stats');
+    if (saved) {
+      try {
+        const stats = JSON.parse(saved);
+        setTotalAnswered(stats.totalAnswered || 0);
+        setBestStreak(stats.bestStreak || 0);
+      } catch { /* ignore */ }
+    }
+    // Fetch topics from API (fallback already set)
+    fetch('/api/learn?topics=true')
+      .then(r => r.json())
+      .then(data => { if (data.topics?.length) setTopics(data.topics); })
+      .catch(() => { /* use fallback */ });
+  }, []);
+
+  const fetchQuestions = useCallback(async (topic?: string) => {
     setState('loading');
     setError(null);
     try {
-      const res = await fetch('/api/learn?count=10');
+      const params = new URLSearchParams({ count: '10' });
+      if (topic) params.set('topic', topic);
+      const res = await fetch(`/api/learn?${params}`);
       if (!res.ok) throw new Error('Failed to load');
       const data = await res.json();
       if (!data.terms?.length) {
-        setError('No vocabulary terms found. Check back soon.');
+        setError('No vocabulary terms found for this topic yet. Try another.');
         return;
       }
       setQuestions(data.terms);
@@ -51,18 +89,12 @@ export default function LearnQuiz() {
     }
   }, []);
 
-  useEffect(() => {
-    fetchQuestions();
-    // Load persisted stats
-    const saved = localStorage.getItem('sl-learn-stats');
-    if (saved) {
-      try {
-        const stats = JSON.parse(saved);
-        setTotalAnswered(stats.totalAnswered || 0);
-        setBestStreak(stats.bestStreak || 0);
-      } catch { /* ignore */ }
-    }
-  }, [fetchQuestions]);
+  const handleTopicSelect = (topicId: string | null) => {
+    setActiveTopic(topicId);
+    setScore(0);
+    setStreak(0);
+    fetchQuestions(topicId || undefined);
+  };
 
   const handleSelect = (idx: number) => {
     if (state !== 'question') return;
@@ -102,22 +134,77 @@ export default function LearnQuiz() {
   const handleNewRound = () => {
     setScore(0);
     setStreak(0);
-    fetchQuestions();
+    fetchQuestions(activeTopic || undefined);
   };
 
-  const q = questions[currentIdx];
+  const handleBackToTopics = () => {
+    setState('topics');
+    setActiveTopic(null);
+    setQuestions([]);
+    setScore(0);
+    setStreak(0);
+    setError(null);
+  };
 
-  if (error) {
+  // ── Topic selection screen ──
+  if (state === 'topics') {
     return (
-      <div className="max-w-xl mx-auto py-16 text-center">
-        <p className="text-secondary mb-6">{error}</p>
-        <button onClick={fetchQuestions} className="text-accent-rust hover:underline">
-          Try again
-        </button>
+      <div className="max-w-2xl mx-auto py-8 md:py-12">
+        <p className="text-secondary font-body text-lg mb-8 leading-relaxed">
+          Test your knowledge of historical terminology drawn from primary sources
+          in the Western esoteric tradition. Choose a topic or dive into everything.
+        </p>
+
+        {totalAnswered > 0 && (
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span>{totalAnswered} terms studied</span>
+            <span>Best streak: {bestStreak}</span>
+          </div>
+        )}
+
+        <div className="grid gap-3">
+          {/* "All topics" option */}
+          <button
+            onClick={() => handleTopicSelect(null)}
+            className="text-left p-5 rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] transition-colors"
+          >
+            <h3 className="font-serif text-xl text-primary mb-1">All Topics</h3>
+            <p className="text-sm text-muted">A mix of vocabulary from across the entire collection</p>
+          </button>
+
+          {topics.map(topic => (
+            <button
+              key={topic.id}
+              onClick={() => handleTopicSelect(topic.id)}
+              className="text-left p-5 rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] transition-colors"
+            >
+              <h3 className="font-serif text-xl text-primary mb-1">{topic.label}</h3>
+              <p className="text-sm text-muted">{topic.description}</p>
+            </button>
+          ))}
+        </div>
       </div>
     );
   }
 
+  // ── Error state ──
+  if (error) {
+    return (
+      <div className="max-w-xl mx-auto py-16 text-center">
+        <p className="text-secondary mb-6">{error}</p>
+        <div className="flex items-center justify-center gap-4">
+          <button onClick={handleBackToTopics} className="text-muted hover:text-primary transition-colors">
+            Back to topics
+          </button>
+          <button onClick={() => fetchQuestions(activeTopic || undefined)} className="text-accent-rust hover:underline">
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Loading state ──
   if (state === 'loading') {
     return (
       <div className="max-w-xl mx-auto py-16">
@@ -134,9 +221,12 @@ export default function LearnQuiz() {
     );
   }
 
+  // ── Round complete ──
   if (state === 'complete') {
+    const topicLabel = activeTopic ? topics.find(t => t.id === activeTopic)?.label : 'All Topics';
     return (
       <div className="max-w-xl mx-auto py-16 text-center">
+        <p className="text-sm text-muted uppercase tracking-wide mb-2">{topicLabel}</p>
         <h2 className="font-serif text-3xl text-primary mb-4">Round Complete</h2>
         <div className="text-6xl font-serif text-accent-rust mb-2">{score}/{questions.length}</div>
         <p className="text-secondary mb-8">
@@ -150,25 +240,43 @@ export default function LearnQuiz() {
           <span>Total answered: {totalAnswered}</span>
           <span>Best streak: {bestStreak}</span>
         </div>
-        <button
-          onClick={handleNewRound}
-          className="bg-[#1a1612] text-white px-8 py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
-        >
-          New round
-        </button>
+        <div className="flex items-center justify-center gap-4">
+          <button
+            onClick={handleBackToTopics}
+            className="px-6 py-3 rounded-lg border border-border-light text-primary hover:bg-stone-50 transition-colors"
+          >
+            Change topic
+          </button>
+          <button
+            onClick={handleNewRound}
+            className="bg-[#1a1612] text-white px-8 py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
+          >
+            Play again
+          </button>
+        </div>
       </div>
     );
   }
 
+  // ── Quiz question ──
+  const q = questions[currentIdx];
   if (!q) return null;
 
-  const isCorrect = selected === q.correctIndex;
   const bookHref = q.slug ? `/book/${q.slug}` : `/book/${q.bookId}`;
+  const isCorrect = selected === q.correctIndex;
+  const topicLabel = activeTopic ? topics.find(t => t.id === activeTopic)?.label : 'All Topics';
 
   return (
     <div className="max-w-2xl mx-auto py-8 md:py-12">
       {/* Progress bar */}
       <div className="flex items-center gap-3 mb-8">
+        <button
+          onClick={handleBackToTopics}
+          className="text-xs text-muted hover:text-primary transition-colors"
+          title="Back to topics"
+        >
+          {topicLabel}
+        </button>
         <div className="flex-1 h-1.5 bg-stone-200 rounded-full overflow-hidden">
           <div
             className="h-full bg-accent-rust transition-all duration-300 rounded-full"
@@ -193,11 +301,23 @@ export default function LearnQuiz() {
         </h2>
       </div>
 
-      {/* Context (shown before answering as a hint) */}
+      {/* Context with source attribution */}
       {q.originalContext && (
-        <div className="bg-white border border-border-light rounded-lg p-4 mb-8 text-sm text-secondary font-body leading-relaxed">
-          <span className="text-muted text-xs uppercase tracking-wide block mb-1">Context</span>
-          &ldquo;...{q.originalContext}...&rdquo;
+        <div className="bg-white border border-border-light rounded-lg p-4 mb-8">
+          <div className="text-sm text-secondary font-body leading-relaxed">
+            &ldquo;...{q.originalContext}...&rdquo;
+          </div>
+          <div className="mt-2 pt-2 border-t border-border-light flex items-center justify-between">
+            <span className="text-xs text-muted truncate mr-2">
+              {q.bookAuthor}, <em>{q.bookTitle}</em>{q.bookDate ? ` (${q.bookDate})` : ''}, p.{q.pageNumber}
+            </span>
+            <Link
+              href={`${bookHref}?page=${q.pageNumber}`}
+              className="text-xs text-accent-rust hover:underline whitespace-nowrap"
+            >
+              Read
+            </Link>
+          </div>
         </div>
       )}
 
@@ -227,33 +347,14 @@ export default function LearnQuiz() {
         })}
       </div>
 
-      {/* Post-answer: source info + next */}
+      {/* Post-answer: next button */}
       {state === 'answered' && (
-        <div className="space-y-4">
-          <div className="flex items-start gap-3 bg-warm rounded-lg p-4 border border-border-light">
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-primary truncate">{q.bookTitle}</p>
-              <p className="text-xs text-muted">
-                {q.bookAuthor}{q.bookDate ? `, ${q.bookDate}` : ''}
-                {q.bookLanguage ? ` · ${q.bookLanguage}` : ''}
-                {' · '}p.{q.pageNumber}
-              </p>
-            </div>
-            <Link
-              href={`${bookHref}?page=${q.pageNumber}`}
-              className="text-sm text-accent-rust hover:underline whitespace-nowrap"
-            >
-              Read in context
-            </Link>
-          </div>
-
-          <button
-            onClick={handleNext}
-            className="w-full bg-[#1a1612] text-white py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
-          >
-            {currentIdx + 1 >= questions.length ? 'See results' : 'Next'}
-          </button>
-        </div>
+        <button
+          onClick={handleNext}
+          className="w-full bg-[#1a1612] text-white py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
+        >
+          {currentIdx + 1 >= questions.length ? 'See results' : 'Next'}
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Follow-up to #1008. Improvements to `/learn`:

- **Topic picker landing screen** — 8 categories (Alchemy, Hermetica, Kabbalah, Astrology, Magic, Medicine, Philosophy, Rosicrucianism) plus "All Topics". Users choose before starting the quiz.
- **Source attribution on context** — the context quote now shows author, title, date, and page number with a "Read" link to the book
- **Answer leak fix** — strip definitions from context text so the answer isn't directly visible in the quote
- **Topic filtering** — API filters by collection membership when a topic is selected

## Test plan
- [ ] Visit `/learn` — see topic picker, not immediate quiz
- [ ] Select a topic — quiz loads with terms from that domain
- [ ] "All Topics" works as before
- [ ] Context quote shows source attribution with link
- [ ] Answers aren't directly readable in the context
- [ ] "Change topic" on round complete returns to picker
- [ ] Mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)