### PR TITLE
Remove Google sign-in button

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { signIn } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useState } from 'react';
 import Link from 'next/link';
@@ -106,7 +105,7 @@ function SignInContent() {
               : error === 'OAuthAccountNotLinked'
                 ? 'This email is already associated with another account.'
                 : error === 'EmailSignin'
-                  ? 'Could not send sign-in email. Please try again or use Google.'
+                  ? 'Could not send sign-in email. Please try again.'
                   : 'An error occurred during sign in. Please try again.'}
           </div>
         )}
@@ -139,28 +138,6 @@ function SignInContent() {
             {loading ? 'Sending link...' : 'Continue with Email'}
           </button>
         </form>
-
-        <div className="flex items-center gap-3 my-6">
-          <div className="flex-1 h-px" style={{ background: 'var(--border-light)' }} />
-          <span className="text-xs" style={{ color: 'var(--text-faint)' }}>or</span>
-          <div className="flex-1 h-px" style={{ background: 'var(--border-light)' }} />
-        </div>
-
-        <div className="space-y-3">
-          <button
-            onClick={() => signIn('google', { callbackUrl })}
-            className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-lg font-medium transition-all hover:opacity-90"
-            style={{ background: 'var(--bg-warm)', color: 'var(--text-primary)', border: '1px solid var(--border-medium)' }}
-          >
-            <svg className="w-5 h-5" viewBox="0 0 24 24">
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-            </svg>
-            Continue with Google
-          </button>
-        </div>
 
         <p className="mt-4 text-center text-xs" style={{ color: 'var(--text-faint)' }}>
           By signing in, you agree to our{' '}

--- a/src/components/auth/AuthPrompt.tsx
+++ b/src/components/auth/AuthPrompt.tsx
@@ -38,24 +38,6 @@ export default function AuthPrompt({
 
       <div className="space-y-2">
         <button
-          onClick={() => signIn('google', { callbackUrl })}
-          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
-          style={{
-            background: 'var(--bg-warm)',
-            color: 'var(--text-primary)',
-            border: '1px solid var(--border-medium)',
-          }}
-        >
-          <svg className="w-4 h-4" viewBox="0 0 24 24">
-            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-          </svg>
-          Continue with Google
-        </button>
-
-        <button
           onClick={() => signIn('email', { callbackUrl })}
           className="w-full px-3 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-90"
           style={{

--- a/src/components/auth/SignUpCTA.tsx
+++ b/src/components/auth/SignUpCTA.tsx
@@ -25,7 +25,7 @@ export default function SignUpCTA({ variant = 'section' }: SignUpCTAProps) {
           className="text-sm font-medium hover:underline"
           style={{ color: 'var(--accent-gold)' }}
         >
-          Sign in with Google or email
+          Sign in with email
         </Link>
       </div>
     );
@@ -62,7 +62,7 @@ export default function SignUpCTA({ variant = 'section' }: SignUpCTAProps) {
           Create free account
         </Link>
         <p className="text-xs mt-5" style={{ color: '#6b6560' }}>
-          Sign in with Google or email &middot; No spam, ever
+          Sign in with email &middot; No spam, ever
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Remove broken Google OAuth button from sign-in page, inline auth prompt, and sign-up CTA
- Update copy from "Google or email" to just "email"
- Clean up unused `signIn` import from sign-in page

Google OAuth provider remains registered in `auth.ts` so existing accounts aren't orphaned — users just sign in via email magic link instead.

## Test plan
- [ ] Visit /auth/signin — only email form shown, no Google button
- [ ] Sign in with email magic link — works end to end
- [ ] Existing Google user signs in with same email — resolves to same account

🤖 Generated with [Claude Code](https://claude.com/claude-code)