### PR TITLE
Add daily Gemini requests chart to analytics

### DIFF
--- a/src/app/api/analytics/usage/route.ts
+++ b/src/app/api/analytics/usage/route.ts
@@ -49,7 +49,7 @@ export const GET = withAuth(async (request, session) => {
         if (!rows || rows.length === 0) return [{}];
 
         let totalCost = 0, totalTokens = 0;
-        const costByDayMap = new Map<string, { cost: number; tokens: number }>();
+        const costByDayMap = new Map<string, { cost: number; tokens: number; requests: number }>();
         const costByActionMap = new Map<string, { cost: number; count: number }>();
         const modelUsageMap = new Map<string, number>();
         let imagePages = 0;
@@ -63,9 +63,10 @@ export const GET = withAuth(async (request, session) => {
 
           // Aggregate by day
           const dayStr = row.day;
-          const existing = costByDayMap.get(dayStr) || { cost: 0, tokens: 0 };
+          const existing = costByDayMap.get(dayStr) || { cost: 0, tokens: 0, requests: 0 };
           existing.cost += cost;
           existing.tokens += tokens;
+          existing.requests += Number(row.call_count) || 0;
           costByDayMap.set(dayStr, existing);
 
           // Aggregate by type
@@ -93,7 +94,7 @@ export const GET = withAuth(async (request, session) => {
           costTotal: [{ totalCost, totalTokens }],
           costByDay: Array.from(costByDayMap.entries())
             .sort(([a], [b]) => a.localeCompare(b))
-            .map(([date, v]) => ({ _id: date, cost: v.cost, tokens: v.tokens })),
+            .map(([date, v]) => ({ _id: date, cost: v.cost, tokens: v.tokens, requests: v.requests })),
           costByAction: Array.from(costByActionMap.entries())
             .sort(([, a], [, b]) => b.cost - a.cost)
             .map(([type, v]) => ({ _id: type, cost: v.cost, count: v.count })),
@@ -222,7 +223,7 @@ export const GET = withAuth(async (request, session) => {
     const costStats = {
       totalCost: gu.costTotal?.[0]?.totalCost || 0,
       totalTokens: gu.costTotal?.[0]?.totalTokens || 0,
-      costByDay: (gu.costByDay || []).map((d: any) => ({ date: d._id, cost: d.cost || 0, tokens: d.tokens || 0 })),
+      costByDay: (gu.costByDay || []).map((d: any) => ({ date: d._id, cost: d.cost || 0, tokens: d.tokens || 0, requests: d.requests || 0 })),
       costByAction: (gu.costByAction || []).map((a: any) => ({ action: a._id || 'unknown', cost: a.cost || 0, count: a.count || 0 })),
     };
 

--- a/src/components/analytics/tabs/UsageTab.tsx
+++ b/src/components/analytics/tabs/UsageTab.tsx
@@ -700,13 +700,18 @@ function ModelPromptUsage({ modelUsage, promptUsage }: { modelUsage: UsageStats[
 }
 
 function CostBreakdown({ costStats }: { costStats: NonNullable<UsageStats['costStats']> }) {
-  const chartData = costStats.costByDay.map(d => ({
+  const costChartData = costStats.costByDay.map(d => ({
     x: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
     y: d.cost,
   }));
 
+  const requestsChartData = costStats.costByDay.map(d => ({
+    x: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    y: d.requests,
+  }));
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="space-y-6">
       <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
         <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
           <DollarSign className="w-5 h-5" style={{ color: '#22c55e' }} />
@@ -731,17 +736,31 @@ function CostBreakdown({ costStats }: { costStats: NonNullable<UsageStats['costS
         </div>
       </div>
       {costStats.costByDay.length > 0 && (
-        <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
-          <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
-            <Coins className="w-5 h-5" style={{ color: '#22c55e' }} />
-            Daily Cost
-          </h2>
-          <AreaChart
-            data={chartData}
-            color="#22c55e"
-            yLabel={(v) => formatCost(v)}
-            height={192}
-          />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+            <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <Coins className="w-5 h-5" style={{ color: '#22c55e' }} />
+              Daily Cost
+            </h2>
+            <AreaChart
+              data={costChartData}
+              color="#22c55e"
+              yLabel={(v) => formatCost(v)}
+              height={192}
+            />
+          </div>
+          <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+            <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <ListChecks className="w-5 h-5" style={{ color: 'var(--accent-violet)' }} />
+              Daily Gemini Requests
+            </h2>
+            <AreaChart
+              data={requestsChartData}
+              color="var(--accent-violet, #8b5cf6)"
+              yLabel={(v) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(Math.round(v))}
+              height={192}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/lib/api-client/types/analytics.ts
+++ b/src/lib/api-client/types/analytics.ts
@@ -37,7 +37,7 @@ export interface UsageStats {
   costStats?: {
     totalCost: number;
     totalTokens: number;
-    costByDay: Array<{ date: string; cost: number; tokens: number }>;
+    costByDay: Array<{ date: string; cost: number; tokens: number; requests: number }>;
     costByAction: Array<{ action: string; cost: number; count: number }>;
   };
   collectionStats?: {


### PR DESCRIPTION
## Summary
- Adds a "Daily Gemini Requests" area chart next to the existing "Daily Cost" chart on the Usage tab
- Pulls request counts from the existing `dashboard_usage` materialized view (no new queries)
- Layout: Cost by Action is full-width, then Daily Cost and Daily Requests side by side

## Test plan
- [ ] Visit https://sourcelibrary.org/analytics → Usage tab
- [ ] Verify both Daily Cost and Daily Gemini Requests charts render
- [ ] Check different time ranges (7d, 30d, 90d) show correct data

Generated with [Claude Code](https://claude.com/claude-code)