### PR TITLE
Librarian streaming + Iconclass subject browser (#903)

### DIFF
--- a/scripts/compute-iconclass-tree.mjs
+++ b/scripts/compute-iconclass-tree.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Pre-compute Iconclass category tree with counts and representative thumbnails.
+ * Stores result in system_config._id: 'iconclass_tree'.
+ *
+ * Usage: set -a; source .env.production.local; set +a; node scripts/compute-iconclass-tree.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set');
+  process.exit(1);
+}
+
+const TOP_DIVISIONS = [
+  { code: '0', label: 'Abstract Art' },
+  { code: '1', label: 'Religion & Magic' },
+  { code: '2', label: 'Nature' },
+  { code: '3', label: 'Human Figure' },
+  { code: '4', label: 'Society & Culture' },
+  { code: '5', label: 'Ideas & Concepts' },
+  { code: '6', label: 'History' },
+  { code: '7', label: 'Bible' },
+  { code: '8', label: 'Literature' },
+  { code: '9', label: 'Classical Mythology' },
+];
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  console.log('Aggregating gallery_images iconclass codes...');
+  const galleryAgg = await db.collection('gallery_images').aggregate([
+    { $match: { 'metadata.iconclass': { $exists: true, $ne: [] } } },
+    { $unwind: '$metadata.iconclass' },
+    {
+      $group: {
+        _id: '$metadata.iconclass',
+        count: { $sum: 1 },
+        sample_url: { $first: '$thumbnail_url' },
+        sample_extracted: { $first: '$extracted_url' },
+      },
+    },
+    { $sort: { count: -1 } },
+  ], { maxTimeMS: 120000, allowDiskUse: true }).toArray();
+  console.log(`  ${galleryAgg.length} unique gallery codes`);
+
+  console.log('Aggregating artworks iconclass codes...');
+  const artworkAgg = await db.collection('books').aggregate([
+    { $match: { 'enrichment.iconclass': { $exists: true, $ne: [] }, resource_type: { $exists: true } } },
+    { $unwind: '$enrichment.iconclass' },
+    {
+      $group: {
+        _id: '$enrichment.iconclass',
+        count: { $sum: 1 },
+        sample_url: { $first: '$thumbnail' },
+      },
+    },
+    { $sort: { count: -1 } },
+  ], { maxTimeMS: 120000, allowDiskUse: true }).toArray();
+  console.log(`  ${artworkAgg.length} unique artwork codes`);
+
+  // Merge into a single map: code -> { gallery_count, artwork_count, thumbnail }
+  const codeMap = new Map();
+  for (const g of galleryAgg) {
+    codeMap.set(g._id, {
+      gallery_count: g.count,
+      artwork_count: 0,
+      thumbnail: g.sample_url || g.sample_extracted || null,
+    });
+  }
+  for (const a of artworkAgg) {
+    const existing = codeMap.get(a._id);
+    if (existing) {
+      existing.artwork_count = a.count;
+      if (!existing.thumbnail && a.sample_url) existing.thumbnail = a.sample_url;
+    } else {
+      codeMap.set(a._id, {
+        gallery_count: 0,
+        artwork_count: a.count,
+        thumbnail: a.sample_url || null,
+      });
+    }
+  }
+
+  // Build hierarchy: aggregate counts up to parent codes
+  // For each code, compute prefix counts at each level
+  const prefixCounts = new Map(); // prefix -> { count, thumbnail, children: Set }
+
+  for (const [code, data] of codeMap) {
+    const total = data.gallery_count + data.artwork_count;
+
+    // Add the full code as a leaf
+    if (!prefixCounts.has(code)) {
+      prefixCounts.set(code, { count: 0, gallery_count: 0, artwork_count: 0, thumbnail: null, children: new Set() });
+    }
+    const leaf = prefixCounts.get(code);
+    leaf.count += total;
+    leaf.gallery_count += data.gallery_count;
+    leaf.artwork_count += data.artwork_count;
+    if (!leaf.thumbnail && data.thumbnail) leaf.thumbnail = data.thumbnail;
+
+    // Aggregate up to parent prefixes
+    for (let len = 1; len < code.length; len++) {
+      const prefix = code.slice(0, len);
+      if (!prefixCounts.has(prefix)) {
+        prefixCounts.set(prefix, { count: 0, gallery_count: 0, artwork_count: 0, thumbnail: null, children: new Set() });
+      }
+      const node = prefixCounts.get(prefix);
+      node.count += total;
+      node.gallery_count += data.gallery_count;
+      node.artwork_count += data.artwork_count;
+      if (!node.thumbnail && data.thumbnail) node.thumbnail = data.thumbnail;
+
+      // Track immediate children (next level only)
+      const childPrefix = code.slice(0, len + 1);
+      if (childPrefix.length <= code.length) {
+        node.children.add(childPrefix);
+      }
+    }
+  }
+
+  // Build the tree document
+  // Top-level: the 10 divisions
+  const nodes = {};
+  for (const div of TOP_DIVISIONS) {
+    const data = prefixCounts.get(div.code);
+    if (!data || data.count === 0) continue;
+
+    // Get immediate children with significant counts
+    const children = [...data.children]
+      .filter(c => {
+        const cd = prefixCounts.get(c);
+        return cd && cd.count >= 3; // minimum threshold
+      })
+      .sort((a, b) => (prefixCounts.get(b)?.count || 0) - (prefixCounts.get(a)?.count || 0))
+      .slice(0, 30); // cap children per node
+
+    nodes[div.code] = {
+      label: div.label,
+      count: data.count,
+      gallery_count: data.gallery_count,
+      artwork_count: data.artwork_count,
+      thumbnail: data.thumbnail,
+      children,
+    };
+
+    // Add sub-nodes (2 levels deep from top)
+    for (const childCode of children) {
+      const childData = prefixCounts.get(childCode);
+      if (!childData) continue;
+
+      const grandchildren = [...childData.children]
+        .filter(c => {
+          const cd = prefixCounts.get(c);
+          return cd && cd.count >= 3;
+        })
+        .sort((a, b) => (prefixCounts.get(b)?.count || 0) - (prefixCounts.get(a)?.count || 0))
+        .slice(0, 20);
+
+      nodes[childCode] = {
+        count: childData.count,
+        gallery_count: childData.gallery_count,
+        artwork_count: childData.artwork_count,
+        thumbnail: childData.thumbnail,
+        children: grandchildren,
+      };
+
+      // One more level
+      for (const gcCode of grandchildren) {
+        const gcData = prefixCounts.get(gcCode);
+        if (!gcData) continue;
+
+        const ggChildren = [...gcData.children]
+          .filter(c => {
+            const cd = prefixCounts.get(c);
+            return cd && cd.count >= 3;
+          })
+          .sort((a, b) => (prefixCounts.get(b)?.count || 0) - (prefixCounts.get(a)?.count || 0))
+          .slice(0, 15);
+
+        nodes[gcCode] = {
+          count: gcData.count,
+          gallery_count: gcData.gallery_count,
+          artwork_count: gcData.artwork_count,
+          thumbnail: gcData.thumbnail,
+          children: ggChildren,
+        };
+      }
+    }
+  }
+
+  const treeDoc = {
+    _id: 'iconclass_tree',
+    nodes,
+    total_codes: codeMap.size,
+    total_items: [...codeMap.values()].reduce((sum, d) => sum + d.gallery_count + d.artwork_count, 0),
+    updated_at: new Date(),
+  };
+
+  console.log(`\nTree: ${Object.keys(nodes).length} nodes, ${treeDoc.total_codes} unique codes, ${treeDoc.total_items} total items`);
+
+  // Top-level summary
+  for (const div of TOP_DIVISIONS) {
+    const n = nodes[div.code];
+    if (n) console.log(`  ${div.code} ${div.label}: ${n.count.toLocaleString()} (${n.children.length} sub-categories)`);
+  }
+
+  await db.collection('system_config').replaceOne(
+    { _id: 'iconclass_tree' },
+    treeDoc,
+    { upsert: true }
+  );
+  console.log('\nSaved to system_config.iconclass_tree');
+
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -150,7 +150,6 @@ export async function POST(request: NextRequest) {
             break;
 
           case 'text':
-            // Send as 'chunk' for backward compat with the existing UI
             fullText += step.text || '';
             await send({ type: 'chunk', text: step.text });
             break;

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -92,6 +92,23 @@ export default function BrowsePage() {
         </div>
       </section>
 
+      {/* By Subject */}
+      <section className="mb-12">
+        <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+          By Subject
+        </h2>
+        <p className="text-sm mb-4" style={{ color: 'var(--text-muted)' }}>
+          Browse illustrations and artworks by visual subject using the Iconclass classification system.
+        </p>
+        <Link
+          href="/browse/subjects"
+          className="inline-flex items-center gap-2 rounded-lg px-4 py-3 text-sm font-medium transition-colors hover:opacity-80"
+          style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-light)' }}
+        >
+          Browse by Subject →
+        </Link>
+      </section>
+
       {/* By Period */}
       <section className="mb-12">
         <h2 className="text-xl font-display mb-4" style={{ color: 'var(--text-primary)' }}>

--- a/src/app/browse/subjects/[...code]/page.tsx
+++ b/src/app/browse/subjects/[...code]/page.tsx
@@ -1,0 +1,278 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { getReadDb } from '@/lib/mongodb';
+import {
+  ICONCLASS_DIVISIONS,
+  getIconclassLabel,
+  buildIconclassPath,
+} from '@/lib/iconclass-categories';
+
+export const revalidate = 86400;
+export const dynamicParams = true;
+
+export function generateStaticParams() {
+  return [];
+}
+
+interface CategoryNode {
+  label?: string;
+  count: number;
+  gallery_count: number;
+  artwork_count: number;
+  thumbnail: string | null;
+  children: string[];
+}
+
+interface GalleryImage {
+  id: string;
+  extracted_url?: string;
+  thumbnail_url?: string;
+  description?: string;
+  book_title?: string;
+  book_author?: string;
+  book_id?: string;
+  book_slug?: string;
+}
+
+interface Props {
+  params: Promise<{ code: string[] }>;
+}
+
+async function getIconclassTree(db: any) {
+  const doc = await db.collection('system_config').findOne({ _id: 'iconclass_tree' as any });
+  return doc?.nodes as Record<string, CategoryNode> | undefined;
+}
+
+async function getImagesForCode(db: any, code: string, limit = 48): Promise<GalleryImage[]> {
+  const escapedCode = code.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const images = await db.collection('gallery_images')
+    .find(
+      { 'metadata.iconclass': { $regex: `^${escapedCode}` } },
+      {
+        projection: {
+          id: 1, extracted_url: 1, thumbnail_url: 1, description: 1,
+          book_title: 1, book_author: 1, book_id: 1, book_slug: 1,
+        },
+      },
+    )
+    .sort({ gallery_quality: -1 })
+    .limit(limit)
+    .toArray();
+
+  return images.map((img: any) => ({
+    id: img.id || img._id?.toString(),
+    extracted_url: img.extracted_url,
+    thumbnail_url: img.thumbnail_url,
+    description: img.description,
+    book_title: img.book_title,
+    book_author: img.book_author,
+    book_id: img.book_id,
+    book_slug: img.book_slug,
+  }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { code: codeSegments } = await params;
+  const code = codeSegments.join('');
+  const label = getIconclassLabel(code) || `Iconclass ${code}`;
+  return {
+    title: `${label} | Browse by Subject | Source Library`,
+    description: `Browse ${label} illustrations and artworks in the Source Library collection, classified with Iconclass code ${code}.`,
+    alternates: { canonical: `/browse/subjects/${code}` },
+  };
+}
+
+export default async function SubjectCategoryPage({ params }: Props) {
+  const { code: codeSegments } = await params;
+  const code = codeSegments.join('');
+
+  let db;
+  try {
+    db = await getReadDb();
+  } catch {
+    notFound();
+  }
+
+  const nodes = await getIconclassTree(db);
+  if (!nodes) notFound();
+
+  const node = nodes[code];
+
+  // Build breadcrumb path
+  const path = buildIconclassPath(code);
+  const label = getIconclassLabel(code) || node?.label || `Iconclass ${code}`;
+
+  // Determine if this is a category page (has children) or a leaf (show images)
+  const hasChildren = node && node.children.length > 0;
+  const isLeaf = !hasChildren || (node && node.children.length <= 2 && node.count < 200);
+
+  // For leaf nodes or nodes with few children, also fetch images
+  const images = isLeaf ? await getImagesForCode(db, code) : [];
+
+  // For category nodes, get child data
+  const children = hasChildren
+    ? node.children
+        .map(childCode => ({
+          code: childCode,
+          label: getIconclassLabel(childCode) || nodes[childCode]?.label || childCode,
+          count: nodes[childCode]?.count || 0,
+          thumbnail: nodes[childCode]?.thumbnail || null,
+        }))
+        .filter(c => c.count > 0)
+        .sort((a, b) => b.count - a.count)
+    : [];
+
+  return (
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-6xl mx-auto px-6 md:px-12 py-12 md:py-20">
+        {/* Breadcrumb */}
+        <nav className="flex flex-wrap items-center gap-1.5 text-sm mb-8" style={{ color: 'var(--text-muted)' }}>
+          <Link href="/browse/subjects" className="hover:underline">Subjects</Link>
+          {path.map(p => (
+            <span key={p.code} className="flex items-center gap-1.5">
+              <span style={{ color: 'var(--border-medium)' }}>/</span>
+              {p.code === code ? (
+                <span style={{ color: 'var(--text-primary)' }}>{p.label}</span>
+              ) : (
+                <Link href={`/browse/subjects/${p.code}`} className="hover:underline">{p.label}</Link>
+              )}
+            </span>
+          ))}
+          {!path.some(p => p.code === code) && (
+            <span className="flex items-center gap-1.5">
+              <span style={{ color: 'var(--border-medium)' }}>/</span>
+              <span style={{ color: 'var(--text-primary)' }}>{label}</span>
+            </span>
+          )}
+        </nav>
+
+        {/* Header */}
+        <div className="mb-10">
+          <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+            {label}
+          </h1>
+          <div className="flex items-center gap-4">
+            <p style={{ color: 'var(--text-muted)' }}>
+              {node ? `${node.count.toLocaleString()} images` : 'No indexed images'}
+              {node && node.gallery_count > 0 && node.artwork_count > 0 && (
+                <span className="text-sm ml-2">
+                  ({node.gallery_count.toLocaleString()} illustrations, {node.artwork_count.toLocaleString()} artworks)
+                </span>
+              )}
+            </p>
+            <a
+              href={`https://iconclass.org/${encodeURIComponent(code)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-mono px-2 py-0.5 rounded"
+              style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)', border: '1px solid var(--border-light)' }}
+            >
+              {code} ↗
+            </a>
+          </div>
+        </div>
+
+        {/* Sub-categories grid */}
+        {children.length > 0 && (
+          <section className="mb-12">
+            <h2 className="text-lg font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+              Sub-categories
+            </h2>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+              {children.map(child => (
+                <Link
+                  key={child.code}
+                  href={`/browse/subjects/${child.code}`}
+                  className="group relative rounded-xl overflow-hidden transition-shadow hover:shadow-lg"
+                  style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
+                >
+                  <div className="aspect-[4/3] relative">
+                    {child.thumbnail ? (
+                      <Image
+                        src={child.thumbnail}
+                        alt={child.label}
+                        fill
+                        sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                        className="object-cover group-hover:scale-105 transition-transform duration-300"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-2xl opacity-20" style={{ color: 'var(--text-muted)' }}>
+                        {child.code}
+                      </div>
+                    )}
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+                  </div>
+                  <div className="absolute bottom-0 left-0 right-0 p-3">
+                    <p className="text-white font-display text-sm leading-tight">{child.label}</p>
+                    <p className="text-white/70 text-xs mt-0.5">
+                      <span className="font-mono">{child.code}</span> · {child.count.toLocaleString()}
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Image grid for leaf nodes */}
+        {images.length > 0 && (
+          <section>
+            {children.length > 0 && (
+              <h2 className="text-lg font-display mb-4" style={{ color: 'var(--text-primary)' }}>
+                Images
+              </h2>
+            )}
+            <div className="columns-2 sm:columns-3 lg:columns-4 gap-4">
+              {images.map(img => (
+                <div key={img.id} className="break-inside-avoid mb-4">
+                  <Link
+                    href={img.book_slug ? `/book/${img.book_slug}` : `/book/${img.book_id}`}
+                    className="block group rounded-lg overflow-hidden transition-shadow hover:shadow-lg"
+                    style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
+                  >
+                    <div className="relative">
+                      <Image
+                        src={img.extracted_url || img.thumbnail_url || ''}
+                        alt={img.description || `Image from ${img.book_title || 'unknown book'}`}
+                        width={400}
+                        height={400}
+                        sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                        className="w-full h-auto group-hover:opacity-90 transition-opacity"
+                      />
+                    </div>
+                    {(img.book_title || img.description) && (
+                      <div className="p-2">
+                        {img.description && (
+                          <p className="text-xs leading-snug line-clamp-2" style={{ color: 'var(--text-primary)' }}>
+                            {img.description}
+                          </p>
+                        )}
+                        {img.book_title && (
+                          <p className="text-xs mt-1 italic line-clamp-1" style={{ color: 'var(--text-muted)' }}>
+                            {img.book_title}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </Link>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {!node && images.length === 0 && (
+          <p style={{ color: 'var(--text-muted)' }}>
+            No images found for this Iconclass code. Try browsing a{' '}
+            <Link href="/browse/subjects" className="underline">broader category</Link>.
+          </p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app/browse/subjects/page.tsx
+++ b/src/app/browse/subjects/page.tsx
@@ -1,0 +1,120 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { getReadDb } from '@/lib/mongodb';
+import { ICONCLASS_DIVISIONS } from '@/lib/iconclass-categories';
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: 'Browse by Subject | Source Library',
+  description: 'Explore illustrations and artworks through the Iconclass visual classification system — from alchemy and mythology to natural history and sacred texts.',
+  alternates: { canonical: '/browse/subjects' },
+};
+
+interface CategoryNode {
+  label: string;
+  count: number;
+  gallery_count: number;
+  artwork_count: number;
+  thumbnail: string | null;
+  children: string[];
+}
+
+async function getIconclassTree(): Promise<{ nodes: Record<string, CategoryNode>; total_items: number } | null> {
+  try {
+    const db = await getReadDb();
+    const doc = await db.collection('system_config').findOne({ _id: 'iconclass_tree' as any });
+    if (!doc) return null;
+    return { nodes: doc.nodes as Record<string, CategoryNode>, total_items: doc.total_items as number };
+  } catch {
+    return null;
+  }
+}
+
+export default async function SubjectsPage() {
+  const tree = await getIconclassTree();
+
+  return (
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-6xl mx-auto px-6 md:px-12 py-12 md:py-20">
+        <div className="mb-12">
+          <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+            Browse by Subject
+          </h1>
+          <p className="text-lg" style={{ color: 'var(--text-muted)' }}>
+            Explore {tree ? tree.total_items.toLocaleString() : ''} classified images through the{' '}
+            <a
+              href="https://iconclass.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline decoration-dotted underline-offset-2 hover:decoration-solid"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              Iconclass
+            </a>{' '}
+            visual classification system.
+          </p>
+        </div>
+
+        {!tree ? (
+          <p style={{ color: 'var(--text-muted)' }}>
+            Subject index is being computed. Check back shortly.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+            {ICONCLASS_DIVISIONS.map(div => {
+              const node = tree.nodes[div.code];
+              if (!node || node.count === 0) return null;
+
+              return (
+                <Link
+                  key={div.code}
+                  href={`/browse/subjects/${div.code}`}
+                  className="group relative rounded-xl overflow-hidden transition-shadow hover:shadow-lg"
+                  style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
+                >
+                  <div className="aspect-[4/3] relative">
+                    {node.thumbnail ? (
+                      <Image
+                        src={node.thumbnail}
+                        alt={div.label}
+                        fill
+                        sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
+                        className="object-cover group-hover:scale-105 transition-transform duration-300"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-4xl opacity-30">
+                        {div.icon}
+                      </div>
+                    )}
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+                  </div>
+                  <div className="absolute bottom-0 left-0 right-0 p-3">
+                    <p className="text-white font-display text-sm leading-tight">{div.label}</p>
+                    <p className="text-white/70 text-xs mt-0.5">
+                      {node.count.toLocaleString()} images
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="mt-16 pt-8" style={{ borderTop: '1px solid var(--border-light)' }}>
+          <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            Classification powered by{' '}
+            <a href="https://iconclass.org" target="_blank" rel="noopener noreferrer" className="underline">
+              Iconclass
+            </a>
+            , the international standard for describing visual subjects in art.
+            Codes assigned by Gemini AI during image extraction.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -516,9 +516,11 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
                     const assistant = msg as AssistantMessage;
                     return (
                       <div key={i} className="flex gap-3">
-                        <div className="flex-shrink-0 w-8 h-8 rounded-full bg-[#f5f0e8] flex items-center justify-center text-[#c9a86c] text-sm" style={{ fontFamily: 'serif' }}>
-                          &#x2609;
-                        </div>
+                        <img
+                          src="/brand/png/logo-compact--black-on-transparent--96h.png"
+                          alt="Librarian"
+                          className="flex-shrink-0 w-10 h-10 rounded-full"
+                        />
                         <div className="max-w-[85%] min-w-0">
                           {/* Thinking (collapsible) */}
                           {assistant.thinking && (

--- a/src/components/gallery/IconclassFilter.tsx
+++ b/src/components/gallery/IconclassFilter.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 
 /**
  * Iconclass top-level categories for gallery filtering.
@@ -171,6 +172,15 @@ export default function IconclassFilter({ value, onChange, compact = false }: Ic
           </button>
         )}
       </div>
+
+      {/* Browse all subjects link */}
+      <Link
+        href="/browse/subjects"
+        className="text-xs hover:underline"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        Browse all subjects →
+      </Link>
 
       {/* Show active code as linked badge */}
       {value && (

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -361,7 +361,7 @@ async function executeTool(
       if (data.passages.length > 0) {
         context += '\nPassages found:\n';
         for (const p of data.passages) {
-          const url = `https://sourcelibrary.org/book/${p.bookSlug || p.book_id}/page/${p.page_number}`;
+          const url = `https://sourcelibrary.org/book/${p.bookSlug || p.book_id}/page-number/${p.page_number}`;
           context += `\n--- ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number} (${url}) ---\n${p.text}\n`;
         }
       }
@@ -492,7 +492,7 @@ You are a research librarian. When a user asks a question:
 
 4. **Be honest about what you find and what you don't.** If a hypothesis doesn't pan out, say so. If a relevant book isn't in the collection, mention it as a gap. "We don't have Ficino's De Vita yet, but Agrippa covers similar ground."
 
-5. **Cite precisely.** Every claim grounded in the collection must include the full URL: https://sourcelibrary.org/book/{slug}/page/{N}. Use the format: "quoted text" — *Title* by Author, [Page N](url).
+5. **Cite precisely.** Every claim grounded in the collection must include the full URL: https://sourcelibrary.org/book/{slug}/page-number/{N}. Use the format: "quoted text" — *Title* by Author, [Page N](url).
 
 ## IMPORTANT: Present a plan before searching
 

--- a/src/lib/iconclass-categories.ts
+++ b/src/lib/iconclass-categories.ts
@@ -1,0 +1,115 @@
+/**
+ * Iconclass top-level divisions and curated sub-categories.
+ * Shared between the subject browser and gallery filter.
+ */
+
+export interface IconclassCategory {
+  code: string;
+  label: string;
+  icon: string;
+}
+
+export interface IconclassSubCategory {
+  code: string;
+  label: string;
+}
+
+export const ICONCLASS_DIVISIONS: IconclassCategory[] = [
+  { code: '0', label: 'Abstract Art', icon: '◇' },
+  { code: '1', label: 'Religion & Magic', icon: '✦' },
+  { code: '2', label: 'Nature', icon: '❧' },
+  { code: '3', label: 'Human Figure', icon: '☉' },
+  { code: '4', label: 'Society & Culture', icon: '⚙' },
+  { code: '5', label: 'Ideas & Concepts', icon: '◈' },
+  { code: '6', label: 'History', icon: '⏳' },
+  { code: '7', label: 'Bible', icon: '✝' },
+  { code: '8', label: 'Literature', icon: '📜' },
+  { code: '9', label: 'Classical Mythology', icon: '⚡' },
+];
+
+export const ICONCLASS_SUB_CATEGORIES: Record<string, IconclassSubCategory[]> = {
+  '1': [
+    { code: '11H', label: 'Saints' },
+    { code: '12', label: 'Non-Christian Religions' },
+    { code: '14', label: 'Astrology & Prophecy' },
+  ],
+  '2': [
+    { code: '21', label: 'Elements' },
+    { code: '22', label: 'Natural Phenomena' },
+    { code: '25F', label: 'Animals' },
+    { code: '25FF', label: 'Fabulous Creatures' },
+    { code: '25G', label: 'Plants & Trees' },
+  ],
+  '3': [
+    { code: '31A', label: 'Nude Figure' },
+    { code: '31A1', label: 'Proportions' },
+  ],
+  '4': [
+    { code: '41', label: 'Domestic Life' },
+    { code: '44', label: 'Government' },
+    { code: '48A98', label: 'Writing & Calligraphy' },
+    { code: '48C', label: 'Emblems & Allegories' },
+    { code: '49C', label: 'Chemistry' },
+    { code: '49E39', label: 'Alchemy' },
+    { code: '49E393', label: 'Alchemical Equipment' },
+  ],
+  '5': [
+    { code: '52', label: 'Knowledge & Learning' },
+    { code: '53', label: 'Astrology in Practice' },
+  ],
+  '7': [
+    { code: '71', label: 'Old Testament' },
+    { code: '73', label: 'New Testament' },
+  ],
+  '9': [
+    { code: '92', label: 'Classical Gods' },
+    { code: '95', label: 'Greek History' },
+    { code: '97', label: 'Metamorphoses (Ovid)' },
+  ],
+};
+
+/** Get the label for a code from our curated lists, or null if unknown. */
+export function getIconclassLabel(code: string): string | null {
+  const div = ICONCLASS_DIVISIONS.find(d => d.code === code);
+  if (div) return div.label;
+  for (const subs of Object.values(ICONCLASS_SUB_CATEGORIES)) {
+    const sub = subs.find(s => s.code === code);
+    if (sub) return sub.label;
+  }
+  return null;
+}
+
+/** Get the parent code for a given code. Returns null for top-level. */
+export function getParentCode(code: string): string | null {
+  if (code.length <= 1) return null;
+  // Try progressively shorter prefixes against our known categories
+  for (let i = code.length - 1; i >= 1; i--) {
+    const prefix = code.slice(0, i);
+    if (ICONCLASS_DIVISIONS.some(d => d.code === prefix)) return prefix;
+    for (const subs of Object.values(ICONCLASS_SUB_CATEGORIES)) {
+      if (subs.some(s => s.code === prefix)) return prefix;
+    }
+  }
+  // Default: first character is the top-level division
+  return code[0];
+}
+
+/** Build breadcrumb path from a code. */
+export function buildIconclassPath(code: string): Array<{ code: string; label: string }> {
+  const path: Array<{ code: string; label: string }> = [];
+  // Always start with the top-level division
+  const divCode = code[0];
+  const div = ICONCLASS_DIVISIONS.find(d => d.code === divCode);
+  if (div) path.push({ code: div.code, label: div.label });
+
+  // Add intermediate levels if they exist in our curated list
+  if (code.length > 1) {
+    for (const sub of ICONCLASS_SUB_CATEGORIES[divCode] || []) {
+      if (code.startsWith(sub.code) && sub.code !== code) {
+        path.push({ code: sub.code, label: sub.label });
+      }
+    }
+  }
+
+  return path;
+}


### PR DESCRIPTION
## Summary

- **Librarian streaming:** Switch from `generateContent` to `generateContentStream` so Librarian responses stream token-by-token instead of arriving all at once. Added `text_chunk`/`reclassify` event types for handling streaming text that may be reclassified as thinking.
- **Librarian avatar:** Replace 32px sun symbol with 40px Source Library circle logo.
- **Librarian 404 fix:** Page links were using `/page/297` (page number) but the route expects page IDs. Switched to `/page-number/N` redirect route.
- **Iconclass subject browser (#903):** New `/browse/subjects` taxonomy landing page for browsing 76K+ classified images through the Iconclass visual classification system. Drill-down from top-level categories through sub-categories to leaf image grids. Pre-computation script aggregates counts across gallery_images and artworks.

## New files
- `src/app/browse/subjects/page.tsx` — landing page with top-level Iconclass divisions
- `src/app/browse/subjects/[...code]/page.tsx` — category drill-down and leaf image grids  
- `src/lib/iconclass-categories.ts` — shared Iconclass labels, path building, lookups
- `scripts/compute-iconclass-tree.mjs` — pre-computation for category counts + thumbnails

## Test plan
- [ ] Run `compute-iconclass-tree.mjs` to populate `system_config.iconclass_tree`
- [ ] Visit `/browse/subjects` — verify top-level category grid with images and counts
- [ ] Click into a category — verify sub-categories render with breadcrumbs
- [ ] Drill to a leaf node — verify image grid loads
- [ ] Test Librarian chat — verify responses stream incrementally
- [ ] Test Librarian page links — verify they resolve (no 404s)
- [ ] Verify gallery IconclassFilter shows "Browse all subjects" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)