### PR TITLE
Learn page: date, author, tradition quiz modes + smarter distractors

### DIFF
--- a/src/app/api/learn/route.ts
+++ b/src/app/api/learn/route.ts
@@ -4,82 +4,48 @@ import { getReadDb } from '@/lib/mongodb';
 export const maxDuration = 15;
 export const dynamic = 'force-dynamic';
 
-interface TermEntry {
-  term: string;
-  definition: string;
-  originalContext?: string;
+// ── Types ──
+
+interface QuestionBase {
+  mode: string;
   bookId: string;
   bookTitle: string;
   bookAuthor: string;
-  bookDate?: string;
+  bookDate?: string | number;
   bookLanguage?: string;
   pageNumber: number;
   slug?: string;
+  options: string[];
+  correctIndex: number;
 }
 
-/** Parse <term>...</term> tags, extracting inline definitions when present */
-function extractTerms(translationText: string): Array<{ term: string; definition: string; context: string }> {
-  const results: Array<{ term: string; definition: string; context: string }> = [];
-
-  // Pattern: <term>word</term> optionally followed by <note>definition</note> or <gloss>definition</gloss>
-  // Also handles inline definitions like "word: definition" or "word; definition"
-  const termRegex = /<term>([\s\S]*?)<\/term>\s*(?:<(?:note|gloss)>([\s\S]*?)<\/(?:note|gloss)>)?/g;
-
-  let match;
-  while ((match = termRegex.exec(translationText)) !== null) {
-    const rawTerm = match[1].trim();
-    const noteOrGloss = match[2]?.trim();
-
-    let term: string;
-    let definition: string;
-
-    // Check if the term itself contains a definition (e.g., "spiritus: the breath of life")
-    const inlineSplit = rawTerm.match(/^([^:;]+?)\s*[:;]\s+([\s\S]+)$/);
-    if (inlineSplit) {
-      term = inlineSplit[1].trim().replace(/\*/g, '');
-      definition = inlineSplit[2].trim().replace(/\*/g, '');
-    } else if (noteOrGloss) {
-      term = rawTerm.replace(/\*/g, '');
-      // Clean up note text — remove "original: " prefix and quote marks
-      definition = noteOrGloss
-        .replace(/^original:\s*/i, '')
-        .replace(/^["']|["']$/g, '')
-        .replace(/<[^>]+>/g, '') // strip nested tags
-        .trim();
-    } else {
-      // Term without definition — skip these for quiz purposes
-      continue;
-    }
-
-    // Skip very long terms (they're more like explanations)
-    if (term.length > 60 || definition.length > 300) continue;
-    // Skip very short/generic terms
-    if (term.length < 3) continue;
-
-    // Get surrounding context (sentence containing the term), stripping the definition
-    // so the context doesn't give away the answer
-    const termIdx = translationText.indexOf(match[0]);
-    const contextStart = Math.max(0, translationText.lastIndexOf('.', termIdx) + 1);
-    const contextEnd = translationText.indexOf('.', termIdx + match[0].length);
-    let context = translationText
-      .slice(contextStart, contextEnd > 0 ? contextEnd + 1 : contextStart + 200)
-      .replace(/<[^>]+>[^<]*<\/[^>]+>/g, '') // strip tag pairs and their content (definitions)
-      .replace(/<[^>]+>/g, '') // strip remaining tags
-      .replace(/\s{2,}/g, ' ')
-      .trim()
-      .substring(0, 200);
-    // If the definition text still appears in context, redact it
-    if (definition.length > 10 && context.toLowerCase().includes(definition.toLowerCase().substring(0, 30))) {
-      context = context.replace(new RegExp(definition.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').substring(0, 40), 'i'), '...');
-    }
-
-    results.push({ term, definition, context });
-  }
-
-  return results;
+interface VocabQuestion extends QuestionBase {
+  mode: 'vocab';
+  term: string;
+  definition: string;
+  originalContext?: string;
 }
 
-// Topics map to collection slugs in the database
+interface DateQuestion extends QuestionBase {
+  mode: 'date';
+  passage: string;
+}
+
+interface AuthorQuestion extends QuestionBase {
+  mode: 'author';
+  passage: string;
+}
+
+interface TraditionQuestion extends QuestionBase {
+  mode: 'tradition';
+  passage: string;
+  collection: string;
+}
+
+type Question = VocabQuestion | DateQuestion | AuthorQuestion | TraditionQuestion;
+
+// ── Topics ──
+
 const TOPICS: Record<string, { label: string; description: string; collections: string[] }> = {
   alchemy: {
     label: 'Alchemy',
@@ -123,161 +89,375 @@ const TOPICS: Record<string, { label: string; description: string; collections: 
   },
 };
 
+// ── Helpers ──
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/** Pick n random items from arr, excluding items matching `exclude` */
+function pickDistractors(pool: string[], correct: string, n: number): string[] {
+  const candidates = pool.filter(d => d !== correct);
+  return shuffle(candidates).slice(0, n);
+}
+
+/** Pick distractors that are similar in length to the correct answer */
+function pickSimilarLengthDistractors(pool: string[], correct: string, n: number): string[] {
+  const correctLen = correct.length;
+  const candidates = pool
+    .filter(d => d !== correct)
+    .map(d => ({ d, diff: Math.abs(d.length - correctLen) }))
+    .sort((a, b) => a.diff - b.diff);
+  // Take the top ~3x candidates by similarity, then shuffle to avoid always picking the same ones
+  const topCandidates = candidates.slice(0, n * 3).map(c => c.d);
+  return shuffle(topCandidates).slice(0, n);
+}
+
+function buildOptions(correct: string, distractors: string[]): { options: string[]; correctIndex: number } {
+  const options = shuffle([correct, ...distractors]);
+  return { options, correctIndex: options.indexOf(correct) };
+}
+
+/** Extract a readable passage from translation text (strip tags, take first ~200 chars of body) */
+function extractPassage(translationText: string): string {
+  // Remove metadata tags at start/end
+  let text = translationText
+    .replace(/<(?:meta|summary|keywords|vocab|warning|page-type|page-num|header|sig|script|language|columns|folio|abbrev)[^>]*>[\s\S]*?<\/[^>]+>/g, '')
+    .replace(/<[^>]+>/g, '') // strip all remaining tags
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  // Skip to first substantial sentence
+  const sentences = text.split(/(?<=[.!?])\s+/).filter(s => s.length > 30);
+  if (sentences.length === 0) return text.substring(0, 200);
+  // Take 1-2 sentences
+  const passage = sentences.slice(0, 2).join(' ');
+  return passage.substring(0, 250);
+}
+
+/** Parse <term>...</term> tags, extracting inline definitions when present */
+function extractTerms(translationText: string): Array<{ term: string; definition: string; context: string }> {
+  const results: Array<{ term: string; definition: string; context: string }> = [];
+  const termRegex = /<term>([\s\S]*?)<\/term>\s*(?:<(?:note|gloss)>([\s\S]*?)<\/(?:note|gloss)>)?/g;
+
+  let match;
+  while ((match = termRegex.exec(translationText)) !== null) {
+    const rawTerm = match[1].trim();
+    const noteOrGloss = match[2]?.trim();
+
+    let term: string;
+    let definition: string;
+
+    const inlineSplit = rawTerm.match(/^([^:;]+?)\s*[:;]\s+([\s\S]+)$/);
+    if (inlineSplit) {
+      term = inlineSplit[1].trim().replace(/\*/g, '');
+      definition = inlineSplit[2].trim().replace(/\*/g, '');
+    } else if (noteOrGloss) {
+      term = rawTerm.replace(/\*/g, '');
+      definition = noteOrGloss
+        .replace(/^original:\s*/i, '')
+        .replace(/^["']|["']$/g, '')
+        .replace(/<[^>]+>/g, '')
+        .trim();
+    } else {
+      continue;
+    }
+
+    if (term.length > 60 || definition.length > 300) continue;
+    if (term.length < 3) continue;
+
+    // Context with definition stripped
+    const termIdx = translationText.indexOf(match[0]);
+    const contextStart = Math.max(0, translationText.lastIndexOf('.', termIdx) + 1);
+    const contextEnd = translationText.indexOf('.', termIdx + match[0].length);
+    let context = translationText
+      .slice(contextStart, contextEnd > 0 ? contextEnd + 1 : contextStart + 200)
+      .replace(/<[^>]+>[^<]*<\/[^>]+>/g, '')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+      .substring(0, 200);
+    if (definition.length > 10 && context.toLowerCase().includes(definition.toLowerCase().substring(0, 30))) {
+      context = context.replace(new RegExp(definition.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').substring(0, 40), 'i'), '...');
+    }
+
+    results.push({ term, definition, context });
+  }
+
+  return results;
+}
+
+/** Normalize a date string or number to a decade label like "1610s" */
+function dateToDecade(date?: string | number): string | null {
+  if (!date) return null;
+  const str = String(date);
+  const m = str.match(/(\d{4})/);
+  if (!m) return null;
+  const year = parseInt(m[1]);
+  if (year < 1000 || year > 2000) return null;
+  const decade = Math.floor(year / 10) * 10;
+  return `${decade}s`;
+}
+
+/** Generate plausible decade distractors near the correct one */
+function decadeDistractors(correctDecade: string): string[] {
+  const base = parseInt(correctDecade);
+  // Pick from a range of +/- 30-100 years, skip the correct one
+  const offsets = [-100, -70, -50, -30, -20, -10, 10, 20, 30, 50, 70, 100];
+  const candidates = offsets
+    .map(o => `${base + o}s`)
+    .filter(d => {
+      const y = parseInt(d);
+      return y >= 1400 && y <= 1800 && d !== correctDecade;
+    });
+  return shuffle(candidates).slice(0, 3);
+}
+
+// ── Main handler ──
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const count = Math.min(parseInt(searchParams.get('count') || '10'), 50);
-    const language = searchParams.get('language');
     const topic = searchParams.get('topic');
+    const mode = searchParams.get('mode') || 'mixed'; // vocab, date, author, tradition, mixed
 
-    // If no topic specified and no count, return available topics
     if (searchParams.get('topics') === 'true') {
       return NextResponse.json({ topics: Object.entries(TOPICS).map(([id, t]) => ({ id, ...t })) });
     }
 
     const db = await getReadDb();
 
-    // If topic specified, first get book IDs from that collection
+    // Resolve topic to book IDs by querying books with matching collection slugs
     let topicBookIds: string[] | null = null;
-    if (topic && TOPICS[topic]) {
-      const collSlugs = TOPICS[topic].collections;
-      const collections = await db.collection('collections')
-        .find({ slug: { $in: collSlugs } })
-        .project({ 'books': 1 })
-        .toArray();
-      topicBookIds = collections.flatMap(c => (c.books || []).map((b: { book_id?: string }) => b.book_id)).filter(Boolean);
-      if (!topicBookIds.length) {
-        return NextResponse.json({ terms: [], total: 0 });
-      }
-    }
-
-    // Build query — find pages with <term> tags that also have adjacent <note> or <gloss>
-    const query: Record<string, unknown> = {
-      'translation.data': { $regex: '<term>.*?</term>\\s*<(?:note|gloss)>' },
-    };
-    if (topicBookIds) {
-      query.book_id = { $in: topicBookIds };
-    }
-
-    // Get pages — we'll fetch more than needed since not all terms parse cleanly
-    const pages = await db.collection('pages')
-      .find(query)
-      .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
-      .limit(count * 5)
-      .maxTimeMS(10000)
-      .toArray();
-
-    // Also try pages with inline definitions (term; definition pattern)
-    if (pages.length < count * 3) {
-      const inlineQuery: Record<string, unknown> = {
-        'translation.data': { $regex: '<term>[^<]*[:;][^<]*</term>' },
-      };
-      if (topicBookIds) {
-        inlineQuery.book_id = { $in: topicBookIds };
-      }
-      const inlinePages = await db.collection('pages')
-        .find(inlineQuery)
-        .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
-        .limit(count * 5)
+    const topicCollSlugs = topic && TOPICS[topic] ? TOPICS[topic].collections : null;
+    if (topicCollSlugs) {
+      const topicBooks = await db.collection('books')
+        .find({ collections: { $in: topicCollSlugs }, visible: true, pages_count: { $gt: 0 } })
+        .project({ id: 1 })
+        .limit(500)
         .maxTimeMS(10000)
         .toArray();
-      const existingIds = new Set(pages.map(p => p._id.toString()));
-      for (const p of inlinePages) {
-        if (!existingIds.has(p._id.toString())) pages.push(p);
+      topicBookIds = topicBooks.map(b => b.id as string).filter(Boolean);
+      if (!topicBookIds.length) {
+        return NextResponse.json({ questions: [], total: 0 });
       }
     }
 
-    // Extract all terms
-    let allTerms: Array<{ term: string; definition: string; context: string; bookId: string; pageNumber: number }> = [];
-    for (const page of pages) {
-      const terms = extractTerms(page.translation?.data || '');
-      for (const t of terms) {
-        allTerms.push({
-          ...t,
-          bookId: page.book_id,
-          pageNumber: page.page_number,
+    const questions: Question[] = [];
+
+    // ── Vocab questions ──
+    if (mode === 'vocab' || mode === 'mixed') {
+      const vocabCount = mode === 'mixed' ? Math.ceil(count * 0.4) : count;
+      const vocabQuery: Record<string, unknown> = {
+        'translation.data': { $regex: '<term>.*?</term>\\s*<(?:note|gloss)>' },
+      };
+      if (topicBookIds) vocabQuery.book_id = { $in: topicBookIds };
+
+      const pages = await db.collection('pages')
+        .find(vocabQuery)
+        .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
+        .limit(vocabCount * 5)
+        .maxTimeMS(10000)
+        .toArray();
+
+      // Also inline definitions
+      if (pages.length < vocabCount * 3) {
+        const inlineQuery: Record<string, unknown> = {
+          'translation.data': { $regex: '<term>[^<]*[:;][^<]*</term>' },
+        };
+        if (topicBookIds) inlineQuery.book_id = { $in: topicBookIds };
+        const more = await db.collection('pages')
+          .find(inlineQuery)
+          .project({ book_id: 1, page_number: 1, 'translation.data': 1 })
+          .limit(vocabCount * 5)
+          .maxTimeMS(10000)
+          .toArray();
+        const ids = new Set(pages.map(p => p._id.toString()));
+        for (const p of more) {
+          if (!ids.has(p._id.toString())) pages.push(p);
+        }
+      }
+
+      // Extract and deduplicate
+      const seen = new Set<string>();
+      let allTerms: Array<{ term: string; definition: string; context: string; bookId: string; pageNumber: number }> = [];
+      for (const page of pages) {
+        for (const t of extractTerms(page.translation?.data || '')) {
+          const key = t.term.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            allTerms.push({ ...t, bookId: page.book_id, pageNumber: page.page_number });
+          }
+        }
+      }
+      allTerms = shuffle(allTerms).slice(0, vocabCount);
+
+      // Collect all definitions for distractor pool
+      const allDefs = allTerms.map(t => t.definition);
+
+      // Enrich with book metadata
+      const bookIds = [...new Set(allTerms.map(t => t.bookId))];
+      const books = await db.collection('books')
+        .find({ id: { $in: bookIds } })
+        .project({ id: 1, title: 1, author: 1, published: 1, year: 1, language: 1, slug: 1 })
+        .toArray();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const bookMap = new Map(books.map((b: any) => [b.id, b]));
+
+      for (const t of allTerms) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const book: any = bookMap.get(t.bookId) || {};
+        const distractors = pickSimilarLengthDistractors(allDefs, t.definition, 3);
+        if (distractors.length < 2) continue; // need at least 2 wrong answers
+        const { options, correctIndex } = buildOptions(t.definition, distractors);
+        questions.push({
+          mode: 'vocab',
+          term: t.term,
+          definition: t.definition,
+          originalContext: t.context,
+          bookId: t.bookId,
+          bookTitle: book.title || 'Unknown',
+          bookAuthor: book.author || 'Unknown',
+          bookDate: book.published || book.year,
+          bookLanguage: book.language,
+          pageNumber: t.pageNumber,
+          slug: book.slug,
+          options,
+          correctIndex,
         });
       }
     }
 
-    // Deduplicate by term (keep first occurrence)
-    const seen = new Set<string>();
-    allTerms = allTerms.filter(t => {
-      const key = t.term.toLowerCase();
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
+    // ── Date, Author, Tradition questions ── (need translated pages with book metadata)
+    if (mode === 'date' || mode === 'author' || mode === 'tradition' || mode === 'mixed') {
+      const needDate = mode === 'date' || mode === 'mixed';
+      const needAuthor = mode === 'author' || mode === 'mixed';
+      const needTradition = mode === 'tradition' || mode === 'mixed';
 
-    // Shuffle
-    for (let i = allTerms.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [allTerms[i], allTerms[j]] = [allTerms[j], allTerms[i]];
-    }
+      const dateCount = mode === 'mixed' ? Math.ceil(count * 0.2) : count;
+      const authorCount = mode === 'mixed' ? Math.ceil(count * 0.2) : count;
+      const traditionCount = mode === 'mixed' ? Math.ceil(count * 0.2) : count;
+      const totalNeeded = (needDate ? dateCount : 0) + (needAuthor ? authorCount : 0) + (needTradition ? traditionCount : 0);
 
-    // Take requested count
-    const selected = allTerms.slice(0, count);
-
-    // Enrich with book metadata
-    const bookIds = [...new Set(selected.map(t => t.bookId))];
-    const books = await db.collection('books')
-      .find({ id: { $in: bookIds } })
-      .project({ id: 1, title: 1, author: 1, date: 1, language: 1, slug: 1 })
-      .toArray();
-    const bookMap = new Map(books.map(b => [b.id as string, b]));
-
-    // Filter by language if requested
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let enriched: TermEntry[] = selected.map(t => {
-      const book: any = bookMap.get(t.bookId) || {};
-      return {
-        term: t.term,
-        definition: t.definition,
-        originalContext: t.context,
-        bookId: t.bookId,
-        bookTitle: book.title || 'Unknown',
-        bookAuthor: book.author || 'Unknown',
-        bookDate: book.date,
-        bookLanguage: book.language,
-        pageNumber: t.pageNumber,
-        slug: book.slug,
+      // Get books with translations for these modes
+      const bookQuery: Record<string, unknown> = {
+        pages_translated: { $gt: 10 },
+        visible: true,
+        pages_count: { $gt: 0 },
       };
-    });
+      if (topicBookIds) bookQuery.id = { $in: topicBookIds };
 
-    if (language) {
-      enriched = enriched.filter(t => t.bookLanguage?.toLowerCase() === language.toLowerCase());
-    }
+      const candidateBooks = await db.collection('books')
+        .find(bookQuery)
+        .project({ id: 1, title: 1, author: 1, published: 1, year: 1, language: 1, slug: 1, collections: 1 })
+        .limit(totalNeeded * 4)
+        .maxTimeMS(10000)
+        .toArray();
 
-    // Generate wrong answers from other terms' definitions (for multiple choice)
-    const allDefinitions = allTerms.map(t => t.definition);
+      if (candidateBooks.length > 0) {
+        const shuffledBooks = shuffle(candidateBooks);
 
-    const questions = enriched.map(entry => {
-      // Pick 3 random wrong answers from other definitions
-      const wrongs: string[] = [];
-      const shuffledDefs = [...allDefinitions].sort(() => Math.random() - 0.5);
-      for (const d of shuffledDefs) {
-        if (d !== entry.definition && wrongs.length < 3) {
-          wrongs.push(d);
+        // Collect pools for distractors
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const allAuthors = [...new Set(candidateBooks.map((b: any) => b.author).filter(Boolean))] as string[];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const allDecades = [...new Set(candidateBooks.map((b: any) => dateToDecade(b.published || b.year)).filter(Boolean))] as string[];
+
+        // Get collection labels for tradition mode
+        let collectionLabelMap = new Map<string, string>();
+        if (needTradition) {
+          const allCollections = await db.collection('collections')
+            .find({})
+            .project({ slug: 1, title: 1 })
+            .limit(200)
+            .maxTimeMS(5000)
+            .toArray();
+          collectionLabelMap = new Map(allCollections.map(c => [c.slug, c.name]));
+        }
+
+        // For each candidate book, get a page with translation for the passage
+        let dateQs = 0, authorQs = 0, traditionQs = 0;
+
+        for (const book of shuffledBooks) {
+          if (questions.length >= count) break;
+
+          // Determine which mode to use for this book
+          let bookMode: 'date' | 'author' | 'tradition' | null = null;
+          if (needDate && dateQs < dateCount && dateToDecade(book.published || book.year)) {
+            bookMode = 'date';
+          } else if (needAuthor && authorQs < authorCount && book.author && allAuthors.length >= 4) {
+            bookMode = 'author';
+          } else if (needTradition && traditionQs < traditionCount && book.collections?.length > 0) {
+            bookMode = 'tradition';
+          }
+          if (!bookMode) continue;
+
+          // Get a page with translation text
+          const page = await db.collection('pages').findOne(
+            { book_id: book.id, 'translation.data': { $exists: true, $ne: '' }, page_number: { $gt: 3 } },
+            { projection: { page_number: 1, 'translation.data': 1 } },
+          );
+          if (!page?.translation?.data) continue;
+
+          const passage = extractPassage(page.translation.data);
+          if (passage.length < 50) continue;
+
+          const base = {
+            bookId: book.id,
+            bookTitle: book.title || 'Unknown',
+            bookAuthor: book.author || 'Unknown',
+            bookDate: book.published || book.year,
+            bookLanguage: book.language,
+            pageNumber: page.page_number,
+            slug: book.slug,
+          };
+
+          if (bookMode === 'date') {
+            const correctDecade = dateToDecade(book.published || book.year)!;
+            // Prefer nearby decades from actual books, fall back to generated
+            const bookDecadeDistractors = pickDistractors(allDecades, correctDecade, 3);
+            const distractors = bookDecadeDistractors.length >= 3
+              ? bookDecadeDistractors
+              : [...bookDecadeDistractors, ...decadeDistractors(correctDecade)].slice(0, 3);
+            if (distractors.length < 3) continue;
+            const { options, correctIndex } = buildOptions(correctDecade, distractors);
+            questions.push({ mode: 'date', passage, ...base, options, correctIndex });
+            dateQs++;
+          } else if (bookMode === 'author') {
+            const distractors = pickDistractors(allAuthors, book.author, 3);
+            if (distractors.length < 3) continue;
+            const { options, correctIndex } = buildOptions(book.author, distractors);
+            questions.push({ mode: 'author', passage, ...base, options, correctIndex });
+            authorQs++;
+          } else if (bookMode === 'tradition') {
+            // Use first collection as the "tradition"
+            const collSlug = book.collections[0];
+            const collLabel = collectionLabelMap.get(collSlug) || collSlug;
+            const allLabels = [...collectionLabelMap.values()];
+            const distractors = pickDistractors(allLabels, collLabel, 3);
+            if (distractors.length < 3) continue;
+            const { options, correctIndex } = buildOptions(collLabel, distractors);
+            questions.push({ mode: 'tradition', passage, collection: collLabel, ...base, options, correctIndex });
+            traditionQs++;
+          }
         }
       }
+    }
 
-      // Shuffle options
-      const options = [entry.definition, ...wrongs].sort(() => Math.random() - 0.5);
-      const correctIndex = options.indexOf(entry.definition);
-
-      return {
-        ...entry,
-        options,
-        correctIndex,
-      };
-    });
+    // Final shuffle and trim
+    const finalQuestions = shuffle(questions).slice(0, count);
 
     return NextResponse.json({
-      terms: questions,
-      total: allTerms.length,
+      questions: finalQuestions,
+      total: finalQuestions.length,
     });
   } catch (error) {
     console.error('Learn API error:', error);
-    return NextResponse.json({ error: 'Failed to fetch terms' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to fetch questions' }, { status: 500 });
   }
 }

--- a/src/app/learn/LearnQuiz.tsx
+++ b/src/app/learn/LearnQuiz.tsx
@@ -9,14 +9,12 @@ interface Topic {
   description: string;
 }
 
-interface TermQuestion {
-  term: string;
-  definition: string;
-  originalContext?: string;
+interface QuestionBase {
+  mode: 'vocab' | 'date' | 'author' | 'tradition';
   bookId: string;
   bookTitle: string;
   bookAuthor: string;
-  bookDate?: string;
+  bookDate?: string | number;
   bookLanguage?: string;
   pageNumber: number;
   slug?: string;
@@ -24,7 +22,31 @@ interface TermQuestion {
   correctIndex: number;
 }
 
+interface VocabQuestion extends QuestionBase {
+  mode: 'vocab';
+  term: string;
+  definition: string;
+  originalContext?: string;
+}
+
+interface PassageQuestion extends QuestionBase {
+  mode: 'date' | 'author' | 'tradition';
+  passage: string;
+  collection?: string;
+}
+
+type Question = VocabQuestion | PassageQuestion;
+
+type QuizMode = 'mixed' | 'vocab' | 'date' | 'author' | 'tradition';
 type QuizState = 'topics' | 'loading' | 'question' | 'answered' | 'complete';
+
+const QUIZ_MODES: { id: QuizMode; label: string; description: string }[] = [
+  { id: 'mixed', label: 'Mixed', description: 'A bit of everything — vocabulary, dates, authors, and traditions' },
+  { id: 'vocab', label: 'Vocabulary', description: 'Technical terms from alchemical, Hermetic, and philosophical texts' },
+  { id: 'date', label: 'Dating', description: 'When was this written? Place passages in their historical decade' },
+  { id: 'author', label: 'Attribution', description: 'Who wrote this? Match passages to their authors' },
+  { id: 'tradition', label: 'Tradition', description: 'Which tradition does this belong to? Identify the school of thought' },
+];
 
 const FALLBACK_TOPICS: Topic[] = [
   { id: 'alchemy', label: 'Alchemy', description: 'The art of transformation — prima materia, the philosopher\'s stone, and the Great Work' },
@@ -37,10 +59,18 @@ const FALLBACK_TOPICS: Topic[] = [
   { id: 'rosicrucianism', label: 'Rosicrucianism', description: 'The Rosicrucian manifestos and the invisible brotherhood' },
 ];
 
+const MODE_PROMPTS: Record<string, string> = {
+  vocab: 'What does this term mean?',
+  date: 'When was this written?',
+  author: 'Who wrote this?',
+  tradition: 'What tradition is this from?',
+};
+
 export default function LearnQuiz() {
   const [topics, setTopics] = useState<Topic[]>(FALLBACK_TOPICS);
   const [activeTopic, setActiveTopic] = useState<string | null>(null);
-  const [questions, setQuestions] = useState<TermQuestion[]>([]);
+  const [activeMode, setActiveMode] = useState<QuizMode>('mixed');
+  const [questions, setQuestions] = useState<Question[]>([]);
   const [currentIdx, setCurrentIdx] = useState(0);
   const [selected, setSelected] = useState<number | null>(null);
   const [state, setState] = useState<QuizState>('topics');
@@ -50,7 +80,6 @@ export default function LearnQuiz() {
   const [totalAnswered, setTotalAnswered] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  // Load persisted stats on mount
   useEffect(() => {
     const saved = localStorage.getItem('sl-learn-stats');
     if (saved) {
@@ -60,27 +89,26 @@ export default function LearnQuiz() {
         setBestStreak(stats.bestStreak || 0);
       } catch { /* ignore */ }
     }
-    // Fetch topics from API (fallback already set)
     fetch('/api/learn?topics=true')
       .then(r => r.json())
       .then(data => { if (data.topics?.length) setTopics(data.topics); })
       .catch(() => { /* use fallback */ });
   }, []);
 
-  const fetchQuestions = useCallback(async (topic?: string) => {
+  const fetchQuestions = useCallback(async (topic?: string, mode: QuizMode = 'mixed') => {
     setState('loading');
     setError(null);
     try {
-      const params = new URLSearchParams({ count: '10' });
+      const params = new URLSearchParams({ count: '10', mode });
       if (topic) params.set('topic', topic);
       const res = await fetch(`/api/learn?${params}`);
       if (!res.ok) throw new Error('Failed to load');
       const data = await res.json();
-      if (!data.terms?.length) {
-        setError('No vocabulary terms found for this topic yet. Try another.');
+      if (!data.questions?.length) {
+        setError('No questions found for this combination. Try another topic or mode.');
         return;
       }
-      setQuestions(data.terms);
+      setQuestions(data.questions);
       setCurrentIdx(0);
       setSelected(null);
       setState('question');
@@ -89,11 +117,12 @@ export default function LearnQuiz() {
     }
   }, []);
 
-  const handleTopicSelect = (topicId: string | null) => {
+  const handleStart = (topicId: string | null, mode: QuizMode) => {
     setActiveTopic(topicId);
+    setActiveMode(mode);
     setScore(0);
     setStreak(0);
-    fetchQuestions(topicId || undefined);
+    fetchQuestions(topicId || undefined, mode);
   };
 
   const handleSelect = (idx: number) => {
@@ -107,17 +136,12 @@ export default function LearnQuiz() {
       setScore(s => s + 1);
       const newStreak = streak + 1;
       setStreak(newStreak);
-      if (newStreak > bestStreak) setBestStreak(newStreak);
-      localStorage.setItem('sl-learn-stats', JSON.stringify({
-        totalAnswered: newTotal,
-        bestStreak: Math.max(newStreak, bestStreak),
-      }));
+      const newBest = Math.max(newStreak, bestStreak);
+      setBestStreak(newBest);
+      localStorage.setItem('sl-learn-stats', JSON.stringify({ totalAnswered: newTotal, bestStreak: newBest }));
     } else {
       setStreak(0);
-      localStorage.setItem('sl-learn-stats', JSON.stringify({
-        totalAnswered: newTotal,
-        bestStreak,
-      }));
+      localStorage.setItem('sl-learn-stats', JSON.stringify({ totalAnswered: newTotal, bestStreak }));
     }
   };
 
@@ -134,7 +158,7 @@ export default function LearnQuiz() {
   const handleNewRound = () => {
     setScore(0);
     setStreak(0);
-    fetchQuestions(activeTopic || undefined);
+    fetchQuestions(activeTopic || undefined, activeMode);
   };
 
   const handleBackToTopics = () => {
@@ -146,39 +170,61 @@ export default function LearnQuiz() {
     setError(null);
   };
 
-  // ── Topic selection screen ──
+  // ── Topic + mode selection screen ──
   if (state === 'topics') {
     return (
       <div className="max-w-2xl mx-auto py-8 md:py-12">
         <p className="text-secondary font-body text-lg mb-8 leading-relaxed">
-          Test your knowledge of historical terminology drawn from primary sources
-          in the Western esoteric tradition. Choose a topic or dive into everything.
+          Test your knowledge of historical texts from the Western esoteric tradition.
+          Choose a quiz type, then pick a topic or dive into everything.
         </p>
 
         {totalAnswered > 0 && (
           <div className="flex items-center gap-6 text-sm text-muted mb-8">
-            <span>{totalAnswered} terms studied</span>
+            <span>{totalAnswered} questions answered</span>
             <span>Best streak: {bestStreak}</span>
           </div>
         )}
 
-        <div className="grid gap-3">
-          {/* "All topics" option */}
-          <button
-            onClick={() => handleTopicSelect(null)}
-            className="text-left p-5 rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] transition-colors"
-          >
-            <h3 className="font-serif text-xl text-primary mb-1">All Topics</h3>
-            <p className="text-sm text-muted">A mix of vocabulary from across the entire collection</p>
-          </button>
+        {/* Quiz mode selector */}
+        <h2 className="font-serif text-2xl text-primary mb-4">Quiz Type</h2>
+        <div className="grid gap-2 mb-10">
+          {QUIZ_MODES.map(m => (
+            <button
+              key={m.id}
+              onClick={() => setActiveMode(m.id)}
+              className={`text-left p-4 rounded-lg border transition-colors ${
+                activeMode === m.id
+                  ? 'border-accent-rust bg-accent-rust/[0.04]'
+                  : 'border-border-light bg-white hover:border-accent-rust/40'
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`w-2 h-2 rounded-full ${activeMode === m.id ? 'bg-accent-rust' : 'bg-stone-300'}`} />
+                <h3 className="font-medium text-primary">{m.label}</h3>
+              </div>
+              <p className="text-sm text-muted ml-5">{m.description}</p>
+            </button>
+          ))}
+        </div>
 
+        {/* Topic selector */}
+        <h2 className="font-serif text-2xl text-primary mb-4">Topic</h2>
+        <div className="grid gap-2">
+          <button
+            onClick={() => handleStart(null, activeMode)}
+            className="text-left p-4 rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] transition-colors"
+          >
+            <h3 className="font-serif text-lg text-primary">All Topics</h3>
+            <p className="text-sm text-muted">A mix from across the entire collection</p>
+          </button>
           {topics.map(topic => (
             <button
               key={topic.id}
-              onClick={() => handleTopicSelect(topic.id)}
-              className="text-left p-5 rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] transition-colors"
+              onClick={() => handleStart(topic.id, activeMode)}
+              className="text-left p-4 rounded-lg border border-border-light bg-white hover:border-accent-rust/40 hover:bg-accent-rust/[0.02] transition-colors"
             >
-              <h3 className="font-serif text-xl text-primary mb-1">{topic.label}</h3>
+              <h3 className="font-serif text-lg text-primary">{topic.label}</h3>
               <p className="text-sm text-muted">{topic.description}</p>
             </button>
           ))}
@@ -194,9 +240,9 @@ export default function LearnQuiz() {
         <p className="text-secondary mb-6">{error}</p>
         <div className="flex items-center justify-center gap-4">
           <button onClick={handleBackToTopics} className="text-muted hover:text-primary transition-colors">
-            Back to topics
+            Back
           </button>
-          <button onClick={() => fetchQuestions(activeTopic || undefined)} className="text-accent-rust hover:underline">
+          <button onClick={() => fetchQuestions(activeTopic || undefined, activeMode)} className="text-accent-rust hover:underline">
             Try again
           </button>
         </div>
@@ -224,9 +270,10 @@ export default function LearnQuiz() {
   // ── Round complete ──
   if (state === 'complete') {
     const topicLabel = activeTopic ? topics.find(t => t.id === activeTopic)?.label : 'All Topics';
+    const modeLabel = QUIZ_MODES.find(m => m.id === activeMode)?.label || 'Mixed';
     return (
       <div className="max-w-xl mx-auto py-16 text-center">
-        <p className="text-sm text-muted uppercase tracking-wide mb-2">{topicLabel}</p>
+        <p className="text-sm text-muted uppercase tracking-wide mb-2">{modeLabel} · {topicLabel}</p>
         <h2 className="font-serif text-3xl text-primary mb-4">Round Complete</h2>
         <div className="text-6xl font-serif text-accent-rust mb-2">{score}/{questions.length}</div>
         <p className="text-secondary mb-8">
@@ -265,6 +312,7 @@ export default function LearnQuiz() {
   const bookHref = q.slug ? `/book/${q.slug}` : `/book/${q.bookId}`;
   const isCorrect = selected === q.correctIndex;
   const topicLabel = activeTopic ? topics.find(t => t.id === activeTopic)?.label : 'All Topics';
+  const isVocab = q.mode === 'vocab';
 
   return (
     <div className="max-w-2xl mx-auto py-8 md:py-12">
@@ -291,30 +339,54 @@ export default function LearnQuiz() {
         )}
       </div>
 
-      {/* Term */}
-      <div className="mb-8">
-        <p className="text-sm text-muted uppercase tracking-wide mb-2">
-          What does this term mean?
-        </p>
-        <h2 className="font-serif text-3xl md:text-4xl text-primary italic">
-          {q.term}
-        </h2>
-      </div>
+      {/* Prompt */}
+      <p className="text-sm text-muted uppercase tracking-wide mb-2">
+        {MODE_PROMPTS[q.mode]}
+      </p>
 
-      {/* Context with source attribution */}
-      {q.originalContext && (
-        <div className="bg-white border border-border-light rounded-lg p-4 mb-8">
-          <div className="text-sm text-secondary font-body leading-relaxed">
-            &ldquo;...{q.originalContext}...&rdquo;
+      {/* Vocab: show term prominently */}
+      {isVocab && (
+        <h2 className="font-serif text-3xl md:text-4xl text-primary italic mb-8">
+          {(q as VocabQuestion).term}
+        </h2>
+      )}
+
+      {/* Passage (for non-vocab, or as context for vocab) */}
+      {isVocab ? (
+        (q as VocabQuestion).originalContext ? (
+          <div className="bg-white border border-border-light rounded-lg p-4 mb-8">
+            <div className="text-sm text-secondary font-body leading-relaxed">
+              &ldquo;...{(q as VocabQuestion).originalContext}...&rdquo;
+            </div>
+            <div className="mt-2 pt-2 border-t border-border-light flex items-center justify-between">
+              <span className="text-xs text-muted truncate mr-2">
+                {q.bookAuthor}, <em>{q.bookTitle}</em>{q.bookDate ? ` (${q.bookDate})` : ''}, p.{q.pageNumber}
+              </span>
+              <Link href={`${bookHref}?page=${q.pageNumber}`} className="text-xs text-accent-rust hover:underline whitespace-nowrap">
+                Read
+              </Link>
+            </div>
           </div>
-          <div className="mt-2 pt-2 border-t border-border-light flex items-center justify-between">
+        ) : null
+      ) : (
+        <div className="bg-white border border-border-light rounded-lg p-5 mb-8">
+          <div className="text-[15px] text-secondary font-body leading-relaxed">
+            &ldquo;{(q as PassageQuestion).passage}&rdquo;
+          </div>
+          <div className="mt-3 pt-3 border-t border-border-light flex items-center justify-between">
             <span className="text-xs text-muted truncate mr-2">
-              {q.bookAuthor}, <em>{q.bookTitle}</em>{q.bookDate ? ` (${q.bookDate})` : ''}, p.{q.pageNumber}
+              {/* For author mode, don't show the author — that's the answer */}
+              {q.mode === 'author' ? (
+                <><em>{q.bookTitle}</em>, p.{q.pageNumber}</>
+              ) : q.mode === 'date' ? (
+                // For date mode, don't show the date
+                <>{q.bookAuthor}, <em>{q.bookTitle}</em>, p.{q.pageNumber}</>
+              ) : (
+                // For tradition mode, show author + title but not collection
+                <>{q.bookAuthor}, <em>{q.bookTitle}</em>{q.bookDate ? ` (${q.bookDate})` : ''}, p.{q.pageNumber}</>
+              )}
             </span>
-            <Link
-              href={`${bookHref}?page=${q.pageNumber}`}
-              className="text-xs text-accent-rust hover:underline whitespace-nowrap"
-            >
+            <Link href={`${bookHref}?page=${q.pageNumber}`} className="text-xs text-accent-rust hover:underline whitespace-nowrap">
               Read
             </Link>
           </div>
@@ -347,14 +419,35 @@ export default function LearnQuiz() {
         })}
       </div>
 
-      {/* Post-answer: next button */}
+      {/* Post-answer: reveal + next */}
       {state === 'answered' && (
-        <button
-          onClick={handleNext}
-          className="w-full bg-[#1a1612] text-white py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
-        >
-          {currentIdx + 1 >= questions.length ? 'See results' : 'Next'}
-        </button>
+        <div className="space-y-4">
+          {/* For non-vocab modes, reveal the full source after answering */}
+          {!isVocab && (
+            <div className="flex items-start gap-3 bg-warm rounded-lg p-4 border border-border-light">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-primary truncate">{q.bookTitle}</p>
+                <p className="text-xs text-muted">
+                  {q.bookAuthor}{q.bookDate ? `, ${q.bookDate}` : ''}
+                  {q.bookLanguage ? ` · ${q.bookLanguage}` : ''}
+                </p>
+              </div>
+              <Link
+                href={`${bookHref}?page=${q.pageNumber}`}
+                className="text-sm text-accent-rust hover:underline whitespace-nowrap"
+              >
+                Read in context
+              </Link>
+            </div>
+          )}
+
+          <button
+            onClick={handleNext}
+            className="w-full bg-[#1a1612] text-white py-3 rounded-lg font-medium hover:bg-[#2a1f17] transition-colors"
+          >
+            {currentIdx + 1 >= questions.length ? 'See results' : 'Next'}
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
Adds 3 new quiz modes to `/learn` and improves answer quality:

**New modes:**
- **Dating** — "When was this written?" Shows a passage, pick the decade (1610s, 1620s, etc.)
- **Attribution** — "Who wrote this?" Shows a passage, pick the author
- **Tradition** — "What tradition is this from?" Shows a passage, pick the collection/school
- **Mixed** — 40% vocab, 20% each of the other three

**Smarter distractors:**
- Vocab wrong answers now match similar definition length instead of random picks
- Date distractors use real decades from actual books in the collection
- Author distractors drawn from the same topic pool
- Tradition distractors from real collection names

**Also fixes:**
- Uses correct DB fields (`published`/`year` not `date`, collection `name` not `title`)
- Mode-specific UI: hides the author when that's the answer, hides the date when that's the answer
- Full source reveal after answering non-vocab questions

## Test plan
- [ ] Visit `/learn`, see quiz type selector + topic list
- [ ] Test each mode individually (Vocabulary, Dating, Attribution, Tradition)
- [ ] Test Mixed mode — should get a variety of question types
- [ ] Verify distractors are plausible (similar length for vocab, real decades/authors)
- [ ] Verify attribution is hidden appropriately per mode
- [ ] Mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)