### PR TITLE
SEO: split sitemap, filter hex IDs, add missing canonicals

### DIFF
--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -67,6 +67,7 @@ export async function generateMetadata({ params }: CategoryPageProps): Promise<M
   return {
     title: `${category.name} — Source Library`,
     description: `Browse ${category.description.toLowerCase()} in Source Library's collection of rare historical texts, digitized and translated with AI.`,
+    alternates: { canonical: `/categories/${id}` },
     openGraph: {
       title: `${category.name} — Source Library`,
       description: category.description,

--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -46,6 +46,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${data.title} | Gallery | Source Library`,
     description: data.description,
+    alternates: { canonical: `/gallery/collections/${slug}` },
     openGraph: {
       title: `${data.title} | Source Library Gallery`,
       description: data.description,

--- a/src/app/research/[id]/page.tsx
+++ b/src/app/research/[id]/page.tsx
@@ -32,6 +32,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title,
     description: `Curator research session from ${new Date(session.date as string).toLocaleDateString()} exploring ${(session.themes as string[])?.join(', ') || 'various topics'}.`,
+    alternates: { canonical: `/research/${id}` },
   };
 }
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -80,5 +80,7 @@ export default function robots(): MetadataRoute.Robots {
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
+    // Note: Next.js generateSitemaps() automatically creates a sitemap index
+    // at /sitemap.xml that references /sitemap/0.xml, /sitemap/1.xml, etc.
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,171 +1,130 @@
 import { MetadataRoute } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 
-// Next.js metadata files (sitemap.ts) are statically generated at build time.
-// Each DB query is independently wrapped so a single timeout doesn't kill the whole sitemap.
-// The gallery images query is removed — it's the heaviest query (9.5M pages collection)
-// and gallery images are low SEO value (priority 0.4). They're discoverable via internal links.
+// Next.js sitemap with generateSitemaps() for multi-file output.
+// Google handles chunked sitemaps much better for large sites (10K+ URLs).
+// Each chunk gets its own sitemap file: /sitemap/0.xml, /sitemap/1.xml, etc.
+//
+// Chunks:
+//   0 = static pages + blog + categories
+//   1 = collections + libraries + languages + works
+//   2+ = books (up to 5000 per chunk)
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://sourcelibrary.org';
+const BASE_URL = 'https://sourcelibrary.org';
+const BOOKS_PER_CHUNK = 5000;
 
-  // Static pages
-  const staticPages: MetadataRoute.Sitemap = [
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/search`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/browse`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/categories`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/encyclopedia`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/census`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/about/progress`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/developers`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/gallery`,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/collections`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/libraries`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/explore`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/explore/map`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/timeline`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/gallery/collections`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/blog`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/curated`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/support`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
+// Helper: run a DB query with independent error handling
+async function safeQuery<T>(
+  label: string,
+  fn: (db: Awaited<ReturnType<typeof getReadDb>>) => Promise<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    const dbPromise = getReadDb();
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label}: DB connection timeout`)), 20000)
+    );
+    const db = await Promise.race([dbPromise, timeoutPromise]);
+    return await fn(db);
+  } catch (error) {
+    console.error(`Sitemap ${label} failed:`, error);
+    return fallback;
+  }
+}
+
+export async function generateSitemaps() {
+  // Count books to determine how many chunks we need
+  const bookCount = await safeQuery('book-count', async (db) => {
+    return db.collection('books').countDocuments(
+      { visible: true, slug: { $exists: true, $ne: null }, pages_ocr: { $gt: 0 } },
+      { maxTimeMS: 10000 }
+    );
+  }, 10000);
+
+  const bookChunks = Math.ceil(bookCount / BOOKS_PER_CHUNK);
+
+  // Chunk 0 = static, 1 = dynamic non-books, 2+ = books
+  const ids = [{ id: 0 }, { id: 1 }];
+  for (let i = 0; i < bookChunks; i++) {
+    ids.push({ id: 2 + i });
+  }
+
+  return ids;
+}
+
+export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
+  // Chunk 0: Static pages + blog + categories
+  if (id === 0) {
+    return [
+      ...staticPages(),
+      ...blogPosts(),
+      ...categoryPages(),
+    ];
+  }
+
+  // Chunk 1: Collections, libraries, languages, works
+  if (id === 1) {
+    const [collectionPages, libraryPages, languagePages, workPages] = await Promise.all([
+      getCollections(),
+      getLibraries(),
+      getLanguages(),
+      getWorks(),
+    ]);
+    return [...collectionPages, ...libraryPages, ...languagePages, ...workPages];
+  }
+
+  // Chunk 2+: Books (paginated)
+  const bookChunkIndex = id - 2;
+  return getBooks(bookChunkIndex);
+}
+
+// --- Static content ---
+
+function staticPages(): MetadataRoute.Sitemap {
+  return [
+    { url: BASE_URL, lastModified: new Date(), changeFrequency: 'daily', priority: 1 },
+    { url: `${BASE_URL}/search`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.8 },
+    { url: `${BASE_URL}/browse`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/categories`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/encyclopedia`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/about`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/census`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/about/progress`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/developers`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE_URL}/gallery`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.7 },
+    { url: `${BASE_URL}/collections`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/libraries`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
+    { url: `${BASE_URL}/explore`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/explore/map`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/timeline`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/gallery/collections`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/blog`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${BASE_URL}/curated`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
+    { url: `${BASE_URL}/support`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
   ];
+}
 
-  // Blog posts — original long-form content, high SEO value
-  const blogPosts: MetadataRoute.Sitemap = [
-    'astrological-diagrams',
-    'chakra-tradition',
-    'demonology',
-    'fechner-bohme',
-    'fire-horse',
-    'first-translation-methodology',
-    'first-translations',
-    'hidden-engineers',
-    'history-of-astrology',
-    'indigenous-traditions',
-    'invisible-hand',
-    'mcp-server',
-    'ocr-consistency',
-    'cuneiform-ocr',
-    'rithmomachia',
-    'progress-studies',
-    '2000-first-translations',
-    'worlds-largest-collection',
-    'origin-story',
-    'counting-the-gap',
-    'untranslated-renaissance',
-    'translation-rate',
-    'hieroglyph-ocr',
-    'rashi-ocr',
-    'clustering',
-    'history-of-classification',
-    'visualizing-classification',
-    'philosophers-stone',
+function blogPosts(): MetadataRoute.Sitemap {
+  return [
+    'astrological-diagrams', 'chakra-tradition', 'demonology', 'fechner-bohme',
+    'fire-horse', 'first-translation-methodology', 'first-translations',
+    'hidden-engineers', 'history-of-astrology', 'indigenous-traditions',
+    'invisible-hand', 'mcp-server', 'ocr-consistency', 'cuneiform-ocr',
+    'rithmomachia', 'progress-studies', '2000-first-translations',
+    'worlds-largest-collection', 'origin-story', 'counting-the-gap',
+    'untranslated-renaissance', 'translation-rate', 'hieroglyph-ocr',
+    'rashi-ocr', 'clustering', 'history-of-classification',
+    'visualizing-classification', 'philosophers-stone',
   ].map((slug) => ({
-    url: `${baseUrl}/blog/${slug}`,
+    url: `${BASE_URL}/blog/${slug}`,
     lastModified: new Date(),
     changeFrequency: 'monthly' as const,
     priority: 0.8,
   }));
+}
 
-  // Category pages — server-rendered with metadata
-  const categoryPages: MetadataRoute.Sitemap = [
+function categoryPages(): MetadataRoute.Sitemap {
+  return [
     'alchemy', 'hermeticism', 'jewish-kabbalah', 'christian-cabala',
     'neoplatonism', 'rosicrucianism', 'freemasonry', 'natural-philosophy',
     'astrology', 'natural-magic', 'ritual-magic', 'theurgy', 'mysticism',
@@ -174,145 +133,122 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     'christian-mysticism', 'prisca-theologia', 'florentine-platonism',
     'renaissance', 'reformation', 'enlightenment', '19th-century-revival',
   ].map((slug) => ({
-    url: `${baseUrl}/categories/${slug}`,
+    url: `${BASE_URL}/categories/${slug}`,
     lastModified: new Date(),
     changeFrequency: 'weekly' as const,
     priority: 0.7,
   }));
+}
 
-  // Helper: run a DB query with independent error handling
-  async function safeQuery<T>(
-    label: string,
-    fn: (db: Awaited<ReturnType<typeof getReadDb>>) => Promise<T>,
-    fallback: T,
-  ): Promise<T> {
-    try {
-      const dbPromise = getReadDb();
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`${label}: DB connection timeout`)), 20000)
-      );
-      const db = await Promise.race([dbPromise, timeoutPromise]);
-      return await fn(db);
-    } catch (error) {
-      console.error(`Sitemap ${label} failed:`, error);
-      return fallback;
-    }
-  }
+// --- Dynamic DB-driven content ---
 
