### PR TITLE
Show all readable books on homepage (not just >=90%)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -327,11 +327,9 @@ const FALLBACK_COUNTS = { totalBooks: 10002, translatedToEnglish: 10002, firstTr
 async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglish: number; firstTranslationCount: number; authorCount: number; languageCount: number }> {
   // 1. Try Supabase (fast Postgres counts, synced every 2h)
   try {
-    const [totalRes, translatedRes, firstTransRes] = await Promise.all([
+    const [totalRes, firstTransRes] = await Promise.all([
       supabase.from('books_catalog').select('id', { count: 'exact', head: true })
         .eq('visible', true).gt('pages_translated', 0),
-      supabase.from('books_catalog').select('id', { count: 'exact', head: true })
-        .eq('visible', true).gte('translation_pct', 90),
       supabase.from('books_catalog').select('id', { count: 'exact', head: true })
         .eq('visible', true).eq('is_first_translation', true).gt('pages_translated', 0),
     ]);
@@ -352,7 +350,7 @@ async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglis
 
       return {
         totalBooks: totalRes.count,
-        translatedToEnglish: translatedRes.count ?? FALLBACK_COUNTS.translatedToEnglish,
+        translatedToEnglish: totalRes.count,
         firstTranslationCount: firstTransRes.count ?? FALLBACK_COUNTS.firstTranslationCount,
         authorCount,
         languageCount,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -322,7 +322,7 @@ async function getCollectionShowcase() {
   return JSON.parse(JSON.stringify(items));
 }
 
-const FALLBACK_COUNTS = { totalBooks: 9924, translatedToEnglish: 9054, firstTranslationCount: 5454, authorCount: 3200, languageCount: 50 };
+const FALLBACK_COUNTS = { totalBooks: 10002, translatedToEnglish: 10002, firstTranslationCount: 5454, authorCount: 3200, languageCount: 50 };
 
 async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglish: number; firstTranslationCount: number; authorCount: number; languageCount: number }> {
   // 1. Try Supabase (fast Postgres counts, synced every 2h)


### PR DESCRIPTION
## Summary
- Changed homepage "translated books and manuscripts" count from `translation_pct >= 90` to `pages_translated > 0`
- This shows all readable books (~10K+) instead of only fully-translated ones (~9K)
- Removed duplicate Supabase query — `totalBooks` and `translatedToEnglish` now share the same count

## Test plan
- [ ] Homepage shows ~10,000+ for "translated books and manuscripts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)