### PR TITLE
Add CLIP visual search to gallery and unified search

### DIFF
--- a/scripts/migration/clip-text-search-rpc.sql
+++ b/scripts/migration/clip-text-search-rpc.sql
@@ -1,0 +1,41 @@
+-- RPC function for text-to-image CLIP search.
+-- Uses the same clip_embeddings table but accepts a text embedding
+-- (encoded by CLIP text encoder) to search against image embeddings.
+-- This enables "search images by description" without metadata — pure visual semantics.
+
+CREATE OR REPLACE FUNCTION match_clip_text(
+  query_embedding vector(512),
+  match_threshold FLOAT DEFAULT 0.20,
+  match_count INT DEFAULT 30
+)
+RETURNS TABLE (
+  id TEXT,
+  source_type TEXT,
+  book_id TEXT,
+  image_url TEXT,
+  title TEXT,
+  author TEXT,
+  resource_type TEXT,
+  thumbnail_url TEXT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id,
+    c.source_type,
+    c.book_id,
+    c.image_url,
+    c.title,
+    c.author,
+    c.resource_type,
+    c.thumbnail_url,
+    1 - (c.embedding <=> query_embedding) AS similarity
+  FROM clip_embeddings c
+  WHERE 1 - (c.embedding <=> query_embedding) > match_threshold
+  ORDER BY c.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/scripts/workers/embedding-server.mjs
+++ b/scripts/workers/embedding-server.mjs
@@ -70,6 +70,26 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  // Proxy /clip/* requests to the CLIP server on port 3457
+  if (req.url?.startsWith('/clip/')) {
+    const clipPath = req.url.replace('/clip', '');
+    try {
+      const clipResp = await fetch(`http://localhost:3457${clipPath}`, {
+        method: req.method,
+        headers: { 'Content-Type': 'application/json' },
+        body: req.method === 'POST' ? await readBody(req) : undefined,
+        signal: AbortSignal.timeout(30000),
+      });
+      const data = await clipResp.text();
+      res.writeHead(clipResp.status, { 'Content-Type': 'application/json' });
+      res.end(data);
+    } catch (e) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'CLIP server unavailable: ' + e.message }));
+    }
+    return;
+  }
+
   res.writeHead(404);
   res.end('Not found');
 });

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -3,6 +3,9 @@ import { getReadDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { generateQueryEmbedding, cosineSimilarity } from '@/lib/embeddings';
 
+// CLIP server on Hetzner for visual text→image search
+const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
+
 export const maxDuration = 30;
 
 /**
@@ -51,10 +54,15 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
 
-    // Semantic search mode — uses embeddings
+    // Visual search mode — uses CLIP image embeddings (text→image)
+    const visual = searchParams.get('visual') === 'true';
+    // Semantic search mode — uses text embeddings
     const semantic = searchParams.get('semantic') === 'true';
     const searchQuery = searchParams.get('q');
 
+    if (visual && searchQuery) {
+      return NextResponse.json(await clipGallerySearch(searchParams, searchQuery));
+    }
     if (semantic && searchQuery) {
       return NextResponse.json(await semanticGallerySearch(searchParams, searchQuery));
     }
@@ -637,5 +645,117 @@ async function legacyGalleryQuery(db: Awaited<ReturnType<typeof getReadDb>>, sea
     offset,
     bookInfo,
     filters: { types, subjects, yearRange },
+  };
+}
+
+/**
+ * CLIP visual search: encode text query via CLIP text encoder,
+ * search against CLIP image embeddings in Supabase.
+ * Returns gallery items ranked by visual similarity.
+ */
+async function clipGallerySearch(searchParams: URLSearchParams, query: string) {
+  const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
+  const offset = parseInt(searchParams.get('offset') || '0');
+
+  // Encode text via CLIP
+  let embedding: number[] | null = null;
+  try {
+    const clipResp = await fetch(`${CLIP_URL}/embed-text`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: query }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (clipResp.ok) {
+      const data = await clipResp.json();
+      embedding = data.embedding;
+    }
+  } catch {
+    // Fall through to semantic search fallback
+  }
+
+  if (!embedding) {
+    // Fall back to text-embedding semantic search
+    return semanticGallerySearch(searchParams, query);
+  }
+
+  // Search Supabase CLIP embeddings
+  const { data: matches, error } = await supabase.rpc('match_clip_text', {
+    query_embedding: embedding,
+    match_threshold: 0.18,
+    match_count: offset + limit + 20,
+  });
+
+  if (error || !matches || matches.length === 0) {
+    return { items: [], total: 0, limit, offset, visual: true, bookInfo: null, filters: { types: [], subjects: [], yearRange: {} } };
+  }
+
+  const total = matches.length;
+  const page = (matches as Array<{
+    id: string; source_type: string; book_id: string; image_url: string;
+    thumbnail_url: string; title: string; author: string; resource_type: string;
+    similarity: number;
+  }>).slice(offset, offset + limit);
+
+  // Resolve full gallery metadata from MongoDB for gallery_image entries
+  const db = await getReadDb();
+  const galleryIds = page.filter(m => m.source_type === 'gallery_image').map(m => m.id.replace('gallery-', ''));
+  const galleryDocs = galleryIds.length > 0
+    ? await db.collection('gallery_images').find({ id: { $in: galleryIds } }, { projection: { _id: 0 } }).toArray()
+    : [];
+  const galleryMap = new Map(galleryDocs.map(d => [d.id as string, d]));
+
+  const items = page.map(m => {
+    // For gallery images, use full metadata from MongoDB
+    if (m.source_type === 'gallery_image') {
+      const doc = galleryMap.get(m.id.replace('gallery-', ''));
+      if (doc) {
+        return {
+          pageId: doc.page_id,
+          bookId: doc.book_id,
+          pageNumber: doc.page_number,
+          detectionIndex: doc.detection_index,
+          imageUrl: doc.extracted_url || doc.thumbnail_url || doc.image_url,
+          bookTitle: doc.book_title,
+          author: doc.book_author,
+          year: doc.book_year,
+          description: doc.description || '',
+          type: doc.type,
+          extractedUrl: doc.extracted_url,
+          thumbnailUrl: doc.thumbnail_url,
+          galleryQuality: doc.gallery_quality,
+          museumDescription: doc.museum_description,
+          metadata: doc.metadata,
+          similarity: Math.round(m.similarity * 1000) / 1000,
+        };
+      }
+    }
+    // For artworks and book covers, use Supabase data directly
+    return {
+      pageId: null,
+      bookId: m.book_id,
+      pageNumber: null,
+      detectionIndex: null,
+      imageUrl: m.thumbnail_url || m.image_url,
+      bookTitle: m.title,
+      author: m.author,
+      year: null,
+      description: m.title || '',
+      type: m.resource_type,
+      extractedUrl: m.image_url,
+      thumbnailUrl: m.thumbnail_url,
+      galleryQuality: null,
+      similarity: Math.round(m.similarity * 1000) / 1000,
+    };
+  });
+
+  return {
+    items,
+    total,
+    limit,
+    offset,
+    visual: true,
+    bookInfo: null,
+    filters: { types: [], subjects: [], yearRange: {} },
   };
 }

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -9,8 +9,8 @@ export const dynamic = 'force-dynamic';
 // Max image size: 4MB (Vercel serverless body limit is 4.5MB)
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
 
-// CLIP server on Hetzner for visual similarity search
-const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3457';
+// CLIP server on Hetzner, proxied through the text embedding server (port 3456)
+const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
 
 const IDENTIFY_PROMPT = `You are an art historian identifying a physical artwork or book page from a photograph taken in a museum or library.
 
@@ -202,7 +202,8 @@ export async function POST(request: NextRequest) {
     // Uses grounding to verify/correct the identification against museum catalogs
     const verifyPromise: Promise<{ corrected_artist?: string; corrected_title?: string; sources?: WebSource[]; catalog_numbers?: string[] } | null> = (async () => {
       try {
-        const verifyModel = 'gemini-2.5-flash-preview-05-20';
+        // google_search grounding requires gemini-2.5-flash (v3 models don't support it yet)
+        const verifyModel = 'gemini-2.5-flash';
         const searchQuery = [
           identification.artist,
           identification.title,
@@ -240,7 +241,7 @@ Return JSON only:
               tools: [{ google_search: {} }],
               generationConfig: { temperature: 0.1 },
             }),
-            signal: AbortSignal.timeout(12000),
+            signal: AbortSignal.timeout(20000),
           },
         );
 

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { supabase } from '@/lib/supabase';
 import type { BookSearchFilters } from '@/lib/atlas-search';
 import type { SearchResult } from '@/lib/api-client/types/search';
 import { searchBookIds } from '@/lib/books-catalog';
+
+// CLIP server on Hetzner for visual text→image search
+const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
 
 const ENTITIES_SEARCH_INDEX = 'entities_search';
 const GALLERY_SEARCH_INDEX = 'gallery_search';
@@ -73,21 +77,22 @@ export async function GET(request: NextRequest) {
     if (firstTranslation) searchFilters.isFirstTranslation = true;
     if (hasTranslation) searchFilters.hasTranslation = true;
 
-    // Run book, index, and gallery search in parallel (each handles its own errors)
-    const [booksResult, indexResult, galleryResult] = await Promise.all([
+    // Run book, index, gallery, and visual search in parallel
+    const [booksResult, indexResult, galleryResult, visualResult] = await Promise.all([
       searchBooks(db, query, queryRegex, limit, searchFilters, library),
       searchIndex(db, query, limit).catch((err) => {
         console.error('Index search error:', err);
         return { results: [] as IndexResult[], total: 0 };
       }),
       searchGallery(db, query, queryRegex, galleryLimit),
+      searchVisual(query, galleryLimit),
     ]);
 
     // Log search query (fire-and-forget)
     db.collection('analytics_events').insertOne({
       event: 'search_query',
       query,
-      results_count: booksResult.total + indexResult.total + galleryResult.total,
+      results_count: booksResult.total + indexResult.total + galleryResult.total + visualResult.total,
       filters: { language, category, library, source: 'unified' },
       timestamp: new Date(),
       ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
@@ -99,6 +104,7 @@ export async function GET(request: NextRequest) {
       books: booksResult,
       index: indexResult,
       gallery: galleryResult,
+      visual: visualResult,
     }, {
       headers: {
         'Cache-Control': 'no-store',
@@ -427,6 +433,60 @@ async function searchGallery(db: any, query: string, queryRegex: RegExp, limit: 
     };
   } catch (err) {
     console.error('Gallery search error:', err);
+    return { results: [], total: 0 };
+  }
+}
+
+/**
+ * CLIP visual search: encode text query via CLIP, search against image embeddings.
+ * Finds images by what they look like, not just their metadata.
+ */
+async function searchVisual(query: string, limit: number): Promise<{ results: GalleryResult[]; total: number }> {
+  try {
+    // Encode text via CLIP text encoder
+    const clipResp = await fetch(`${CLIP_URL}/embed-text`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: query }),
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!clipResp.ok) return { results: [], total: 0 };
+    const { embedding } = await clipResp.json();
+    if (!embedding) return { results: [], total: 0 };
+
+    // Search Supabase CLIP embeddings
+    const { data, error } = await supabase.rpc('match_clip_text', {
+      query_embedding: embedding,
+      match_threshold: 0.22,
+      match_count: limit * 2,
+    });
+    if (error || !data) return { results: [], total: 0 };
+
+    // Deduplicate by book (max 2 per book)
+    const byBook = new Map<string, number>();
+    const deduped = (data as Array<{
+      id: string; book_id: string; image_url: string; thumbnail_url: string;
+      title: string; author: string; resource_type: string; similarity: number;
+    }>).filter(m => {
+      const count = byBook.get(m.book_id) || 0;
+      if (count >= 2) return false;
+      byBook.set(m.book_id, count + 1);
+      return true;
+    }).slice(0, limit);
+
+    return {
+      results: deduped.map(m => ({
+        id: m.id,
+        imageUrl: m.thumbnail_url || m.image_url || '',
+        description: m.title || '',
+        type: m.resource_type || undefined,
+        bookTitle: m.title || '',
+        bookId: m.book_id || '',
+        similarity: m.similarity,
+      })),
+      total: deduped.length,
+    };
+  } catch {
     return { results: [], total: 0 };
   }
 }

--- a/src/app/api/search/visual/route.ts
+++ b/src/app/api/search/visual/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+
+export const maxDuration = 15;
+
+// CLIP server on Hetzner, proxied through the text embedding server
+const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
+
+/**
+ * GET /api/search/visual?q=ouroboros&limit=20
+ *
+ * Text-to-image search using CLIP embeddings.
+ * Encodes the text query via CLIP text encoder, then searches
+ * against CLIP image embeddings in Supabase for visual matches.
+ *
+ * This finds images by what they LOOK like, not just their metadata.
+ * "skeleton playing music" finds skeleton images even if no metadata says "skeleton".
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q')?.trim();
+  const limit = Math.min(parseInt(searchParams.get('limit') || '24'), 100);
+  const offset = parseInt(searchParams.get('offset') || '0');
+  const threshold = parseFloat(searchParams.get('threshold') || '0.20');
+
+  if (!query || query.length < 2) {
+    return NextResponse.json({ results: [], query: '', total: 0 });
+  }
+
+  try {
+    // Encode text query via CLIP text encoder on Hetzner
+    const clipResp = await fetch(`${CLIP_URL}/embed-text`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: query }),
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!clipResp.ok) {
+      return NextResponse.json(
+        { error: 'Visual search unavailable', results: [], query, total: 0 },
+        { status: 502 },
+      );
+    }
+
+    const { embedding } = await clipResp.json();
+    if (!embedding) {
+      return NextResponse.json(
+        { error: 'Failed to encode query', results: [], query, total: 0 },
+        { status: 502 },
+      );
+    }
+
+    // Search Supabase for visually matching images
+    const { data, error } = await supabase.rpc('match_clip_text', {
+      query_embedding: embedding,
+      match_threshold: threshold,
+      match_count: offset + limit + 10,
+    });
+
+    if (error) {
+      console.error('[visual-search] Supabase error:', error.message);
+      return NextResponse.json(
+        { error: 'Search failed', results: [], query, total: 0 },
+        { status: 500 },
+      );
+    }
+
+    const matches = (data || []) as Array<{
+      id: string;
+      source_type: string;
+      book_id: string;
+      image_url: string;
+      title: string;
+      author: string;
+      resource_type: string;
+      thumbnail_url: string;
+      similarity: number;
+    }>;
+
+    // Deduplicate by book — max 3 per book for diversity
+    const byBook = new Map<string, number>();
+    const deduped = matches.filter(m => {
+      const count = byBook.get(m.book_id) || 0;
+      if (count >= 3) return false;
+      byBook.set(m.book_id, count + 1);
+      return true;
+    });
+
+    const page = deduped.slice(offset, offset + limit);
+
+    return NextResponse.json({
+      results: page.map(m => ({
+        id: m.id,
+        sourceType: m.source_type,
+        bookId: m.book_id,
+        imageUrl: m.thumbnail_url || m.image_url,
+        fullImageUrl: m.image_url,
+        title: m.title,
+        author: m.author,
+        resourceType: m.resource_type,
+        similarity: Math.round(m.similarity * 1000) / 1000,
+      })),
+      query,
+      total: deduped.length,
+      limit,
+      offset,
+      mode: 'visual',
+    }, {
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error('[visual-search] Error:', msg);
+    return NextResponse.json(
+      { error: 'Visual search failed', results: [], query, total: 0 },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- New `/api/search/visual?q=ouroboros` endpoint — text-to-image search via CLIP embeddings
- Gallery API gets `?visual=true` mode — returns images ranked by visual similarity to text query
- Unified search now returns `visual` results alongside books, index, and gallery
- New Supabase RPC `match_clip_text` for text→image CLIP queries
- All searches go through CLIP proxy on port 3456, graceful fallback if unavailable

## How it works
1. Text query → CLIP text encoder on Hetzner (port 3456/clip/embed-text)
2. 512-dim text embedding → Supabase IVFFlat cosine search against 31K image embeddings
3. Top matches returned with similarity scores, deduplicated by book

## Test plan
- [ ] `curl "https://sourcelibrary.org/api/search/visual?q=skeleton"` — should return visually matching images
- [ ] `curl "https://sourcelibrary.org/api/gallery?q=ouroboros&visual=true"` — gallery mode
- [ ] Verify unified search includes `visual` field in response
- [ ] Verify graceful fallback when CLIP server is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)