### PR TITLE
Fix timeline tooltip + match map page layout

### DIFF
--- a/src/app/explore/map/page.tsx
+++ b/src/app/explore/map/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
-import SiteHeader from '@/components/layout/SiteHeader';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import ExploreTabBar from '@/components/explore/ExploreTabBar';
 import BookMapLoader from '@/components/explore/BookMapLoader';
 import type { BookLocation } from '@/components/explore/BookMap';
@@ -96,26 +96,42 @@ async function fetchMapData() {
 export default async function MapPage() {
   try {
     const data = await fetchMapData();
+    const locationCount = data.stats.total_locations;
     return (
-      <>
-        <SiteHeader />
-        <div className="relative">
-          <div className="absolute top-3 left-3 z-[1000]">
-            <ExploreTabBar />
-          </div>
-          <BookMapLoader locations={data.locations} stats={data.stats} />
-        </div>
-      </>
+      <ContentPageLayout
+        header={
+          <ContentHeader
+            title="Map"
+            subtitle={`${locationCount.toLocaleString()} locations across Europe and beyond — publication cities, birthplaces, and institutions`}
+          >
+            <div className="mt-5">
+              <ExploreTabBar />
+            </div>
+          </ContentHeader>
+        }
+        maxWidth="full"
+        noPadding
+      >
+        <BookMapLoader locations={data.locations} stats={data.stats} />
+      </ContentPageLayout>
     );
   } catch (err) {
     console.error('Map page error:', err);
     return (
-      <>
-        <SiteHeader />
+      <ContentPageLayout
+        header={
+          <ContentHeader title="Map" subtitle="Map data is temporarily unavailable. Please try again shortly." >
+            <div className="mt-5">
+              <ExploreTabBar />
+            </div>
+          </ContentHeader>
+        }
+        maxWidth="full"
+      >
         <div className="min-h-[60vh] flex items-center justify-center">
-          <p className="text-stone-500">Map data is temporarily unavailable. Please try again shortly.</p>
+          <p className="text-stone-500">Map data is temporarily unavailable.</p>
         </div>
-      </>
+      </ContentPageLayout>
     );
   }
 }

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -613,35 +613,36 @@ function DecadeBar({
   era?: Era;
   onClick: () => void;
 }) {
-  const [hovered, setHovered] = useState(false);
+  const barRef = useRef<HTMLDivElement>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
   const isClipped = bucket.count > barCap;
   // Clipped bars fill to 100%, normal bars scale linearly against the cap
   const heightPct = isClipped ? 100 : Math.max(1.5, (bucket.count / barCap) * 100);
   const top3 = bucket.languages.slice(0, 3);
   const rest = bucket.count - top3.reduce((s, l) => s + l.count, 0);
 
+  const handleMouseEnter = useCallback(() => {
+    if (!barRef.current) return;
+    const rect = barRef.current.getBoundingClientRect();
+    setTooltipPos({ x: rect.left + rect.width / 2, y: rect.top });
+  }, []);
+
   return (
     <div
+      ref={barRef}
       className="flex-1 relative cursor-pointer group"
       style={{ minWidth: 8, height: '100%' }}
       onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={() => setTooltipPos(null)}
     >
-      {/* Count label above clipped bars */}
-      {isClipped && (
+      {/* Tooltip — fixed position to escape overflow:hidden */}
+      {tooltipPos && (
         <div
-          className="absolute left-1/2 -translate-x-1/2 text-[8px] font-mono text-stone-500 whitespace-nowrap z-10"
-          style={{ bottom: `calc(${heightPct}% + 10px)` }}
+          className="fixed z-50 pointer-events-none"
+          style={{ left: tooltipPos.x, top: tooltipPos.y, transform: 'translate(-50%, -100%)' }}
         >
-          {bucket.count}
-        </div>
-      )}
-
-      {/* Tooltip */}
-      {hovered && (
-        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20 pointer-events-none">
-          <div className="bg-[#1a1612] text-white text-xs rounded-lg px-3 py-2.5 whitespace-nowrap shadow-lg">
+          <div className="bg-[#1a1612] text-white text-xs rounded-lg px-3 py-2.5 whitespace-nowrap shadow-lg mb-2">
             <div className="font-serif text-sm mb-1">
               {formatDecadeLabel(bucket.decade)}
               <span className="text-stone-400 font-sans text-[10px] ml-1.5">

--- a/src/components/layout/ContentPageLayout.tsx
+++ b/src/components/layout/ContentPageLayout.tsx
@@ -88,10 +88,13 @@ interface ContentPageLayoutProps {
    *  narrow: 672px — focused reading, forms
    *  standard: 1024px — most content pages (default)
    *  wide: 1280px — browse, multi-column
+   *  full: no max-width, edge-to-edge
    */
-  maxWidth?: 'narrow' | 'standard' | 'wide';
+  maxWidth?: 'narrow' | 'standard' | 'wide' | 'full';
   /** Background color — defaults to stone-50 */
   bg?: string;
+  /** Remove padding from main content area (e.g. for full-bleed maps) */
+  noPadding?: boolean;
 }
 
 export default function ContentPageLayout({
@@ -100,18 +103,21 @@ export default function ContentPageLayout({
   className = '',
   maxWidth = 'standard',
   bg = 'bg-stone-50',
+  noPadding = false,
 }: ContentPageLayoutProps) {
   const widthClass =
-    maxWidth === 'narrow'
-      ? 'max-w-[var(--container-narrow)]'
-      : maxWidth === 'wide'
-        ? 'max-w-[var(--container-wide)]'
-        : 'max-w-[var(--container-standard)]';
+    maxWidth === 'full'
+      ? ''
+      : maxWidth === 'narrow'
+        ? 'max-w-[var(--container-narrow)]'
+        : maxWidth === 'wide'
+          ? 'max-w-[var(--container-wide)]'
+          : 'max-w-[var(--container-standard)]';
 
   return (
     <div className={`min-h-screen ${bg}`}>
       {header}
-      <main className={`${widthClass} mx-auto px-6 py-12 ${className}`}>
+      <main className={`${widthClass} ${widthClass ? 'mx-auto' : ''} ${noPadding ? '' : 'px-6 py-12'} ${className}`}>
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- **Tooltip fix**: Timeline histogram tooltip now uses `position: fixed` so it escapes the `overflow-x-auto` container that was clipping it (showed as black box with invisible text)
- **Map page layout**: Now uses `ContentPageLayout` with dark hero header, title, subtitle, and Timeline/Map tab bar — matches the timeline page design
- **ContentPageLayout**: Added `maxWidth="full"` and `noPadding` props for edge-to-edge content like maps

## Test plan
- [ ] Hover over bars on `/timeline` — tooltip should show decade, count, and language breakdown
- [ ] `/explore/map` should have a dark hero header with "Map" title, subtitle, and Timeline/Map tabs
- [ ] Map should still be full-width below the header
- [ ] Timeline/Map tab navigation works from both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)