### PR TITLE
Improve search: cover summaries, descriptions, page content by default

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,7 +7,7 @@ import { searchBookIds } from '@/lib/books-catalog';
 
 export const preferredRegion = 'fra1';
 
-const MAX_PAGE_RESULTS = 10;
+const MAX_PAGE_RESULTS = 25;
 
 /** Strip XML/HTML tags and clean up OCR artifacts for display */
 function cleanText(text: string): string {
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
     const firstTranslation = searchParams.get('first_translation');
     const library = searchParams.get('library');
     const bookId = searchParams.get('book_id'); // Filter to specific book
-    const searchContent = searchParams.get('search_content') === 'true'; // Default false (page search is slow on 300K+ docs)
+    const searchContent = searchParams.get('search_content') !== 'false'; // Default true — only skip page search if explicitly disabled
     const pagesOnly = searchParams.get('pages_only') === 'true'; // Return only page-level results (for MCP passage search)
     const sortBy = searchParams.get('sort') || 'relevance'; // relevance | date_asc | date_desc | title
     const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -306,7 +306,7 @@ export async function searchBookIds(
   // Build OR filter: exact phrase match + word-level AND matches
   // "mathematical magick" should match "Mathematicall Magick" by matching each word
   const words = text.trim().split(/\s+/).filter(w => w.length >= 2);
-  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`;
+  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%,summary_text.ilike.%${text}%,description.ilike.%${text}%`;
 
   let orFilter = phraseFilters;
   if (words.length >= 2) {


### PR DESCRIPTION
## Summary
- **searchBookIds()** now also searches `summary_text` and `description` columns on `books_catalog`, not just title/display_title/author. A search for "alchemy" or "transmutation" now finds books whose summaries mention those terms even if the title doesn't.
- **search_content defaults to true** — page-level Atlas Search (OCR + translation text) runs automatically on every query. Callers can still pass `search_content=false` to disable. The existing search page already passed `search_content=true` explicitly, so no UI change.
- **MAX_PAGE_RESULTS raised from 10 to 25** for richer results on research queries.

## Test plan
- [ ] Search for a concept term like "transmutation" — should return books whose summaries mention it, not just title matches
- [ ] Search for an author name — should still work as before (no regression)
- [ ] Verify `search_content=false` still skips page search
- [ ] Check that page-level snippets appear in default search results

Generated with [Claude Code](https://claude.com/claude-code)