### PR TITLE
Filter artworks out of the book pipeline

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1989,6 +1989,26 @@ async function run() {
       console.log(`  Enrolled: ${log.enrolled}`);
     }
 
+    // Artwork resource types — these skip the book pipeline entirely (no text to OCR/translate)
+    const ARTWORK_TYPES = ['painting', 'print', 'drawing', 'fresco', 'papyrus_fragment', 'object'];
+
+    // ── Phase 0: Skip artworks that somehow entered the pipeline ──
+    if (shouldRun(1)) {
+      const artworks = await db.collection('books').find({
+        'pipeline_auto.status': { $in: ['queued', 'archiving', 'archive_complete'] },
+        resource_type: { $in: ARTWORK_TYPES },
+      }).project({ id: 1, title: 1 }).toArray();
+      if (artworks.length > 0) {
+        console.log(`\n--- Phase 0: Skipping ${artworks.length} artworks ---`);
+        if (!DRY_RUN) {
+          for (const art of artworks) {
+            await setPipelineStatus(db, art.id, 'complete', { skipped: 'artwork' });
+            console.log(`  Skipped artwork: ${art.title}`);
+          }
+        }
+      }
+    }
+
     // ── Phase 1: Archive check (queued/archiving -> archive_complete) ──
     if (shouldRun(1)) {
       console.log('\n--- Phase 1: Archive check ---');
@@ -1998,7 +2018,7 @@ async function run() {
       const ENGLISH_VARIANTS_P1 = ['english', 'eng', 'en'];
       const queuedBooks = await db.collection('books')
         .aggregate([
-          { $match: { 'pipeline_auto.status': 'queued' } },
+          { $match: { 'pipeline_auto.status': 'queued', resource_type: { $nin: ARTWORK_TYPES } } },
           { $addFields: {
             _priority: {
               $switch: {

--- a/src/app/api/admin/enroll-pipeline/route.ts
+++ b/src/app/api/admin/enroll-pipeline/route.ts
@@ -70,19 +70,23 @@ export const POST = withAdminAuth(async (request, session) => {
   // just those new phases without redoing OCR/translation/summary.
   let enrollStatus: PipelineAutoStatus = 'queued';
 
+  // Artworks (paintings, prints, etc.) have no text — skip them entirely
+  const ARTWORK_TYPES = ['painting', 'print', 'drawing', 'fresco', 'papyrus_fragment', 'object'];
+  const artworkFilter = { resource_type: { $nin: ARTWORK_TYPES } };
+
   if (bookIds?.length) {
-    // Enroll specific books
+    // Enroll specific books (allow explicit artwork enrollment if intentional)
     query = { id: { $in: bookIds } };
   } else if (reEnrollCompleted) {
     // Backfill completed books through new pipeline phases (chapters, images)
-    query = { 'pipeline_auto.status': 'complete' };
+    query = { 'pipeline_auto.status': 'complete', ...artworkFilter };
     enrollStatus = 'enriched';
   } else if (reEnrollFailed) {
     // Re-enroll failed books
-    query = { 'pipeline_auto.status': 'failed' };
+    query = { 'pipeline_auto.status': 'failed', ...artworkFilter };
   } else {
     // Enroll all books without pipeline_auto
-    query = { pipeline_auto: { $exists: false } };
+    query = { pipeline_auto: { $exists: false }, ...artworkFilter };
   }
 
   const books = await db.collection('books')


### PR DESCRIPTION
## Summary
- Adds Phase 0 guard in `pipeline-orchestrator.mjs` that catches artworks (paintings, prints, drawings, frescoes, papyrus fragments, objects) and marks them `complete` with `skipped: 'artwork'` before they enter Phase 1
- Filters artworks from the `enroll-pipeline` API so they're never queued in the first place
- Explicit `bookIds` enrollment still works for artworks (intentional override)

Closes #900

## Context
6,651 artworks exist in the books collection. While they currently don't cause damage (0 pages = nothing to OCR), they shouldn't occupy pipeline slots or appear in processing dashboards. The `resource_type` field reliably identifies all artworks.

## Test plan
- [ ] `--dry-run` the orchestrator to verify Phase 0 logs correctly
- [ ] Confirm `POST /api/admin/enroll-pipeline` excludes artworks from bulk enrollment
- [ ] Verify explicit `bookIds` enrollment still works for artworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)