### PR TITLE
Cap timeline range: -800 BC to 1930

### DIFF
--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -65,7 +65,7 @@ const ERAS: Era[] = [
     name: 'modern',
     label: 'Modern',
     from: 1800,
-    to: 2100,
+    to: 1930,
     color: '#8a8480',
     description: 'Revival and scholarship — the Golden Dawn, Theosophy, and the academic study of Western esotericism.',
   },
@@ -137,7 +137,8 @@ export default function TimelineClient({ initialData }: Props) {
 
   // Filter decades by language and/or era
   const filteredDecades = useMemo(() => {
-    let decades = overviewData.decades;
+    // Cap at 1930 — the library focuses on pre-modern texts
+    let decades = overviewData.decades.filter(d => d.decade < 1930);
 
     if (language) {
       decades = decades
@@ -260,7 +261,7 @@ export default function TimelineClient({ initialData }: Props) {
       <div className="flex flex-wrap gap-2 justify-center">
         {ERAS.filter(era => {
           // Only show eras that have data
-          return overviewData.decades.some(d => d.decade >= era.from && d.decade < era.to);
+          return overviewData.decades.some(d => d.decade < 1930 && d.decade >= era.from && d.decade < era.to);
         }).map(era => {
           const isActive = selectedEraName === era.name;
           const eraCount = overviewData.decades

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -20,11 +20,15 @@ interface Era {
   description: string;
 }
 
+// Timeline range: classical antiquity through the early modern period
+const TIMELINE_YEAR_MIN = -800;
+const TIMELINE_YEAR_MAX = 1930;
+
 const ERAS: Era[] = [
   {
     name: 'antiquity',
     label: 'Antiquity',
-    from: -3000,
+    from: -800,
     to: 500,
     color: 'var(--accent-sage)',
     description: 'The classical foundations — Hermes Trismegistus, Plato, the Neoplatonists, and the Corpus Hermeticum.',
@@ -137,8 +141,8 @@ export default function TimelineClient({ initialData }: Props) {
 
   // Filter decades by language and/or era
   const filteredDecades = useMemo(() => {
-    // Cap at 1930 — the library focuses on pre-modern texts
-    let decades = overviewData.decades.filter(d => d.decade < 1930);
+    // Show only the core range: classical antiquity through the early modern period
+    let decades = overviewData.decades.filter(d => d.decade >= TIMELINE_YEAR_MIN && d.decade < TIMELINE_YEAR_MAX);
 
     if (language) {
       decades = decades
@@ -261,7 +265,7 @@ export default function TimelineClient({ initialData }: Props) {
       <div className="flex flex-wrap gap-2 justify-center">
         {ERAS.filter(era => {
           // Only show eras that have data
-          return overviewData.decades.some(d => d.decade < 1930 && d.decade >= era.from && d.decade < era.to);
+          return overviewData.decades.some(d => d.decade >= TIMELINE_YEAR_MIN && d.decade < TIMELINE_YEAR_MAX && d.decade >= era.from && d.decade < era.to);
         }).map(era => {
           const isActive = selectedEraName === era.name;
           const eraCount = overviewData.decades


### PR DESCRIPTION
## Summary
- Caps timeline at -800 BC (classical antiquity) through 1930
- Removes the -2000 decade Sumerian spike (373 batch-imported texts) that created 120+ empty decades of horizontal whitespace
- Also removes post-1930 decades (modern reprints, not the library's focus)

## Test plan
- [ ] Timeline histogram starts around 800 BC, not 2270 BC
- [ ] No bars visible past 1920s
- [ ] Era pills and totals reflect the filtered range

🤖 Generated with [Claude Code](https://claude.com/claude-code)