### PR TITLE
Fix reading room quote click showing raw RSC data

### DIFF
--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -89,6 +89,7 @@ interface FeaturedPassage {
   bookYear: number | null;
   bookSlug: string;
   pageNumber: number;
+  pageId?: string;
 }
 
 interface ReadingRoomClientProps {
@@ -512,7 +513,7 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
               <p className="text-[11px] text-white/40 tracking-[0.15em] uppercase font-sans mb-2">
                 The Librarian is reading
               </p>
-              <Link href={`/book/${featuredPassage.bookSlug}?page=${featuredPassage.pageNumber}`} className="block group">
+              <Link href={featuredPassage.pageId ? `/book/${featuredPassage.bookSlug}/page/${featuredPassage.pageId}` : `/book/${featuredPassage.bookSlug}`} className="block group">
                 <blockquote className="text-white/70 text-[15px] font-body leading-relaxed italic border-l-2 border-[#c9a86c]/40 pl-4">
                   &ldquo;{featuredPassage.text}&rdquo;
                 </blockquote>

--- a/src/app/reading-room/page.tsx
+++ b/src/app/reading-room/page.tsx
@@ -59,13 +59,28 @@ async function getFeaturedPassage() {
         text = cut > 80 ? truncated.slice(0, cut + 1) : truncated.slice(0, 280) + '...';
       }
       if (text.length >= 60) {
+        // Resolve page _id for deep linking (notebook stores slug, pages use book.id)
+        const bookSlug = f.source.bookSlug || f.source.bookId;
+        let pageId: string | undefined;
+        const bookDoc = await db.collection('books').findOne(
+          { $or: [{ slug: bookSlug }, { id: bookSlug }] },
+          { projection: { id: 1 }, maxTimeMS: 3000 }
+        );
+        if (bookDoc) {
+          const pageDoc = await db.collection('pages').findOne(
+            { book_id: bookDoc.id, page_number: f.source.pageNumber },
+            { projection: { _id: 1 }, maxTimeMS: 3000 }
+          );
+          pageId = pageDoc?._id?.toString();
+        }
         return {
           text,
           bookTitle: f.source.bookTitle,
           bookAuthor: f.source.bookAuthor,
           bookYear: null,
-          bookSlug: f.source.bookSlug || f.source.bookId,
+          bookSlug: bookSlug,
           pageNumber: f.source.pageNumber,
+          pageId,
         };
       }
     }
@@ -122,6 +137,7 @@ async function getFeaturedPassage() {
       bookYear: book.year,
       bookSlug: book.slug || book.id,
       pageNumber: bestPage.page_number,
+      pageId: bestPage._id?.toString() || undefined,
     };
   } catch (err) {
     console.error('[reading-room] Failed to load featured passage:', err);


### PR DESCRIPTION
## Summary
- User on Safari clicked the featured quote on `/reading-room` and saw raw RSC flight data instead of the book page
- Root cause: the link used `?page=N` query param which the book page route doesn't handle, causing a client-side navigation failure in Safari
- Fix: resolve the actual page `_id` and deep-link to `/book/slug/page/pageId` (the proper route)
- Handles both notebook findings path (slug→book.id→page._id lookup) and fallback random page path (already has `_id`)

## Test plan
- [ ] Click the featured quote on https://sourcelibrary.org/reading-room — should navigate to the specific book page
- [ ] Test on Safari specifically (where the original bug occurred)
- [ ] Verify fallback works when pageId isn't found (links to book without page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)