### PR TITLE
Podcast: formats, RSS feed, interactive mode

### DIFF
--- a/src/app/api/embassy/threads/[id]/podcast/route.ts
+++ b/src/app/api/embassy/threads/[id]/podcast/route.ts
@@ -2,22 +2,39 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
-import { generatePodcast, getPodcastForThread } from '@/lib/embassy/podcast';
+import {
+  generatePodcast,
+  getPodcastForThread,
+  getAllPodcastsForThread,
+  type PodcastFormat,
+  PODCAST_FORMATS,
+} from '@/lib/embassy/podcast';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 120; // TTS can take a while
+export const maxDuration = 120;
+
+const VALID_FORMATS = Object.keys(PODCAST_FORMATS) as PodcastFormat[];
 
 /**
- * GET /api/embassy/threads/[id]/podcast — Get existing podcast for a thread.
- * Returns { audioUrl, generatedAt, topic, findingCount } or 404.
+ * GET /api/embassy/threads/[id]/podcast — Get podcasts for a thread.
+ * ?format=deep-dive  → specific format
+ * ?all=true          → all generated formats
+ * No params          → first available
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
+  const url = new URL(request.url);
 
-  const podcast = await getPodcastForThread(id);
+  if (url.searchParams.get('all') === 'true') {
+    const podcasts = await getAllPodcastsForThread(id);
+    return NextResponse.json({ podcasts });
+  }
+
+  const format = url.searchParams.get('format') as PodcastFormat | null;
+  const podcast = await getPodcastForThread(id, format || undefined);
   if (!podcast) {
     return NextResponse.json({ error: 'No podcast generated yet' }, { status: 404 });
   }
@@ -26,11 +43,12 @@ export async function GET(
 }
 
 /**
- * POST /api/embassy/threads/[id]/podcast — Generate a podcast from research findings.
+ * POST /api/embassy/threads/[id]/podcast — Generate a podcast.
+ * Body: { format?: "deep-dive" | "brief" | "critique" | "guided-reading" }
  * Auth required (must be thread creator).
  */
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const session = await auth();
@@ -40,6 +58,15 @@ export async function POST(
 
   const { id } = await params;
   const db = await getDb();
+
+  // Parse format from body
+  let format: PodcastFormat = 'deep-dive';
+  try {
+    const body = await request.json().catch(() => ({}));
+    if (body.format && VALID_FORMATS.includes(body.format)) {
+      format = body.format;
+    }
+  } catch { /* default format */ }
 
   // Verify thread ownership
   const thread = await db.collection('embassy_threads').findOne({
@@ -61,20 +88,21 @@ export async function POST(
     );
   }
 
-  // Check if podcast already exists (don't regenerate without explicit intent)
-  const existing = await getPodcastForThread(id);
+  // Check if this format already exists
+  const existing = await getPodcastForThread(id, format);
   if (existing) {
     return NextResponse.json({ podcast: existing, cached: true });
   }
 
   try {
     const topic = notebook.topic || thread.title || 'Research Discussion';
-    const result = await generatePodcast(id, topic, notebook.findings);
+    const result = await generatePodcast(id, topic, notebook.findings, format);
 
     return NextResponse.json({
       podcast: {
         audioUrl: result.audioUrl,
         script: result.script,
+        format: result.format,
         generatedAt: new Date(),
         topic,
         findingCount: notebook.findings.length,
@@ -87,4 +115,46 @@ export async function POST(
       { status: 500 },
     );
   }
+}
+
+/**
+ * PATCH /api/embassy/threads/[id]/podcast — Update podcast metadata (e.g., publish).
+ * Body: { format: "deep-dive", published: true }
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Sign in required' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const db = await getDb();
+
+  const body = await request.json();
+  const format = body.format as PodcastFormat;
+  if (!format || !VALID_FORMATS.includes(format)) {
+    return NextResponse.json({ error: 'Invalid format' }, { status: 400 });
+  }
+
+  // Verify thread ownership
+  const thread = await db.collection('embassy_threads').findOne({
+    _id: new ObjectId(id),
+    creatorId: session.user.id,
+  });
+  if (!thread) {
+    return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+  }
+
+  // Update published status
+  if (typeof body.published === 'boolean') {
+    await db.collection('embassy_threads').updateOne(
+      { _id: new ObjectId(id) },
+      { $set: { [`podcasts.${format}.published`]: body.published } },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/podcast/feed.xml/route.ts
+++ b/src/app/api/podcast/feed.xml/route.ts
@@ -1,0 +1,83 @@
+import { getPublishedEpisodes, PODCAST_FORMATS } from '@/lib/embassy/podcast';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 3600; // 1 hour
+
+/**
+ * GET /api/podcast/feed.xml — Podcast RSS 2.0 feed for published episodes.
+ * Compatible with Apple Podcasts, Spotify, Overcast, etc.
+ */
+export async function GET() {
+  const episodes = await getPublishedEpisodes(50);
+
+  const lastBuildDate = episodes.length > 0
+    ? new Date(episodes[0].podcast.generatedAt).toUTCString()
+    : new Date().toUTCString();
+
+  const items = episodes.map(ep => {
+    const pubDate = new Date(ep.podcast.generatedAt).toUTCString();
+    const formatLabel = PODCAST_FORMATS[ep.podcast.format]?.label || 'Deep Dive';
+    const title = escapeXml(`${formatLabel}: ${ep.podcast.topic}`);
+    const description = escapeXml(
+      `${formatLabel} episode exploring "${ep.podcast.topic}" — generated from ${ep.podcast.findingCount} research findings in the Source Library Reading Room. By ${ep.creatorName}.`,
+    );
+    const threadUrl = `https://sourcelibrary.org/reading-room/thread/${ep.threadId}`;
+    const guid = `sourcelibrary-podcast-${ep.threadId}-${ep.podcast.format}`;
+
+    return `    <item>
+      <title>${title}</title>
+      <description>${description}</description>
+      <enclosure url="${escapeXml(ep.podcast.audioUrl)}" type="audio/wav" />
+      <guid isPermaLink="false">${guid}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <link>${threadUrl}</link>
+      <itunes:author>${escapeXml(ep.creatorName)}</itunes:author>
+      <itunes:subtitle>${escapeXml(ep.podcast.topic)}</itunes:subtitle>
+      <itunes:summary>${description}</itunes:summary>
+      <podcast:transcript url="${threadUrl}" type="text/html" />
+    </item>`;
+  }).join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+  xmlns:podcast="https://podcastindex.org/namespace/1.0"
+  xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Source Library Deep Dive</title>
+    <link>https://sourcelibrary.org/reading-room</link>
+    <description>AI-generated scholarly podcasts from the Embassy of the Free Mind's rare book collection. Explore alchemy, Hermetica, Kabbalah, and the Western esoteric tradition through primary sources from the 15th-18th centuries.</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="https://sourcelibrary.org/api/podcast/feed.xml" rel="self" type="application/rss+xml" />
+    <itunes:author>Source Library</itunes:author>
+    <itunes:owner>
+      <itunes:name>Source Library</itunes:name>
+      <itunes:email>hello@sourcelibrary.org</itunes:email>
+    </itunes:owner>
+    <itunes:image href="https://sourcelibrary.org/brand/png/logo-dark--512.png" />
+    <itunes:category text="Education">
+      <itunes:category text="Higher Education" />
+    </itunes:category>
+    <itunes:category text="History" />
+    <itunes:explicit>false</itunes:explicit>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, use } from 'react';
+import { useState, useEffect, useCallback, useRef, use } from 'react';
 import Link from 'next/link';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ReactMarkdown from 'react-markdown';
@@ -41,8 +41,19 @@ interface PodcastData {
   generatedAt: string;
   topic: string;
   findingCount: number;
+  format: string;
   script?: string;
+  published?: boolean;
 }
+
+type PodcastFormat = 'deep-dive' | 'brief' | 'critique' | 'guided-reading';
+
+const FORMAT_OPTIONS: { value: PodcastFormat; label: string; desc: string }[] = [
+  { value: 'deep-dive', label: 'Deep Dive', desc: 'Two hosts explore findings in depth' },
+  { value: 'brief', label: 'The Brief', desc: '2-minute summary' },
+  { value: 'critique', label: 'The Critique', desc: 'Critical analysis of sources' },
+  { value: 'guided-reading', label: 'Guided Reading', desc: 'Commentary for reading alongside' },
+];
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr);
@@ -54,7 +65,7 @@ function formatDate(dateStr: string): string {
   });
 }
 
-// ── Podcast Player ────────────────────────────────────────────────────
+// ── Transcript ────────────────────────────────────────────────────────
 
 function formatTranscript(script: string): { speaker: string; text: string }[] {
   return script
@@ -64,26 +75,151 @@ function formatTranscript(script: string): { speaker: string; text: string }[] {
       const colonIdx = line.indexOf(':');
       const speaker = line.slice(0, colonIdx).trim();
       const text = line.slice(colonIdx + 1).trim()
-        // Strip audio tags for display
         .replace(/\[(laughs|whispers|enthusiasm|thoughtful|determination)\]/gi, '');
       return { speaker, text };
     })
     .filter(entry => entry.text.length > 0);
 }
 
