### PR TITLE
Fix Supabase count timeout breaking catalog page

### DIFF
--- a/src/app/api/catalog/browse/route.ts
+++ b/src/app/api/catalog/browse/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
     const includeLangs = searchParams.get('langs') === '1';
 
     const promises: [Promise<{ books: unknown[]; total: number }>, Promise<{ lang: string; count: number }[]> | null] = [
-      browseBooks({ hasTranslation: true, language, search, sort, offset, limit }),
+      browseBooks({ hasTranslation: true, language, search, sort, offset, limit, exactCount: true }),
       includeLangs ? getLanguageCounts({}) : null,
     ];
 

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -65,6 +65,7 @@ export async function GET(
         hasTranslation: !skipTranslationFilter,
         sort: sbSort,
         limit: 1000, // manifest wants everything
+        exactCount: true,
       });
 
       const books = sbBooks.map(b => ({
@@ -92,6 +93,7 @@ export async function GET(
       sort: sbSort,
       offset,
       limit,
+      exactCount: true,
     });
 
     const books = sbBooks.map(b => ({

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -98,16 +98,23 @@ export async function browseBooks(opts: {
   sort?: SortOption;
   offset?: number;
   limit?: number;
-  /** Skip count: 'exact' to avoid expensive seq scans on large collections.
-   *  Callers that already have a cached count (e.g. collection pages) should set this. */
+  /** Skip count: use 'planned' instead of 'exact' to avoid expensive seq scans.
+   *  Default changed to 'planned' because 'exact' causes Supabase statement timeouts
+   *  on 17K+ rows with filter conditions on unindexed columns. */
   skipCount?: boolean;
+  /** Request exact count — only use for client-side paginated requests where accuracy matters. */
+  exactCount?: boolean;
 }): Promise<{ books: CatalogBook[]; total: number }> {
   const limit = opts.limit || 60;
   const offset = opts.offset || 0;
 
+  // Default to 'planned' (fast estimate) to avoid Supabase statement timeouts.
+  // Only use 'exact' when explicitly requested (e.g. client-side pagination).
+  const countMode = opts.exactCount ? 'exact' : (opts.skipCount ? 'planned' : 'estimated');
+
   let query = supabase
     .from('books_catalog')
-    .select(BOOK_SELECT, opts.skipCount ? { count: 'planned' } : { count: 'exact' })
+    .select(BOOK_SELECT, { count: countMode })
     .eq('visible', true);
 
   if (opts.hasPages !== false) query = query.gt('pages_count', 0);


### PR DESCRIPTION
## Summary
- `browseBooks()` used `count: 'exact'` by default, triggering sequential scans on 17K+ rows
- With filter conditions on unindexed columns (`pages_translated > 0`), this exceeds Supabase's 8s statement timeout
- Catalog page renders "0 books" because the query fails and `.catch()` returns empty data
- Changed default to `count: 'estimated'` (fast, uses Postgres table statistics)
- API endpoints that serve client-side pagination explicitly opt in with `exactCount: true`

## Test plan
- [ ] `/catalog` shows 10K+ books after deploy
- [ ] Collection pages load with correct book counts
- [ ] `npx playwright test e2e/catalog.spec.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)