### PR TITLE
Fix collection page timeouts from Supabase count queries

### DIFF
--- a/scripts/migration/add-books-catalog-gin-indexes.sql
+++ b/scripts/migration/add-books-catalog-gin-indexes.sql
@@ -1,0 +1,10 @@
+-- Add GIN index on books_catalog.collections for fast array containment queries.
+-- Without this, `collections @> '["some-slug"]'` does a sequential scan on ~17K rows,
+-- causing 30s+ timeouts for large collections like 'miscellany' (2,222 books).
+-- Also add GIN on categories for the same reason.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_books_catalog_collections_gin
+  ON books_catalog USING GIN (collections);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_books_catalog_categories_gin
+  ON books_catalog USING GIN (categories);

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -275,6 +275,7 @@ async function fetchCollectionData(id: string) {
         collection: id,
         sort: 'popular',
         limit: COMPACT_LIMIT,
+        skipCount: true, // collection.book_count is cached — skip expensive Supabase count
       });
       return sbBooks.map(b => ({
         id: b.id, slug: b.slug, title: b.title, display_title: b.display_title,

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -98,13 +98,16 @@ export async function browseBooks(opts: {
   sort?: SortOption;
   offset?: number;
   limit?: number;
+  /** Skip count: 'exact' to avoid expensive seq scans on large collections.
+   *  Callers that already have a cached count (e.g. collection pages) should set this. */
+  skipCount?: boolean;
 }): Promise<{ books: CatalogBook[]; total: number }> {
   const limit = opts.limit || 60;
   const offset = opts.offset || 0;
 
   let query = supabase
     .from('books_catalog')
-    .select(BOOK_SELECT, { count: 'exact' })
+    .select(BOOK_SELECT, opts.skipCount ? { count: 'planned' } : { count: 'exact' })
     .eq('visible', true);
 
   if (opts.hasPages !== false) query = query.gt('pages_count', 0);


### PR DESCRIPTION
## Summary
- **Skip `count: 'exact'`** on collection page browseBooks calls — collection pages already have `book_count` cached on the collection document, so the expensive Supabase count is redundant
- **Add GIN index migration SQL** for `books_catalog.collections` and `books_catalog.categories` — without these indexes, array containment queries (`@>`) do sequential scans on ~17K rows
- Root cause: 5 collection pages (`miscellany`, `ancient-epic-drama`, `geography-exploration`, `natural-magic-sub`, `russian-political-thought`) consistently timeout during ISR generation

## Manual step required
Run this SQL in the [Supabase SQL Editor](https://supabase.com/dashboard/project/ykhxaecbbxaaqlujuzde/sql/new):
```sql
CREATE INDEX IF NOT EXISTS idx_books_catalog_collections_gin
  ON books_catalog USING GIN (collections);
CREATE INDEX IF NOT EXISTS idx_books_catalog_categories_gin
  ON books_catalog USING GIN (categories);
```

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] After merge + deploy, visit `/collections/miscellany` and `/collections/ancient-epic-drama` — should load within 10s instead of timing out
- [ ] After running GIN index SQL, all collection pages should load under 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)