### PR TITLE
Fix artist browse: remove pages_count filter for visual works

### DIFF
--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -242,7 +242,6 @@ export async function browseArtists(letter: string): Promise<{ name: string; cou
       .from('books_catalog')
       .select('author')
       .eq('visible', true)
-      .gt('pages_count', 0)
       .in('resource_type', VISUAL_RESOURCE_TYPES)
       .ilike('author', `${letter}%`)
       .range(offset, offset + PAGE - 1);


### PR DESCRIPTION
Visual artworks are single-page catalog entries with pages_count=0. The browseArtists query was filtering all 6,463 visual works out with `.gt('pages_count', 0)`, producing 0 results on /browse/artists.

One-line fix: remove that filter.