### PR TITLE
Fix entities API: same 625K scan as encyclopedia pages

### DIFF
--- a/src/app/api/entities/[id]/route.ts
+++ b/src/app/api/entities/[id]/route.ts
@@ -29,9 +29,13 @@ export async function GET(
     }
 
     // If not found, try by URL-encoded name (for friendly URLs)
+    // Exact match first (indexed, 2ms) then case-insensitive fallback (625K scan, 20s)
     if (!entity) {
       const decodedName = decodeURIComponent(id);
       entity = await db.collection('entities').findOne(
+        { name: decodedName },
+        { sort: { book_count: -1 } }
+      ) ?? await db.collection('entities').findOne(
         { name: { $regex: `^${escapeRegex(decodedName)}$`, $options: 'i' } },
         { sort: { book_count: -1 } }
       );


### PR DESCRIPTION
## Summary
- `/api/entities/[id]` had the same case-insensitive regex issue as the encyclopedia page (fixed in #1018)
- Exact match first (2ms), regex fallback only for case mismatches

## Other regex queries audited
- `books` collection regex (artist pages): 55ms on 20K docs, `revalidate=false` (one-time build) — acceptable
- Admin/API routes (identify, gallery, USTC search): infrequent, not hot-path — leave as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)