### PR TITLE
Fix: add missing signIn import (unblocks all deploys)

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useState } from 'react';
+import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { BookLoader } from '@/components/ui/BookLoader';
 


### PR DESCRIPTION
The `signIn` function was used in `src/app/auth/signin/page.tsx` but never imported from `next-auth/react`. This has been failing all Vercel production builds since PR #1048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)