### PR TITLE
Fix search: strip XML from snippets, improve word-level matching

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -255,7 +255,7 @@ export async function GET(request: NextRequest) {
           // Prefer translation highlights over OCR
           const translationHL = highlights.find(h => h.path === 'translation.data');
           const hl = translationHL || highlights[0];
-          snippet = hl.texts.map(t => t.value).join('');
+          snippet = cleanText(hl.texts.map(t => t.value).join(''));
           snippetType = hl.path === 'translation.data' ? 'translation' : 'ocr';
         } else {
           // Fallback to full text extraction

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -303,11 +303,24 @@ export async function searchBookIds(
 ): Promise<string[]> {
   const limit = opts?.limit || 500;
 
+  // Build OR filter: exact phrase match + word-level AND matches
+  // "mathematical magick" should match "Mathematicall Magick" by matching each word
+  const words = text.trim().split(/\s+/).filter(w => w.length >= 2);
+  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`;
+
+  let orFilter = phraseFilters;
+  if (words.length >= 2) {
+    // Add word-level AND: title contains ALL words (handles spelling variants)
+    const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
+    const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');
+    orFilter += `,and(${titleAnds}),and(${displayAnds})`;
+  }
+
   let query = supabase
     .from('books_catalog')
     .select('id')
     .gt('pages_count', 0)
-    .or(`title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`)
+    .or(orFilter)
     .limit(limit);
 
   if (!opts?.includeHidden) query = query.eq('visible', true);


### PR DESCRIPTION
## Summary
- **XML in snippets:** `cleanText()` was only applied to fallback snippets, not Atlas Search highlights. Now strips XML/HTML tags from all snippet sources — no more `<image-desc>`, `<vocab>` tags in search results.
- **"All" tab missing exact book:** `searchBookIds` used full-phrase `ilike` which missed spelling variants (e.g. "mathematical magick" vs "Mathematicall Magick"). Added word-level AND matching so each query word is matched individually.

## Test plan
- [ ] Search "mathematical magick" — verify no XML tags in snippets
- [ ] Search "mathematical magick" — verify the actual book appears in the All tab, not just related books
- [ ] Search single-word queries still work normally
- [ ] Search author names still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)