### PR TITLE
Fix unified search endpoint hanging on Vercel

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -24,6 +24,7 @@ const ROUTES = [
   `/book/${BOOK.slug}`,
   `/book/${BOOK.slug}/page/${PAGE.id}`,
   `/search?q=${SEARCH.query}`,
+  `/api/search/unified?q=${SEARCH.query}&limit=3`,
   '/api/books/search?q=alchemy&limit=1',
   '/api/collections',
   '/api/books/timeline?era=renaissance&limit=1',

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -77,15 +77,33 @@ export async function GET(request: NextRequest) {
     if (firstTranslation) searchFilters.isFirstTranslation = true;
     if (hasTranslation) searchFilters.hasTranslation = true;
 
-    // Run book, index, gallery, and visual search in parallel
+    // Run book, index, gallery, and visual search in parallel.
+    // Each operation gets a hard timeout — Atlas Search $search doesn't respect maxTimeMS,
+    // and hung operations would block the entire response indefinitely.
+    const withTimeout = <T>(promise: Promise<T>, fallback: T, label: string, ms = 8000): Promise<T> =>
+      Promise.race([
+        promise,
+        new Promise<T>((resolve) => setTimeout(() => {
+          console.warn(`[unified-search] ${label} timed out after ${ms}ms`);
+          resolve(fallback);
+        }, ms)),
+      ]);
+
+    const emptyBooks = { results: [] as SearchResult[], total: 0, hasMore: false };
+    const emptyIndex = { results: [] as IndexResult[], total: 0, hasMore: false };
+    const emptyGallery = { results: [] as GalleryResult[], total: 0 };
+
     const [booksResult, indexResult, galleryResult, visualResult] = await Promise.all([
-      searchBooks(db, query, queryRegex, limit, searchFilters, library),
-      searchIndex(db, query, limit).catch((err) => {
-        console.error('Index search error:', err);
-        return { results: [] as IndexResult[], total: 0 };
-      }),
-      searchGallery(db, query, queryRegex, galleryLimit),
-      searchVisual(query, galleryLimit),
+      withTimeout(searchBooks(db, query, queryRegex, limit, searchFilters, library), emptyBooks, 'books'),
+      withTimeout(
+        searchIndex(db, query, limit).catch((err) => {
+          console.error('Index search error:', err);
+          return emptyIndex;
+        }),
+        emptyIndex, 'index',
+      ),
+      withTimeout(searchGallery(db, query, queryRegex, galleryLimit), emptyGallery, 'gallery'),
+      withTimeout(searchVisual(query, galleryLimit), emptyGallery, 'visual', 5000),
     ]);
 
     // Log search query (fire-and-forget)


### PR DESCRIPTION
## Summary
- The `/api/search/unified` endpoint intermittently hangs on Vercel because Atlas Search `$search` aggregations don't respect `maxTimeMS`, and the CLIP visual search can stall on connection timeouts
- Any single hung operation in the 4-way `Promise.all` blocks the entire response indefinitely
- Added `Promise.race` timeout wrappers (8s for DB operations, 5s for CLIP) so the endpoint always responds within a bounded time — returning partial results instead of hanging
- Added the unified API endpoint to e2e warm-up routes

## Root cause
The unified search endpoint runs 4 parallel operations: books, index (Atlas Search on entities), gallery (Atlas Search on gallery_images), and visual (CLIP on Hetzner). From Vercel's `fra1` region, these operations intermittently hang:
- Atlas Search `$search` ignores `maxTimeMS` when the index is slow
- CLIP HTTP connections can stall without triggering `AbortSignal.timeout`

Without the timeout wrapper, a single hung operation blocks the entire `Promise.all`, causing the endpoint to never respond.

## Test plan
- [ ] Verify unified search responds within 10s even when operations are slow
- [ ] Run `npx playwright test e2e/search.spec.ts` — search tests should pass more reliably
- [ ] Check `/api/search/unified?q=Ficino` returns results on the Vercel preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)