### PR TITLE
Add Supabase sync health monitoring

### DIFF
--- a/scripts/migration/supabase-sync-health.sql
+++ b/scripts/migration/supabase-sync-health.sql
@@ -21,28 +21,52 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pages_updated_at
 -- Run this block separately after the index is created.
 -- ============================================================
 
+-- NOTE: plpgsql with sequential queries avoids Postgres planner combining
+-- all subqueries into one plan that exceeds the 3s statement timeout.
 CREATE OR REPLACE FUNCTION sync_health()
 RETURNS JSON
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 AS $$
-  SELECT json_build_object(
+DECLARE
+  pages_count bigint;
+  pages_updated timestamptz;
+  pages_ocr timestamptz;
+  pages_translation timestamptz;
+  entities_count bigint;
+  entities_updated timestamptz;
+  gemini_count bigint;
+  gemini_latest timestamptz;
+BEGIN
+  SELECT reltuples::bigint INTO pages_count FROM pg_class WHERE relname = 'pages';
+  SELECT updated_at INTO pages_updated FROM pages ORDER BY updated_at DESC LIMIT 1;
+  SELECT ocr_updated_at INTO pages_ocr FROM pages WHERE ocr_updated_at IS NOT NULL ORDER BY ocr_updated_at DESC LIMIT 1;
+  SELECT translation_updated_at INTO pages_translation FROM pages WHERE translation_updated_at IS NOT NULL ORDER BY translation_updated_at DESC LIMIT 1;
+
+  SELECT reltuples::bigint INTO entities_count FROM pg_class WHERE relname = 'entities';
+  SELECT updated_at INTO entities_updated FROM entities ORDER BY updated_at DESC LIMIT 1;
+
+  SELECT reltuples::bigint INTO gemini_count FROM pg_class WHERE relname = 'gemini_usage';
+  SELECT timestamp INTO gemini_latest FROM gemini_usage ORDER BY timestamp DESC LIMIT 1;
+
+  RETURN json_build_object(
     'pages', json_build_object(
-      'approx_count', (SELECT reltuples::bigint FROM pg_class WHERE relname = 'pages'),
-      'latest_updated_at', (SELECT updated_at FROM pages ORDER BY updated_at DESC LIMIT 1),
-      'latest_ocr_at', (SELECT ocr_updated_at FROM pages ORDER BY ocr_updated_at DESC LIMIT 1),
-      'latest_translation_at', (SELECT translation_updated_at FROM pages ORDER BY translation_updated_at DESC LIMIT 1)
+      'approx_count', pages_count,
+      'latest_updated_at', pages_updated,
+      'latest_ocr_at', pages_ocr,
+      'latest_translation_at', pages_translation
     ),
     'entities', json_build_object(
-      'approx_count', (SELECT reltuples::bigint FROM pg_class WHERE relname = 'entities'),
-      'latest_updated_at', (SELECT updated_at FROM entities ORDER BY updated_at DESC LIMIT 1)
+      'approx_count', entities_count,
+      'latest_updated_at', entities_updated
     ),
     'gemini_usage', json_build_object(
-      'approx_count', (SELECT reltuples::bigint FROM pg_class WHERE relname = 'gemini_usage'),
-      'latest_at', (SELECT timestamp FROM gemini_usage ORDER BY timestamp DESC LIMIT 1)
+      'approx_count', gemini_count,
+      'latest_at', gemini_latest
     ),
     'checked_at', now()
   );
+END;
 $$;
 
 -- Grant access so health checks work without service role key

--- a/scripts/migration/supabase-sync-health.sql
+++ b/scripts/migration/supabase-sync-health.sql
@@ -1,0 +1,50 @@
+-- Supabase sync health improvements
+-- Fixes timeout issues on pages and gemini_usage tables
+-- Run via Supabase SQL Editor with service role permissions.
+--
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+-- Run the index creation statement separately from the rest.
+
+-- ============================================================
+-- 1. Missing index: pages.updated_at
+-- Without this, ORDER BY updated_at DESC seq-scans 3.5M rows → timeout
+-- Run this statement ALONE (not inside a transaction block):
+-- ============================================================
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pages_updated_at
+  ON pages (updated_at DESC);
+
+-- ============================================================
+-- 2. Fast sync health check RPC
+-- Uses pg_class for approximate counts (instant, no seq scan)
+-- and indexed queries for latest timestamps.
+-- Run this block separately after the index is created.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION sync_health()
+RETURNS JSON
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT json_build_object(
+    'pages', json_build_object(
+      'approx_count', (SELECT reltuples::bigint FROM pg_class WHERE relname = 'pages'),
+      'latest_updated_at', (SELECT updated_at FROM pages ORDER BY updated_at DESC LIMIT 1),
+      'latest_ocr_at', (SELECT ocr_updated_at FROM pages ORDER BY ocr_updated_at DESC LIMIT 1),
+      'latest_translation_at', (SELECT translation_updated_at FROM pages ORDER BY translation_updated_at DESC LIMIT 1)
+    ),
+    'entities', json_build_object(
+      'approx_count', (SELECT reltuples::bigint FROM pg_class WHERE relname = 'entities'),
+      'latest_updated_at', (SELECT updated_at FROM entities ORDER BY updated_at DESC LIMIT 1)
+    ),
+    'gemini_usage', json_build_object(
+      'approx_count', (SELECT reltuples::bigint FROM pg_class WHERE relname = 'gemini_usage'),
+      'latest_at', (SELECT timestamp FROM gemini_usage ORDER BY timestamp DESC LIMIT 1)
+    ),
+    'checked_at', now()
+  );
+$$;
+
+-- Grant access so health checks work without service role key
+GRANT EXECUTE ON FUNCTION sync_health() TO anon;
+GRANT EXECUTE ON FUNCTION sync_health() TO authenticated;

--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { withAdminAuth } from '@/lib/auth-helpers';
 import { QUEUE_URLS, getQueueDepth } from '@/lib/sqs-client';
+import { getSupabaseSyncHealth } from '@/lib/supabase-health';
 
 export const maxDuration = 30;
 
@@ -85,6 +86,7 @@ export const GET = withAdminAuth(async () => {
     systemConfig,
     sqsDepths,
     recentCronRuns,
+    supabaseSync,
   ] = await Promise.all([
     // Active Lambda jobs
     db.collection('jobs').aggregate([
@@ -135,6 +137,9 @@ export const GET = withAdminAuth(async () => {
         last_run: { $max: '$timestamp' },
       }},
     ]).toArray(),
+
+    // Supabase sync health
+    getSupabaseSyncHealth().catch(() => null),
   ]);
 
   // --- 2. Active jobs ---
@@ -225,6 +230,13 @@ export const GET = withAdminAuth(async () => {
     last_4h: cronSummary,
     total_failures: cronFailures,
   };
+
+  // --- 9. Supabase sync ---
+  if (supabaseSync) {
+    checks.supabase_sync = { ...supabaseSync } as CheckResult;
+  } else {
+    checks.supabase_sync = { status: 'warning', error: 'sync_health RPC unavailable' };
+  }
 
   // --- Overall health ---
   const hasAnyCritical = Object.values(checks).some(c => c.status === 'critical');

--- a/src/app/api/admin/supabase-sync/route.ts
+++ b/src/app/api/admin/supabase-sync/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth-helpers';
+import { getSupabaseSyncHealth } from '@/lib/supabase-health';
+
+export const maxDuration = 10;
+
+/**
+ * GET /api/admin/supabase-sync
+ *
+ * Lightweight Supabase sync health check.
+ * Returns approximate row counts, latest update timestamps,
+ * and lag in minutes for each synced table.
+ *
+ * Requires the sync_health() RPC on Supabase for best results.
+ * Falls back to individual queries if the RPC doesn't exist yet.
+ */
+export const GET = withAdminAuth(async () => {
+  const started = Date.now();
+  const result = await getSupabaseSyncHealth();
+
+  return NextResponse.json({
+    ...result,
+    duration_ms: Date.now() - started,
+  });
+});

--- a/src/lib/supabase-health.ts
+++ b/src/lib/supabase-health.ts
@@ -1,0 +1,117 @@
+/**
+ * Supabase sync health checker.
+ *
+ * Calls the sync_health() RPC function (created by supabase-sync-health.sql)
+ * which uses pg_class for instant approximate counts and indexed lookups
+ * for latest timestamps. Falls back to individual queries if the RPC
+ * doesn't exist yet.
+ */
+
+import { supabase } from './supabase';
+
+interface SyncHealthResult {
+  status: 'ok' | 'warning' | 'critical';
+  pages?: { approx_count: number; latest_updated_at: string | null; latest_ocr_at: string | null; latest_translation_at: string | null };
+  entities?: { approx_count: number; latest_updated_at: string | null };
+  gemini_usage?: { approx_count: number; latest_at: string | null };
+  lag_minutes?: Record<string, number | null>;
+  checked_at?: string;
+  error?: string;
+}
+
+export async function getSupabaseSyncHealth(): Promise<SyncHealthResult> {
+  // Try the RPC function first (instant, uses pg_class)
+  const { data, error } = await supabase.rpc('sync_health');
+
+  if (error) {
+    // RPC doesn't exist yet — fall back to lightweight individual queries
+    return getFallbackHealth();
+  }
+
+  const result = data as {
+    pages: { approx_count: number; latest_updated_at: string | null; latest_ocr_at: string | null; latest_translation_at: string | null };
+    entities: { approx_count: number; latest_updated_at: string | null };
+    gemini_usage: { approx_count: number; latest_at: string | null };
+    checked_at: string;
+  };
+
+  // Calculate lag: how many minutes since the latest update in each table
+  const now = Date.now();
+  const lag: Record<string, number | null> = {};
+
+  if (result.pages?.latest_updated_at) {
+    lag.pages = Math.round((now - new Date(result.pages.latest_updated_at).getTime()) / 60000);
+  }
+  if (result.entities?.latest_updated_at) {
+    lag.entities = Math.round((now - new Date(result.entities.latest_updated_at).getTime()) / 60000);
+  }
+  if (result.gemini_usage?.latest_at) {
+    lag.gemini_usage = Math.round((now - new Date(result.gemini_usage.latest_at).getTime()) / 60000);
+  }
+
+  // Status: warning if any table hasn't been updated in 60+ minutes,
+  // critical if 6+ hours (likely sync is broken)
+  const maxLag = Math.max(...Object.values(lag).filter((v): v is number => v !== null));
+  const status = maxLag > 360 ? 'critical'
+    : maxLag > 60 ? 'warning'
+    : 'ok';
+
+  return {
+    status,
+    pages: result.pages,
+    entities: result.entities,
+    gemini_usage: result.gemini_usage,
+    lag_minutes: lag,
+    checked_at: result.checked_at,
+  };
+}
+
+/** Fallback when the sync_health() RPC hasn't been created yet */
+async function getFallbackHealth(): Promise<SyncHealthResult> {
+  const now = Date.now();
+  const lag: Record<string, number | null> = {};
+
+  // Entities — has an index on updated_at, should be fast
+  const { data: entityRow } = await supabase
+    .from('entities')
+    .select('updated_at')
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (entityRow?.updated_at) {
+    lag.entities = Math.round((now - new Date(entityRow.updated_at).getTime()) / 60000);
+  }
+
+  // Pages — may timeout without the index, use a 3s abort
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const { data: pageRow } = await supabase
+      .from('pages')
+      .select('updated_at')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .abortSignal(controller.signal)
+      .single();
+    clearTimeout(timeout);
+
+    if (pageRow?.updated_at) {
+      lag.pages = Math.round((now - new Date(pageRow.updated_at).getTime()) / 60000);
+    }
+  } catch {
+    lag.pages = null; // timed out — index not yet created
+  }
+
+  const maxLag = Math.max(...Object.values(lag).filter((v): v is number => v !== null), 0);
+  const status = maxLag > 360 ? 'critical'
+    : maxLag > 60 ? 'warning'
+    : 'ok';
+
+  return {
+    status,
+    lag_minutes: lag,
+    checked_at: new Date().toISOString(),
+    ...(lag.pages === null ? { error: 'pages query timed out — run supabase-sync-health.sql to add idx_pages_updated_at' } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- Fixes Supabase query timeouts on `pages` (3.5M rows) and `gemini_usage` tables
- Adds `idx_pages_updated_at` index and `sync_health()` RPC using `pg_class` for instant counts
- New `/api/admin/supabase-sync` endpoint for lightweight sync checks
- Integrates Supabase sync into existing `/api/admin/health` with lag tracking (warns at 60min, critical at 6h)

## Manual step required
After merge, run the SQL migration in Supabase SQL Editor:
1. Run `CREATE INDEX CONCURRENTLY` statement **alone** (can't be in a transaction)
2. Run the `CREATE OR REPLACE FUNCTION sync_health()` block separately

File: `scripts/migration/supabase-sync-health.sql`

## Test plan
- [ ] Deploy and hit `/api/admin/supabase-sync` — should return fallback health before SQL migration
- [ ] Run SQL migration in Supabase
- [ ] Re-hit `/api/admin/supabase-sync` — should return instant counts via RPC
- [ ] Verify `/api/admin/health` includes `supabase_sync` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)