### PR TITLE
Prefer enhanced_photo for scan-corrected pages

### DIFF
--- a/src/app/api/admin/sync-gallery-images/route.ts
+++ b/src/app/api/admin/sync-gallery-images/route.ts
@@ -92,7 +92,7 @@ export const POST = withAdminAuth(async (request: NextRequest) => {
           book_id: '$book_id',
           page_number: '$page_number',
           detection_index: '$detection_index',
-          image_url: { $ifNull: ['$cropped_photo', { $ifNull: ['$archived_photo', { $ifNull: ['$photo_original', '$photo'] }] }] },
+          image_url: { $ifNull: ['$enhanced_photo', { $ifNull: ['$cropped_photo', { $ifNull: ['$archived_photo', { $ifNull: ['$photo_original', '$photo'] }] }] }] },
           thumbnail_url: '$detected_images.thumbnail_url',
           extracted_url: '$detected_images.extracted_url',
           description: { $ifNull: ['$detected_images.description', ''] },

--- a/src/app/book/[id]/page/[pageId]/opengraph-image.tsx
+++ b/src/app/book/[id]/page/[pageId]/opengraph-image.tsx
@@ -43,7 +43,7 @@ export default async function Image({ params }: { params: Promise<{ id: string; 
   const title = book?.display_title || book?.title || 'Unknown Title';
   const author = book?.author || 'Unknown Author';
   const pageNum = page?.page_number || '?';
-  const imageUrl = page?.compressed_photo || page?.archived_photo || page?.photo;
+  const imageUrl = (page as any)?.enhanced_photo || page?.compressed_photo || page?.archived_photo || page?.photo;
 
   // Truncate title if too long
   const displayTitle = title.length > 50 ? title.substring(0, 47) + '...' : title;

--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -179,7 +179,7 @@ export default async function ImageLayout({
   if (!data) return <div className="min-h-screen bg-black">{children}</div>;
 
   const { page, detection } = data;
-  const imageUrl = page.cropped_photo || page.archived_photo || page.photo;
+  const imageUrl = (page as any).enhanced_photo || page.cropped_photo || page.archived_photo || page.photo;
 
   return (
     <div className="min-h-screen bg-black">

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -491,10 +491,10 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
       // For main thumbnail, prefer archived/cropped photos, fall back to direct source URL.
       // NEVER store /api/image?url= wrappers — they crash Next.js Image during SSR.
       // Split-from-spread pages: use photo directly (no legacy fallback)
-      const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string };
+      const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string; enhanced_photo?: string };
       const directUrl = page.split_from_spread
         ? page.photo
-        : (typedPage.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
+        : (typedPage.enhanced_photo || typedPage.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
       if (directUrl) {
         updates.thumbnail = directUrl;
       }

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -78,10 +78,10 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
 
       // For the main thumbnail, prefer cropped_photo (split pages) > archived_photo > direct source URL.
       // NEVER store /api/image?url= wrappers — they crash Next.js Image during SSR.
-      const typedPageWithCrop = page as Page & { archived_photo?: string; cropped_photo?: string };
+      const typedPageWithCrop = page as Page & { archived_photo?: string; cropped_photo?: string; enhanced_photo?: string };
       const directUrl = page.split_from_spread
         ? page.photo
-        : (typedPageWithCrop.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
+        : (typedPageWithCrop.enhanced_photo || typedPageWithCrop.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
       if (directUrl) {
         updates.thumbnail = directUrl;
       }

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -60,6 +60,7 @@ export interface Page {
   photo_original?: string;      // Original S3 URL before cropping
   cropped_photo?: string;       // Local path to cropped image
   archived_photo?: string;      // Full-res archived JPEG in R2
+  enhanced_photo?: string;      // Contrast/brightness-enhanced copy of archived_photo in R2
   display_photo?: string;       // 1200px display-size JPEG in R2 (with provenance marks baked in)
   thumbnail_blob?: string;      // Pre-generated 150px JPEG thumbnail in R2
   crop?: CropData;              // Crop coordinates used
@@ -246,4 +247,19 @@ export interface DetectedImage {
   metadata?: ImageMetadata;     // Structured tags for search/filtering
   museum_description?: string;  // 2-3 sentence museum-style label
   job_id?: string;              // Processing job that produced this detection
+}
+
+/**
+ * Get the best available image URL for a page.
+ * Prefers enhanced > cropped > archived > photo_original > photo.
+ * For split-from-spread pages, uses photo directly (skip legacy fallback).
+ */
+export function pageImageUrl(page: Partial<Page>): string {
+  if ((page as any).split_from_spread) return page.photo || '';
+  return (page as any).enhanced_photo
+    || (page as any).cropped_photo
+    || page.archived_photo
+    || page.photo_original
+    || page.photo
+    || '';
 }

--- a/src/workers/image-extraction-processor-logic.ts
+++ b/src/workers/image-extraction-processor-logic.ts
@@ -249,7 +249,7 @@ async function buildGalleryDocs(
       { projection: { display_title: 1, title: 1, author: 1, year: 1, language: 1, visible: 1, hidden: 1 } }
     );
 
-    const imageUrl = page.cropped_photo || page.archived_photo || page.photo_original || page.photo || '';
+    const imageUrl = (page as any).enhanced_photo || page.cropped_photo || page.archived_photo || page.photo_original || page.photo || '';
 
     const docs = images
       .map((img, idx) => {


### PR DESCRIPTION
## Summary
- Grayscale/B&W microfilm scans get per-page adaptive enhancement (brightness + contrast correction) stored at `enhanced/{bookId}/{page}.jpg` on R2
- Original `archived_photo` stays untouched — enhancement is a separate copy
- This PR wires `enhanced_photo` into the image URL fallback chain so users see the improved versions automatically
- Added `enhanced_photo` to Page type and `pageImageUrl()` utility
- Updated: BookPagesSection, CoverImagePicker, gallery image layout, OG image, image extraction processor, sync-gallery-images pipeline

## Before/after
- **Aurora p.4 original:** https://images.sourcelibrary.org/archived/69520185ab34727b1f0416bc/4.jpg
- **Aurora p.4 enhanced:** https://images.sourcelibrary.org/enhanced/69520185ab34727b1f0416bc/4.jpg
- **Clavicules p.5 original:** https://images.sourcelibrary.org/archived/69592f6ca41e40e9146a45d7/5.jpg
- **Clavicules p.5 enhanced:** https://images.sourcelibrary.org/enhanced/69592f6ca41e40e9146a45d7/5.jpg

## Test plan
- [x] TypeScript compiles clean
- [ ] Check Aurora book page renders enhanced images
- [ ] Gallery images from enhanced books show improved versions
- [ ] Reversal: `$unset enhanced_photo` on any page reverts to original

🤖 Generated with [Claude Code](https://claude.com/claude-code)