### PR TITLE
Fix paragraph spacing and auto-linkify source URLs

### DIFF
--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -5,7 +5,24 @@ import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import SiteHeader from '@/components/layout/SiteHeader';
+
+/**
+ * Post-process Gemini output: convert bare sourcelibrary URLs to markdown links.
+ * Gemini often outputs `https://sourcelibrary.org/book/slug?page=5` as plain text
+ * instead of wrapping it in `[text](url)`. This catches those and linkifies them.
+ */
+function linkifySourceUrls(text: string): string {
+  // Don't linkify URLs that are already inside markdown link syntax [text](url)
+  return text.replace(
+    /(?<!\]\()https:\/\/sourcelibrary\.org\/book\/([a-z0-9-]+)(?:\?page=(\d+))?/g,
+    (match, slug, page) => {
+      const label = page ? `View source (p. ${page})` : 'View in collection';
+      return `[${label}](${match})`;
+    },
+  );
+}
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -549,13 +566,13 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
                             <div className="bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3">
                               <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed prose-p:mb-3 prose-p:mt-0 prose-headings:mb-2 prose-headings:mt-4 prose-ul:my-2 prose-li:my-0.5 prose-a:text-[#9e4a3a] prose-a:underline prose-a:underline-offset-2 prose-a:decoration-[#9e4a3a]/30 hover:prose-a:decoration-[#9e4a3a] prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-strong:text-[#1a1612]">
                                 <ReactMarkdown
-                                  remarkPlugins={[remarkGfm]}
+                                  remarkPlugins={[remarkGfm, remarkBreaks]}
                                   components={{
                                     a: ({ href, children }) => (
                                       <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
                                     ),
                                   }}
-                                >{assistant.content}</ReactMarkdown>
+                                >{linkifySourceUrls(assistant.content)}</ReactMarkdown>
                               </div>
                             </div>
                           )}


### PR DESCRIPTION
remarkBreaks for single-newline paragraphs, linkifySourceUrls for bare URLs.