### PR TITLE
Fix search 500: remove ilike on unindexed text fields

### DIFF
--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -309,7 +309,9 @@ export async function searchBookIds(
   // Build OR filter: exact phrase match + word-level AND matches
   // "mathematical magick" should match "Mathematicall Magick" by matching each word
   const words = text.trim().split(/\s+/).filter(w => w.length >= 2);
-  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%,summary_text.ilike.%${text}%,description.ilike.%${text}%`;
+  // Only ilike on indexed/short fields — summary_text and description cause
+  // full-table scans and Supabase statement timeouts (no trigram indexes)
+  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`;
 
   let orFilter = phraseFilters;
   if (words.length >= 2) {


### PR DESCRIPTION
## Summary
- `searchBookIds` was doing `ilike` on `summary_text` and `description` — large unindexed text fields that cause full table scans and Supabase statement timeouts
- Short/common queries (e.g. "sex") match thousands of rows in these fields, exceeding the 8s timeout
- Fix: restrict `ilike` to `title`, `display_title`, and `author` (short, indexed fields). Full-text content search is already handled separately by the MongoDB page aggregation pipeline

## Reproduction
```
curl "https://sourcelibrary.org/api/search?q=sex&limit=5"
# → 500: "searchBookIds failed: canceling statement due to statement timeout"
```

## Test plan
- [ ] Verify `?q=sex` no longer 500s
- [ ] Verify reading room AI can search successfully
- [ ] Verify search page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)