### PR TITLE
Update homepage fallback counts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -322,7 +322,7 @@ async function getCollectionShowcase() {
   return JSON.parse(JSON.stringify(items));
 }
 
-const FALLBACK_COUNTS = { totalBooks: 13058, translatedToEnglish: 5190, firstTranslationCount: 4087, authorCount: 3200, languageCount: 50 };
+const FALLBACK_COUNTS = { totalBooks: 9924, translatedToEnglish: 9054, firstTranslationCount: 5454, authorCount: 3200, languageCount: 50 };
 
 async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglish: number; firstTranslationCount: number; authorCount: number; languageCount: number }> {
   // 1. Try Supabase (fast Postgres counts, synced every 2h)


### PR DESCRIPTION
## Summary
- Updated stale fallback counts on the homepage to match current live Supabase data
- Translated (>=90%): 5,190 → 9,054
- First translations: 4,087 → 5,454
- Total with translation: 13,058 → 9,924

These fallbacks only kick in when Supabase is unreachable, but were very outdated.

## Test plan
- [ ] Verify homepage still renders correct counts from Supabase
- [ ] Verify fallback displays reasonable numbers if Supabase is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)