### PR TITLE
Fix 48K gallery images invisible due to missing book_visible field

### DIFF
--- a/src/app/api/admin/sync-gallery-images/route.ts
+++ b/src/app/api/admin/sync-gallery-images/route.ts
@@ -108,6 +108,7 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
           book_author: '$book.author',
           book_year: '$book.year',
           book_language: '$book.language',
+          book_visible: { $ifNull: ['$book.visible', false] },
           book_hidden: '$book.hidden',
           book_provider: '$book.image_source.provider',
           book_rank: '$book_rank',

--- a/src/workers/image-extraction-processor-logic.ts
+++ b/src/workers/image-extraction-processor-logic.ts
@@ -246,7 +246,7 @@ async function buildGalleryDocs(
     // Fetch book metadata for denormalization
     const book = await db.collection('books').findOne(
       { id: bookId },
-      { projection: { display_title: 1, title: 1, author: 1, year: 1, language: 1 } }
+      { projection: { display_title: 1, title: 1, author: 1, year: 1, language: 1, visible: 1, hidden: 1 } }
     );
 
     const imageUrl = page.cropped_photo || page.archived_photo || page.photo_original || page.photo || '';
@@ -279,6 +279,8 @@ async function buildGalleryDocs(
           book_author: book?.author || null,
           book_year: book?.year || null,
           book_language: book?.language || null,
+          book_visible: book?.visible ?? false,
+          book_hidden: book?.hidden || null,
           book_rank: 0,
           updated_at: new Date(),
         };


### PR DESCRIPTION
## Summary
- The `gallery_images` materialized view queries all filter on `book_visible: true`, but neither the sync pipeline nor the image extraction worker ever set this field
- 57% of all gallery images (48,676) were invisible — including entire books like Spence's *Encyclopaedia of Occultism* (18 images, all hidden)
- Added `book_visible` to the `$project` stage in `sync-gallery-images` and to `buildGalleryDocs` in the extraction worker
- Data backfill already applied directly to MongoDB (48,676 images set to `book_visible: true`)

## Test plan
- [x] Verified Spence book now has 18 gallery images with `book_visible: true`
- [ ] Check https://sourcelibrary.org/book/an-encyclopaedia-of-occultism-spence shows gallery
- [ ] Spot-check /gallery page shows more images than before
- [ ] Run sync-gallery-images to verify new images get `book_visible` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)