### PR TITLE
Clean up stale analytics dashboard sections

### DIFF
--- a/src/app/api/analytics/usage/route.ts
+++ b/src/app/api/analytics/usage/route.ts
@@ -49,7 +49,7 @@ export const GET = withAuth(async (request, session) => {
         if (!rows || rows.length === 0) return [{}];
 
         let totalCost = 0, totalTokens = 0;
-        const costByDayMap = new Map<string, { cost: number; tokens: number }>();
+        const costByDayMap = new Map<string, { cost: number; tokens: number; requests: number }>();
         const costByActionMap = new Map<string, { cost: number; count: number }>();
         const modelUsageMap = new Map<string, number>();
         let imagePages = 0;
@@ -63,9 +63,10 @@ export const GET = withAuth(async (request, session) => {
 
           // Aggregate by day
           const dayStr = row.day;
-          const existing = costByDayMap.get(dayStr) || { cost: 0, tokens: 0 };
+          const existing = costByDayMap.get(dayStr) || { cost: 0, tokens: 0, requests: 0 };
           existing.cost += cost;
           existing.tokens += tokens;
+          existing.requests += Number(row.call_count) || 0;
           costByDayMap.set(dayStr, existing);
 
           // Aggregate by type
@@ -93,7 +94,7 @@ export const GET = withAuth(async (request, session) => {
           costTotal: [{ totalCost, totalTokens }],
           costByDay: Array.from(costByDayMap.entries())
             .sort(([a], [b]) => a.localeCompare(b))
-            .map(([date, v]) => ({ _id: date, cost: v.cost, tokens: v.tokens })),
+            .map(([date, v]) => ({ _id: date, cost: v.cost, tokens: v.tokens, requests: v.requests })),
           costByAction: Array.from(costByActionMap.entries())
             .sort(([, a], [, b]) => b.cost - a.cost)
             .map(([type, v]) => ({ _id: type, cost: v.cost, count: v.count })),
@@ -222,7 +223,7 @@ export const GET = withAuth(async (request, session) => {
     const costStats = {
       totalCost: gu.costTotal?.[0]?.totalCost || 0,
       totalTokens: gu.costTotal?.[0]?.totalTokens || 0,
-      costByDay: (gu.costByDay || []).map((d: any) => ({ date: d._id, cost: d.cost || 0, tokens: d.tokens || 0 })),
+      costByDay: (gu.costByDay || []).map((d: any) => ({ date: d._id, cost: d.cost || 0, tokens: d.tokens || 0, requests: d.requests || 0 })),
       costByAction: (gu.costByAction || []).map((a: any) => ({ action: a._id || 'unknown', cost: a.cost || 0, count: a.count || 0 })),
     };
 

--- a/src/app/api/analytics/usage/route.ts
+++ b/src/app/api/analytics/usage/route.ts
@@ -166,9 +166,6 @@ export const GET = withAuth(async (request, session) => {
     // Collection stats from snapshot
     const collectionStats = {
       blobStorage: {
-        pagesWithCroppedPhoto: 0,
-        pagesWithArchivedPhoto: 0,
-        totalBlobPages: 0,
         booksWithSplitPages: snap?.splitting?.booksWithSplitPages || 0,
       },
       byLanguage: (snap?.byLanguage || []).map((l: any) => ({ language: l._id || 'Unknown', count: l.count })),

--- a/src/components/analytics/tabs/PipelineTab.tsx
+++ b/src/components/analytics/tabs/PipelineTab.tsx
@@ -75,7 +75,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
         .animate-loading-bar { animation: loading-bar 2s ease-in-out infinite; }
       `}</style>
       <p className="text-center text-sm" style={{ color: 'var(--text-muted)' }}>
-        {slow ? 'Still loading — pipeline queries can be slow on Atlas...' : 'Loading pipeline data...'}
+        {slow ? 'Still loading — large time ranges can be slow...' : 'Loading pipeline data...'}
       </p>
     </div>
   );

--- a/src/components/analytics/tabs/UsageTab.tsx
+++ b/src/components/analytics/tabs/UsageTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { BookOpen, FileText, Languages, Users, DollarSign, Coins, ListChecks, Database, HardDrive, Archive, AlertTriangle, Loader2 } from 'lucide-react';
+import { BookOpen, FileText, Languages, Users, DollarSign, Coins, ListChecks, Database, HardDrive, AlertTriangle, Loader2 } from 'lucide-react';
 import { analytics } from '@/lib/api-client';
 import { BookLoader } from '@/components/ui/BookLoader';
 import type { UsageStats } from '@/lib/api-client/types/analytics';
@@ -353,37 +353,14 @@ function CollectionPipeline({ summary, collectionStats }: { summary: UsageStats[
     <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
       <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
         <Database className="w-5 h-5" style={{ color: 'var(--accent-violet)' }} />
-        Collection Processing Pipeline
+        Processing Progress
       </h2>
       <div className="space-y-4">
-        {/* Total Pages Bar */}
-        <div>
-          <div className="flex justify-between text-sm mb-2">
-            <span style={{ color: 'var(--text-primary)' }}>Total Pages</span>
-            <span style={{ color: 'var(--text-muted)' }}>{formatNumber(summary.totalPages)}</span>
-          </div>
-          <div className="h-8 rounded-lg overflow-hidden flex" style={{ background: 'var(--bg-warm)' }}>
-            <div
-              className="h-full flex items-center justify-center text-xs font-medium text-white"
-              style={{
-                width: `${(collectionStats.blobStorage.totalBlobPages / summary.totalPages) * 100}%`,
-                background: '#22c55e',
-                minWidth: collectionStats.blobStorage.totalBlobPages > 0 ? '60px' : '0',
-              }}
-              title={`${formatNumber(collectionStats.blobStorage.totalBlobPages)} pages archived to Vercel Blob`}
-            >
-              {((collectionStats.blobStorage.totalBlobPages / summary.totalPages) * 100).toFixed(0)}% Blob
-            </div>
-            <div className="h-full flex items-center justify-center text-xs" style={{ flex: 1, color: 'var(--text-muted)' }}>
-              {formatNumber(summary.totalPages - collectionStats.blobStorage.totalBlobPages)} from external sources
-            </div>
-          </div>
-        </div>
         {/* OCR Progress */}
         <div>
           <div className="flex justify-between text-sm mb-2">
-            <span style={{ color: 'var(--text-primary)' }}>OCR Progress</span>
-            <span style={{ color: 'var(--text-muted)' }}>{formatNumber(summary.pagesWithOcr)} / {formatNumber(summary.totalPages)}</span>
+            <span style={{ color: 'var(--text-primary)' }}>OCR</span>
+            <span style={{ color: 'var(--text-muted)' }}>{formatNumber(summary.pagesWithOcr)} / {formatNumber(summary.totalPages)} pages</span>
           </div>
           <div className="h-6 rounded-lg overflow-hidden flex" style={{ background: 'var(--bg-warm)' }}>
             <div className="h-full flex items-center justify-center text-xs font-medium text-white" style={{ width: `${summary.ocrPercentage}%`, background: 'var(--accent-sage)', minWidth: summary.ocrPercentage > 0 ? '40px' : '0' }}>
@@ -394,8 +371,8 @@ function CollectionPipeline({ summary, collectionStats }: { summary: UsageStats[
         {/* Translation Progress */}
         <div>
           <div className="flex justify-between text-sm mb-2">
-            <span style={{ color: 'var(--text-primary)' }}>Translation Progress</span>
-            <span style={{ color: 'var(--text-muted)' }}>{formatNumber(summary.pagesWithTranslation)} / {formatNumber(summary.totalPages)}</span>
+            <span style={{ color: 'var(--text-primary)' }}>Translation</span>
+            <span style={{ color: 'var(--text-muted)' }}>{formatNumber(summary.pagesWithTranslation)} / {formatNumber(summary.totalPages)} pages</span>
           </div>
           <div className="h-6 rounded-lg overflow-hidden flex" style={{ background: 'var(--bg-warm)' }}>
             <div className="h-full flex items-center justify-center text-xs font-medium text-white" style={{ width: `${summary.translationPercentage}%`, background: 'var(--accent-rust)', minWidth: summary.translationPercentage > 0 ? '40px' : '0' }}>
@@ -404,24 +381,16 @@ function CollectionPipeline({ summary, collectionStats }: { summary: UsageStats[
           </div>
         </div>
       </div>
-      {/* Storage Breakdown Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
-        {[
-          { icon: Archive, color: '#22c55e', label: 'Archived', value: collectionStats.blobStorage.pagesWithArchivedPhoto, sub: 'full pages' },
-          { icon: HardDrive, color: 'var(--accent-violet)', label: 'Cropped', value: collectionStats.blobStorage.pagesWithCroppedPhoto, sub: 'split pages' },
-          { icon: BookOpen, color: 'var(--accent-sage)', label: 'Split Books', value: collectionStats.blobStorage.booksWithSplitPages, sub: 'books processed' },
-          { icon: Database, color: 'var(--accent-rust)', label: 'Total Blob', value: collectionStats.blobStorage.totalBlobPages, sub: `${((collectionStats.blobStorage.totalBlobPages / summary.totalPages) * 100).toFixed(1)}% of collection` },
-        ].map((item) => (
-          <div key={item.label} className="p-3 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
-            <div className="flex items-center gap-2 mb-1">
-              <item.icon className="w-4 h-4" style={{ color: item.color }} />
-              <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>{item.label}</span>
-            </div>
-            <div className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>{formatNumber(item.value)}</div>
-            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>{item.sub}</div>
+      {collectionStats.blobStorage.booksWithSplitPages > 0 && (
+        <div className="mt-4 p-3 rounded-lg" style={{ background: 'var(--bg-warm)' }}>
+          <div className="flex items-center gap-2 mb-1">
+            <BookOpen className="w-4 h-4" style={{ color: 'var(--accent-sage)' }} />
+            <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>Split Books</span>
           </div>
-        ))}
-      </div>
+          <div className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>{formatNumber(collectionStats.blobStorage.booksWithSplitPages)}</div>
+          <div className="text-xs" style={{ color: 'var(--text-muted)' }}>books with spread pages split</div>
+        </div>
+      )}
     </div>
   );
 }
@@ -604,7 +573,7 @@ function CostToComplete({ summary, costStats }: { summary: UsageStats['summary']
 
 function CollectionBreakdown({ collectionStats }: { collectionStats: NonNullable<UsageStats['collectionStats']> }) {
   const colors = ['var(--accent-rust)', 'var(--accent-sage)', 'var(--accent-violet)', '#f59e0b', '#22c55e'];
-  const providerLabels: Record<string, string> = { internet_archive: 'Internet Archive', gallica: 'Gallica (BnF)', mdz: 'MDZ (Bavarian)', bph: 'BPH Manuscripts', iiif: 'IIIF Generic', vercel_blob: 'Vercel Blob' };
+  const providerLabels: Record<string, string> = { internet_archive: 'Internet Archive', gallica: 'Gallica (BnF)', mdz: 'MDZ (Bavarian)', bph: 'BPH Manuscripts', iiif: 'IIIF Generic', vercel_blob: 'R2 (Archived)' };
   const providerColors: Record<string, string> = { internet_archive: '#f59e0b', gallica: '#3b82f6', mdz: '#22c55e', bph: 'var(--accent-violet)', iiif: 'var(--accent-rust)', vercel_blob: '#22c55e' };
 
   return (

--- a/src/components/analytics/tabs/UsageTab.tsx
+++ b/src/components/analytics/tabs/UsageTab.tsx
@@ -700,13 +700,18 @@ function ModelPromptUsage({ modelUsage, promptUsage }: { modelUsage: UsageStats[
 }
 
 function CostBreakdown({ costStats }: { costStats: NonNullable<UsageStats['costStats']> }) {
-  const chartData = costStats.costByDay.map(d => ({
+  const costChartData = costStats.costByDay.map(d => ({
     x: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
     y: d.cost,
   }));
 
+  const requestsChartData = costStats.costByDay.map(d => ({
+    x: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    y: d.requests,
+  }));
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="space-y-6">
       <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
         <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
           <DollarSign className="w-5 h-5" style={{ color: '#22c55e' }} />
@@ -731,17 +736,31 @@ function CostBreakdown({ costStats }: { costStats: NonNullable<UsageStats['costS
         </div>
       </div>
       {costStats.costByDay.length > 0 && (
-        <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
-          <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
-            <Coins className="w-5 h-5" style={{ color: '#22c55e' }} />
-            Daily Cost
-          </h2>
-          <AreaChart
-            data={chartData}
-            color="#22c55e"
-            yLabel={(v) => formatCost(v)}
-            height={192}
-          />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+            <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <Coins className="w-5 h-5" style={{ color: '#22c55e' }} />
+              Daily Cost
+            </h2>
+            <AreaChart
+              data={costChartData}
+              color="#22c55e"
+              yLabel={(v) => formatCost(v)}
+              height={192}
+            />
+          </div>
+          <div className="p-6 rounded-xl" style={{ background: 'var(--bg-white)', border: '1px solid var(--border-light)' }}>
+            <h2 className="text-lg font-medium mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <ListChecks className="w-5 h-5" style={{ color: 'var(--accent-violet)' }} />
+              Daily Gemini Requests
+            </h2>
+            <AreaChart
+              data={requestsChartData}
+              color="var(--accent-violet, #8b5cf6)"
+              yLabel={(v) => v >= 1000 ? `${(v / 1000).toFixed(1)}k` : String(Math.round(v))}
+              height={192}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/lib/api-client/types/analytics.ts
+++ b/src/lib/api-client/types/analytics.ts
@@ -42,9 +42,6 @@ export interface UsageStats {
   };
   collectionStats?: {
     blobStorage: {
-      pagesWithCroppedPhoto: number;
-      pagesWithArchivedPhoto: number;
-      totalBlobPages: number;
       booksWithSplitPages: number;
     };
     byLanguage: Array<{ language: string; count: number }>;

--- a/src/lib/api-client/types/analytics.ts
+++ b/src/lib/api-client/types/analytics.ts
@@ -37,7 +37,7 @@ export interface UsageStats {
   costStats?: {
     totalCost: number;
     totalTokens: number;
-    costByDay: Array<{ date: string; cost: number; tokens: number }>;
+    costByDay: Array<{ date: string; cost: number; tokens: number; requests: number }>;
     costByAction: Array<{ action: string; cost: number; count: number }>;
   };
   collectionStats?: {


### PR DESCRIPTION
## Summary
- Remove dead blob storage fields (pagesWithCroppedPhoto, pagesWithArchivedPhoto, totalBlobPages) — all hardcoded to 0 since R2 migration
- Simplify "Collection Processing Pipeline" → "Processing Progress" (OCR + Translation bars, split books stat)
- Fix misleading "slow on Atlas" loading message — data comes from Supabase
- Fix "Vercel Blob" → "R2 (Archived)" in image source breakdown

## Test plan
- [ ] Usage tab: Processing Progress section shows OCR/Translation bars correctly
- [ ] Usage tab: Image Sources breakdown shows "R2 (Archived)" not "Vercel Blob"
- [ ] Pipeline tab: loading message says "large time ranges can be slow"

Generated with [Claude Code](https://claude.com/claude-code)