### PR TITLE
Fix 404 page and enable feedback widget

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -107,7 +107,7 @@ export default async function RootLayout({
         <CookieConsent />
         <AnalyticsScripts />
         <PageTracker />
-        <InputWidget allowedHosts={["localhost"]} />
+        <InputWidget allowedHosts={["localhost", "vercel.app", "sourcelibrary.org"]} />
       </body>
     </html>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Search, Home, BookOpen } from 'lucide-react';
+import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 
 const QUOTES = [
   { text: 'The lips of Wisdom are closed, except to the ears of Understanding.', source: 'The Kybalion' },
@@ -82,9 +83,11 @@ export default function NotFound() {
 
         <p className="text-xs text-faint">
           Something broken?{' '}
-          <Link href="mailto:derek@sourcelibrary.org" className="text-accent-rust/70 hover:text-accent-rust underline">
-            Let us know
-          </Link>
+          <FeedbackWidget
+            label="Let us know"
+            initialMessage="I hit a 404 on: "
+            className="text-accent-rust/70 hover:text-accent-rust underline"
+          />
         </p>
       </div>
     </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,13 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Search, Home, Book } from 'lucide-react';
+import { Search, Home, BookOpen } from 'lucide-react';
+
+const QUOTES = [
+  { text: 'The lips of Wisdom are closed, except to the ears of Understanding.', source: 'The Kybalion' },
+  { text: 'Nature is the living visible garment of God.', source: 'Goethe' },
+  { text: 'All that we see or seem is but a dream within a dream.', source: 'Poe' },
+  { text: 'The universe is not only queerer than we suppose, but queerer than we can suppose.', source: 'Haldane' },
+  { text: 'As above, so below; as below, so above.', source: 'Hermes Trismegistus' },
+];
 
 export default function NotFound() {
   const [searchQuery, setSearchQuery] = useState('');
+  const [quote, setQuote] = useState(QUOTES[0]);
   const router = useRouter();
+
+  useEffect(() => {
+    setQuote(QUOTES[Math.floor(Math.random() * QUOTES.length)]);
+  }, []);
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -17,30 +30,26 @@ export default function NotFound() {
   };
 
   return (
-    <div className="min-h-screen bg-cream flex items-center justify-center px-4">
-      <div className="max-w-2xl w-full text-center">
-        <div className="mb-8">
-          <h1 className="text-6xl font-bold text-accent-rust mb-4 font-serif">404</h1>
-          <h2 className="text-2xl font-serif font-semibold text-primary mb-2">
-            Page Not Found
-          </h2>
-          <p className="text-muted">
-            The page you seek has eluded the archive.
-          </p>
-        </div>
+    <div className="min-h-screen bg-cream flex items-center justify-center px-4 py-12">
+      <div className="max-w-xl w-full text-center">
+        <h1 className="text-7xl font-bold text-accent-rust/20 mb-2 font-serif">404</h1>
+        <h2 className="text-2xl font-serif font-semibold text-primary mb-3">
+          Lost in the Stacks
+        </h2>
+        <p className="text-muted mb-8 italic">
+          &ldquo;{quote.text}&rdquo;
+          <span className="block text-faint text-sm mt-1 not-italic">&mdash; {quote.source}</span>
+        </p>
 
-        <div className="bg-white rounded-xl border border-light p-8 mb-6">
-          <h3 className="text-lg font-medium text-secondary mb-4">
-            Search the Library
-          </h3>
-          <form onSubmit={handleSearch} className="mb-6">
+        <div className="bg-white rounded-xl border border-light p-6 mb-6">
+          <form onSubmit={handleSearch} className="mb-5">
             <div className="relative">
               <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted" />
               <input
                 type="text"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search books, authors, translations..."
+                placeholder="Search the library..."
                 className="w-full pl-12 pr-4 py-3 border border-medium rounded-xl focus:outline-none focus:ring-2 focus:ring-accent-rust/40 focus:border-accent-rust/50 text-lg"
                 autoFocus
               />
@@ -53,30 +62,29 @@ export default function NotFound() {
             </button>
           </form>
 
-          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <div className="flex gap-3 justify-center">
             <Link
               href="/"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-warm hover:bg-accent-rust/10 text-secondary rounded-xl transition-colors"
+              className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-warm hover:bg-accent-rust/10 text-secondary rounded-xl transition-colors text-sm"
             >
-              <Home className="w-5 h-5" />
-              Go Home
+              <Home className="w-4 h-4" />
+              Home
             </Link>
             <Link
               href="/search"
-              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-warm hover:bg-accent-rust/10 text-secondary rounded-xl transition-colors"
+              className="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-warm hover:bg-accent-rust/10 text-secondary rounded-xl transition-colors text-sm"
             >
-              <Book className="w-5 h-5" />
-              Browse Library
+              <BookOpen className="w-4 h-4" />
+              Browse
             </Link>
           </div>
         </div>
 
-        <p className="text-sm text-faint">
-          If you believe this is an error, please{' '}
-          <Link href="/support" className="text-accent-rust hover:text-accent-rust/80 underline">
-            contact support
+        <p className="text-xs text-faint">
+          Something broken?{' '}
+          <Link href="mailto:derek@sourcelibrary.org" className="text-accent-rust/70 hover:text-accent-rust underline">
+            Let us know
           </Link>
-          .
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace broken "contact support" link (pointed to donation page) with a mailto for actual error reports
- Add rotating quotes from the canon for personality — "Lost in the Stacks"
- Enable InputWidget feedback on `vercel.app` and `sourcelibrary.org` (was localhost-only)

## Test plan
- [ ] Visit a nonexistent URL (e.g., `/asdf`) and verify the 404 renders with a quote
- [ ] Confirm search works from the 404 page
- [ ] Append `?getinput` to any page URL and confirm the feedback widget appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)