### PR TITLE
Import 29 Theosophical Society books + curated collections

### DIFF
--- a/scripts/import/batch-import-theosophy-art.mjs
+++ b/scripts/import/batch-import-theosophy-art.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Batch import: Theosophical art & visual culture
+ * Kandinsky, Bragdon, Leadbeater illustrated works, Hambidge
+ */
+
+const API_BASE = 'https://sourcelibrary.org/api/import/ia';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const books = [
+  // === KANDINSKY ===
+  {
+    ia_identifier: 'concerningspirit00kand',
+    title: 'Concerning the Spiritual in Art',
+    author: 'Wassily Kandinsky',
+    year: 1914,
+    original_language: 'German',
+    language: 'English',
+  },
+
+  // === BRAGDON — Theosophist architect, 4D geometry ===
+  {
+    ia_identifier: 'beautifulnecessi00bragiala',
+    title: 'The Beautiful Necessity: Seven Essays on Theosophy and Architecture',
+    author: 'Claude Fayette Bragdon',
+    year: 1910,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'aprimerhighersp00braggoog',
+    title: 'A Primer of Higher Space (The Fourth Dimension)',
+    author: 'Claude Fayette Bragdon',
+    year: 1913,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'projectiveorname00brag',
+    title: 'Projective Ornament',
+    author: 'Claude Fayette Bragdon',
+    year: 1915,
+    original_language: 'English',
+  },
+
+  // === LEADBEATER — illustrated esoteric works ===
+  {
+    ia_identifier: 'hiddensideofthin0000cwle',
+    title: 'The Hidden Side of Things',
+    author: 'Charles Webster Leadbeater',
+    year: 1913,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'innerlife00lead',
+    title: 'The Inner Life',
+    author: 'Charles Webster Leadbeater',
+    year: 1910,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'invisiblehelpers00leadrich',
+    title: 'Invisible Helpers',
+    author: 'Charles Webster Leadbeater',
+    year: 1896,
+    original_language: 'English',
+  },
+
+  // === STEINER — art/color theory ===
+  {
+    ia_identifier: 'theosophyanintr01steigoog',
+    title: 'Theosophy: An Introduction to the Supersensible Knowledge of the World and the Destination of Man',
+    author: 'Rudolf Steiner',
+    year: 1910,
+    original_language: 'German',
+    language: 'English',
+  },
+
+  // === HAMBIDGE — sacred geometry / dynamic symmetry ===
+  {
+    ia_identifier: 'dynamicsymmetry00hamb',
+    title: 'Dynamic Symmetry: The Greek Vase',
+    author: 'Jay Hambidge',
+    year: 1920,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'elementsofdynami0000hamb',
+    title: 'The Elements of Dynamic Symmetry',
+    author: 'Jay Hambidge',
+    year: 1926,
+    original_language: 'English',
+  },
+];
+
+async function importBook(book, index) {
+  console.log(`\n[${index + 1}/${books.length}] Importing: ${book.title} (${book.year})`);
+  console.log(`  IA: ${book.ia_identifier}`);
+
+  try {
+    const res = await fetch(API_BASE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+
+    if (res.ok) {
+      console.log(`  OK — ${data.slug || data.id || 'imported'}`);
+      return { success: true, title: book.title };
+    } else {
+      console.log(`  FAIL — ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ERROR — ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  console.log(`=== Theosophical Art & Visual Culture Import ===`);
+  console.log(`Books: ${books.length}\n`);
+
+  const results = [];
+  for (let i = 0; i < books.length; i++) {
+    results.push(await importBook(books[i], i));
+    if (i < books.length - 1) await new Promise(r => setTimeout(r, 2000));
+  }
+
+  const ok = results.filter(r => r.success).length;
+  const fail = results.filter(r => !r.success);
+  console.log(`\n=== ${ok}/${books.length} imported ===`);
+  if (fail.length) fail.forEach(f => console.log(`  FAIL: ${f.title} — ${f.error}`));
+}
+
+main().catch(console.error);

--- a/scripts/import/batch-import-theosophy.mjs
+++ b/scripts/import/batch-import-theosophy.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Batch import: Theosophical Society publications pre-1930
+ * Focus on California/Point Loma + foundational texts
+ */
+
+const API_BASE = 'https://sourcelibrary.org/api/import/ia';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const books = [
+  // === FOUNDATIONAL TEXTS ===
+  {
+    ia_identifier: 'voiceofsilencebe0000blav',
+    title: 'The Voice of the Silence: Being Chosen Fragments from the "Book of the Golden Precepts"',
+    author: 'Helena Petrovna Blavatsky',
+    year: 1889,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'oceanoftheosophy00judgiala',
+    title: 'The Ocean of Theosophy',
+    author: 'William Quan Judge',
+    year: 1893,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'esotericbuddhis00sinn',
+    title: 'Esoteric Buddhism',
+    author: 'Alfred Percy Sinnett',
+    year: 1883,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'occultworld1885sinn',
+    title: 'The Occult World',
+    author: 'Alfred Percy Sinnett',
+    year: 1885, // 4th edition; 1st was 1881
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'mahatmalettersto00sinnuoft',
+    title: 'The Mahatma Letters to A. P. Sinnett from the Mahatmas M. & K. H.',
+    author: 'Alfred Percy Sinnett',
+    year: 1923,
+    original_language: 'English',
+  },
+
+  // === BESANT & LEADBEATER ===
+  {
+    ia_identifier: 'ancientwisdomout00besa',
+    title: 'The Ancient Wisdom: An Outline of Theosophical Teachings',
+    author: 'Annie Besant',
+    year: 1897,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'b24885939',
+    title: 'Esoteric Christianity, or The Lesser Mysteries',
+    author: 'Annie Besant',
+    year: 1901,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'thoughtforms00besarich',
+    title: 'Thought-Forms',
+    author: 'Annie Besant & C. W. Leadbeater',
+    year: 1901,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'manvisibleandin00leadgoog',
+    title: 'Man Visible and Invisible: Examples of Different Types of Men as Seen by Means of Trained Clairvoyance',
+    author: 'Charles Webster Leadbeater',
+    year: 1902,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'theastralplane00leaduoft',
+    title: 'The Astral Plane: Its Scenery, Inhabitants and Phenomena',
+    author: 'Charles Webster Leadbeater',
+    year: 1895,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'Clairvoyance1899',
+    title: 'Clairvoyance',
+    author: 'Charles Webster Leadbeater',
+    year: 1899,
+    original_language: 'English',
+  },
+
+  // === CALIFORNIA / POINT LOMA ===
+  {
+    ia_identifier: 'theosophypathofm00tingrich',
+    title: 'Theosophy: The Path of the Mystic',
+    author: 'Katherine Tingley',
+    year: 1922,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'godsawait0000ting',
+    title: 'The Gods Await',
+    author: 'Katherine Tingley',
+    year: 1926,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'mysteriesofheart00tingrich',
+    title: 'The Mysteries of the Heart Doctrine',
+    author: 'Katherine Tingley',
+    year: 1902,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'fundamentalsofth032110mbp',
+    title: 'Fundamentals of the Esoteric Philosophy',
+    author: 'Gottfried de Purucker',
+    year: 1932,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'helenapetrovnabl00ting',
+    title: 'Helena Petrovna Blavatsky: Foundress of the Original Theosophical Society in New York, 1875',
+    author: 'Katherine Tingley',
+    year: 1921,
+    original_language: 'English',
+  },
+
+  // === OTHER KEY TEXTS ===
+  {
+    ia_identifier: 'lightonpath00coll_0',
+    title: 'Light on the Path: A Treatise Written for the Personal Use of Those Who Are Ignorant of the Eastern Wisdom',
+    author: 'Mabel Collins',
+    year: 1885,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'echoesfromorien02judggoog',
+    title: 'Echoes from the Orient: A Broad Outline of Theosophical Doctrines',
+    author: 'William Quan Judge',
+    year: 1890,
+    original_language: 'English',
+  },
+  {
+    ia_identifier: 'philosophyofbhag00subbiala',
+    title: 'The Philosophy of the Bhagavad-Gita',
+    author: 'T. Subba Row',
+    year: 1912,
+    original_language: 'English',
+  },
+];
+
+async function importBook(book, index) {
+  console.log(`\n[${index + 1}/${books.length}] Importing: ${book.title} (${book.year})`);
+  console.log(`  IA: ${book.ia_identifier}`);
+
+  try {
+    const res = await fetch(API_BASE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || data._id || 'OK'}`);
+      return { success: true, title: book.title, id: data.id || data._id };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  console.log(`=== Theosophical Society Import ===`);
+  console.log(`Books to import: ${books.length}`);
+  console.log(`Focus: California/Point Loma + foundational texts\n`);
+
+  const results = [];
+
+  for (let i = 0; i < books.length; i++) {
+    const result = await importBook(books[i], i);
+    results.push(result);
+    // 2s delay between imports
+    if (i < books.length - 1) {
+      await new Promise(r => setTimeout(r, 2000));
+    }
+  }
+
+  console.log(`\n=== SUMMARY ===`);
+  const successes = results.filter(r => r.success);
+  const failures = results.filter(r => !r.success);
+  console.log(`Imported: ${successes.length}/${books.length}`);
+
+  if (failures.length > 0) {
+    console.log(`\nFailed:`);
+    failures.forEach(f => console.log(`  - ${f.title}: ${f.error}`));
+  }
+
+  if (successes.length > 0) {
+    console.log(`\nSuccessful imports:`);
+    successes.forEach(s => console.log(`  - ${s.title} → ${s.id}`));
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Batch import scripts for 29 Theosophical Society publications from Internet Archive (pre-1930)
- Two batches: foundational texts + art-adjacent works (Kandinsky, Bragdon, Hambidge)
- Created 4 curated collections with editorial content: `theosophical-society` (parent), `blavatsky-mahatmas`, `point-loma`, `spiritual-in-art`

## Books imported
- **Foundational:** Voice of the Silence, Ocean of Theosophy, Esoteric Buddhism, The Occult World, Mahatma Letters
- **Besant/Leadbeater:** Ancient Wisdom, Esoteric Christianity, Thought-Forms, Man Visible and Invisible, Astral Plane, Clairvoyance
- **Point Loma (California):** Tingley — Path of the Mystic, Gods Await, Mysteries of the Heart Doctrine, HPB biography; de Purucker — Fundamentals
- **Art:** Kandinsky — Concerning the Spiritual in Art; Bragdon — Beautiful Necessity, Primer of Higher Space, Projective Ornament; Hambidge — Dynamic Symmetry (2 vols)
- **Other:** Light on the Path (Collins), Echoes from the Orient (Judge), Philosophy of the Bhagavad-Gita (Subba Row), Steiner Theosophy, Leadbeater — Hidden Side, Inner Life, Invisible Helpers

## Collections
- Editorial descriptions trace the Besant/Leadbeater → Kandinsky → Bragdon line (clairvoyant illustration to abstract art)
- 39 highlighted books across tiers, 17 mentioned_books for auto-linking, gallery images curated
- `show_all_books: true` on all four (English originals readable without translation)

## Test plan
- [ ] Verify collection pages load after Supabase sync: /collection/theosophical-society
- [ ] Verify subcollection pages: /collection/blavatsky-mahatmas, /collection/point-loma, /collection/spiritual-in-art
- [ ] Confirm pipeline is processing new books (preview OCR already running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)