-  // Run all queries in parallel — each independently fault-tolerant
-  const [bookPages, collectionPages, libraryPages, languagePages, workPages] = await Promise.all([
-    // Books — the most important query (13K+ URLs)
-    safeQuery('books', async (db) => {
-      const books = await db.collection('books').find(
-        { visible: true },
-        {
-          projection: { id: 1, slug: 1, updated_at: 1, pages_ocr: 1, pages_translated: 1, is_first_translation: 1, read_count: 1 },
-          maxTimeMS: 25000,
+async function getBooks(chunkIndex: number): Promise<MetadataRoute.Sitemap> {
+  return safeQuery('books', async (db) => {
+    const books = await db.collection('books').find(
+      {
+        visible: true,
+        // Only include books with slugs — hex IDs are bad for SEO
+        slug: { $exists: true, $ne: null },
+        pages_ocr: { $gt: 0 },
+      },
+      {
+        projection: { slug: 1, updated_at: 1, pages_ocr: 1, pages_translated: 1, is_first_translation: 1, read_count: 1 },
+        sort: { _id: 1 },
+        skip: chunkIndex * BOOKS_PER_CHUNK,
+        limit: BOOKS_PER_CHUNK,
+        maxTimeMS: 25000,
+      }
+    ).toArray();
+
+    return books
+      .filter((book) => book.slug && (book.pages_ocr > 3 || book.pages_translated > 0))
+      .map((book) => {
+        let lastModified: Date;
+        try {
+          lastModified = book.updated_at ? new Date(book.updated_at) : new Date();
+          if (isNaN(lastModified.getTime())) lastModified = new Date();
+        } catch {
+          lastModified = new Date();
         }
-      ).toArray();
 
-      return books
-        .filter((book) => book.pages_ocr > 0 && (book.pages_ocr > 3 || book.pages_translated > 0))
-        .map((book) => {
-          let lastModified: Date;
-          try {
-            lastModified = book.updated_at ? new Date(book.updated_at) : new Date();
-            if (isNaN(lastModified.getTime())) lastModified = new Date();
-          } catch {
-            lastModified = new Date();
-          }
+        let priority = 0.5;
+        if (book.pages_translated > 0) priority = 0.7;
+        if (book.is_first_translation) priority = 0.85;
+        if (book.read_count >= 10) priority = Math.max(priority, 0.85);
+        if (book.is_first_translation && book.pages_translated > 0) priority = 0.9;
 
-          let priority = 0.5;
-          if (book.pages_translated > 0) priority = 0.7;
-          if (book.is_first_translation) priority = 0.85;
-          if (book.read_count >= 10) priority = Math.max(priority, 0.85);
-          if (book.is_first_translation && book.pages_translated > 0) priority = 0.9;
+        return {
+          url: `${BASE_URL}/book/${book.slug}`,
+          lastModified,
+          changeFrequency: 'weekly' as const,
+          priority,
+        };
+      });
+  }, [] as MetadataRoute.Sitemap);
+}
 
-          return {
-            url: `${baseUrl}/book/${book.slug || book.id}`,
-            lastModified,
-            changeFrequency: 'weekly' as const,
-            priority,
-          };
-        });
-    }, [] as MetadataRoute.Sitemap),
+async function getCollections(): Promise<MetadataRoute.Sitemap> {
+  return safeQuery('collections', async (db) => {
+    const collections = await db.collection('collections').find(
+      { visible: true },
+      { projection: { slug: 1, updated_at: 1 }, maxTimeMS: 5000 }
+    ).toArray();
 
-    // Collections
-    safeQuery('collections', async (db) => {
-      const collections = await db.collection('collections').find(
-        { visible: true },
-        { projection: { slug: 1, updated_at: 1 }, maxTimeMS: 5000 }
-      ).toArray();
+    return collections.map((col) => ({
+      url: `${BASE_URL}/collections/${col.slug}`,
+      lastModified: col.updated_at ? new Date(col.updated_at) : new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    }));
+  }, [] as MetadataRoute.Sitemap);
+}
 
-      return collections.map((col) => ({
-        url: `${baseUrl}/collections/${col.slug}`,
-        lastModified: col.updated_at ? new Date(col.updated_at) : new Date(),
-        changeFrequency: 'weekly' as const,
-        priority: 0.7,
-      }));
-    }, [] as MetadataRoute.Sitemap),
+async function getLibraries(): Promise<MetadataRoute.Sitemap> {
+  return safeQuery('libraries', async (db) => {
+    const libraries = await db.collection('libraries').find(
+      {},
+      { projection: { slug: 1, updated_at: 1 }, maxTimeMS: 5000 }
+    ).toArray();
 
-    // Libraries
-    safeQuery('libraries', async (db) => {
-      const libraries = await db.collection('libraries').find(
-        {},
-        { projection: { slug: 1, updated_at: 1 }, maxTimeMS: 5000 }
-      ).toArray();
+    return libraries.map((lib) => ({
+      url: `${BASE_URL}/libraries/${lib.slug}`,
+      lastModified: lib.updated_at ? new Date(lib.updated_at) : new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.5,
+    }));
+  }, [] as MetadataRoute.Sitemap);
+}
 
-      return libraries.map((lib) => ({
-        url: `${baseUrl}/libraries/${lib.slug}`,
-        lastModified: lib.updated_at ? new Date(lib.updated_at) : new Date(),
-        changeFrequency: 'monthly' as const,
-        priority: 0.5,
-      }));
-    }, [] as MetadataRoute.Sitemap),
+async function getLanguages(): Promise<MetadataRoute.Sitemap> {
+  return safeQuery('languages', async (db) => {
+    const languages = await db.collection('books').aggregate([
+      { $match: { visible: true, pages_count: { $gt: 0 }, language: { $exists: true, $ne: null } } },
+      { $group: { _id: '$language', count: { $sum: 1 } } },
+      { $match: { count: { $gte: 5 } } },
+    ], { maxTimeMS: 10000 }).toArray();
 
-    // Languages
-    safeQuery('languages', async (db) => {
-      const languages = await db.collection('books').aggregate([
-        { $match: { visible: true, pages_count: { $gt: 0 }, language: { $exists: true, $ne: null } } },
-        { $group: { _id: '$language', count: { $sum: 1 } } },
-        { $match: { count: { $gte: 5 } } },
-      ], { maxTimeMS: 10000 }).toArray();
+    return languages.map((lang) => ({
+      url: `${BASE_URL}/languages/${(lang._id as string).toLowerCase().replace(/\s+/g, '-')}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.5,
+    }));
+  }, [] as MetadataRoute.Sitemap);
+}
 
-      return languages.map((lang) => ({
-        url: `${baseUrl}/languages/${(lang._id as string).toLowerCase().replace(/\s+/g, '-')}`,
-        lastModified: new Date(),
-        changeFrequency: 'weekly' as const,
-        priority: 0.5,
-      }));
-    }, [] as MetadataRoute.Sitemap),
+async function getWorks(): Promise<MetadataRoute.Sitemap> {
+  return safeQuery('works', async (db) => {
+    const works = await db.collection('books').aggregate([
+      { $match: { work_id: { $exists: true, $ne: null }, visible: true } },
+      { $group: { _id: '$work_id', count: { $sum: 1 } } },
+      { $match: { count: { $gte: 2 } } },
+    ], { maxTimeMS: 10000 }).toArray();
 
-    // Works
-    safeQuery('works', async (db) => {
-      const works = await db.collection('books').aggregate([
-        { $match: { work_id: { $exists: true, $ne: null }, visible: true } },
-        { $group: { _id: '$work_id', count: { $sum: 1 } } },
-        { $match: { count: { $gte: 2 } } },
-      ], { maxTimeMS: 10000 }).toArray();
-
-      return works.map((w) => ({
-        url: `${baseUrl}/work/${w._id}`,
-        lastModified: new Date(),
-        changeFrequency: 'monthly' as const,
-        priority: 0.5,
-      }));
-    }, [] as MetadataRoute.Sitemap),
-  ]);
-
-  const total = staticPages.length + blogPosts.length + categoryPages.length +
-    bookPages.length + collectionPages.length + libraryPages.length +
-    languagePages.length + workPages.length;
-  console.log(`Sitemap: ${total} URLs (${bookPages.length} books, ${collectionPages.length} collections, ${libraryPages.length} libraries, ${languagePages.length} languages, ${workPages.length} works)`);
-
-  return [
-    ...staticPages,
-    ...blogPosts,
-    ...categoryPages,
-    ...bookPages,
-    ...collectionPages,
-    ...libraryPages,
-    ...languagePages,
-    ...workPages,
-  ];
+    return works.map((w) => ({
+      url: `${BASE_URL}/work/${w._id}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.5,
+    }));
+  }, [] as MetadataRoute.Sitemap);
 }


### PR DESCRIPTION
## Summary
- **Split sitemap into chunks** using Next.js `generateSitemaps()` — static pages, collections/libs/works, and books in 5K-URL chunks. Google handles multi-file sitemaps much better for large sites.
- **Filter books without slugs** from sitemap — hex MongoDB IDs were appearing as URLs (e.g. `/book/69c867a26c6f3cc53c8565d3`), which are bad SEO signals.
- **Deleted 3 legacy 2011 sitemaps** from GSC via API — these were from a previous site owner and wasting crawl budget.
- **Added missing canonical tags** on `categories/[id]`, `gallery/collections/[slug]`, and `research/[id]` pages.

## Context
GSC audit showed only 2,001 of 10,821 sitemap URLs had any impressions. 82% of URLs were "unknown to Google" — never even crawled. The monolithic sitemap + hex IDs + legacy sitemaps were the main culprits.

## Test plan
- [ ] Verify `/sitemap.xml` returns a sitemap index (not a flat list)
- [ ] Verify `/sitemap/0.xml` returns static + blog + category pages
- [ ] Verify `/sitemap/1.xml` returns collections, libraries, languages, works
- [ ] Verify `/sitemap/2.xml` returns books (slug-based URLs only)
- [ ] Spot-check that no hex IDs appear in any sitemap chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)