### PR TITLE
Fix encyclopedia query perf: 20s → 2ms per page

### DIFF
--- a/src/app/encyclopedia/[name]/layout.tsx
+++ b/src/app/encyclopedia/[name]/layout.tsx
@@ -26,7 +26,11 @@ export interface SharedConnection {
 export const getSharedBooks = cache(async (name: string): Promise<SharedConnection[] | null> => {
   try {
     const db = await getReadDb();
+    // Exact match uses name index (2ms). Regex fallback scans 625K docs (20s).
     const entity = await db.collection('entities').findOne(
+      { name },
+      { sort: { book_count: -1 } }
+    ) ?? await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },
       { sort: { book_count: -1 } }
     );
@@ -74,7 +78,11 @@ export const getSharedBooks = cache(async (name: string): Promise<SharedConnecti
 export const getEntity = cache(async (name: string) => {
   try {
     const db = await getReadDb();
+    // Exact match uses name index (2ms). Regex fallback scans 625K docs (20s).
     const entity = await db.collection('entities').findOne(
+      { name },
+      { sort: { book_count: -1 } }
+    ) ?? await db.collection('entities').findOne(
       { name: { $regex: `^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, $options: 'i' } },
       { sort: { book_count: -1 } }
     );

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -56,6 +56,10 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: 'FacebookBot',
         disallow: '/',
       },
+      {
+        userAgent: 'Applebot',
+        disallow: '/',
+      },
 
       // AI assistants: welcome to use the API and llms.txt
       // GPTBot, Claude-Web, etc. — access the structured API


### PR DESCRIPTION
## Summary
- Encyclopedia entity lookups used case-insensitive regex (`$options: 'i'`), which bypasses the `name_1_type_1` index — scanning all 625K entities (20s) per cold ISR build
- With bots hitting ~96K encyclopedia URLs/week, many are cold builds triggering full collection scans on Atlas
- Fix: try exact match first (2ms, indexed), regex fallback only for case mismatches (~1% of requests)
- Also blocks Applebot in robots.txt (55K requests/week, 0 referrals)

## Evidence
```
REGEX:  keysExamined: 625808, docsExamined: 625808, executionTimeMs: 20217
EXACT:  keysExamined: 2,      docsExamined: 2,      executionTimeMs: 2
```

## Test plan
- [ ] Visit https://sourcelibrary.org/encyclopedia/Hermes%20Trismegistus on preview deploy
- [ ] Verify page loads quickly and content renders correctly
- [ ] Check Atlas metrics for reduced query load after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)