+// ── Interactive Mini-Chat ─────────────────────────────────────────────
+
+function AskWhileListening({ threadId }: { threadId: string }) {
+  const [open, setOpen] = useState(false);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+  }, [open]);
+
+  const handleAsk = useCallback(async () => {
+    if (!question.trim() || loading) return;
+    setLoading(true);
+    setAnswer('');
+
+    try {
+      const res = await fetch('/api/embassy/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          threadId,
+          message: question,
+        }),
+      });
+
+      if (!res.ok) {
+        setAnswer('Could not reach the Librarian. Please try again.');
+        return;
+      }
+
+      // Read SSE stream for text chunks
+      const reader = res.body?.getReader();
+      if (!reader) return;
+      const decoder = new TextDecoder();
+      let accumulated = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        // Parse SSE events
+        for (const line of chunk.split('\n')) {
+          if (line.startsWith('data: ')) {
+            try {
+              const event = JSON.parse(line.slice(6));
+              if (event.type === 'chunk' && event.text) {
+                accumulated += event.text;
+                setAnswer(accumulated);
+              }
+            } catch { /* skip malformed */ }
+          }
+        }
+      }
+    } catch {
+      setAnswer('Network error — please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [question, loading, threadId]);
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="mt-3 text-[12px] text-[#9e4a3a] font-sans hover:underline flex items-center gap-1"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25z" />
+        </svg>
+        Ask a question while listening
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-3 p-3 bg-white rounded-lg border border-[#e0d9cc]">
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={question}
+          onChange={e => setQuestion(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleAsk()}
+          placeholder="Ask the Librarian about what you're hearing..."
+          className="flex-1 text-sm font-body px-3 py-2 border border-[#ddd] rounded-lg focus:outline-none focus:border-[#9e4a3a] text-[#1a1612]"
+          disabled={loading}
+        />
+        <button
+          onClick={handleAsk}
+          disabled={loading || !question.trim()}
+          className="px-3 py-2 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] disabled:opacity-50"
+        >
+          {loading ? '...' : 'Ask'}
+        </button>
+        <button
+          onClick={() => { setOpen(false); setAnswer(''); setQuestion(''); }}
+          className="px-2 py-2 text-[#8a8480] hover:text-[#444] text-sm"
+        >
+          x
+        </button>
+      </div>
+      {answer && (
+        <div className="mt-3 text-[13px] font-body leading-relaxed text-[#333] prose prose-sm max-w-none prose-a:text-[#9e4a3a] prose-a:underline">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {ensureParagraphBreaks(linkifySourceUrls(answer))}
+          </ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Podcast Player ────────────────────────────────────────────────────
+
 function PodcastPlayer({ threadId }: { threadId: string }) {
-  const [podcast, setPodcast] = useState<PodcastData | null>(null);
+  const [podcasts, setPodcasts] = useState<Record<string, PodcastData>>({});
+  const [selectedFormat, setSelectedFormat] = useState<PodcastFormat>('deep-dive');
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [checked, setChecked] = useState(false);
   const [showTranscript, setShowTranscript] = useState(false);
 
-  // Check for existing podcast on mount
+  const activePodcast = podcasts[selectedFormat] || null;
+
+  // Load all existing podcasts on mount
   useEffect(() => {
-    fetch(`/api/embassy/threads/${threadId}/podcast`)
-      .then(r => r.ok ? r.json() : null)
+    fetch(`/api/embassy/threads/${threadId}/podcast?all=true`)
+      .then(r => r.ok ? r.json() : { podcasts: {} })
       .then(data => {
-        if (data?.podcast) setPodcast(data.podcast);
+        setPodcasts(data.podcasts || {});
+        // Select first available format
+        const available = Object.keys(data.podcasts || {});
+        if (available.length > 0) {
+          setSelectedFormat(available[0] as PodcastFormat);
+        }
         setChecked(true);
       })
       .catch(() => setChecked(true));
@@ -95,97 +231,162 @@ function PodcastPlayer({ threadId }: { threadId: string }) {
     try {
       const res = await fetch(`/api/embassy/threads/${threadId}/podcast`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ format: selectedFormat }),
       });
       const data = await res.json();
       if (!res.ok) {
         setError(data.error || 'Generation failed');
         return;
       }
-      setPodcast(data.podcast);
+      setPodcasts(prev => ({ ...prev, [selectedFormat]: data.podcast }));
     } catch {
       setError('Network error — please try again');
     } finally {
       setGenerating(false);
     }
-  }, [threadId]);
+  }, [threadId, selectedFormat]);
+
+  const handlePublish = useCallback(async (publish: boolean) => {
+    await fetch(`/api/embassy/threads/${threadId}/podcast`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ format: selectedFormat, published: publish }),
+    });
+    setPodcasts(prev => ({
+      ...prev,
+      [selectedFormat]: { ...prev[selectedFormat], published: publish },
+    }));
+  }, [threadId, selectedFormat]);
 
   if (!checked) return null;
 
