### PR TITLE
Unique collection card images: prefer gallery crops, deduplicate heroes

### DIFF
--- a/scripts/thumbnails/backfill-collection-images.mjs
+++ b/scripts/thumbnails/backfill-collection-images.mjs
@@ -76,7 +76,8 @@ function thematicRelevance(image, collectionKeywords) {
 async function run() {
   const client = await MongoClient.connect(process.env.MONGODB_URI, {
     serverSelectionTimeoutMS: 30000,
-    socketTimeoutMS: 60000,
+    socketTimeoutMS: 120000,
+    maxIdleTimeMS: 60000,
   });
   const db = client.db('bookstore');
 
@@ -195,6 +196,9 @@ async function run() {
     for (const img of candidates) {
       img._relevance = thematicRelevance(img, colKeywords);
       img._total_score = (img._quality_score || 0) + img._relevance;
+      // Strong bonus for images with proper gallery crops (thumbnail/extracted).
+      // Raw page URLs show full scans including margins, bookplates, ex-libris.
+      if (img.thumbnail_url || img.extracted_url) img._total_score += 20;
     }
     candidates.sort((a, b) => b._total_score - a._total_score);
 
@@ -239,14 +243,28 @@ async function run() {
 
   console.log(`Reordered ${reordered} collections to avoid duplicate thumbnails`);
 
-  // Phase 3: Write to DB
+  // Phase 3: Write to DB with a fresh connection (long query phase can stale the first)
   if (!DRY_RUN) {
-    for (const col of pending) {
-      await db.collection('collections').updateOne(
-        { slug: col.slug },
-        { $set: { featured_images: col.images } }
-      );
+    await client.close();
+    const writeClient = await MongoClient.connect(process.env.MONGODB_URI, {
+      serverSelectionTimeoutMS: 30000,
+      socketTimeoutMS: 60000,
+    });
+    const writeDb = writeClient.db('bookstore');
+    const ops = pending.map(col => ({
+      updateOne: {
+        filter: { slug: col.slug },
+        update: { $set: { featured_images: col.images } },
+      },
+    }));
+    // Batch in chunks of 50 to avoid timeout
+    for (let i = 0; i < ops.length; i += 50) {
+      const chunk = ops.slice(i, i + 50);
+      await writeDb.collection('collections').bulkWrite(chunk, { ordered: false });
+      console.log(`  Written ${Math.min(i + 50, ops.length)}/${ops.length}`);
     }
+    await writeClient.close();
+    return { populated, noImages, noBooks, reordered };
   }
 
   console.log('\n--- Results ---');

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -685,7 +685,9 @@ export default async function CollectionDetailPage({ params }: Props) {
             <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
               {childCollections.map((child) => {
                 const hero = child.featured_images?.find(
-                  (img) => img.thumbnail_url || img.extracted_url || img.image_url
+                  (img) => img.thumbnail_url || img.extracted_url
+                ) || child.featured_images?.find(
+                  (img) => img.image_url
                 );
                 const heroUrl = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
                 return (

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -104,8 +104,11 @@ async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total:
 }
 
 function CollectionCard({ col, priority = false }: { col: CollectionDoc; priority?: boolean }) {
+  // Prefer images with proper gallery crops (thumbnail/extracted) over raw page URLs
   const hero = col.featured_images?.find(
-    img => img.thumbnail_url || img.extracted_url || img.image_url
+    img => img.thumbnail_url || img.extracted_url
+  ) || col.featured_images?.find(
+    img => img.image_url
   );
   // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
   const heroUrl = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;

--- a/src/app/curated/page.tsx
+++ b/src/app/curated/page.tsx
@@ -43,7 +43,9 @@ interface CuratedCollection {
 
 function getHeroImage(col: CuratedCollection): string | undefined {
   const hero = col.featured_images?.find(
-    (img) => img.thumbnail_url || img.extracted_url || img.image_url,
+    (img) => img.thumbnail_url || img.extracted_url,
+  ) || col.featured_images?.find(
+    (img) => img.image_url,
   );
   // Prefer thumbnail for card grids — extracted images are ~2MB vs ~38KB thumbnails
   const raw = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;

--- a/src/components/home/CollectionsShowcase.tsx
+++ b/src/components/home/CollectionsShowcase.tsx
@@ -19,7 +19,9 @@ export interface CollectionSummary {
 
 function CollectionCard({ col, size }: { col: CollectionSummary; size: 'large' | 'small' }) {
   const hero = col.featured_images?.find(
-    img => img.thumbnail_url || img.extracted_url || img.image_url
+    img => img.thumbnail_url || img.extracted_url
+  ) || col.featured_images?.find(
+    img => img.image_url
   );
   const heroUrl = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
   const topLangs = (col.languages || []).slice(0, 3).map(l => l.lang).join(', ');


### PR DESCRIPTION
## Summary
- All 4 collection card components now prefer images with proper gallery crops (`thumbnail_url`/`extracted_url`) over raw page scan URLs that show margins, bookplates, and ex-libris stamps
- Backfill script updated with +20 score bonus for gallery-cropped images, fresh DB connection for writes (fixes Atlas timeout), and bulkWrite batching
- **Fixes:** Secret Societies showing an ex-libris page scan; Emblems & Alchemy sharing the same hero image

## Data migration
Running `backfill-collection-images.mjs --all` to regenerate all 271 collection images with global deduplication (48 collections reordered to avoid duplicate thumbnails).

## Test plan
- [ ] Check https://sourcelibrary.org/collections — Secret Societies should show a proper gallery image, not the ex-libris page scan
- [ ] Verify Emblems & the Great Work and Alchemy, Magic & Occult Sciences have different hero images
- [ ] Spot-check sub-collection pages for unique images

🤖 Generated with [Claude Code](https://claude.com/claude-code)