### PR TITLE
Fix catalog page showing 0 books

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -24,6 +24,7 @@ const ROUTES = [
   `/book/${BOOK.slug}`,
   `/book/${BOOK.slug}/page/${PAGE.id}`,
   `/search?q=${SEARCH.query}`,
+  `/api/search/unified?q=${SEARCH.query}&limit=3`,
   '/api/books/search?q=alchemy&limit=1',
   '/api/collections',
   '/api/books/timeline?era=renaissance&limit=1',

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -77,15 +77,33 @@ export async function GET(request: NextRequest) {
     if (firstTranslation) searchFilters.isFirstTranslation = true;
     if (hasTranslation) searchFilters.hasTranslation = true;
 
-    // Run book, index, gallery, and visual search in parallel
+    // Run book, index, gallery, and visual search in parallel.
+    // Each operation gets a hard timeout — Atlas Search $search doesn't respect maxTimeMS,
+    // and hung operations would block the entire response indefinitely.
+    const withTimeout = <T>(promise: Promise<T>, fallback: T, label: string, ms = 8000): Promise<T> =>
+      Promise.race([
+        promise,
+        new Promise<T>((resolve) => setTimeout(() => {
+          console.warn(`[unified-search] ${label} timed out after ${ms}ms`);
+          resolve(fallback);
+        }, ms)),
+      ]);
+
+    const emptyBooks = { results: [] as SearchResult[], total: 0, hasMore: false };
+    const emptyIndex = { results: [] as IndexResult[], total: 0, hasMore: false };
+    const emptyGallery = { results: [] as GalleryResult[], total: 0 };
+
     const [booksResult, indexResult, galleryResult, visualResult] = await Promise.all([
-      searchBooks(db, query, queryRegex, limit, searchFilters, library),
-      searchIndex(db, query, limit).catch((err) => {
-        console.error('Index search error:', err);
-        return { results: [] as IndexResult[], total: 0 };
-      }),
-      searchGallery(db, query, queryRegex, galleryLimit),
-      searchVisual(query, galleryLimit),
+      withTimeout(searchBooks(db, query, queryRegex, limit, searchFilters, library), emptyBooks, 'books'),
+      withTimeout(
+        searchIndex(db, query, limit).catch((err) => {
+          console.error('Index search error:', err);
+          return emptyIndex;
+        }),
+        emptyIndex, 'index',
+      ),
+      withTimeout(searchGallery(db, query, queryRegex, galleryLimit), emptyGallery, 'gallery'),
+      withTimeout(searchVisual(query, galleryLimit), emptyGallery, 'visual', 5000),
     ]);
 
     // Log search query (fire-and-forget)

--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -4,6 +4,7 @@ import CatalogBrowser from '@/components/catalog/CatalogBrowser';
 import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
 
 export const revalidate = 86400;
+export const maxDuration = 30;
 
 export const metadata: Metadata = {
   title: 'Catalog - Source Library',
@@ -13,8 +14,14 @@ export const metadata: Metadata = {
 
 export default async function CatalogPage() {
   const [browseResult, languages] = await Promise.all([
-    browseBooks({ hasTranslation: true, sort: 'popular', limit: 60 }).catch(() => ({ books: [], total: 0 })),
-    getLanguageCounts({}).catch(() => []),
+    browseBooks({ hasTranslation: true, sort: 'popular', limit: 60 }).catch((err) => {
+      console.error('[catalog] browseBooks failed:', err?.message || err);
+      return { books: [], total: 0 };
+    }),
+    getLanguageCounts({}).catch((err) => {
+      console.error('[catalog] getLanguageCounts failed:', err?.message || err);
+      return [];
+    }),
   ]);
   const { books, total } = browseResult;
 

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -175,7 +175,9 @@ export async function getLanguageCounts(filter: {
   if (filter.provider) query = query.eq('image_source_provider', filter.provider);
   if (filter.collection) query = query.contains('collections', [filter.collection]);
 
-  const { data } = await query;
+  // Supabase default limit is 1000 — need explicit limit for 17K+ books.
+  // Only fetching the language column, so this is lightweight.
+  const { data } = await query.limit(20000);
   const counts = new Map<string, number>();
   for (const row of (data || [])) {
     if (row.language) counts.set(row.language, (counts.get(row.language) || 0) + 1);


### PR DESCRIPTION
## Summary
- Catalog page was showing "0 books" on production and caching that empty result for 24h
- Root causes: no `maxDuration` (defaulting to 10s), `getLanguageCounts` hitting Supabase's 1000-row default limit on 17K+ books, and silent `.catch()` handlers
- Added `maxDuration=30`, explicit `.limit(20000)` on language query, error logging

## Test plan
- [ ] After deploy, verify `/catalog` shows 10K+ books
- [ ] Check language filter dropdown has entries
- [ ] Run `npx playwright test e2e/catalog.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)