### PR TITLE
Boost gallery_quality for scan-enhanced pages

### DIFF
--- a/src/workers/image-extraction-processor-logic.ts
+++ b/src/workers/image-extraction-processor-logic.ts
@@ -255,6 +255,11 @@ function adjustForScanQuality(
     adjustment = 0.05;       // 1000×1000+ — high-res bonus
   }
 
+  // Enhanced scans have been contrast/brightness corrected — illustrations render better
+  if (page.enhanced_photo) {
+    adjustment += 0.03;
+  }
+
   return Math.max(0, Math.min(1, aiQuality + adjustment));
 }
 


### PR DESCRIPTION
## Summary
- Pages with `enhanced_photo` (histogram-corrected scans) get a +0.03 gallery quality bonus
- Stacks with the resolution-based adjustment from #1067
- Enhanced scans have better contrast/brightness, so illustrations display better in the gallery

## Test plan
- [ ] Pages with `enhanced_photo` get slightly higher gallery_quality than identical pages without
- [ ] Bonus is small enough not to push low-quality illustrations over the 0.5 threshold alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)