### PR TITLE
MCP: return inline images from search_images

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -348,6 +348,24 @@ async function handleToolCall(name: string, args: ToolArgs) {
   }
 }
 
+// ── Fetch image as base64 (with timeout) ───────────────────────────
+
+async function fetchImageBase64(url: string): Promise<{ data: string; mimeType: string } | null> {
+  try {
+    const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (!resp.ok) return null;
+    const contentType = resp.headers.get('content-type') || 'image/jpeg';
+    const mimeType = contentType.split(';')[0].trim();
+    const buffer = await resp.arrayBuffer();
+    // Skip images larger than 1MB to keep responses reasonable
+    if (buffer.byteLength > 1_000_000) return null;
+    const data = Buffer.from(buffer).toString('base64');
+    return { data, mimeType };
+  } catch {
+    return null;
+  }
+}
+
 // ── Create a fresh MCP server instance (stateless per-request) ─────
 
 function createServer() {
@@ -367,6 +385,29 @@ function createServer() {
     const { name, arguments: args } = request.params;
     try {
       const result = await handleToolCall(name, (args || {}) as ToolArgs);
+
+      // search_images: return image content blocks alongside text metadata
+      if (name === 'search_images' && result && typeof result === 'object' && 'images' in result) {
+        const imageResult = result as { total: unknown; showing: unknown; images: Array<{ image_url: string; description: string; book: { title: string }; url: string; [k: string]: unknown }> };
+        const content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [];
+
+        // Text summary first
+        content.push({ type: 'text' as const, text: JSON.stringify({ total: imageResult.total, showing: imageResult.showing, images: imageResult.images }, null, 2) });
+
+        // Fetch actual images in parallel (limit to first 5 to keep response size manageable)
+        const imagesToFetch = imageResult.images.slice(0, 5);
+        const fetched = await Promise.all(imagesToFetch.map(img => fetchImageBase64(img.image_url)));
+        for (let i = 0; i < imagesToFetch.length; i++) {
+          const img = fetched[i];
+          if (img) {
+            content.push({ type: 'image' as const, data: img.data, mimeType: img.mimeType });
+            content.push({ type: 'text' as const, text: `${imagesToFetch[i].description || 'Image'}\n${imagesToFetch[i].url}` });
+          }
+        }
+
+        return { content };
+      }
+
       const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
       return { content: [{ type: 'text' as const, text }] };
     } catch (error) {


### PR DESCRIPTION
## Summary
- MCP `search_images` tool now returns actual image content blocks (base64) alongside text metadata
- Claude Chat and other MCP clients can display historical illustrations inline instead of just seeing URLs
- Fetches up to 5 images per response, 5s timeout per fetch, skips images >1MB

## Test plan
- [ ] Call `search_images` via Claude Chat MCP integration — verify images render inline
- [ ] Verify text metadata JSON still appears alongside images
- [ ] Test with a query that returns no results — should still return text-only response
- [ ] Test with large/slow images — verify timeout and size limit work gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)