### PR TITLE
Fix: add alignment data for word alignment blog post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ next-env.d.ts
 data/
 !src/app/data/
 !src/data/
+!public/data/
 src/data/*
 !src/data/concept-diffusion.json
 !src/data/concept-diffusion-research.json

--- a/public/data/experiments/alignment-results.json
+++ b/public/data/experiments/alignment-results.json
@@ -1,0 +1,7371 @@
+{
+  "generated": "2026-04-12T23:43:49.916Z",
+  "pages": [
+    {
+      "id": "ficino-de-voluptate-p6",
+      "book": "De Voluptate (On Pleasure)",
+      "author": "Marsilio Ficino",
+      "page": 6,
+      "sourceLanguage": "Latin",
+      "sourceText": "## ¶ Caput primū. De partibus animæ.\n## ¶ Item de læticia, gaudio, & uoluptate, secundū Platonem.\n\nPLATO igitur (ut ab eorum principe initium faciam) cū\nanimum in duas partes distribuisset, mente scilicet, ac sen-\nsum, menti læticiam, & gaudium attribuit, sensibus uolu-\nptatem. Verum prima duo hæc īter se differre putat, quod\nomne gaudium laude sit dignū, læticia uero partim lau-\ndanda, partim uituperanda sit. Esse enim lætitiam ī bonis alicuius pos-\nsessione quandam mentis elationem, quæ tamen modestiam excede-\nre pariter, atq; seruare queat. gaudium uero illam ipsam, quæ ex contē-\nplatione, aut alio quopiam uirtutum usu suscipitur iocunditatem. Itaq;\n& ipse idem in phædro, cum de prima illa, ac uera uita, qua in cælorum\nsedibus animus fruitur loqueretur ait, ueritatis contēplatione nutritur,\n& gaudet. unde sæpenumero gaudium mentis alimoniam uocitat. nā\nipsam agro similem uult esse ueritatem, frugibus uero ueritatis ipsius cō-\ntemplationem. Alimoniæ deinde, quæ ex iis duobus capitur gaudium,\nquo mens ueritatis contemplatione perfruitur. Quapropter & idem in\neodem phædro cum de iis tenebris, in quas animus e summa, ac uera lu-\nce depressus, ac demersus est disputaret, ubi inquit multus inest conatus\nueritatis campus, quonam sit intueri, nam conueniens animæ cibus ex\nillo extitit, & alarum natura, qua anima eleuatur hac aliter. Alas plato uo-\ncat, quibus animus ad supera, unde ob terrenarum rerum cogitationē\ndescenderat reuolat. id autem cum duabus uirtutibus, contemplatiua, ui-\ndelicet atq; morali consequi possit, easdem plato, ut ego interpretor uir-\ntutes animæ ipsius alas intelligit, quas ueritatis diuinarumq; rerum con-\ntemplatione recuperet, quemadmodum horum appetitione terrenorū\namiserat. Cum uero per utriusq; philosophiæ naturalis pariter & mora-\nlis exercitationem recuperatis alis ad superos reuolauerit, tum redeunti\nanimo duo putat præmia reddi, & unum quidem esse diuinitatis contē-\nplationem. Alterum perfectum quoddam, atq; absolutum gaudiū, quo\nin ea ipsa dei cognitione animus perfruatur. Illud quidem ambrosiam\nhoc nectar Plato in phædro appellat his uerbis, quæ uere ē speculata ani-\nma, atq; iis nutrita subiens rursus ītra cælum domum reuertitur, Cum\nautem redierit auriga ad præsepe sistens equos obiicit ambrosiam, & su-\nper ipsam nectar potandum. Aurigam more pythagoræ rationem uo-\ncat. equos uero cæteras animi partes, atq; naturas, q̄ illa ducat. reliqua\n\n<vocab>Plato, Phaedrus, Pythagoras, anima, gaudium, laetitia, voluptas, ambrosia, nectar, auriga</vocab>",
+      "translationText": "## ¶ Chapter One. Concerning the parts of the soul.\n## ¶ Likewise concerning gladness, joy, and pleasure, according to Plato.\n\nPlato, therefore (to begin with him as the leader of these philosophers), when he had divided the soul into two parts—namely, the mind and the senses—attributed **gladness** and **joy** to the mind, and **pleasure** to the senses. However, he thinks these first two differ from one another, because all joy is worthy of praise, whereas gladness is partly to be praised and partly to be blamed. For he defines gladness  as a certain elevation of the mind in the possession of some good things, which is able to both exceed and preserve moderation. Joy , however, is that very delight which is received from contemplation or some other practice of the virtues. And so, in the *Phaedrus* , when he spoke of that first and true life which the soul enjoys in the heavenly seats, he says that it is \"nourished by the contemplation of truth, and it rejoices.\" For this reason, he frequently calls joy the \"nourishment of the mind.\" For he wants truth itself to be like a field, and the contemplation of that truth to be like the fruits of that field. Then, the nourishment which is taken from these two is the joy by which the mind thoroughly enjoys the contemplation of truth. \n\nFor this reason, in the same *Phaedrus*, when he was disputing about those shadows into which the soul has been pressed down and submerged from the highest and true light, he says: \"There is much effort to see where the field of truth is; for the suitable food of the soul comes from there, and the nature of the wings by which the soul is raised up is nourished by this.\" Plato calls these \"wings\" those by which the soul flies back to the things above, from where it had descended on account of the thought of earthly things. Since this can be achieved through two virtues—namely, the contemplative and the moral—Plato understands these same virtues (as I interpret him) to be the \"wings\" of the soul itself. These the soul recovers by the contemplation of truth and divine things, just as it had lost them through the desire for these earthly things. When, indeed, having recovered its wings through the practice of both natural and moral philosophy, it has flown back to the heavens, he thinks two rewards are given to the returning soul: one is the contemplation of divinity. The other is a certain perfect and absolute joy, which the soul enjoys in that very knowledge of God. Plato calls the former \"ambrosia\"  and the latter \"nectar\"  in the *Phaedrus* with these words: \"The soul which has truly beheld and been nourished by these things, entering again within the heaven, returns home. But when the charioteer has returned, standing the horses at the manger, he sets before them ambrosia, and over it nectar to drink.\" Following the manner of Pythagoras , he calls the \"charioteer\" reason. The \"horses,\" however, are the other parts and natures of the soul which reason leads. the rest\n\n<summary>Marsilio Ficino begins his treatise by defining the Platonic divisions of the soul and the resulting types of happiness, distinguishing between sensory pleasure, mental gladness, and spiritual joy. He utilizes the allegory of the winged chariot from Plato's Phaedrus to explain how the soul ascends to divine contemplation.</summary>\n<keywords>Plato, Phaedrus, Pythagoras, soul, joy, gladness, pleasure, ambrosia, nectar, charioteer, virtues, contemplation</keywords>",
+      "alignments": {
+        "llm": [
+          {
+            "en": [
+              140,
+              145
+            ],
+            "src": [
+              78,
+              83
+            ],
+            "en_text": "Plato",
+            "src_text": "PLATO",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              147,
+              156
+            ],
+            "src": [
+              84,
+              90
+            ],
+            "en_text": "therefore",
+            "src_text": "igitur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              158,
+              219
+            ],
+            "src": [
+              91,
+              130
+            ],
+            "en_text": "(to begin with him as the leader of these philosophers)",
+            "src_text": "(ut ab eorum principe initium faciam)",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              221,
+              237
+            ],
+            "src": [
+              131,
+              133
+            ],
+            "en_text": "when he had divided",
+            "src_text": "cū",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              238,
+              246
+            ],
+            "src": [
+              134,
+              140
+            ],
+            "en_text": "the soul",
+            "src_text": "animum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              247,
+              261
+            ],
+            "src": [
+              141,
+              154
+            ],
+            "en_text": "into two parts",
+            "src_text": "in duas partes",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              221,
+              237
+            ],
+            "src": [
+              160,
+              171
+            ],
+            "en_text": "when he had divided",
+            "src_text": "distribuisset",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              263,
+              293
+            ],
+            "src": [
+              173,
+              197
+            ],
+            "en_text": "namely, the mind and the senses",
+            "src_text": "mente scilicet, ac sen-\nsum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              295,
+              305
+            ],
+            "src": [
+              220,
+              229
+            ],
+            "en_text": "attributed",
+            "src_text": "attribuit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              306,
+              314
+            ],
+            "src": [
+              206,
+              214
+            ],
+            "en_text": "gladness",
+            "src_text": "læticiam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              315,
+              318
+            ],
+            "src": [
+              215,
+              216
+            ],
+            "en_text": "and",
+            "src_text": "&",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              319,
+              322
+            ],
+            "src": [
+              217,
+              224
+            ],
+            "en_text": "joy",
+            "src_text": "gaudium",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              323,
+              333
+            ],
+            "src": [
+              199,
+              204
+            ],
+            "en_text": "to the mind",
+            "src_text": "menti",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              335,
+              338
+            ],
+            "src": [
+              229,
+              230
+            ],
+            "en_text": "and",
+            "src_text": ",",
+            "weight": 0.4,
+            "method": "llm"
+          },
+          {
+            "en": [
+              339,
+              346
+            ],
+            "src": [
+              238,
+              247
+            ],
+            "en_text": "pleasure",
+            "src_text": "uoluptatem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              347,
+              359
+            ],
+            "src": [
+              230,
+              237
+            ],
+            "en_text": "to the senses",
+            "src_text": "sensibus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              361,
+              368
+            ],
+            "src": [
+              249,
+              254
+            ],
+            "en_text": "However",
+            "src_text": "Verum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              370,
+              379
+            ],
+            "src": [
+              275,
+              280
+            ],
+            "en_text": "he thinks",
+            "src_text": "putat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              380,
+              394
+            ],
+            "src": [
+              256,
+              268
+            ],
+            "en_text": "these first two",
+            "src_text": "prima duo hæc",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              395,
+              400
+            ],
+            "src": [
+              269,
+              276
+            ],
+            "en_text": "differ",
+            "src_text": "differre",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              401,
+              418
+            ],
+            "src": [
+              262,
+              268
+            ],
+            "en_text": "from one another",
+            "src_text": "īter se",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              420,
+              427
+            ],
+            "src": [
+              282,
+              286
+            ],
+            "en_text": "because",
+            "src_text": "quod",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              428,
+              431
+            ],
+            "src": [
+              287,
+              291
+            ],
+            "en_text": "all",
+            "src_text": "omne",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              432,
+              435
+            ],
+            "src": [
+              292,
+              299
+            ],
+            "en_text": "joy",
+            "src_text": "gaudium",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              436,
+              454
+            ],
+            "src": [
+              300,
+              313
+            ],
+            "en_text": "is worthy of praise",
+            "src_text": "laude sit dignū",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              456,
+              463
+            ],
+            "src": [
+              322,
+              326
+            ],
+            "en_text": "whereas",
+            "src_text": "uero",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              464,
+              472
+            ],
+            "src": [
+              314,
+              321
+            ],
+            "en_text": "gladness",
+            "src_text": "læticia",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              473,
+              495
+            ],
+            "src": [
+              327,
+              340
+            ],
+            "en_text": "is partly to be praised",
+            "src_text": "partim lau-\ndanda",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              496,
+              499
+            ],
+            "src": [
+              340,
+              341
+            ],
+            "en_text": "and",
+            "src_text": ",",
+            "weight": 0.4,
+            "method": "llm"
+          },
+          {
+            "en": [
+              500,
+              519
+            ],
+            "src": [
+              341,
+              359
+            ],
+            "en_text": "partly to be blamed",
+            "src_text": "partim uituperanda sit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              521,
+              524
+            ],
+            "src": [
+              365,
+              369
+            ],
+            "en_text": "For",
+            "src_text": "enim",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              525,
+              534
+            ],
+            "src": [
+              360,
+              364
+            ],
+            "en_text": "he defines",
+            "src_text": "Esse",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              535,
+              543
+            ],
+            "src": [
+              370,
+              378
+            ],
+            "en_text": "gladness",
+            "src_text": "lætitiam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              544,
+              564
+            ],
+            "src": [
+              394,
+              400
+            ],
+            "en_text": "as a certain elevation",
+            "src_text": "quandam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              544,
+              564
+            ],
+            "src": [
+              408,
+              417
+            ],
+            "en_text": "as a certain elevation",
+            "src_text": "elationem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              565,
+              575
+            ],
+            "src": [
+              401,
+              407
+            ],
+            "en_text": "of the mind",
+            "src_text": "mentis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              576,
+              591
+            ],
+            "src": [
+              385,
+              393
+            ],
+            "en_text": "in the possession",
+            "src_text": "pos-\nsessione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              592,
+              609
+            ],
+            "src": [
+              379,
+              393
+            ],
+            "en_text": "of some good things",
+            "src_text": "ī bonis alicuius pos-\nsessione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              611,
+              616
+            ],
+            "src": [
+              419,
+              422
+            ],
+            "en_text": "which",
+            "src_text": "quæ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              617,
+              624
+            ],
+            "src": [
+              423,
+              428
+            ],
+            "en_text": "tamen",
+            "src_text": "tamen",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              625,
+              635
+            ],
+            "src": [
+              457,
+              462
+            ],
+            "en_text": "is able to",
+            "src_text": "queat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              636,
+              647
+            ],
+            "src": [
+              438,
+              450
+            ],
+            "en_text": "both exceed",
+            "src_text": "excede-\nre pariter",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              648,
+              651
+            ],
+            "src": [
+              451,
+              454
+            ],
+            "en_text": "and",
+            "src_text": "atq;",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              652,
+              659
+            ],
+            "src": [
+              455,
+              461
+            ],
+            "en_text": "preserve",
+            "src_text": "seruare",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              660,
+              670
+            ],
+            "src": [
+              429,
+              437
+            ],
+            "en_text": "moderation",
+            "src_text": "modestiam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              672,
+              675
+            ],
+            "src": [
+              464,
+              471
+            ],
+            "en_text": "Joy",
+            "src_text": "gaudium",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              678,
+              685
+            ],
+            "src": [
+              472,
+              476
+            ],
+            "en_text": "however",
+            "src_text": "uero",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              687,
+              706
+            ],
+            "src": [
+              477,
+              486
+            ],
+            "en_text": "is that very delight",
+            "src_text": "illam ipsam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              687,
+              706
+            ],
+            "src": [
+              520,
+              531
+            ],
+            "en_text": "is that very delight",
+            "src_text": "iocunditatem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              707,
+              712
+            ],
+            "src": [
+              488,
+              491
+            ],
+            "en_text": "which",
+            "src_text": "quæ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              713,
+              724
+            ],
+            "src": [
+              510,
+              519
+            ],
+            "en_text": "is received",
+            "src_text": "suscipitur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              725,
+              742
+            ],
+            "src": [
+              492,
+              506
+            ],
+            "en_text": "from contemplation",
+            "src_text": "ex contē-\nplatione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              743,
+              745
+            ],
+            "src": [
+              507,
+              510
+            ],
+            "en_text": "or",
+            "src_text": "aut",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              746,
+              765
+            ],
+            "src": [
+              511,
+              519
+            ],
+            "en_text": "some other practice",
+            "src_text": "alio quopiam usu",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              766,
+              779
+            ],
+            "src": [
+              511,
+              519
+            ],
+            "en_text": "of the virtues",
+            "src_text": "uirtutum usu",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              781,
+              787
+            ],
+            "src": [
+              533,
+              538
+            ],
+            "en_text": "And so",
+            "src_text": "Itaq;",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              789,
+              804
+            ],
+            "src": [
+              549,
+              557
+            ],
+            "en_text": "in the Phaedrus",
+            "src_text": "in phædro",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              807,
+              819
+            ],
+            "src": [
+              559,
+              562
+            ],
+            "en_text": "when he spoke",
+            "src_text": "cum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              807,
+              819
+            ],
+            "src": [
+              600,
+              609
+            ],
+            "en_text": "when he spoke",
+            "src_text": "loqueretur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              820,
+              848
+            ],
+            "src": [
+              563,
+              586
+            ],
+            "en_text": "of that first and true life",
+            "src_text": "de prima illa, ac uera uita",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              849,
+              869
+            ],
+            "src": [
+              587,
+              590
+            ],
+            "en_text": "which the soul enjoys",
+            "src_text": "qua",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              849,
+              869
+            ],
+            "src": [
+              591,
+              596
+            ],
+            "en_text": "which the soul enjoys",
+            "src_text": "animus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              849,
+              869
+            ],
+            "src": [
+              597,
+              603
+            ],
+            "en_text": "which the soul enjoys",
+            "src_text": "fruitur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              870,
+              890
+            ],
+            "src": [
+              591,
+              603
+            ],
+            "en_text": "in the heavenly seats",
+            "src_text": "in cælorum\nsedibus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              892,
+              899
+            ],
+            "src": [
+              610,
+              613
+            ],
+            "en_text": "he says",
+            "src_text": "ait",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              905,
+              918
+            ],
+            "src": [
+              629,
+              637
+            ],
+            "en_text": "it is \"nourished",
+            "src_text": "nutritur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              919,
+              938
+            ],
+            "src": [
+              615,
+              628
+            ],
+            "en_text": "by the contemplation",
+            "src_text": "ueritatis contē-\nplatione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              939,
+              947
+            ],
+            "src": [
+              615,
+              622
+            ],
+            "en_text": "of truth",
+            "src_text": "ueritatis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              949,
+              963
+            ],
+            "src": [
+              638,
+              646
+            ],
+            "en_text": "and it rejoices.\"",
+            "src_text": "& gaudet",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              965,
+              979
+            ],
+            "src": [
+              648,
+              652
+            ],
+            "en_text": "For this reason",
+            "src_text": "unde",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              981,
+              999
+            ],
+            "src": [
+              653,
+              663
+            ],
+            "en_text": "he frequently calls",
+            "src_text": "sæpenumero",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              981,
+              999
+            ],
+            "src": [
+              679,
+              685
+            ],
+            "en_text": "he frequently calls",
+            "src_text": "uocitat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1000,
+              1003
+            ],
+            "src": [
+              664,
+              671
+            ],
+            "en_text": "joy",
+            "src_text": "gaudium",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1004,
+              1019
+            ],
+            "src": [
+              672,
+              679
+            ],
+            "en_text": "the \"nourishment",
+            "src_text": "alimoniam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1020,
+              1030
+            ],
+            "src": [
+              664,
+              671
+            ],
+            "en_text": "of the mind.\"",
+            "src_text": "mentis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1032,
+              1035
+            ],
+            "src": [
+              687,
+              689
+            ],
+            "en_text": "For",
+            "src_text": "nā",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1036,
+              1044
+            ],
+            "src": [
+              706,
+              710
+            ],
+            "en_text": "he wants",
+            "src_text": "uult",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1045,
+              1057
+            ],
+            "src": [
+              690,
+              695
+            ],
+            "en_text": "truth itself",
+            "src_text": "ipsam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1045,
+              1057
+            ],
+            "src": [
+              716,
+              724
+            ],
+            "en_text": "truth itself",
+            "src_text": "ueritatem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1058,
+              1074
+            ],
+            "src": [
+              696,
+              705
+            ],
+            "en_text": "to be like a field",
+            "src_text": "agro similem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1058,
+              1074
+            ],
+            "src": [
+              711,
+              715
+            ],
+            "en_text": "to be like a field",
+            "src_text": "esse",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1076,
+              1079
+            ],
+            "src": [
+              732,
+              736
+            ],
+            "en_text": "and",
+            "src_text": "uero",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1080,
+              1095
+            ],
+            "src": [
+              749,
+              762
+            ],
+            "en_text": "the contemplation",
+            "src_text": "cō-\ntemplationem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1096,
+              1110
+            ],
+            "src": [
+              737,
+              748
+            ],
+            "en_text": "of that truth",
+            "src_text": "ueritatis ipsius",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1111,
+              1132
+            ],
+            "src": [
+              725,
+              731
+            ],
+            "en_text": "to be like the fruits",
+            "src_text": "frugibus",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1133,
+              1146
+            ],
+            "src": [
+              696,
+              700
+            ],
+            "en_text": "of that field",
+            "src_text": "agro",
+            "weight": 0.4,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1148,
+              1152
+            ],
+            "src": [
+              764,
+              770
+            ],
+            "en_text": "Then",
+            "src_text": "deinde",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1154,
+              1168
+            ],
+            "src": [
+              763,
+              771
+            ],
+            "en_text": "the nourishment",
+            "src_text": "Alimoniæ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1169,
+              1174
+            ],
+            "src": [
+              772,
+              775
+            ],
+            "en_text": "which",
+            "src_text": "quæ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1175,
+              1184
+            ],
+            "src": [
+              787,
+              793
+            ],
+            "en_text": "is taken",
+            "src_text": "capitur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1185,
+              1199
+            ],
+            "src": [
+              776,
+              786
+            ],
+            "en_text": "from these two",
+            "src_text": "ex iis duobus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1200,
+              1209
+            ],
+            "src": [
+              794,
+              801
+            ],
+            "en_text": "is the joy",
+            "src_text": "gaudium",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1210,
+              1218
+            ],
+            "src": [
+              803,
+              806
+            ],
+            "en_text": "by which",
+            "src_text": "quo",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1219,
+              1227
+            ],
+            "src": [
+              807,
+              811
+            ],
+            "en_text": "the mind",
+            "src_text": "mens",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1228,
+              1245
+            ],
+            "src": [
+              829,
+              838
+            ],
+            "en_text": "thoroughly enjoys",
+            "src_text": "perfruatur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1246,
+              1261
+            ],
+            "src": [
+              819,
+              829
+            ],
+            "en_text": "the contemplation",
+            "src_text": "contemplatione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1262,
+              1270
+            ],
+            "src": [
+              812,
+              819
+            ],
+            "en_text": "of truth",
+            "src_text": "ueritatis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1272,
+              1286
+            ],
+            "src": [
+              840,
+              849
+            ],
+            "en_text": "For this reason",
+            "src_text": "Quapropter",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1288,
+              1309
+            ],
+            "src": [
+              853,
+              867
+            ],
+            "en_text": "in the same Phaedrus",
+            "src_text": "in eodem phædro",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1311,
+              1330
+            ],
+            "src": [
+              868,
+              871
+            ],
+            "en_text": "when he was disputing",
+            "src_text": "cum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1311,
+              1330
+            ],
+            "src": [
+              927,
+              936
+            ],
+            "en_text": "when he was disputing",
+            "src_text": "disputaret",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1331,
+              1348
+            ],
+            "src": [
+              872,
+              885
+            ],
+            "en_text": "about those shadows",
+            "src_text": "de iis tenebris",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1349,
+              1359
+            ],
+            "src": [
+              887,
+              893
+            ],
+            "en_text": "into which",
+            "src_text": "in quas",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1360,
+              1368
+            ],
+            "src": [
+              894,
+              900
+            ],
+            "en_text": "the soul",
+            "src_text": "animus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1369,
+              1389
+            ],
+            "src": [
+              910,
+              918
+            ],
+            "en_text": "has been pressed down",
+            "src_text": "depressus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1390,
+              1393
+            ],
+            "src": [
+              919,
+              921
+            ],
+            "en_text": "and",
+            "src_text": "ac",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1394,
+              1403
+            ],
+            "src": [
+              922,
+              926
+            ],
+            "en_text": "submerged",
+            "src_text": "demersus est",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1404,
+              1436
+            ],
+            "src": [
+              901,
+              909
+            ],
+            "en_text": "from the highest and true light",
+            "src_text": "e summa, ac uera lu-\nce",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1438,
+              1445
+            ],
+            "src": [
+              939,
+              944
+            ],
+            "en_text": "he says",
+            "src_text": "inquit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1447,
+              1467
+            ],
+            "src": [
+              945,
+              963
+            ],
+            "en_text": "\"There is much effort",
+            "src_text": "multus inest conatus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1468,
+              1474
+            ],
+            "src": [
+              984,
+              991
+            ],
+            "en_text": "to see",
+            "src_text": "intueri",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1475,
+              1502
+            ],
+            "src": [
+              964,
+              983
+            ],
+            "en_text": "where the field of truth is",
+            "src_text": "ueritatis campus, quonam sit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1504,
+              1507
+            ],
+            "src": [
+              993,
+              996
+            ],
+            "en_text": "for",
+            "src_text": "nam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1508,
+              1524
+            ],
+            "src": [
+              997,
+              1006
+            ],
+            "en_text": "the suitable food",
+            "src_text": "conueniens",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1508,
+              1524
+            ],
+            "src": [
+              1014,
+              1019
+            ],
+            "en_text": "the suitable food",
+            "src_text": "cibus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1525,
+              1535
+            ],
+            "src": [
+              1007,
+              1013
+            ],
+            "en_text": "of the soul",
+            "src_text": "animæ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1536,
+              1552
+            ],
+            "src": [
+              1020,
+              1032
+            ],
+            "en_text": "comes from there",
+            "src_text": "ex illo extitit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1553,
+              1556
+            ],
+            "src": [
+              1033,
+              1034
+            ],
+            "en_text": "and",
+            "src_text": "&",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1557,
+              1579
+            ],
+            "src": [
+              1035,
+              1047
+            ],
+            "en_text": "the nature of the wings",
+            "src_text": "alarum natura",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1580,
+              1588
+            ],
+            "src": [
+              1049,
+              1052
+            ],
+            "en_text": "by which",
+            "src_text": "qua",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1589,
+              1597
+            ],
+            "src": [
+              1053,
+              1058
+            ],
+            "en_text": "the soul",
+            "src_text": "anima",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1598,
+              1609
+            ],
+            "src": [
+              1059,
+              1067
+            ],
+            "en_text": "is raised up",
+            "src_text": "eleuatur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1610,
+              1629
+            ],
+            "src": [
+              1068,
+              1077
+            ],
+            "en_text": "is nourished by this.\"",
+            "src_text": "hac aliter",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1631,
+              1636
+            ],
+            "src": [
+              1079,
+              1084
+            ],
+            "en_text": "Plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1637,
+              1642
+            ],
+            "src": [
+              1085,
+              1090
+            ],
+            "en_text": "calls",
+            "src_text": "uocat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1643,
+              1655
+            ],
+            "src": [
+              1078,
+              1082
+            ],
+            "en_text": "these \"wings\"",
+            "src_text": "Alas",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1656,
+              1669
+            ],
+            "src": [
+              1092,
+              1097
+            ],
+            "en_text": "those by which",
+            "src_text": "quibus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1670,
+              1678
+            ],
+            "src": [
+              1098,
+              1104
+            ],
+            "en_text": "the soul",
+            "src_text": "animus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1679,
+              1689
+            ],
+            "src": [
+              1144,
+              1150
+            ],
+            "en_text": "flies back",
+            "src_text": "reuolat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1690,
+              1707
+            ],
+            "src": [
+              1105,
+              1113
+            ],
+            "en_text": "to the things above",
+            "src_text": "ad supera",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1708,
+              1718
+            ],
+            "src": [
+              1115,
+              1119
+            ],
+            "en_text": "from where",
+            "src_text": "unde",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1719,
+              1734
+            ],
+            "src": [
+              1134,
+              1143
+            ],
+            "en_text": "it had descended",
+            "src_text": "descenderat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1735,
+              1748
+            ],
+            "src": [
+              1120,
+              1122
+            ],
+            "en_text": "on account of",
+            "src_text": "ob",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1749,
+              1759
+            ],
+            "src": [
+              1123,
+              1133
+            ],
+            "en_text": "the thought",
+            "src_text": "terrenarum rerum cogitationē",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1760,
+              1776
+            ],
+            "src": [
+              1123,
+              1133
+            ],
+            "en_text": "of earthly things",
+            "src_text": "terrenarum rerum cogitationē",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1778,
+              1783
+            ],
+            "src": [
+              1154,
+              1157
+            ],
+            "en_text": "Since",
+            "src_text": "cum",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1784,
+              1788
+            ],
+            "src": [
+              1152,
+              1154
+            ],
+            "en_text": "this",
+            "src_text": "id",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1789,
+              1804
+            ],
+            "src": [
+              1190,
+              1203
+            ],
+            "en_text": "can be achieved",
+            "src_text": "consequi possit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1805,
+              1823
+            ],
+            "src": [
+              1162,
+              1176
+            ],
+            "en_text": "through two virtues",
+            "src_text": "duabus uirtutibus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1825,
+              1848
+            ],
+            "src": [
+              1178,
+              1190
+            ],
+            "en_text": "namely, the contemplative",
+            "src_text": "contemplatiua, ui-\ndelicet",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1849,
+              1863
+            ],
+            "src": [
+              1191,
+              1199
+            ],
+            "en_text": "and the moral",
+            "src_text": "atq; morali",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1865,
+              1870
+            ],
+            "src": [
+              1205,
+              1210
+            ],
+            "en_text": "Plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1871,
+              1882
+            ],
+            "src": [
+              1243,
+              1252
+            ],
+            "en_text": "understands",
+            "src_text": "intelligit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1883,
+              1902
+            ],
+            "src": [
+              1204,
+              1210
+            ],
+            "en_text": "these same virtues",
+            "src_text": "easdem plato",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1883,
+              1902
+            ],
+            "src": [
+              1224,
+              1231
+            ],
+            "en_text": "these same virtues",
+            "src_text": "uirtutes",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1904,
+              1924
+            ],
+            "src": [
+              1212,
+              1227
+            ],
+            "en_text": "(as I interpret him)",
+            "src_text": "ut ego interpretor",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1925,
+              1942
+            ],
+            "src": [
+              1238,
+              1242
+            ],
+            "en_text": "to be the \"wings\"",
+            "src_text": "alas",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1943,
+              1960
+            ],
+            "src": [
+              1232,
+              1242
+            ],
+            "en_text": "of the soul itself",
+            "src_text": "animæ ipsius alas",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1962,
+              1967
+            ],
+            "src": [
+              1253,
+              1257
+            ],
+            "en_text": "These",
+            "src_text": "quas",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1968,
+              1976
+            ],
+            "src": [
+              1232,
+              1237
+            ],
+            "en_text": "the soul",
+            "src_text": "animæ",
+            "weight": 0.4,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1977,
+              1985
+            ],
+            "src": [
+              1286,
+              1294
+            ],
+            "en_text": "recovers",
+            "src_text": "recuperet",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1986,
+              2005
+            ],
+            "src": [
+              1275,
+              1285
+            ],
+            "en_text": "by the contemplation",
+            "src_text": "contemplatione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2006,
+              2014
+            ],
+            "src": [
+              1258,
+              1265
+            ],
+            "en_text": "of truth",
+            "src_text": "ueritatis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2015,
+              2032
+            ],
+            "src": [
+              1266,
+              1274
+            ],
+            "en_text": "and divine things",
+            "src_text": "diuinarumq; rerum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2034,
+              2041
+            ],
+            "src": [
+              1296,
+              1306
+            ],
+            "en_text": "just as",
+            "src_text": "quemadmodum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2042,
+              2056
+            ],
+            "src": [
+              1324,
+              1331
+            ],
+            "en_text": "it had lost them",
+            "src_text": "amiserat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2057,
+              2074
+            ],
+            "src": [
+              1314,
+              1323
+            ],
+            "en_text": "through the desire",
+            "src_text": "appetitione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2075,
+              2097
+            ],
+            "src": [
+              1307,
+              1313
+            ],
+            "en_text": "for these earthly things",
+            "src_text": "horum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2075,
+              2097
+            ],
+            "src": [
+              1314,
+              1323
+            ],
+            "en_text": "for these earthly things",
+            "src_text": "terrenorū",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2099,
+              2103
+            ],
+            "src": [
+              1333,
+              1336
+            ],
+            "en_text": "When",
+            "src_text": "Cum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2105,
+              2111
+            ],
+            "src": [
+              1337,
+              1341
+            ],
+            "en_text": "indeed",
+            "src_text": "uero",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2113,
+              2138
+            ],
+            "src": [
+              1378,
+              1391
+            ],
+            "en_text": "having recovered its wings",
+            "src_text": "recuperatis alis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2139,
+              2157
+            ],
+            "src": [
+              1342,
+              1345
+            ],
+            "en_text": "through the practice",
+            "src_text": "per",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2139,
+              2157
+            ],
+            "src": [
+              1368,
+              1377
+            ],
+            "en_text": "through the practice",
+            "src_text": "exercitationem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2158,
+              2204
+            ],
+            "src": [
+              1346,
+              1367
+            ],
+            "en_text": "of both natural and moral philosophy",
+            "src_text": "utriusq; philosophiæ naturalis pariter & mora-\nlis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2206,
+              2222
+            ],
+            "src": [
+              1402,
+              1412
+            ],
+            "en_text": "it has flown back",
+            "src_text": "reuolauerit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2223,
+              2236
+            ],
+            "src": [
+              1392,
+              1401
+            ],
+            "en_text": "to the heavens",
+            "src_text": "ad superos",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2238,
+              2247
+            ],
+            "src": [
+              1428,
+              1433
+            ],
+            "en_text": "he thinks",
+            "src_text": "putat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2248,
+              2260
+            ],
+            "src": [
+              1434,
+              1443
+            ],
+            "en_text": "two rewards",
+            "src_text": "duo præmia",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2261,
+              2270
+            ],
+            "src": [
+              1444,
+              1449
+            ],
+            "en_text": "are given",
+            "src_text": "reddi",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2271,
+              2291
+            ],
+            "src": [
+              1414,
+              1427
+            ],
+            "en_text": "to the returning soul",
+            "src_text": "redeunti\nanimo",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2293,
+              2299
+            ],
+            "src": [
+              1452,
+              1464
+            ],
+            "en_text": "one is",
+            "src_text": "unum quidem esse",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2300,
+              2315
+            ],
+            "src": [
+              1475,
+              1488
+            ],
+            "en_text": "the contemplation",
+            "src_text": "contē-\nplationem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2316,
+              2327
+            ],
+            "src": [
+              1465,
+              1474
+            ],
+            "en_text": "of divinity",
+            "src_text": "diuinitatis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2329,
+              2338
+            ],
+            "src": [
+              1490,
+              1497
+            ],
+            "en_text": "The other",
+            "src_text": "Alterum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2339,
+              2358
+            ],
+            "src": [
+              1498,
+              1512
+            ],
+            "en_text": "is a certain perfect",
+            "src_text": "perfectum quoddam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2359,
+              2362
+            ],
+            "src": [
+              1513,
+              1516
+            ],
+            "en_text": "and",
+            "src_text": "atq;",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2363,
+              2376
+            ],
+            "src": [
+              1517,
+              1531
+            ],
+            "en_text": "absolute joy",
+            "src_text": "absolutum gaudiū",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2378,
+              2383
+            ],
+            "src": [
+              1533,
+              1536
+            ],
+            "en_text": "which",
+            "src_text": "quo",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2384,
+              2392
+            ],
+            "src": [
+              1559,
+              1565
+            ],
+            "en_text": "the soul",
+            "src_text": "animus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2393,
+              2399
+            ],
+            "src": [
+              1566,
+              1575
+            ],
+            "en_text": "enjoys",
+            "src_text": "perfruatur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2400,
+              2420
+            ],
+            "src": [
+              1537,
+              1542
+            ],
+            "en_text": "in that very knowledge",
+            "src_text": "in ea",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2400,
+              2420
+            ],
+            "src": [
+              1543,
+              1547
+            ],
+            "en_text": "in that very knowledge",
+            "src_text": "ipsa",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2400,
+              2420
+            ],
+            "src": [
+              1550,
+              1558
+            ],
+            "en_text": "in that very knowledge",
+            "src_text": "cognitione",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2421,
+              2427
+            ],
+            "src": [
+              1548,
+              1551
+            ],
+            "en_text": "of God",
+            "src_text": "dei",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2429,
+              2434
+            ],
+            "src": [
+              1590,
+              1595
+            ],
+            "en_text": "Plato",
+            "src_text": "Plato",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2435,
+              2440
+            ],
+            "src": [
+              1604,
+              1611
+            ],
+            "en_text": "calls",
+            "src_text": "appellat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2441,
+              2451
+            ],
+            "src": [
+              1577,
+              1587
+            ],
+            "en_text": "the former",
+            "src_text": "Illud quidem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2452,
+              2462
+            ],
+            "src": [
+              1588,
+              1596
+            ],
+            "en_text": "\"ambrosia\"",
+            "src_text": "ambrosiam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2463,
+              2476
+            ],
+            "src": [
+              1597,
+              1600
+            ],
+            "en_text": "and the latter",
+            "src_text": "hoc",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2477,
+              2485
+            ],
+            "src": [
+              1601,
+              1606
+            ],
+            "en_text": "\"nectar\"",
+            "src_text": "nectar",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2486,
+              2501
+            ],
+            "src": [
+              1598,
+              1606
+            ],
+            "en_text": "in the Phaedrus",
+            "src_text": "in phædro",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2502,
+              2517
+            ],
+            "src": [
+              1612,
+              1621
+            ],
+            "en_text": "with these words",
+            "src_text": "his uerbis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2520,
+              2528
+            ],
+            "src": [
+              1639,
+              1644
+            ],
+            "en_text": "The soul",
+            "src_text": "anima",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2529,
+              2534
+            ],
+            "src": [
+              1623,
+              1626
+            ],
+            "en_text": "which",
+            "src_text": "quæ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2535,
+              2552
+            ],
+            "src": [
+              1627,
+              1638
+            ],
+            "en_text": "has truly beheld",
+            "src_text": "uere ē speculata",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2553,
+              2570
+            ],
+            "src": [
+              1645,
+              1657
+            ],
+            "en_text": "and been nourished",
+            "src_text": "atq; iis nutrita",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2571,
+              2585
+            ],
+            "src": [
+              1649,
+              1652
+            ],
+            "en_text": "by these things",
+            "src_text": "iis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2587,
+              2601
+            ],
+            "src": [
+              1658,
+              1670
+            ],
+            "en_text": "entering again",
+            "src_text": "subiens rursus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2602,
+              2619
+            ],
+            "src": [
+              1671,
+              1680
+            ],
+            "en_text": "within the heaven",
+            "src_text": "ītra cælum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2620,
+              2632
+            ],
+            "src": [
+              1681,
+              1695
+            ],
+            "en_text": "returns home.",
+            "src_text": "domum reuertitur",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2634,
+              2642
+            ],
+            "src": [
+              1697,
+              1706
+            ],
+            "en_text": "But when",
+            "src_text": "Cum autem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2643,
+              2657
+            ],
+            "src": [
+              1715,
+              1721
+            ],
+            "en_text": "the charioteer",
+            "src_text": "auriga",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2658,
+              2670
+            ],
+            "src": [
+              1707,
+              1714
+            ],
+            "en_text": "has returned",
+            "src_text": "redierit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2672,
+              2690
+            ],
+            "src": [
+              1730,
+              1741
+            ],
+            "en_text": "standing the horses",
+            "src_text": "sistens equos",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2691,
+              2703
+            ],
+            "src": [
+              1722,
+              1729
+            ],
+            "en_text": "at the manger",
+            "src_text": "ad præsepe",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2705,
+              2724
+            ],
+            "src": [
+              1742,
+              1748
+            ],
+            "en_text": "he sets before them",
+            "src_text": "obiicit",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2725,
+              2733
+            ],
+            "src": [
+              1749,
+              1758
+            ],
+            "en_text": "ambrosia",
+            "src_text": "ambrosiam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2735,
+              2738
+            ],
+            "src": [
+              1759,
+              1760
+            ],
+            "en_text": "and",
+            "src_text": "&",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2739,
+              2746
+            ],
+            "src": [
+              1761,
+              1770
+            ],
+            "en_text": "over it",
+            "src_text": "super ipsam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2747,
+              2753
+            ],
+            "src": [
+              1771,
+              1776
+            ],
+            "en_text": "nectar",
+            "src_text": "nectar",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2754,
+              2762
+            ],
+            "src": [
+              1777,
+              1784
+            ],
+            "en_text": "to drink.\"",
+            "src_text": "potandum",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2764,
+              2796
+            ],
+            "src": [
+              1793,
+              1806
+            ],
+            "en_text": "Following the manner of Pythagoras",
+            "src_text": "more pythagoræ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2798,
+              2806
+            ],
+            "src": [
+              1816,
+              1821
+            ],
+            "en_text": "he calls",
+            "src_text": "uocat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2807,
+              2822
+            ],
+            "src": [
+              1786,
+              1792
+            ],
+            "en_text": "the \"charioteer\"",
+            "src_text": "Aurigam",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2823,
+              2829
+            ],
+            "src": [
+              1807,
+              1815
+            ],
+            "en_text": "reason.",
+            "src_text": "rationem",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2831,
+              2842
+            ],
+            "src": [
+              1823,
+              1828
+            ],
+            "en_text": "The \"horses,\"",
+            "src_text": "equos",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2844,
+              2851
+            ],
+            "src": [
+              1829,
+              1833
+            ],
+            "en_text": "however",
+            "src_text": "uero",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2853,
+              2856
+            ],
+            "src": [
+              1833,
+              1834
+            ],
+            "en_text": "are",
+            "src_text": " ",
+            "weight": 0.4,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2857,
+              2872
+            ],
+            "src": [
+              1834,
+              1841
+            ],
+            "en_text": "the other parts",
+            "src_text": "cæteras",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2857,
+              2872
+            ],
+            "src": [
+              1848,
+              1854
+            ],
+            "en_text": "the other parts",
+            "src_text": "partes",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2873,
+              2884
+            ],
+            "src": [
+              1855,
+              1864
+            ],
+            "en_text": "and natures",
+            "src_text": "atq; naturas",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2885,
+              2895
+            ],
+            "src": [
+              1842,
+              1847
+            ],
+            "en_text": "of the soul",
+            "src_text": "animi",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2896,
+              2901
+            ],
+            "src": [
+              1866,
+              1868
+            ],
+            "en_text": "which",
+            "src_text": "q̄",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2902,
+              2908
+            ],
+            "src": [
+              1869,
+              1873
+            ],
+            "en_text": "reason",
+            "src_text": "illa",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2909,
+              2914
+            ],
+            "src": [
+              1874,
+              1879
+            ],
+            "en_text": "leads.",
+            "src_text": "ducat",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              2916,
+              2924
+            ],
+            "src": [
+              1881,
+              1887
+            ],
+            "en_text": "the rest",
+            "src_text": "reliqua",
+            "weight": 1,
+            "method": "llm"
+          }
+        ],
+        "embedding": [
+          {
+            "en": [
+              5,
+              12
+            ],
+            "src": [
+              5,
+              10
+            ],
+            "en_text": "chapter",
+            "src_text": "caput",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              18,
+              28
+            ],
+            "src": [
+              583,
+              588
+            ],
+            "en_text": "concerning",
+            "src_text": "contē",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              33,
+              38
+            ],
+            "src": [
+              21,
+              29
+            ],
+            "en_text": "parts",
+            "src_text": "partibus",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              46,
+              50
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              66,
+              76
+            ],
+            "src": [
+              583,
+              588
+            ],
+            "en_text": "concerning",
+            "src_text": "contē",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              87,
+              90
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              96,
+              104
+            ],
+            "src": [
+              2476,
+              2484
+            ],
+            "en_text": "pleasure",
+            "src_text": "voluptas",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              119,
+              124
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              127,
+              132
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              186,
+              198
+            ],
+            "src": [
+              1748,
+              1759
+            ],
+            "en_text": "philosophers",
+            "src_text": "philosophiæ",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              225,
+              229
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              230,
+              234
+            ],
+            "src": [
+              1249,
+              1256
+            ],
+            "en_text": "into",
+            "src_text": "intueri",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              239,
+              244
+            ],
+            "src": [
+              21,
+              29
+            ],
+            "en_text": "parts",
+            "src_text": "partibus",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              257,
+              261
+            ],
+            "src": [
+              190,
+              195
+            ],
+            "en_text": "mind",
+            "src_text": "mente",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              270,
+              276
+            ],
+            "src": [
+              256,
+              264
+            ],
+            "en_text": "senses",
+            "src_text": "sensibus",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              277,
+              287
+            ],
+            "src": [
+              245,
+              254
+            ],
+            "en_text": "attributed",
+            "src_text": "attribuit",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              307,
+              310
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              320,
+              324
+            ],
+            "src": [
+              190,
+              195
+            ],
+            "en_text": "mind",
+            "src_text": "mente",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              332,
+              340
+            ],
+            "src": [
+              2476,
+              2484
+            ],
+            "en_text": "pleasure",
+            "src_text": "voluptas",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              350,
+              356
+            ],
+            "src": [
+              256,
+              264
+            ],
+            "en_text": "senses",
+            "src_text": "sensibus",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              383,
+              388
+            ],
+            "src": [
+              285,
+              290
+            ],
+            "en_text": "first",
+            "src_text": "prima",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              393,
+              399
+            ],
+            "src": [
+              307,
+              315
+            ],
+            "en_text": "differ",
+            "src_text": "differre",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              430,
+              433
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              447,
+              453
+            ],
+            "src": [
+              341,
+              346
+            ],
+            "en_text": "praise",
+            "src_text": "laude",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              475,
+              481
+            ],
+            "src": [
+              371,
+              377
+            ],
+            "en_text": "partly",
+            "src_text": "partim",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              500,
+              506
+            ],
+            "src": [
+              371,
+              377
+            ],
+            "en_text": "partly",
+            "src_text": "partim",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              559,
+              568
+            ],
+            "src": [
+              1329,
+              1337
+            ],
+            "en_text": "elevation",
+            "src_text": "eleuatur",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              576,
+              580
+            ],
+            "src": [
+              190,
+              195
+            ],
+            "en_text": "mind",
+            "src_text": "mente",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              581,
+              583
+            ],
+            "src": [
+              160,
+              162
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              588,
+              598
+            ],
+            "src": [
+              1533,
+              1539
+            ],
+            "en_text": "possession",
+            "src_text": "possit",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              607,
+              611
+            ],
+            "src": [
+              435,
+              440
+            ],
+            "en_text": "good",
+            "src_text": "bonis",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              642,
+              648
+            ],
+            "src": [
+              510,
+              516
+            ],
+            "en_text": "exceed",
+            "src_text": "excede",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              662,
+              672
+            ],
+            "src": [
+              500,
+              509
+            ],
+            "en_text": "moderation",
+            "src_text": "modestiam",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              674,
+              677
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              697,
+              701
+            ],
+            "src": [
+              279,
+              284
+            ],
+            "en_text": "very",
+            "src_text": "verum",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              702,
+              709
+            ],
+            "src": [
+              1504,
+              1511
+            ],
+            "en_text": "delight",
+            "src_text": "delicet",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              719,
+              727
+            ],
+            "src": [
+              1665,
+              1674
+            ],
+            "en_text": "received",
+            "src_text": "recuperet",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              733,
+              746
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              794,
+              796
+            ],
+            "src": [
+              160,
+              162
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              802,
+              810
+            ],
+            "src": [
+              2428,
+              2436
+            ],
+            "en_text": "phaedrus",
+            "src_text": "phaedrus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              836,
+              841
+            ],
+            "src": [
+              285,
+              290
+            ],
+            "en_text": "first",
+            "src_text": "prima",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              846,
+              850
+            ],
+            "src": [
+              279,
+              284
+            ],
+            "en_text": "true",
+            "src_text": "verum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              866,
+              870
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              878,
+              880
+            ],
+            "src": [
+              160,
+              162
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              938,
+              951
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1017,
+              1020
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1045,
+              1049
+            ],
+            "src": [
+              190,
+              195
+            ],
+            "en_text": "mind",
+            "src_text": "mente",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1106,
+              1119
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1149,
+              1155
+            ],
+            "src": [
+              747,
+              754
+            ],
+            "en_text": "fruits",
+            "src_text": "fruitur",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1230,
+              1233
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1247,
+              1251
+            ],
+            "src": [
+              190,
+              195
+            ],
+            "en_text": "mind",
+            "src_text": "mente",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1274,
+              1287
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1317,
+              1319
+            ],
+            "src": [
+              160,
+              162
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1330,
+              1338
+            ],
+            "src": [
+              2428,
+              2436
+            ],
+            "en_text": "phaedrus",
+            "src_text": "phaedrus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1353,
+              1362
+            ],
+            "src": [
+              1176,
+              1186
+            ],
+            "en_text": "disputing",
+            "src_text": "disputaret",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1383,
+              1387
+            ],
+            "src": [
+              1249,
+              1256
+            ],
+            "en_text": "into",
+            "src_text": "intueri",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1398,
+              1402
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1429,
+              1438
+            ],
+            "src": [
+              2155,
+              2162
+            ],
+            "en_text": "submerged",
+            "src_text": "subiens",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1460,
+              1464
+            ],
+            "src": [
+              279,
+              284
+            ],
+            "en_text": "true",
+            "src_text": "verum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1568,
+              1572
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1599,
+              1605
+            ],
+            "src": [
+              1311,
+              1317
+            ],
+            "en_text": "nature",
+            "src_text": "natura",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1632,
+              1636
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1673,
+              1678
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1718,
+              1722
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1773,
+              1782
+            ],
+            "src": [
+              1432,
+              1443
+            ],
+            "en_text": "descended",
+            "src_text": "descenderat",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1887,
+              1900
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplative",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1909,
+              1914
+            ],
+            "src": [
+              1517,
+              1523
+            ],
+            "en_text": "moral",
+            "src_text": "morali",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1915,
+              1920
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1921,
+              1932
+            ],
+            "src": [
+              815,
+              819
+            ],
+            "en_text": "understands",
+            "src_text": "unde",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1958,
+              1967
+            ],
+            "src": [
+              1562,
+              1573
+            ],
+            "en_text": "interpret",
+            "src_text": "interpretor",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1998,
+              2002
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2021,
+              2025
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2026,
+              2034
+            ],
+            "src": [
+              1665,
+              1674
+            ],
+            "en_text": "recovers",
+            "src_text": "recuperet",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2042,
+              2055
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2121,
+              2127
+            ],
+            "src": [
+              1432,
+              1443
+            ],
+            "en_text": "desire",
+            "src_text": "descenderat",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2175,
+              2184
+            ],
+            "src": [
+              1665,
+              1674
+            ],
+            "en_text": "recovered",
+            "src_text": "recuperet",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2224,
+              2231
+            ],
+            "src": [
+              1311,
+              1317
+            ],
+            "en_text": "natural",
+            "src_text": "natura",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2236,
+              2241
+            ],
+            "src": [
+              1517,
+              1523
+            ],
+            "en_text": "moral",
+            "src_text": "morali",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2242,
+              2252
+            ],
+            "src": [
+              1748,
+              1759
+            ],
+            "en_text": "philosophy",
+            "src_text": "philosophiæ",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2337,
+              2341
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2354,
+              2367
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2404,
+              2411
+            ],
+            "src": [
+              1946,
+              1955
+            ],
+            "en_text": "perfect",
+            "src_text": "perfectum",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2416,
+              2424
+            ],
+            "src": [
+              1970,
+              1979
+            ],
+            "en_text": "absolute",
+            "src_text": "absolutum",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2425,
+              2428
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2440,
+              2444
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2452,
+              2454
+            ],
+            "src": [
+              160,
+              162
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2460,
+              2464
+            ],
+            "src": [
+              279,
+              284
+            ],
+            "en_text": "very",
+            "src_text": "verum",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2478,
+              2481
+            ],
+            "src": [
+              2003,
+              2006
+            ],
+            "en_text": "god",
+            "src_text": "dei",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2483,
+              2488
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2507,
+              2515
+            ],
+            "src": [
+              2486,
+              2494
+            ],
+            "en_text": "ambrosia",
+            "src_text": "ambrosia",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2534,
+              2540
+            ],
+            "src": [
+              2064,
+              2070
+            ],
+            "en_text": "nectar",
+            "src_text": "nectar",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2543,
+              2545
+            ],
+            "src": [
+              160,
+              162
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2551,
+              2559
+            ],
+            "src": [
+              2428,
+              2436
+            ],
+            "en_text": "phaedrus",
+            "src_text": "phaedrus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2584,
+              2588
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2747,
+              2753
+            ],
+            "src": [
+              1688,
+              1693
+            ],
+            "en_text": "horses",
+            "src_text": "horum",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2789,
+              2797
+            ],
+            "src": [
+              2486,
+              2494
+            ],
+            "en_text": "ambrosia",
+            "src_text": "ambrosia",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2811,
+              2817
+            ],
+            "src": [
+              2064,
+              2070
+            ],
+            "en_text": "nectar",
+            "src_text": "nectar",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2853,
+              2863
+            ],
+            "src": [
+              2438,
+              2448
+            ],
+            "en_text": "pythagoras",
+            "src_text": "pythagoras",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2905,
+              2911
+            ],
+            "src": [
+              1688,
+              1693
+            ],
+            "en_text": "horses",
+            "src_text": "horum",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2937,
+              2942
+            ],
+            "src": [
+              21,
+              29
+            ],
+            "en_text": "parts",
+            "src_text": "partibus",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2947,
+              2954
+            ],
+            "src": [
+              1311,
+              1317
+            ],
+            "en_text": "natures",
+            "src_text": "natura",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2962,
+              2966
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2998,
+              3005
+            ],
+            "src": [
+              1127,
+              1132
+            ],
+            "en_text": "summary",
+            "src_text": "summa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3029,
+              3032
+            ],
+            "src": [
+              2096,
+              2099
+            ],
+            "en_text": "his",
+            "src_text": "his",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3058,
+              3066
+            ],
+            "src": [
+              88,
+              96
+            ],
+            "en_text": "platonic",
+            "src_text": "platonem",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3084,
+              3088
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3127,
+              3141
+            ],
+            "src": [
+              175,
+              188
+            ],
+            "en_text": "distinguishing",
+            "src_text": "distribuisset",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3150,
+              3157
+            ],
+            "src": [
+              256,
+              264
+            ],
+            "en_text": "sensory",
+            "src_text": "sensibus",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3158,
+              3166
+            ],
+            "src": [
+              2476,
+              2484
+            ],
+            "en_text": "pleasure",
+            "src_text": "voluptas",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3168,
+              3174
+            ],
+            "src": [
+              190,
+              195
+            ],
+            "en_text": "mental",
+            "src_text": "mente",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3199,
+              3202
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3256,
+              3261
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3264,
+              3272
+            ],
+            "src": [
+              2428,
+              2436
+            ],
+            "en_text": "phaedrus",
+            "src_text": "phaedrus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3292,
+              3296
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3315,
+              3328
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3331,
+              3338
+            ],
+            "src": [
+              1127,
+              1132
+            ],
+            "en_text": "summary",
+            "src_text": "summa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3350,
+              3355
+            ],
+            "src": [
+              99,
+              104
+            ],
+            "en_text": "plato",
+            "src_text": "plato",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3357,
+              3365
+            ],
+            "src": [
+              2428,
+              2436
+            ],
+            "en_text": "phaedrus",
+            "src_text": "phaedrus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3367,
+              3377
+            ],
+            "src": [
+              2438,
+              2448
+            ],
+            "en_text": "pythagoras",
+            "src_text": "pythagoras",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3379,
+              3383
+            ],
+            "src": [
+              153,
+              159
+            ],
+            "en_text": "soul",
+            "src_text": "animum",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3385,
+              3388
+            ],
+            "src": [
+              59,
+              65
+            ],
+            "en_text": "joy",
+            "src_text": "gaudio",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3400,
+              3408
+            ],
+            "src": [
+              2476,
+              2484
+            ],
+            "en_text": "pleasure",
+            "src_text": "voluptas",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3410,
+              3418
+            ],
+            "src": [
+              2486,
+              2494
+            ],
+            "en_text": "ambrosia",
+            "src_text": "ambrosia",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3420,
+              3426
+            ],
+            "src": [
+              2064,
+              2070
+            ],
+            "en_text": "nectar",
+            "src_text": "nectar",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              3449,
+              3462
+            ],
+            "src": [
+              1028,
+              1042
+            ],
+            "en_text": "contemplation",
+            "src_text": "contemplatione",
+            "weight": 0.8,
+            "method": "embedding"
+          }
+        ]
+      }
+    },
+    {
+      "id": "pymander-p8",
+      "book": "Pymander (Mercurii Trismegisti)",
+      "author": "Hermes Trismegistus / Ficino",
+      "page": 8,
+      "sourceLanguage": "Latin",
+      "sourceText": "<header>ARGVMENTVM.</header>\n\nbo sancto clamasse, pululate, adolescite, propagate uniuersa germina, atq; opera mea, quàm id Mosaicum: Crescite & multiplicamini, & replete terram. Mox Mercurius nos instruit, quâ pateat aditus ad mentẽ, & quis nos ab ea tandem malus auferat error, & quibus mens abunde bonorũ largitrix assit, quibus ue pariter absit, & quo pacto quemadmodũ certis gradibus ab intellectuali immortaliq; natura labimur, degeneramusq; ad caduca, ita quoq; certis oppositisq; gradibus in priorẽ purgatæ mentis statum redintegramur. Moses diuino instituto dux sit Hebræi gregis, Mercurius Aegyptij, et nunc sancta institutione gregem suum pascit, actiuam uitam uiuens: nunc uero hymnis gratiarumq; actionibus rerũ patrem collaudans, in contemplationis uitam lumenq; assurgit. Hæc Pymandri summa est.\n\n<column-break/>\n\n# MERCVRII TRIS-\n### MEGISTI PYMANDER, DE POTESTATE ET SAPIENTIA DEI.\n### MARSILIO FICINO FLORENTINO INTERP.\n\n<image-desc>An ornamental woodcut drop cap 'C' featuring a seated figure, possibly a scholar or scribe, working at a desk or table with books.</image-desc>\n\nCum de rerum natura cogitarẽ, ac mentis aciẽ ad superna erigerẽ, sopitis iam corporis sensibus, quemadmodũ accidere solet ijs, qui ob saturitatem uel defatigationem somno grauati, sunt; subitò mihi uisus sum cernere quendã immensa magnitudine corporis, qui me nomine uocans, in hunc modum clamaret: Quid est ô Mercuri, quod et audire & intueri desideras? quid est qd discere atque intelligere cupis? Tum ego: Quisnam es inqua? Sum inquit ille Pymander, mens diuinæ potentiæ, ac tu uide quid uelis, ipse uero tibi ubiq; adero. Cupio inquã rerũ naturã discere, deumq; cognoscere. Ad hæc ille: Tua me mente cõplectere, & ego te in cunctis quæ optaris erudiã.\n\n<vocab>Mercurius Trismegistus, Pymander, Marsilio Ficino, creation, Moses, contemplation, divine power</vocab>",
+      "translationText": "[I heard the] holy [voice] cry out: \"Sprout, grow, and propagate all seeds and my works,\" which is much like the Mosaic saying: \"Increase and multiply, and fill the earth.\"  Soon Mercury instructs us on how the way to the Mind <term>Mind: The Latin 'Mens' (equivalent to the Greek 'Nous') refers here to the Divine Intellect or the highest spark of human consciousness that connects us to God.</term> lies open, and what evil error finally leads us away from it; he shows to whom the Mind is present as a bountiful giver of goods, and from whom it is likewise absent. He explains how, just as we fall by certain steps from an intellectual and immortal nature and degenerate into decaying things, we are also restored to that prior state of a purified mind by certain opposite steps. Let Moses be the leader of the Hebrew flock by divine decree, and let Mercury be the leader of the Egyptian flock. Now, by holy instruction, he feeds his flock, living an active life; but then, praising the Father of all things with hymns and thanksgivings, he rises into the light of the contemplative life. This is the summary of the Pymander.\n\n<column-break/>\n\n# THE PYMANDER OF MERCURY\n### TRISMEGISTUS, ON THE POWER AND WISDOM OF GOD.\n### MARSILIO FICINO OF FLORENCE, TRANSLATOR.\n\n<image-desc>An ornamental woodcut drop cap 'C' featuring a seated figure, possibly a scholar or scribe, working at a desk or table with books.</image-desc>\n\nWHILE I WAS REFLECTING on the nature of things, and raising the sharp edge of my mind to higher realms, my bodily senses were already lulled to sleep—just as usually happens to those who are weighed down by sleep due to fullness or exhaustion. Suddenly, I seemed to see someone of immense bodily size, who, calling me by name, cried out in this manner: \"What is it, O Mercury , that you desire to both hear and behold? What is it that you wish to learn and understand?\" Then I said: \"Who are you?\" He replied: \"I am Pymander, the Mind of divine power. See what you wish, for I will be with you everywhere.\" I said: \"I desire to learn the nature of things and to know God.\" To this he replied: \"Embrace me in your mind, and I will instruct you in all that you hope for.\"\n\n<summary>This page concludes the introductory summary comparing Hermes to Moses and begins the Pymander, the most famous Hermetic text, where Hermes Trismegistus encounters a divine vision of the \"Mind of Power.\"</summary>\n<keywords>Hermes Trismegistus, Pymander, Divine Mind, creation, active vs contemplative life, Marsilio Ficino, Neoplatonism</keywords>",
+      "alignments": {
+        "llm": [
+          {
+            "en": [
+              12,
+              28
+            ],
+            "src": [
+              32,
+              47
+            ],
+            "en_text": "holy [voice] cry out",
+            "src_text": "sancto clamasse",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              31,
+              37
+            ],
+            "src": [
+              49,
+              57
+            ],
+            "en_text": "Sprout",
+            "src_text": "pululate",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              39,
+              43
+            ],
+            "src": [
+              59,
+              68
+            ],
+            "en_text": "grow",
+            "src_text": "adolescite",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              49,
+              58
+            ],
+            "src": [
+              70,
+              79
+            ],
+            "en_text": "propagate",
+            "src_text": "propagate",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              59,
+              68
+            ],
+            "src": [
+              80,
+              96
+            ],
+            "en_text": "all seeds",
+            "src_text": "uniuersa germina",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              69,
+              81
+            ],
+            "src": [
+              98,
+              111
+            ],
+            "en_text": "and my works",
+            "src_text": "atq; opera mea",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              84,
+              119
+            ],
+            "src": [
+              113,
+              128
+            ],
+            "en_text": "which is much like the Mosaic saying",
+            "src_text": "quàm id Mosaicum",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              122,
+              177
+            ],
+            "src": [
+              130,
+              176
+            ],
+            "en_text": "\"Increase and multiply, and fill the earth.\"",
+            "src_text": "Crescite & multiplicamini, & replete terram.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              179,
+              205
+            ],
+            "src": [
+              178,
+              205
+            ],
+            "en_text": "Soon Mercury instructs us",
+            "src_text": "Mox Mercurius nos instruit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              206,
+              334
+            ],
+            "src": [
+              207,
+              235
+            ],
+            "en_text": "on how the way to the Mind lies open",
+            "src_text": "quâ pateat aditus ad mentẽ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              336,
+              390
+            ],
+            "src": [
+              237,
+              285
+            ],
+            "en_text": "and what evil error finally leads us away from it",
+            "src_text": "& quis nos ab ea tandem malus auferat error",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              392,
+              461
+            ],
+            "src": [
+              287,
+              332
+            ],
+            "en_text": "he shows to whom the Mind is present as a bountiful giver of goods",
+            "src_text": "& quibus mens abunde bonorũ largitrix assit",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              463,
+              498
+            ],
+            "src": [
+              334,
+              354
+            ],
+            "en_text": "and from whom it is likewise absent",
+            "src_text": "quibus ue pariter absit",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              500,
+              615
+            ],
+            "src": [
+              356,
+              459
+            ],
+            "en_text": "He explains how, just as we fall by certain steps from an intellectual and immortal nature and degenerate into decaying things",
+            "src_text": "& quo pacto quemadmodũ certis gradibus ab intellectuali immortaliq; natura labimur, degeneramusq; ad caduca",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              617,
+              715
+            ],
+            "src": [
+              461,
+              546
+            ],
+            "en_text": "we are also restored to that prior state of a purified mind by certain opposite steps.",
+            "src_text": "ita quoq; certis oppositisq; gradibus in priorẽ purgatæ mentis statum redintegramur.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              717,
+              776
+            ],
+            "src": [
+              548,
+              595
+            ],
+            "en_text": "Let Moses be the leader of the Hebrew flock by divine decree",
+            "src_text": "Moses diuino instituto dux sit Hebræi gregis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              778,
+              831
+            ],
+            "src": [
+              597,
+              613
+            ],
+            "en_text": "and let Mercury be the leader of the Egyptian flock.",
+            "src_text": "Mercurius Aegyptij",
+            "weight": 0.7,
+            "method": "llm"
+          },
+          {
+            "en": [
+              833,
+              901
+            ],
+            "src": [
+              615,
+              678
+            ],
+            "en_text": "Now, by holy instruction, he feeds his flock, living an active life",
+            "src_text": "et nunc sancta institutione gregem suum pascit, actiuam uitam uiuens",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              903,
+              1016
+            ],
+            "src": [
+              680,
+              788
+            ],
+            "en_text": "but then, praising the Father of all things with hymns and thanksgivings, he rises into the light of the contemplative life.",
+            "src_text": "nunc uero hymnis gratiarumq; actionibus rerũ patrem collaudans, in contemplationis uitam lumenq; assurgit.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1018,
+              1053
+            ],
+            "src": [
+              790,
+              813
+            ],
+            "en_text": "This is the summary of the Pymander.",
+            "src_text": "Hæc Pymandri summa est.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1095,
+              1141
+            ],
+            "src": [
+              990,
+              1017
+            ],
+            "en_text": "WHILE I WAS REFLECTING on the nature of things",
+            "src_text": "Cum de rerum natura cogitarẽ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1143,
+              1198
+            ],
+            "src": [
+              1019,
+              1050
+            ],
+            "en_text": "and raising the sharp edge of my mind to higher realms",
+            "src_text": "ac mentis aciẽ ad superna erigerẽ",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1200,
+              1250
+            ],
+            "src": [
+              1052,
+              1080
+            ],
+            "en_text": "my bodily senses were already lulled to sleep",
+            "src_text": "sopitis iam corporis sensibus",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1251,
+              1353
+            ],
+            "src": [
+              1082,
+              1170
+            ],
+            "en_text": "just as usually happens to those who are weighed down by sleep due to fullness or exhaustion.",
+            "src_text": "quemadmodũ accidere solet ijs, qui ob saturitatem uel defatigationem somno grauati, sunt",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1355,
+              1414
+            ],
+            "src": [
+              1172,
+              1237
+            ],
+            "en_text": "Suddenly, I seemed to see someone of immense bodily size",
+            "src_text": "subitò mihi uisus sum cernere quendã immensa magnitudine corporis",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1416,
+              1471
+            ],
+            "src": [
+              1239,
+              1285
+            ],
+            "en_text": "who, calling me by name, cried out in this manner",
+            "src_text": "qui me nomine uocans, in hunc modum clamaret",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1474,
+              1543
+            ],
+            "src": [
+              1287,
+              1344
+            ],
+            "en_text": "\"What is it, O Mercury , that you desire to both hear and behold?",
+            "src_text": "Quid est ô Mercuri, quod et audire & intueri desideras?",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1544,
+              1600
+            ],
+            "src": [
+              1346,
+              1386
+            ],
+            "en_text": "What is it that you wish to learn and understand?\"",
+            "src_text": "quid est qd discere atque intelligere cupis?",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1602,
+              1630
+            ],
+            "src": [
+              1388,
+              1412
+            ],
+            "en_text": "Then I said: \"Who are you?\"",
+            "src_text": "Tum ego: Quisnam es inqua?",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1631,
+              1691
+            ],
+            "src": [
+              1414,
+              1459
+            ],
+            "en_text": "He replied: \"I am Pymander, the Mind of divine power.",
+            "src_text": "Sum inquit ille Pymander, mens diuinæ potentiæ.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1692,
+              1751
+            ],
+            "src": [
+              1461,
+              1507
+            ],
+            "en_text": "See what you wish, for I will be with you everywhere.\"",
+            "src_text": "ac tu uide quid uelis, ipse uero tibi ubiq; adero.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1752,
+              1818
+            ],
+            "src": [
+              1509,
+              1564
+            ],
+            "en_text": "I said: \"I desire to learn the nature of things and to know God.\"",
+            "src_text": "Cupio inquã rerũ naturã discere, deumq; cognoscere.",
+            "weight": 1,
+            "method": "llm"
+          },
+          {
+            "en": [
+              1819,
+              1913
+            ],
+            "src": [
+              1566,
+              1647
+            ],
+            "en_text": "To this he replied: \"Embrace me in your mind, and I will instruct you in all that you hope for.\"",
+            "src_text": "Ad hæc ille: Tua me mente cõplectere, & ego te in cunctis quæ optaris erudiã.",
+            "weight": 1,
+            "method": "llm"
+          }
+        ],
+        "embedding": [
+          {
+            "en": [
+              3,
+              8
+            ],
+            "src": [
+              1,
+              7
+            ],
+            "en_text": "heard",
+            "src_text": "header",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              55,
+              64
+            ],
+            "src": [
+              72,
+              81
+            ],
+            "en_text": "propagate",
+            "src_text": "propagate",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              82,
+              87
+            ],
+            "src": [
+              1043,
+              1050
+            ],
+            "en_text": "works",
+            "src_text": "working",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              113,
+              119
+            ],
+            "src": [
+              124,
+              132
+            ],
+            "en_text": "mosaic",
+            "src_text": "mosaicum",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              142,
+              150
+            ],
+            "src": [
+              145,
+              159
+            ],
+            "en_text": "multiply",
+            "src_text": "multiplicamini",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              179,
+              186
+            ],
+            "src": [
+              183,
+              192
+            ],
+            "en_text": "mercury",
+            "src_text": "mercurius",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              187,
+              196
+            ],
+            "src": [
+              197,
+              205
+            ],
+            "en_text": "instructs",
+            "src_text": "instruit",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              222,
+              226
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              228,
+              232
+            ],
+            "src": [
+              171,
+              177
+            ],
+            "en_text": "term",
+            "src_text": "terram",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              233,
+              237
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              250,
+              254
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mens",
+            "src_text": "mens",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              275,
+              280
+            ],
+            "src": [
+              582,
+              588
+            ],
+            "en_text": "greek",
+            "src_text": "gregis",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              308,
+              314
+            ],
+            "src": [
+              1843,
+              1849
+            ],
+            "en_text": "divine",
+            "src_text": "divine",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              315,
+              324
+            ],
+            "src": [
+              392,
+              405
+            ],
+            "en_text": "intellect",
+            "src_text": "intellectuali",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              325,
+              327
+            ],
+            "src": [
+              1032,
+              1034
+            ],
+            "en_text": "or",
+            "src_text": "or",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              355,
+              368
+            ],
+            "src": [
+              747,
+              762
+            ],
+            "en_text": "consciousness",
+            "src_text": "contemplationis",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              374,
+              382
+            ],
+            "src": [
+              747,
+              762
+            ],
+            "en_text": "connects",
+            "src_text": "contemplationis",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              389,
+              392
+            ],
+            "src": [
+              894,
+              897
+            ],
+            "en_text": "god",
+            "src_text": "dei",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              395,
+              399
+            ],
+            "src": [
+              171,
+              177
+            ],
+            "en_text": "term",
+            "src_text": "terram",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              406,
+              410
+            ],
+            "src": [
+              105,
+              110
+            ],
+            "en_text": "open",
+            "src_text": "opera",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              426,
+              431
+            ],
+            "src": [
+              273,
+              278
+            ],
+            "en_text": "error",
+            "src_text": "error",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              484,
+              488
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              503,
+              504
+            ],
+            "src": [
+              996,
+              997
+            ],
+            "en_text": "a",
+            "src_text": "a",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              560,
+              566
+            ],
+            "src": [
+              343,
+              348
+            ],
+            "en_text": "absent",
+            "src_text": "absit",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              604,
+              611
+            ],
+            "src": [
+              373,
+              379
+            ],
+            "en_text": "certain",
+            "src_text": "certis",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              623,
+              625
+            ],
+            "src": [
+              951,
+              953
+            ],
+            "en_text": "an",
+            "src_text": "an",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              626,
+              638
+            ],
+            "src": [
+              392,
+              405
+            ],
+            "en_text": "intellectual",
+            "src_text": "intellectuali",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              643,
+              651
+            ],
+            "src": [
+              406,
+              416
+            ],
+            "en_text": "immortal",
+            "src_text": "immortaliq",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              652,
+              658
+            ],
+            "src": [
+              418,
+              424
+            ],
+            "en_text": "nature",
+            "src_text": "natura",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              663,
+              673
+            ],
+            "src": [
+              434,
+              446
+            ],
+            "en_text": "degenerate",
+            "src_text": "degeneramusq",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              674,
+              678
+            ],
+            "src": [
+              392,
+              405
+            ],
+            "en_text": "into",
+            "src_text": "intellectuali",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              725,
+              730
+            ],
+            "src": [
+              500,
+              505
+            ],
+            "en_text": "prior",
+            "src_text": "prior",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              731,
+              736
+            ],
+            "src": [
+              522,
+              528
+            ],
+            "en_text": "state",
+            "src_text": "statum",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              740,
+              741
+            ],
+            "src": [
+              996,
+              997
+            ],
+            "en_text": "a",
+            "src_text": "a",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              742,
+              750
+            ],
+            "src": [
+              507,
+              514
+            ],
+            "en_text": "purified",
+            "src_text": "purgatæ",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              751,
+              755
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              759,
+              766
+            ],
+            "src": [
+              373,
+              379
+            ],
+            "en_text": "certain",
+            "src_text": "certis",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              767,
+              775
+            ],
+            "src": [
+              476,
+              486
+            ],
+            "en_text": "opposite",
+            "src_text": "oppositisq",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              787,
+              792
+            ],
+            "src": [
+              544,
+              549
+            ],
+            "en_text": "moses",
+            "src_text": "moses",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              814,
+              820
+            ],
+            "src": [
+              575,
+              581
+            ],
+            "en_text": "hebrew",
+            "src_text": "hebræi",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              821,
+              826
+            ],
+            "src": [
+              919,
+              929
+            ],
+            "en_text": "flock",
+            "src_text": "florentino",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              830,
+              836
+            ],
+            "src": [
+              1843,
+              1849
+            ],
+            "en_text": "divine",
+            "src_text": "divine",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              853,
+              860
+            ],
+            "src": [
+              183,
+              192
+            ],
+            "en_text": "mercury",
+            "src_text": "mercurius",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              891,
+              896
+            ],
+            "src": [
+              919,
+              929
+            ],
+            "en_text": "flock",
+            "src_text": "florentino",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              911,
+              922
+            ],
+            "src": [
+              197,
+              205
+            ],
+            "en_text": "instruction",
+            "src_text": "instruit",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              937,
+              942
+            ],
+            "src": [
+              919,
+              929
+            ],
+            "en_text": "flock",
+            "src_text": "florentino",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              951,
+              953
+            ],
+            "src": [
+              951,
+              953
+            ],
+            "en_text": "an",
+            "src_text": "an",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              954,
+              960
+            ],
+            "src": [
+              658,
+              665
+            ],
+            "en_text": "active",
+            "src_text": "actiuam",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1011,
+              1015
+            ],
+            "src": [
+              1070,
+              1074
+            ],
+            "en_text": "with",
+            "src_text": "with",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1016,
+              1021
+            ],
+            "src": [
+              690,
+              696
+            ],
+            "en_text": "hymns",
+            "src_text": "hymnis",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1050,
+              1054
+            ],
+            "src": [
+              392,
+              405
+            ],
+            "en_text": "into",
+            "src_text": "intellectuali",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1072,
+              1085
+            ],
+            "src": [
+              747,
+              762
+            ],
+            "en_text": "contemplative",
+            "src_text": "contemplationis",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1104,
+              1111
+            ],
+            "src": [
+              800,
+              805
+            ],
+            "en_text": "summary",
+            "src_text": "summa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1119,
+              1127
+            ],
+            "src": [
+              858,
+              866
+            ],
+            "en_text": "pymander",
+            "src_text": "pymander",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1131,
+              1137
+            ],
+            "src": [
+              813,
+              819
+            ],
+            "en_text": "column",
+            "src_text": "column",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1138,
+              1143
+            ],
+            "src": [
+              820,
+              825
+            ],
+            "en_text": "break",
+            "src_text": "break",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1153,
+              1161
+            ],
+            "src": [
+              858,
+              866
+            ],
+            "en_text": "pymander",
+            "src_text": "pymander",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1165,
+              1172
+            ],
+            "src": [
+              183,
+              192
+            ],
+            "en_text": "mercury",
+            "src_text": "mercurius",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1177,
+              1189
+            ],
+            "src": [
+              1770,
+              1782
+            ],
+            "en_text": "trismegistus",
+            "src_text": "trismegistus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1198,
+              1203
+            ],
+            "src": [
+              1850,
+              1855
+            ],
+            "en_text": "power",
+            "src_text": "power",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1218,
+              1221
+            ],
+            "src": [
+              894,
+              897
+            ],
+            "en_text": "god",
+            "src_text": "dei",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1227,
+              1235
+            ],
+            "src": [
+              903,
+              911
+            ],
+            "en_text": "marsilio",
+            "src_text": "marsilio",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1236,
+              1242
+            ],
+            "src": [
+              912,
+              918
+            ],
+            "en_text": "ficino",
+            "src_text": "ficino",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1246,
+              1254
+            ],
+            "src": [
+              919,
+              929
+            ],
+            "en_text": "florence",
+            "src_text": "florentino",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1270,
+              1275
+            ],
+            "src": [
+              940,
+              945
+            ],
+            "en_text": "image",
+            "src_text": "image",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1276,
+              1280
+            ],
+            "src": [
+              946,
+              950
+            ],
+            "en_text": "desc",
+            "src_text": "desc",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1281,
+              1283
+            ],
+            "src": [
+              951,
+              953
+            ],
+            "en_text": "an",
+            "src_text": "an",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1284,
+              1294
+            ],
+            "src": [
+              954,
+              964
+            ],
+            "en_text": "ornamental",
+            "src_text": "ornamental",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1295,
+              1302
+            ],
+            "src": [
+              965,
+              972
+            ],
+            "en_text": "woodcut",
+            "src_text": "woodcut",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1303,
+              1307
+            ],
+            "src": [
+              973,
+              977
+            ],
+            "en_text": "drop",
+            "src_text": "drop",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1308,
+              1311
+            ],
+            "src": [
+              978,
+              981
+            ],
+            "en_text": "cap",
+            "src_text": "cap",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1313,
+              1314
+            ],
+            "src": [
+              983,
+              984
+            ],
+            "en_text": "c",
+            "src_text": "c",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1316,
+              1325
+            ],
+            "src": [
+              986,
+              995
+            ],
+            "en_text": "featuring",
+            "src_text": "featuring",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1326,
+              1327
+            ],
+            "src": [
+              996,
+              997
+            ],
+            "en_text": "a",
+            "src_text": "a",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1328,
+              1334
+            ],
+            "src": [
+              998,
+              1004
+            ],
+            "en_text": "seated",
+            "src_text": "seated",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1335,
+              1341
+            ],
+            "src": [
+              1005,
+              1011
+            ],
+            "en_text": "figure",
+            "src_text": "figure",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1343,
+              1351
+            ],
+            "src": [
+              1013,
+              1021
+            ],
+            "en_text": "possibly",
+            "src_text": "possibly",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1352,
+              1353
+            ],
+            "src": [
+              996,
+              997
+            ],
+            "en_text": "a",
+            "src_text": "a",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1354,
+              1361
+            ],
+            "src": [
+              1024,
+              1031
+            ],
+            "en_text": "scholar",
+            "src_text": "scholar",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1362,
+              1364
+            ],
+            "src": [
+              1032,
+              1034
+            ],
+            "en_text": "or",
+            "src_text": "or",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1365,
+              1371
+            ],
+            "src": [
+              1035,
+              1041
+            ],
+            "en_text": "scribe",
+            "src_text": "scribe",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1373,
+              1380
+            ],
+            "src": [
+              1043,
+              1050
+            ],
+            "en_text": "working",
+            "src_text": "working",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1381,
+              1383
+            ],
+            "src": [
+              1051,
+              1053
+            ],
+            "en_text": "at",
+            "src_text": "at",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1384,
+              1385
+            ],
+            "src": [
+              996,
+              997
+            ],
+            "en_text": "a",
+            "src_text": "a",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1386,
+              1390
+            ],
+            "src": [
+              1056,
+              1060
+            ],
+            "en_text": "desk",
+            "src_text": "desk",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1391,
+              1393
+            ],
+            "src": [
+              1032,
+              1034
+            ],
+            "en_text": "or",
+            "src_text": "or",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1394,
+              1399
+            ],
+            "src": [
+              1064,
+              1069
+            ],
+            "en_text": "table",
+            "src_text": "table",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1400,
+              1404
+            ],
+            "src": [
+              1070,
+              1074
+            ],
+            "en_text": "with",
+            "src_text": "with",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1405,
+              1410
+            ],
+            "src": [
+              1075,
+              1080
+            ],
+            "en_text": "books",
+            "src_text": "books",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1413,
+              1418
+            ],
+            "src": [
+              940,
+              945
+            ],
+            "en_text": "image",
+            "src_text": "image",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1419,
+              1423
+            ],
+            "src": [
+              946,
+              950
+            ],
+            "en_text": "desc",
+            "src_text": "desc",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1456,
+              1462
+            ],
+            "src": [
+              418,
+              424
+            ],
+            "en_text": "nature",
+            "src_text": "natura",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1507,
+              1511
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1540,
+              1546
+            ],
+            "src": [
+              1182,
+              1190
+            ],
+            "en_text": "senses",
+            "src_text": "sensibus",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1655,
+              1657
+            ],
+            "src": [
+              1032,
+              1034
+            ],
+            "en_text": "or",
+            "src_text": "or",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1696,
+              1703
+            ],
+            "src": [
+              1261,
+              1266
+            ],
+            "en_text": "someone",
+            "src_text": "somno",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1707,
+              1714
+            ],
+            "src": [
+              1319,
+              1326
+            ],
+            "en_text": "immense",
+            "src_text": "immensa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1741,
+              1743
+            ],
+            "src": [
+              1353,
+              1355
+            ],
+            "en_text": "me",
+            "src_text": "me",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1763,
+              1765
+            ],
+            "src": [
+              497,
+              499
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1794,
+              1801
+            ],
+            "src": [
+              183,
+              192
+            ],
+            "en_text": "mercury",
+            "src_text": "mercurius",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1813,
+              1819
+            ],
+            "src": [
+              1440,
+              1449
+            ],
+            "en_text": "desire",
+            "src_text": "desideras",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1828,
+              1832
+            ],
+            "src": [
+              1,
+              7
+            ],
+            "en_text": "hear",
+            "src_text": "header",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1927,
+              1934
+            ],
+            "src": [
+              163,
+              170
+            ],
+            "en_text": "replied",
+            "src_text": "replete",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1942,
+              1950
+            ],
+            "src": [
+              858,
+              866
+            ],
+            "en_text": "pymander",
+            "src_text": "pymander",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1956,
+              1960
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1964,
+              1970
+            ],
+            "src": [
+              1843,
+              1849
+            ],
+            "en_text": "divine",
+            "src_text": "divine",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              1971,
+              1976
+            ],
+            "src": [
+              1850,
+              1855
+            ],
+            "en_text": "power",
+            "src_text": "power",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2011,
+              2015
+            ],
+            "src": [
+              1070,
+              1074
+            ],
+            "en_text": "with",
+            "src_text": "with",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2044,
+              2050
+            ],
+            "src": [
+              1440,
+              1449
+            ],
+            "en_text": "desire",
+            "src_text": "desideras",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2064,
+              2070
+            ],
+            "src": [
+              418,
+              424
+            ],
+            "en_text": "nature",
+            "src_text": "natura",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2093,
+              2096
+            ],
+            "src": [
+              894,
+              897
+            ],
+            "en_text": "god",
+            "src_text": "dei",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2110,
+              2117
+            ],
+            "src": [
+              163,
+              170
+            ],
+            "en_text": "replied",
+            "src_text": "replete",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2128,
+              2130
+            ],
+            "src": [
+              1353,
+              1355
+            ],
+            "en_text": "me",
+            "src_text": "me",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2131,
+              2133
+            ],
+            "src": [
+              497,
+              499
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2139,
+              2143
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2156,
+              2164
+            ],
+            "src": [
+              197,
+              205
+            ],
+            "en_text": "instruct",
+            "src_text": "instruit",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2169,
+              2171
+            ],
+            "src": [
+              497,
+              499
+            ],
+            "en_text": "in",
+            "src_text": "in",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2198,
+              2205
+            ],
+            "src": [
+              800,
+              805
+            ],
+            "en_text": "summary",
+            "src_text": "summa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2216,
+              2225
+            ],
+            "src": [
+              747,
+              762
+            ],
+            "en_text": "concludes",
+            "src_text": "contemplationis",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2230,
+              2242
+            ],
+            "src": [
+              392,
+              405
+            ],
+            "en_text": "introductory",
+            "src_text": "intellectuali",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2243,
+              2250
+            ],
+            "src": [
+              800,
+              805
+            ],
+            "en_text": "summary",
+            "src_text": "summa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2271,
+              2276
+            ],
+            "src": [
+              544,
+              549
+            ],
+            "en_text": "moses",
+            "src_text": "moses",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2292,
+              2300
+            ],
+            "src": [
+              858,
+              866
+            ],
+            "en_text": "pymander",
+            "src_text": "pymander",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2306,
+              2310
+            ],
+            "src": [
+              124,
+              132
+            ],
+            "en_text": "most",
+            "src_text": "mosaicum",
+            "weight": 0.4,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2346,
+              2358
+            ],
+            "src": [
+              1770,
+              1782
+            ],
+            "en_text": "trismegistus",
+            "src_text": "trismegistus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2370,
+              2371
+            ],
+            "src": [
+              996,
+              997
+            ],
+            "en_text": "a",
+            "src_text": "a",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2372,
+              2378
+            ],
+            "src": [
+              1843,
+              1849
+            ],
+            "en_text": "divine",
+            "src_text": "divine",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2394,
+              2398
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2402,
+              2407
+            ],
+            "src": [
+              1850,
+              1855
+            ],
+            "en_text": "power",
+            "src_text": "power",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2411,
+              2418
+            ],
+            "src": [
+              800,
+              805
+            ],
+            "en_text": "summary",
+            "src_text": "summa",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2437,
+              2449
+            ],
+            "src": [
+              1770,
+              1782
+            ],
+            "en_text": "trismegistus",
+            "src_text": "trismegistus",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2451,
+              2459
+            ],
+            "src": [
+              858,
+              866
+            ],
+            "en_text": "pymander",
+            "src_text": "pymander",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2461,
+              2467
+            ],
+            "src": [
+              1843,
+              1849
+            ],
+            "en_text": "divine",
+            "src_text": "divine",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2468,
+              2472
+            ],
+            "src": [
+              289,
+              293
+            ],
+            "en_text": "mind",
+            "src_text": "mens",
+            "weight": 0.95,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2474,
+              2482
+            ],
+            "src": [
+              1811,
+              1819
+            ],
+            "en_text": "creation",
+            "src_text": "creation",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2484,
+              2490
+            ],
+            "src": [
+              658,
+              665
+            ],
+            "en_text": "active",
+            "src_text": "actiuam",
+            "weight": 0.6,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2494,
+              2507
+            ],
+            "src": [
+              747,
+              762
+            ],
+            "en_text": "contemplative",
+            "src_text": "contemplationis",
+            "weight": 0.8,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2514,
+              2522
+            ],
+            "src": [
+              903,
+              911
+            ],
+            "en_text": "marsilio",
+            "src_text": "marsilio",
+            "weight": 1,
+            "method": "embedding"
+          },
+          {
+            "en": [
+              2523,
+              2529
+            ],
+            "src": [
+              912,
+              918
+            ],
+            "en_text": "ficino",
+            "src_text": "ficino",
+            "weight": 1,
+            "method": "embedding"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The alignment results JSON was generated but never committed to `public/data/` — the blog post at `/blog/word-alignment` was showing "Alignment data unavailable."

- Added `!public/data/` exception to `.gitignore` (was blocked by `data/` pattern)
- Copied `alignment-results.json` to `public/data/experiments/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)