### PR TITLE
Fix _id conflict in warehouse promotion, bump limit to 50

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3107,7 +3107,7 @@ Rules:
     // they must be promoted to the live collection before OCR can run.
     // The old Vercel cron that did this was archived — this replaces it.
     if (shouldRun(2)) {
-      const PROMOTE_LIMIT = 20; // Conservative: each book copies all pages (can be hundreds)
+      const PROMOTE_LIMIT = 50; // Each book copies all pages — keep moderate to avoid Atlas spikes
       const ENGLISH_VARIANTS_WH = ['english', 'eng', 'en'];
       const promoteCandidates = await db.collection('books_warehouse')
         .aggregate([
@@ -3139,15 +3139,30 @@ Rules:
             const book = await db.collection('books_warehouse').findOne({ id: candidate.id });
             if (!book) continue;
 
-            // Upsert to live
-            await db.collection('books').replaceOne({ id: candidate.id }, book, { upsert: true });
+            // Check if book already exists in live (can have different _id)
+            const existingLive = await db.collection('books').findOne({ id: candidate.id }, { projection: { _id: 1 } });
+            if (existingLive) {
+              // Update in place, preserving live _id
+              const { _id, ...bookWithoutId } = book;
+              await db.collection('books').updateOne({ id: candidate.id }, { $set: bookWithoutId });
+            } else {
+              // Fresh insert
+              await db.collection('books').insertOne(book);
+            }
 
-            // Move pages in bulk
+            // Move pages — handle _id conflicts by stripping _id for upserts matched by book_id+page_number
             const pages = await db.collection('pages_warehouse').find({ book_id: candidate.id }).toArray();
             if (pages.length > 0) {
-              const bulkOps = pages.map(page => ({
-                replaceOne: { filter: { _id: page._id }, replacement: page, upsert: true },
-              }));
+              const bulkOps = pages.map(page => {
+                const { _id, ...pageWithoutId } = page;
+                return {
+                  updateOne: {
+                    filter: { book_id: page.book_id, page_number: page.page_number },
+                    update: { $set: pageWithoutId },
+                    upsert: true,
+                  },
+                };
+              });
               await db.collection('pages').bulkWrite(bulkOps, { ordered: false });
             }
 


### PR DESCRIPTION
## Summary
- First promotion run promoted 7 books but 13 failed with `_id` immutable field error — books exist in both warehouse and live with different `_id` values
- Fix: strip `_id` when updating existing live books, match pages by `book_id+page_number` instead of `_id`
- Bump promotion limit from 20 → 50 per cycle (~3,750 books/hour at 2-min orchestrator interval)

## Test plan
- [ ] Verify 0 `_id` errors in next promotion cycle
- [ ] Verify promotion rate increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)