### PR TITLE
Slugified URLs for Iconclass subject browser

### DIFF
--- a/src/app/browse/subjects/[...code]/page.tsx
+++ b/src/app/browse/subjects/[...code]/page.tsx
@@ -1,13 +1,15 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { getReadDb } from '@/lib/mongodb';
 import {
   ICONCLASS_DIVISIONS,
   getIconclassLabel,
   buildIconclassPath,
+  subjectUrl,
+  parseSubjectSlug,
 } from '@/lib/iconclass-categories';
 
 export const revalidate = 86400;
@@ -77,18 +79,18 @@ async function getImagesForCode(db: any, code: string, limit = 48): Promise<Gall
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { code: codeSegments } = await params;
-  const code = codeSegments.join('');
+  const code = parseSubjectSlug(codeSegments);
   const label = getIconclassLabel(code) || `Iconclass ${code}`;
   return {
     title: `${label} | Browse by Subject | Source Library`,
     description: `Browse ${label} illustrations and artworks in the Source Library collection, classified with Iconclass code ${code}.`,
-    alternates: { canonical: `/browse/subjects/${code}` },
+    alternates: { canonical: subjectUrl(code, label) },
   };
 }
 
 export default async function SubjectCategoryPage({ params }: Props) {
   const { code: codeSegments } = await params;
-  const code = codeSegments.join('');
+  const code = parseSubjectSlug(codeSegments);
 
   let db;
   try {
@@ -101,10 +103,17 @@ export default async function SubjectCategoryPage({ params }: Props) {
   if (!nodes) notFound();
 
   const node = nodes[code];
+  const label = getIconclassLabel(code) || node?.label || `Iconclass ${code}`;
+
+  // Redirect bare codes to slugified URL (e.g. /26 → /26-meteorological-phenomena)
+  const rawPath = codeSegments.join('/');
+  const expectedSlug = subjectUrl(code, label).replace('/browse/subjects/', '');
+  if (rawPath !== expectedSlug && label !== `Iconclass ${code}`) {
+    redirect(subjectUrl(code, label));
+  }
 
   // Build breadcrumb path
   const path = buildIconclassPath(code);
-  const label = getIconclassLabel(code) || node?.label || `Iconclass ${code}`;
 
   // Determine if this is a category page (has children) or a leaf (show images)
   const hasChildren = node && node.children.length > 0;
@@ -139,7 +148,7 @@ export default async function SubjectCategoryPage({ params }: Props) {
               {p.code === code ? (
                 <span style={{ color: 'var(--text-primary)' }}>{p.label}</span>
               ) : (
-                <Link href={`/browse/subjects/${p.code}`} className="hover:underline">{p.label}</Link>
+                <Link href={subjectUrl(p.code, p.label)} className="hover:underline">{p.label}</Link>
               )}
             </span>
           ))}
@@ -187,7 +196,7 @@ export default async function SubjectCategoryPage({ params }: Props) {
               {children.map(child => (
                 <Link
                   key={child.code}
-                  href={`/browse/subjects/${child.code}`}
+                  href={subjectUrl(child.code, child.label)}
                   className="group relative rounded-xl overflow-hidden transition-shadow hover:shadow-lg"
                   style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
                 >

--- a/src/app/browse/subjects/page.tsx
+++ b/src/app/browse/subjects/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { getReadDb } from '@/lib/mongodb';
-import { ICONCLASS_DIVISIONS } from '@/lib/iconclass-categories';
+import { ICONCLASS_DIVISIONS, subjectUrl } from '@/lib/iconclass-categories';
 
 export const revalidate = 86400;
 
@@ -72,7 +72,7 @@ export default async function SubjectsPage() {
               return (
                 <Link
                   key={div.code}
-                  href={`/browse/subjects/${div.code}`}
+                  href={subjectUrl(div.code, node.label || div.label)}
                   className="group relative rounded-xl overflow-hidden transition-shadow hover:shadow-lg"
                   style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
                 >

--- a/src/lib/iconclass-categories.ts
+++ b/src/lib/iconclass-categories.ts
@@ -94,6 +94,34 @@ export function getParentCode(code: string): string | null {
   return code[0];
 }
 
+/** Slugify a label for URL use. */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Build a subject browser URL: /browse/subjects/26-meteorological-phenomena */
+export function subjectUrl(code: string, label?: string | null): string {
+  if (label) {
+    return `/browse/subjects/${code}-${slugify(label)}`;
+  }
+  return `/browse/subjects/${code}`;
+}
+
+/** Extract the Iconclass code from a slug like "26-meteorological-phenomena" → "26" */
+export function parseSubjectSlug(segments: string[]): string {
+  // Join segments and extract the code prefix (everything before the first dash
+  // that follows the Iconclass code pattern: digits, uppercase letters, parens)
+  const joined = segments.join('/');
+  // Iconclass codes: start with digit, may contain uppercase letters, digits, parens, plus
+  const match = joined.match(/^([0-9][0-9A-Z()+ ]*?)(?:-[a-z]|$)/);
+  if (match) return match[1];
+  // Fallback: just return first segment as-is (handles bare codes like "26")
+  return segments[0];
+}
+
 /** Build breadcrumb path from a code. */
 export function buildIconclassPath(code: string): Array<{ code: string; label: string }> {
   const path: Array<{ code: string; label: string }> = [];


### PR DESCRIPTION
## Summary
- `/browse/subjects/26` → `/browse/subjects/26-meteorological-phenomena`
- Bare codes redirect to slugified version
- Labels fetched from iconclass.org API during pre-computation (230/249 resolved)

## Test plan
- [ ] Visit `/browse/subjects` — links should have slugified URLs
- [ ] Visit `/browse/subjects/26` — should redirect to `/browse/subjects/26-meteorological-phenomena`
- [ ] Breadcrumbs and child cards use slugified URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)