### PR TITLE
Clean up book detail + collections page

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -588,29 +588,19 @@ async function BookInfo({ id }: { id: string }) {
                 </div>
               )}
 
-              {/* Source attribution — always visible */}
-              {(book.image_source?.provider_name || book.image_source?.contributing_library) && (
-                <p className="text-xs text-stone-500 mt-3">
-                  Images:{' '}
-                  {book.image_source.source_url ? (
-                    <a href={book.image_source.source_url} target="_blank" rel="noopener noreferrer" className="hover:text-stone-300 transition-colors">
-                      {book.image_source.attribution || book.image_source.contributing_library || book.image_source.provider_name}
-                    </a>
-                  ) : (
-                    <span>{book.image_source.attribution || book.image_source.contributing_library || book.image_source.provider_name}</span>
-                  )}
-                </p>
-              )}
-
-              {/* Translation credit */}
-              {translatedCount > 0 && (
-                <p className="text-xs text-stone-500 mt-2">
-                  Translated by Source Library AI{' '}
-                  <span className="text-stone-600">&middot;</span>{' '}
-                  <Link href="/about/research" className="hover:text-stone-300 transition-colors underline underline-offset-2">
-                    How our translations work
-                  </Link>
-                </p>
+              {/* Collections */}
+              {bookCollections.length > 0 && (
+                <div className="flex flex-wrap items-center gap-2 mt-3">
+                  {bookCollections.map(col => (
+                    <Link
+                      key={col.slug}
+                      href={`/collections/${col.slug}`}
+                      className="text-xs text-stone-400 hover:text-white bg-white/5 hover:bg-white/10 px-2.5 py-1 rounded-full transition-colors"
+                    >
+                      {col.name}
+                    </Link>
+                  ))}
+                </div>
               )}
 
               {/* Dedication */}
@@ -691,15 +681,14 @@ async function BookInfo({ id }: { id: string }) {
                 <SearchPanel bookId={book.id} />
               </div>
 
-              {/* Bibliographic Info */}
-              <BibliographicInfo book={book} pagesCount={pages.length} />
-
-              {/* Related Editions (WEMI work_id linking) */}
-              {(book as unknown as { work_id?: string }).work_id && (
-                <Suspense fallback={null}>
-                  <RelatedEditions bookId={book.id} workId={(book as unknown as { work_id?: string }).work_id!} />
-                </Suspense>
-              )}
+              {/* Bibliographic Info (includes related editions, attribution) */}
+              <BibliographicInfo book={book} pagesCount={pages.length} hasTranslations={translatedCount > 0}>
+                {(book as unknown as { work_id?: string }).work_id && (
+                  <Suspense fallback={null}>
+                    <RelatedEditions bookId={book.id} workId={(book as unknown as { work_id?: string }).work_id!} />
+                  </Suspense>
+                )}
+              </BibliographicInfo>
 
               {/* Cross-reference: artworks by this author (pre-computed) */}
               {(book as any).author_cross_ref && (

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -2,7 +2,7 @@ import { getReadDb } from '@/lib/mongodb';
 import Link from 'next/link';
 import Image from 'next/image';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
-import { sortCollections } from '@/lib/collections-utils';
+import { sortCollections, sanitizeThumbnail } from '@/lib/collections-utils';
 import EraTimeline, { type DecadeBucket } from '@/components/collections/EraTimeline';
 import type { Metadata } from 'next';
 
@@ -63,6 +63,16 @@ async function fetchCollections(): Promise<CollectionDoc[]> {
   })) as unknown as CollectionDoc[];
 
   return sortCollections(all);
+}
+
+async function fetchCuratedCollections(): Promise<CollectionDoc[]> {
+  const db = await getReadDb();
+  const docs = await db.collection('collections')
+    .find({ type: 'curated', published: true })
+    .sort({ book_count: -1, name: 1 })
+    .toArray();
+
+  return docs.map(({ _id, ...rest }) => rest) as unknown as CollectionDoc[];
 }
 
 async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total: number }> {
@@ -149,33 +159,65 @@ function CollectionCard({ col, priority = false }: { col: CollectionDoc; priorit
 
 
 
+function CuratedCard({ col, priority = false }: { col: CollectionDoc; priority?: boolean }) {
+  const hero = col.featured_images?.find(
+    img => img.thumbnail_url || img.extracted_url
+  ) || col.featured_images?.find(
+    img => img.image_url
+  );
+  const raw = hero?.thumbnail_url || hero?.extracted_url || hero?.image_url;
+  const heroUrl = sanitizeThumbnail(raw);
+
+  return (
+    <Link
+      href={`/collections/${col.slug}`}
+      className="group relative block overflow-hidden rounded-lg aspect-[3/2]"
+    >
+      {heroUrl ? (
+        <Image
+          src={heroUrl}
+          alt={`Illustration from ${col.name}`}
+          fill
+          sizes="(max-width: 640px) 100vw, 33vw"
+          className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+          unoptimized
+          priority={priority}
+          loading={priority ? 'eager' : 'lazy'}
+        />
+      ) : (
+        <div className="absolute inset-0 bg-warm" />
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
+      <div className="absolute inset-0 flex flex-col justify-end p-4 sm:p-5">
+        <h3 className="font-serif text-base sm:text-lg text-white font-semibold leading-tight mb-1 group-hover:text-accent-gold transition-colors">
+          {col.name}
+        </h3>
+        {col.subtitle && (
+          <p className="text-xs sm:text-sm text-white/60 leading-relaxed line-clamp-2">
+            {col.subtitle}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
 export default async function CollectionsPage() {
-  const [categories, timeline] = await Promise.all([
+  const [categories, curated, timeline] = await Promise.all([
     fetchCollections(),
+    fetchCuratedCollections(),
     fetchTimelineDecades(),
   ]);
-  const totalBooks = categories.reduce((s, c) => s + c.book_count, 0);
 
   return (
     <ContentPageLayout
       header={
         <ContentHeader
           title="Collections"
-          subtitle={`${totalBooks.toLocaleString()} books organized into ${categories.length} thematic collections spanning three millennia of human knowledge.`}
+          subtitle="10,000+ books across three millennia of human knowledge."
         />
       }
     >
-
-      {/* Link to curated exhibitions */}
-      <div className="mb-8">
-        <Link
-          href="/curated"
-          className="group inline-flex items-center gap-2 text-sm text-accent-rust hover:text-accent-rust/80 transition-colors"
-        >
-          Browse curated exhibitions
-          <span className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
-        </Link>
-      </div>
 
       {/* Category collections */}
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
@@ -183,6 +225,26 @@ export default async function CollectionsPage() {
           <CollectionCard key={col.slug} col={col} priority={i < 8} />
         ))}
       </div>
+
+      {/* Curated exhibitions */}
+      {curated.length > 0 && (
+        <div className="mt-12">
+          <div className="flex items-baseline justify-between mb-4">
+            <h2 className="font-display text-2xl text-primary">Curated Exhibitions</h2>
+            <Link
+              href="/curated"
+              className="text-sm text-accent-rust hover:text-accent-rust/80 transition-colors"
+            >
+              View all &rarr;
+            </Link>
+          </div>
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {curated.map((col, i) => (
+              <CuratedCard key={col.slug} col={col} priority={i < 3} />
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Era timeline — full-bleed dark section */}
       <EraTimeline decades={timeline.decades} total={timeline.total} />

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -109,9 +109,11 @@ function getCatalogLabel(source: string): string {
 interface BibliographicInfoProps {
   book: Book;
   pagesCount: number;
+  hasTranslations?: boolean;
+  children?: React.ReactNode;
 }
 
-export default function BibliographicInfo({ book, pagesCount }: BibliographicInfoProps) {
+export default function BibliographicInfo({ book, pagesCount, hasTranslations, children }: BibliographicInfoProps) {
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -471,6 +473,21 @@ export default function BibliographicInfo({ book, pagesCount }: BibliographicInf
             </div>
           ) : null}
 
+          {/* Translation credit */}
+          {hasTranslations && (
+            <div className="mt-4 pt-4 border-t border-stone-700">
+              <div className="flex gap-2 text-sm">
+                <span className="text-stone-500 w-24 flex-shrink-0">Translation:</span>
+                <span className="text-stone-200">
+                  Source Library AI{' '}
+                  <a href="/about/research" className="text-accent-gold hover:text-accent-gold/80 text-xs ml-1">
+                    How our translations work
+                  </a>
+                </span>
+              </div>
+            </div>
+          )}
+
           {/* Data Provenance */}
           {book.field_provenance && Object.keys(book.field_provenance).length > 0 && (
             <div className="mt-4 pt-4 border-t border-stone-700">
@@ -537,6 +554,9 @@ export default function BibliographicInfo({ book, pagesCount }: BibliographicInf
               )}
             </div>
           )}
+
+          {/* Extra content (e.g. related editions) */}
+          {children}
 
           {/* Copy citation button */}
           <div className="mt-4 pt-3 border-t border-stone-700">

--- a/src/components/book/RelatedEditions.tsx
+++ b/src/components/book/RelatedEditions.tsx
@@ -22,17 +22,17 @@ export default async function RelatedEditions({ bookId, workId }: RelatedEdition
   ).size;
 
   return (
-    <Link
-      href={`/work/${workId}`}
-      className="mt-6 flex items-center gap-2.5 px-4 py-3 rounded-lg border border-stone-200 hover:border-stone-300 hover:bg-stone-50 transition-all group"
-    >
-      <Library className="w-4 h-4 text-stone-400 group-hover:text-stone-600 flex-shrink-0" />
-      <span className="text-sm text-stone-600 group-hover:text-stone-800">
-        <strong className="font-semibold">{related.length}</strong>{' '}
-        other edition{related.length !== 1 ? 's' : ''}{' '}
-        across {libraryCount} {libraryCount === 1 ? 'library' : 'libraries'}
-      </span>
-      <span className="ml-auto text-stone-400 group-hover:text-stone-600 text-sm">&rarr;</span>
-    </Link>
+    <div className="mt-4 pt-4 border-t border-stone-700">
+      <div className="flex gap-2 text-sm">
+        <span className="text-stone-500 w-24 flex-shrink-0">Editions:</span>
+        <Link
+          href={`/work/${workId}`}
+          className="text-accent-gold hover:text-accent-gold/80 flex items-center gap-1.5 transition-colors"
+        >
+          {related.length} other edition{related.length !== 1 ? 's' : ''}{' '}
+          across {libraryCount} {libraryCount === 1 ? 'library' : 'libraries'}
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/src/components/search/SearchPanel.tsx
+++ b/src/components/search/SearchPanel.tsx
@@ -151,7 +151,7 @@ export default function SearchPanel({ bookId, className = '' }: SearchPanelProps
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search pages..."
-          className="bg-transparent text-white placeholder-white/50 outline-none text-sm w-48"
+          className="bg-transparent text-white placeholder-white/50 outline-none text-sm w-64 sm:w-80"
           autoFocus
         />
         {query && (


### PR DESCRIPTION
## Summary
- Move source attribution, translation credit, and related editions into collapsible Bibliographic Info panel (less header clutter)
- Show collection tags as linked pills in book detail header
- Add curated collections grid to /collections page with hero images
- Simplify collections subtitle to "10,000+ books across three millennia of human knowledge"
- Widen book search bar

## Test plan
- [ ] Check book detail page — header should be cleaner, collection pills visible
- [ ] Expand Bibliographic Info — should show image source, translation credit, related editions
- [ ] Check /collections — curated exhibitions section should appear below thematic grid
- [ ] Search bar should be wider on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)