-  // Already have a podcast — show player
-  if (podcast) {
-    return (
-      <div className="mt-8 p-5 bg-[#f5f0e8] rounded-xl border border-[#e0d9cc]">
-        <div className="flex items-center gap-2 mb-3">
-          <svg className="w-5 h-5 text-[#9e4a3a]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z" />
-          </svg>
-          <p className="text-sm font-sans font-medium text-[#1a1612]">
-            Deep Dive — {podcast.topic}
-          </p>
-        </div>
-        <audio
-          controls
-          src={podcast.audioUrl}
-          className="w-full"
-          preload="metadata"
-        />
-        <div className="flex items-center justify-between mt-2">
-          <p className="text-[11px] text-[#8a8480] font-sans">
-            Generated from {podcast.findingCount} research findings
-          </p>
-          {podcast.script && (
+  return (
+    <div className="mt-8">
+      {/* Format selector */}
+      <div className="flex gap-1.5 mb-3 overflow-x-auto pb-1">
+        {FORMAT_OPTIONS.map(opt => {
+          const hasEpisode = !!podcasts[opt.value];
+          return (
             <button
-              onClick={() => setShowTranscript(!showTranscript)}
-              className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
+              key={opt.value}
+              onClick={() => { setSelectedFormat(opt.value); setShowTranscript(false); }}
+              className={`flex-shrink-0 px-3 py-1.5 rounded-full text-[12px] font-sans transition-colors ${
+                selectedFormat === opt.value
+                  ? 'bg-[#1a1612] text-white'
+                  : hasEpisode
+                    ? 'bg-[#f5f0e8] text-[#1a1612] hover:bg-[#ebe5d8]'
+                    : 'bg-[#f5f0e8]/50 text-[#8a8480] hover:bg-[#f5f0e8]'
+              }`}
+              title={opt.desc}
             >
-              {showTranscript ? 'Hide transcript' : 'Show transcript'}
+              {opt.label}
+              {hasEpisode && selectedFormat !== opt.value && (
+                <span className="ml-1 w-1.5 h-1.5 bg-[#9e4a3a] rounded-full inline-block" />
+              )}
             </button>
+          );
+        })}
+      </div>
+
+      {/* Active podcast or generate prompt */}
+      {activePodcast ? (
+        <div className="p-5 bg-[#f5f0e8] rounded-xl border border-[#e0d9cc]">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-[#9e4a3a]" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z" />
+              </svg>
+              <p className="text-sm font-sans font-medium text-[#1a1612]">
+                {FORMAT_OPTIONS.find(f => f.value === selectedFormat)?.label} — {activePodcast.topic}
+              </p>
+            </div>
+            <button
+              onClick={() => handlePublish(!activePodcast.published)}
+              className={`text-[11px] font-sans px-2 py-0.5 rounded ${
+                activePodcast.published
+                  ? 'bg-[#9e4a3a]/10 text-[#9e4a3a]'
+                  : 'bg-[#e8e4dc] text-[#6b6560] hover:bg-[#ddd]'
+              }`}
+              title={activePodcast.published ? 'Published to podcast feed' : 'Publish to podcast feed'}
+            >
+              {activePodcast.published ? 'Published' : 'Publish'}
+            </button>
+          </div>
+          <audio
+            controls
+            src={activePodcast.audioUrl}
+            className="w-full"
+            preload="metadata"
+          />
+          <div className="flex items-center justify-between mt-2">
+            <p className="text-[11px] text-[#8a8480] font-sans">
+              {activePodcast.findingCount} findings
+              {activePodcast.published && (
+                <span className="ml-2">
+                  <a
+                    href="/api/podcast/feed.xml"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[#9e4a3a] hover:underline"
+                  >
+                    RSS feed
+                  </a>
+                </span>
+              )}
+            </p>
+            {activePodcast.script && (
+              <button
+                onClick={() => setShowTranscript(!showTranscript)}
+                className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
+              >
+                {showTranscript ? 'Hide transcript' : 'Show transcript'}
+              </button>
+            )}
+          </div>
+          {showTranscript && activePodcast.script && (
+            <div className="mt-3 pt-3 border-t border-[#e0d9cc] space-y-2 max-h-[400px] overflow-y-auto">
+              {formatTranscript(activePodcast.script).map((entry, i) => (
+                <p key={i} className="text-[13px] font-body leading-relaxed text-[#333]">
+                  <span className="font-semibold text-[#1a1612]">{entry.speaker}:</span>{' '}
+                  {entry.text}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {/* Interactive mode */}
+          <AskWhileListening threadId={threadId} />
+        </div>
+      ) : (
+        <div className="p-5 bg-[#f5f0e8]/50 rounded-xl border border-[#e0d9cc] border-dashed text-center">
+          <p className="text-sm font-sans font-medium text-[#1a1612] mb-1">
+            {FORMAT_OPTIONS.find(f => f.value === selectedFormat)?.label}
+          </p>
+          <p className="text-[13px] text-[#6b6560] font-body mb-3">
+            {FORMAT_OPTIONS.find(f => f.value === selectedFormat)?.desc}
+          </p>
+          <button
+            onClick={handleGenerate}
+            disabled={generating}
+            className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {generating ? (
+              <>
+                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                Generating...
+              </>
+            ) : (
+              'Generate'
+            )}
+          </button>
+          {error && (
+            <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
           )}
         </div>
-        {showTranscript && podcast.script && (
-          <div className="mt-3 pt-3 border-t border-[#e0d9cc] space-y-2 max-h-[400px] overflow-y-auto">
-            {formatTranscript(podcast.script).map((entry, i) => (
-              <p key={i} className="text-[13px] font-body leading-relaxed text-[#333]">
-                <span className="font-semibold text-[#1a1612]">{entry.speaker}:</span>{' '}
-                {entry.text}
-              </p>
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // No podcast yet — show generate button
-  return (
-    <div className="mt-8 p-5 bg-[#f5f0e8]/50 rounded-xl border border-[#e0d9cc] border-dashed text-center">
-      <p className="text-sm text-[#6b6560] font-body mb-3">
-        Turn this research into a podcast episode
-      </p>
-      <button
-        onClick={handleGenerate}
-        disabled={generating}
-        className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {generating ? (
-          <>
-            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-            Generating podcast...
-          </>
-        ) : (
-          <>
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z" />
-            </svg>
-            Generate Deep Dive
-          </>
-        )}
-      </button>
-      {error && (
-        <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
       )}
     </div>
   );
@@ -313,7 +514,7 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
           ))}
         </div>
 
-        {/* Podcast player / generator */}
+        {/* Podcast section */}
         <PodcastPlayer threadId={id} />
 
         <div className="mt-12 pt-8 border-t border-[#e8e4dc] text-center">

--- a/src/lib/embassy/podcast.ts
+++ b/src/lib/embassy/podcast.ts
@@ -1,26 +1,42 @@
 /**
  * Podcast generation from research notebooks.
  *
- * Two-stage pipeline:
- *   1. Gemini Flash writes a two-host conversation script from notebook findings
- *   2. Gemini TTS voices it with multi-speaker support
+ * Pipeline:
+ *   1. Gemini Flash writes a script (format-specific) from notebook findings
+ *   2. Gemini TTS voices it (multi-speaker or single-speaker)
+ *
+ * Formats:
+ *   - deep-dive: Two hosts discuss findings in depth (default)
+ *   - brief: Single narrator, 2-minute key points
+ *   - critique: Critical analysis of the sources
+ *   - guided-reading: Commentary track for reading alongside the text
  *
  * Audio stored on R2, metadata in MongoDB (embassy_threads.podcast).
  */
 
 import { GoogleGenAI } from '@google/genai';
 import { getDb } from '@/lib/mongodb';
-import { storagePut, r2Url } from '@/lib/storage';
+import { storagePut } from '@/lib/storage';
 import { ObjectId } from 'mongodb';
 
 const SCRIPT_MODEL = 'gemini-3-flash-preview';
 const TTS_MODEL = 'gemini-2.5-flash-preview-tts';
 
-// Two hosts for the podcast
+// Voices
 const HOST_A = 'Elena';
 const HOST_B = 'Marcus';
-const VOICE_A = 'Kore';    // Female scholarly voice
-const VOICE_B = 'Puck';    // Male scholarly voice
+const NARRATOR = 'Elena';
+const VOICE_A = 'Kore';
+const VOICE_B = 'Puck';
+
+export type PodcastFormat = 'deep-dive' | 'brief' | 'critique' | 'guided-reading';
+
+export const PODCAST_FORMATS: Record<PodcastFormat, { label: string; description: string; icon: string }> = {
+  'deep-dive': { label: 'Deep Dive', description: 'Two hosts explore your findings in depth', icon: 'conversation' },
+  'brief': { label: 'The Brief', description: '2-minute summary of key discoveries', icon: 'lightning' },
+  'critique': { label: 'The Critique', description: 'Critical analysis of sources and arguments', icon: 'magnifier' },
+  'guided-reading': { label: 'Guided Reading', description: 'Commentary track for reading alongside the text', icon: 'book' },
+};
 
 // Gemini TTS audio tags for natural delivery
 const AUDIO_TAG_GUIDE = `
@@ -46,33 +62,47 @@ interface NotebookFinding {
   };
 }
 
-interface PodcastResult {
+export interface PodcastResult {
   audioUrl: string;
   script: string;
+  format: PodcastFormat;
   duration?: number;
 }
 
+export interface PodcastMetadata {
+  audioUrl: string;
+  r2Key: string;
+  script: string;
+  format: PodcastFormat;
+  generatedAt: Date;
+  topic: string;
+  findingCount: number;
+  published?: boolean;
+}
+
 /**
- * Generate a podcast-style Audio Overview from research notebook findings.
+ * Generate a podcast from research notebook findings.
  */
 export async function generatePodcast(
   threadId: string,
   topic: string,
   findings: NotebookFinding[],
+  format: PodcastFormat = 'deep-dive',
 ): Promise<PodcastResult> {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) throw new Error('GEMINI_API_KEY not set');
 
   const ai = new GoogleGenAI({ apiKey });
 
-  // Stage 1: Generate the conversation script
-  const script = await generateScript(ai, topic, findings);
+  // Stage 1: Generate the script
+  const script = await generateScript(ai, topic, findings, format);
 
   // Stage 2: Convert script to audio via Gemini TTS
-  const audioBuffer = await generateAudio(ai, script);
+  const isMultiSpeaker = format === 'deep-dive' || format === 'critique';
+  const audioBuffer = await generateAudio(ai, script, isMultiSpeaker);
 
   // Stage 3: Upload to R2
-  const key = `podcasts/${threadId}-${Date.now()}.wav`;
+  const key = `podcasts/${threadId}-${format}-${Date.now()}.wav`;
   const { url } = await storagePut(key, audioBuffer, {
     contentType: 'audio/wav',
   });
@@ -83,34 +113,26 @@ export async function generatePodcast(
     { _id: new ObjectId(threadId) },
     {
       $set: {
-        podcast: {
+        [`podcasts.${format}`]: {
           audioUrl: url,
           r2Key: key,
           script,
+          format,
           generatedAt: new Date(),
           topic,
           findingCount: findings.length,
-        },
+        } satisfies PodcastMetadata,
       },
     },
   );
 
-  return { audioUrl: url, script };
+  return { audioUrl: url, script, format };
 }
 
-/**
- * Stage 1: Generate a two-host conversation script from findings.
- *
- * Multi-pass pipeline (inspired by NotebookLM's internal process):
- *   Pass 1: Generate a draft script
- *   Pass 2: Critique and revise for naturalness, pacing, and citation quality
- */
-async function generateScript(
-  ai: GoogleGenAI,
-  topic: string,
-  findings: NotebookFinding[],
-): Promise<string> {
-  const findingsText = findings
+// ── Script Generation ────────────────────────────────────────────────
+
+function formatFindings(findings: NotebookFinding[]): string {
+  return findings
     .map((f, i) => {
       let entry = `Finding ${i + 1}: "${f.quote}"`;
       entry += `\n  — ${f.source.bookTitle} by ${f.source.bookAuthor}, Page ${f.source.pageNumber}`;
@@ -118,15 +140,52 @@ async function generateScript(
       return entry;
     })
     .join('\n\n');
+}
 
-  // Pass 1: Draft script
-  const draftPrompt = `You are a scriptwriter for "Source Library Deep Dive," a scholarly podcast about rare books and the Western esoteric tradition. Write a natural two-person conversation between ${HOST_A} (lead host, enthusiastic and deeply knowledgeable) and ${HOST_B} (co-host, asks sharp questions and draws unexpected connections).
+async function generateScript(
+  ai: GoogleGenAI,
+  topic: string,
+  findings: NotebookFinding[],
+  format: PodcastFormat,
+): Promise<string> {
+  const findingsText = formatFindings(findings);
+
+  const promptFn = FORMAT_PROMPTS[format];
+  const draftPrompt = promptFn(topic, findingsText, findings);
+
+  // Pass 1: Draft
+  const draftResponse = await ai.models.generateContent({
+    model: SCRIPT_MODEL,
+    contents: draftPrompt,
+    config: { temperature: format === 'brief' ? 0.6 : 0.85 },
+  });
+
+  const draft = draftResponse.text;
+  if (!draft) throw new Error('Script draft returned empty response');
+
+  // Pass 2: Critique and revise (skip for brief — it's short enough)
+  if (format === 'brief') return draft;
+
+  const critiquePrompt = buildCritiquePrompt(draft, format);
+  const revisedResponse = await ai.models.generateContent({
+    model: SCRIPT_MODEL,
+    contents: critiquePrompt,
+    config: { temperature: 0.7 },
+  });
+
+  return revisedResponse.text || draft;
+}
+
+// ── Format-Specific Prompts ──────────────────────────────────────────
+
+const FORMAT_PROMPTS: Record<PodcastFormat, (topic: string, findings: string, raw: NotebookFinding[]) => string> = {
+  'deep-dive': (topic, findings) => `You are a scriptwriter for "Source Library Deep Dive," a scholarly podcast about rare books and the Western esoteric tradition. Write a natural two-person conversation between ${HOST_A} (lead host, enthusiastic and deeply knowledgeable) and ${HOST_B} (co-host, asks sharp questions and draws unexpected connections).
 
 ## Topic: ${topic}
 
 ## Source material (verbatim quotes from rare books, 15th-18th century):
 
-${findingsText}
+${findings}
 
 ## Guidelines:
 - This is a 3-5 minute podcast episode (roughly 600-900 words of dialogue)
@@ -144,81 +203,152 @@ ${AUDIO_TAG_GUIDE}
 ## Output format:
 Write ONLY the dialogue, one line per speaker turn:
 ${HOST_A}: So I've been digging into something fascinating...
-${HOST_B}: Oh? What did you find?`;
+${HOST_B}: Oh? What did you find?`,
 
-  const draftResponse = await ai.models.generateContent({
-    model: SCRIPT_MODEL,
-    contents: draftPrompt,
-    config: { temperature: 0.85 },
-  });
+  'brief': (topic, findings) => `You are a narrator for "Source Library Briefing," delivering concise scholarly summaries. Write a single-narrator script for ${NARRATOR}.
 
-  const draft = draftResponse.text;
-  if (!draft) throw new Error('Script draft returned empty response');
+## Topic: ${topic}
 
-  // Pass 2: Critique and revise
-  const critiquePrompt = `You are a podcast director reviewing a script for "Source Library Deep Dive." Your job is to make it sound MORE natural and engaging, not less.
+## Source material:
+
+${findings}
+
+## Guidelines:
+- This is a 1-2 minute briefing (roughly 200-350 words)
+- Open with a single compelling sentence that frames the topic
+- Hit 3-4 key points from the findings, citing book and author for each
+- Quote one passage verbatim — the most striking one
+- Close with one sentence on why this matters or what it connects to
+- Tone: confident, clear, like a museum audio guide for a scholar
+- No filler, no hedging, no "in this episode we'll explore..."
+
+${AUDIO_TAG_GUIDE}
+
+## Output format:
+Write ONLY the narration as a single block of text for ${NARRATOR}:
+${NARRATOR}: [the full narration]`,
+
+  'critique': (topic, findings) => `You are a scriptwriter for "Source Library Critical Review." Write a two-person conversation where ${HOST_A} presents findings and ${HOST_B} plays devil's advocate — questioning interpretations, pointing out gaps, challenging assumptions.
+
+## Topic: ${topic}
+
+## Source material:
+
+${findings}
+
+## Guidelines:
+- This is a 3-5 minute episode (roughly 600-900 words)
+- ${HOST_A} presents each finding enthusiastically
+- ${HOST_B} pushes back constructively: "But isn't that a common trope?", "How do we know this isn't just...", "The dating on that source is questionable..."
+- The critique should be scholarly, not dismissive — ${HOST_B} respects the material but wants rigor
+- Still cite sources precisely — book, author, page
+- End with what remains compelling AFTER the critique — what survives scrutiny
+- Include moments where ${HOST_B} concedes: "Actually, that's a strong point..."
+
+${AUDIO_TAG_GUIDE}
+
+## Output format:
+Write ONLY the dialogue, one line per speaker turn:
+${HOST_A}: I want to look at something that challenges the standard narrative...
+${HOST_B}: [thoughtful] Alright, I'm listening. But I'm skeptical.`,
+
+  'guided-reading': (_topic, findings, raw) => {
+    // For guided reading, we organize by page order
+    const sorted = [...raw].sort((a, b) => {
+      if (a.source.bookId !== b.source.bookId) return a.source.bookTitle.localeCompare(b.source.bookTitle);
+      return a.source.pageNumber - b.source.pageNumber;
+    });
+    const sortedText = sorted
+      .map((f, i) => {
+        let entry = `Finding ${i + 1}: "${f.quote}"`;
+        entry += `\n  — ${f.source.bookTitle} by ${f.source.bookAuthor}, Page ${f.source.pageNumber}`;
+        if (f.note) entry += `\n  Note: ${f.note}`;
+        return entry;
+      })
+      .join('\n\n');
+
+    return `You are a narrator for "Source Library Guided Reading," creating a commentary track that readers listen to while reading alongside the original text. Write narration for ${NARRATOR}.
+
+## Source material (in page order):
+
+${sortedText}
+
+## Guidelines:
+- This is a 4-6 minute guided reading (roughly 500-800 words)
+- Address the listener directly: "Turn to page 42...", "Now look at this passage...", "Notice how Agrippa shifts his argument here..."
+- For each finding, give context BEFORE the quote: what to look for, what the author is doing
+- Then read or paraphrase the key passage
+- Then explain what it means — historical context, connections to other works, why it matters
+- Pace for someone actually turning pages — leave natural pauses between sections
+- Tone: a knowledgeable guide in a rare book library, pointing things out as you walk through
+- Group findings by book, moving through pages in order
+- End with a synthesis: what these passages reveal when read together
+
+${AUDIO_TAG_GUIDE}
+
+## Output format:
+Write ONLY the narration for ${NARRATOR}:
+${NARRATOR}: Let's open to page twelve...`;
+  },
+};
+
+function buildCritiquePrompt(draft: string, format: PodcastFormat): string {
+  const speakers = format === 'deep-dive' || format === 'critique'
+    ? `${HOST_A} and ${HOST_B}`
+    : NARRATOR;
+
+  return `You are a podcast director reviewing a script. Your job is to make it sound MORE natural and engaging.
 
 ## Original script:
 ${draft}
 
-## Critique checklist — fix these issues:
-1. **Robotic turns:** If any line sounds like an AI wrote it (too formal, too complete, no hesitation), rewrite it with natural speech patterns. Real people don't speak in perfect paragraphs.
-2. **Missing reactions:** After a surprising quote or revelation, ${HOST_B} should react before ${HOST_A} continues. Add brief interjections: "Wait, really?", "Hmm, that's...", "[laughs] Of course they did."
-3. **Citation quality:** Every direct quote MUST name the book and author. Page numbers should be mentioned naturally: "on page 42" or "a few pages later." If a citation is vague, make it specific.
-4. **Pacing:** The opening should grab attention in the first 2 lines. The middle should build. The ending should land with weight, not trail off.
-5. **Audio tags:** Add [enthusiasm], [thoughtful], [laughs], or [whispers] where they'd enhance delivery. Use sparingly — max 6-8 tags total.
-6. **Length:** Keep it at 600-900 words. Cut filler if it's too long, add depth if too short.
+## Critique checklist:
+1. **Robotic turns:** If any line sounds like an AI wrote it (too formal, too complete, no hesitation), rewrite it with natural speech patterns.
+2. **Missing reactions:** After a surprising quote or revelation, there should be a genuine reaction before moving on.
+3. **Citation quality:** Every direct quote MUST name the book and author. Page numbers mentioned naturally.
+4. **Pacing:** Opening grabs attention in 1-2 lines. Middle builds. Ending lands with weight.
+5. **Audio tags:** Add [enthusiasm], [thoughtful], [laughs], or [whispers] where they'd enhance delivery. Max 6-8 tags.
+6. **Length:** Keep within the target word count. Cut filler, add depth.
 
 ## Output:
-Write the REVISED script only. Same format (SpeakerName: dialogue), no commentary.`;
-
-  const revisedResponse = await ai.models.generateContent({
-    model: SCRIPT_MODEL,
-    contents: critiquePrompt,
-    config: { temperature: 0.7 },
-  });
-
-  const revised = revisedResponse.text;
-  if (!revised) throw new Error('Script revision returned empty response');
-  return revised;
+Write the REVISED script only. Same format (${speakers}), no commentary.`;
 }
 
-/**
- * Stage 2: Convert a two-host script to audio via Gemini multi-speaker TTS.
- */
+// ── Audio Generation ─────────────────────────────────────────────────
+
 async function generateAudio(
   ai: GoogleGenAI,
   script: string,
+  multiSpeaker: boolean,
 ): Promise<Buffer> {
-  const prompt = `TTS the following conversation between ${HOST_A} and ${HOST_B}:\n\n${script}`;
+  const config: Record<string, unknown> = {
+    responseModalities: ['AUDIO'],
+    speechConfig: multiSpeaker
+      ? {
+          multiSpeakerVoiceConfig: {
+            speakerVoiceConfigs: [
+              { speaker: HOST_A, voiceConfig: { prebuiltVoiceConfig: { voiceName: VOICE_A } } },
+              { speaker: HOST_B, voiceConfig: { prebuiltVoiceConfig: { voiceName: VOICE_B } } },
+            ],
+          },
+        }
+      : {
+          voiceConfig: {
+            prebuiltVoiceConfig: { voiceName: VOICE_A },
+          },
+        },
+  };
+
+  const prompt = multiSpeaker
+    ? `TTS the following conversation between ${HOST_A} and ${HOST_B}:\n\n${script}`
+    : `TTS the following narration by ${NARRATOR}:\n\n${script}`;
 
   const response = await ai.models.generateContent({
     model: TTS_MODEL,
     contents: prompt,
-    config: {
-      responseModalities: ['AUDIO'],
-      speechConfig: {
-        multiSpeakerVoiceConfig: {
-          speakerVoiceConfigs: [
-            {
-              speaker: HOST_A,
-              voiceConfig: {
-                prebuiltVoiceConfig: { voiceName: VOICE_A },
-              },
-            },
-            {
-              speaker: HOST_B,
-              voiceConfig: {
-                prebuiltVoiceConfig: { voiceName: VOICE_B },
-              },
-            },
-          ],
-        },
-      },
-    } as Record<string, unknown>,
+    config,
   });
 
-  // Extract base64-encoded PCM audio from response
   const candidate = response.candidates?.[0];
   const part = candidate?.content?.parts?.[0];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -228,14 +358,9 @@ async function generateAudio(
   }
 
   const pcmData = Buffer.from(inlineData.data, 'base64');
-
-  // Wrap raw PCM in a WAV header (24kHz, 16-bit, mono)
   return createWavBuffer(pcmData, 24000, 1, 16);
 }
 
-/**
- * Create a WAV file buffer from raw PCM data.
- */
 function createWavBuffer(
   pcmData: Buffer,
   sampleRate: number,
@@ -251,8 +376,8 @@ function createWavBuffer(
   header.writeUInt32LE(36 + dataSize, 4);
   header.write('WAVE', 8);
   header.write('fmt ', 12);
-  header.writeUInt32LE(16, 16);           // fmt chunk size
-  header.writeUInt16LE(1, 20);            // PCM format
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
   header.writeUInt16LE(channels, 22);
   header.writeUInt32LE(sampleRate, 24);
   header.writeUInt32LE(byteRate, 28);
@@ -264,20 +389,110 @@ function createWavBuffer(
   return Buffer.concat([header, pcmData]);
 }
 
-/**
- * Get existing podcast metadata for a thread.
- */
-export async function getPodcastForThread(threadId: string): Promise<{
-  audioUrl: string;
-  generatedAt: Date;
-  topic: string;
-  findingCount: number;
-  script?: string;
-} | null> {
+// ── Query helpers ────────────────────────────────────────────────────
+
+export async function getPodcastForThread(
+  threadId: string,
+  format?: PodcastFormat,
+): Promise<PodcastMetadata | null> {
   const db = await getDb();
   const thread = await db.collection('embassy_threads').findOne(
     { _id: new ObjectId(threadId) },
-    { projection: { podcast: 1 } },
+    { projection: { podcasts: 1, podcast: 1 } },
   );
-  return thread?.podcast || null;
+  if (!thread) return null;
+
+  // New schema: podcasts.{format}
+  if (thread.podcasts) {
+    if (format) return thread.podcasts[format] || null;
+    // Return first available
+    for (const f of ['deep-dive', 'brief', 'critique', 'guided-reading'] as PodcastFormat[]) {
+      if (thread.podcasts[f]) return thread.podcasts[f];
+    }
+  }
+
+  // Legacy schema: podcast (single)
+  if (thread.podcast) {
+    return { ...thread.podcast, format: 'deep-dive' };
+  }
+
+  return null;
+}
+
+export async function getAllPodcastsForThread(
+  threadId: string,
+): Promise<Record<string, PodcastMetadata>> {
+  const db = await getDb();
+  const thread = await db.collection('embassy_threads').findOne(
+    { _id: new ObjectId(threadId) },
+    { projection: { podcasts: 1, podcast: 1 } },
+  );
+  if (!thread) return {};
+
+  const result: Record<string, PodcastMetadata> = {};
+
+  if (thread.podcasts) {
+    for (const [f, data] of Object.entries(thread.podcasts)) {
+      if (data) result[f] = data as PodcastMetadata;
+    }
+  }
+
+  // Legacy migration
+  if (thread.podcast && !result['deep-dive']) {
+    result['deep-dive'] = { ...thread.podcast, format: 'deep-dive' as PodcastFormat };
+  }
+
+  return result;
+}
+
+/**
+ * Get all published podcast episodes across all threads (for RSS feed).
+ */
+export async function getPublishedEpisodes(limit = 50): Promise<Array<{
+  threadId: string;
+  threadTitle: string;
+  creatorName: string;
+  podcast: PodcastMetadata;
+}>> {
+  const db = await getDb();
+
+  // Find threads with published podcasts
+  const threads = await db.collection('embassy_threads')
+    .find({
+      $or: [
+        { 'podcasts.deep-dive.published': true },
+        { 'podcasts.brief.published': true },
+        { 'podcasts.critique.published': true },
+        { 'podcasts.guided-reading.published': true },
+      ],
+    })
+    .sort({ 'podcasts.deep-dive.generatedAt': -1 })
+    .limit(limit)
+    .project({ title: 1, creatorName: 1, podcasts: 1 })
+    .toArray();
+
+  const episodes: Array<{
+    threadId: string;
+    threadTitle: string;
+    creatorName: string;
+    podcast: PodcastMetadata;
+  }> = [];
+
+  for (const thread of threads) {
+    for (const format of ['deep-dive', 'brief', 'critique', 'guided-reading']) {
+      const p = thread.podcasts?.[format];
+      if (p?.published) {
+        episodes.push({
+          threadId: thread._id.toString(),
+          threadTitle: thread.title || p.topic,
+          creatorName: thread.creatorName || 'Anonymous',
+          podcast: p,
+        });
+      }
+    }
+  }
+
+  return episodes.sort((a, b) =>
+    new Date(b.podcast.generatedAt).getTime() - new Date(a.podcast.generatedAt).getTime(),
+  );
 }


### PR DESCRIPTION
## Summary

Builds out the full podcast system from issues #1137, #1138, #1139.

### Multiple formats (#1137)
Four podcast formats, each with its own script generation prompt:
- **Deep Dive** — two hosts explore findings in depth (default)
- **The Brief** — single narrator, 2-minute key points summary
- **The Critique** — two hosts, one plays devil's advocate
- **Guided Reading** — commentary track for reading alongside the text ("Turn to page 42...")

Format selector appears as pill buttons above the player. Each format generates and stores independently.

### RSS feed (#1138)
- `GET /api/podcast/feed.xml` — standard RSS 2.0 with iTunes + podcast namespace tags
- Users click "Publish" on any generated episode to add it to the feed
- Compatible with Apple Podcasts, Spotify, Overcast
- Transcript links back to the thread page
- Category: Education > Higher Education, History

### Interactive mode (#1139)
- "Ask a question while listening" link below the audio player
- Opens an inline mini-chat that streams Librarian responses via SSE
- Grounded in the same thread context + can search the full library
- No page navigation needed — answers appear below the player

### Schema
`embassy_threads.podcast` (single) → `embassy_threads.podcasts.{format}` (multi). Backward-compatible: reads legacy field.

Closes #1137, #1138, #1139

## Test plan
- [ ] Generate a Deep Dive, then switch to Brief and generate — both should coexist
- [ ] Generate a Guided Reading — verify it addresses reader ("Turn to page...")
- [ ] Click "Publish" on an episode, then visit `/api/podcast/feed.xml` — verify valid RSS
- [ ] While audio plays, click "Ask a question" — verify Librarian responds inline
- [ ] Verify format pills show dots for formats that have episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)