### PR TITLE
Fix sign-in link disappearing on stale ISR pages

### DIFF
--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -23,11 +23,8 @@ export default function UserMenu({ variant = 'default' }: UserMenuProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  if (status === 'loading') {
-    return null;
-  }
-
-  // Anonymous user: show sign-in link
+  // Show sign-in link for anonymous users AND during loading.
+  // This ensures the link is visible in SSR and survives hydration failures.
   if (!session) {
     const textColor = variant === 'hero' ? 'text-white/80 hover:text-white' : '';
     const textStyle = variant === 'hero' ? {} : { color: 'var(--text-muted)' };


### PR DESCRIPTION
## Summary
- **UserMenu** returned `null` during `useSession()` loading state, making the sign-in link invisible in server-rendered HTML
- If JS hydration failed (stale ISR chunks, network issues), the link never appeared — users couldn't sign in
- Now renders "Sign in" as the default state, swapping to the avatar dropdown only after session confirms authentication

## Root cause
Stale ISR page served old JS bundle references → hydration silently failed → `useSession()` never resolved → `status === 'loading'` → `return null` forever.

## Test plan
- [ ] Visit sourcelibrary.org in incognito — "Sign in" should appear immediately in header
- [ ] Sign in with email — should swap to avatar dropdown after auth
- [ ] View page source — "Sign in" should be in the SSR HTML (not injected by JS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)