### PR TITLE
Book-level semantic search via enrichment embeddings

### DIFF
--- a/scripts/migration/backfill-book-embeddings.mjs
+++ b/scripts/migration/backfill-book-embeddings.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * Backfill book_embeddings table on Supabase from MongoDB book_indexes + books.
+ *
+ * Composes a rich text representation from enrichment data (summaries, vocabulary,
+ * entities) and embeds it via Gemini embedding-2-preview (768 dims).
+ *
+ * For unenriched books, falls back to title + author + description + categories.
+ *
+ * Cost: $0 (Gemini free tier). Time: ~20 min for 17K books.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/backfill-book-embeddings.mjs
+ *   node scripts/migration/backfill-book-embeddings.mjs --dry-run
+ *   node scripts/migration/backfill-book-embeddings.mjs --book BOOK_ID
+ *   node scripts/migration/backfill-book-embeddings.mjs --incremental
+ *
+ * Issue: #1158
+ */
+
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+
+// ── Config ──────────────────────────────────────────────────────────
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_URL = (process.env.SUPABASE_URL || '').trim();
+const SUPABASE_KEY = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+const GEMINI_KEY = process.env.GEMINI_API_KEY;
+
+if (!MONGODB_URI || !SUPABASE_KEY || !GEMINI_KEY) {
+  console.error('Missing env: MONGODB_URI, SUPABASE_SERVICE_ROLE_KEY, or GEMINI_API_KEY');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const INCREMENTAL = args.includes('--incremental');
+const BOOK_ID = args.find((_, i, a) => a[i - 1] === '--book');
+const LIMIT = parseInt(args.find((_, i, a) => a[i - 1] === '--limit') || '0') || 0;
+
+const BATCH_SIZE = 50; // Gemini batchEmbedContents limit is 100
+const DIMS = 768;
+const MODEL = 'gemini-embedding-2-preview';
+const GEMINI_URL = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:batchEmbedContents?key=${GEMINI_KEY}`;
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+// ── Gemini Embedding ────────────────────────────────────────────────
+
+let rateLimitBackoff = 0;
+
+async function embedBatch(texts) {
+  const requests = texts.map(text => ({
+    model: `models/${MODEL}`,
+    content: { parts: [{ text }] },
+    outputDimensionality: DIMS,
+  }));
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (rateLimitBackoff > 0) {
+      await sleep(rateLimitBackoff);
+      rateLimitBackoff = Math.max(0, rateLimitBackoff - 1000);
+    }
+
+    try {
+      const res = await fetch(GEMINI_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requests }),
+        signal: AbortSignal.timeout(30000),
+      });
+
+      if (res.status === 429) {
+        rateLimitBackoff = Math.min(60000, (rateLimitBackoff || 2000) * 2);
+        console.warn(`  Rate limited, backing off ${rateLimitBackoff}ms`);
+        continue;
+      }
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        console.error(`  Gemini error ${res.status}: ${body.slice(0, 200)}`);
+        return null;
+      }
+
+      const data = await res.json();
+      if (!data?.embeddings?.length) return null;
+
+      // Decrease backoff on success
+      rateLimitBackoff = Math.max(0, rateLimitBackoff - 500);
+
+      return data.embeddings.map(e => e.values);
+    } catch (err) {
+      console.error(`  Embedding error (attempt ${attempt + 1}):`, err.message);
+      await sleep(2000 * (attempt + 1));
+    }
+  }
+  return null;
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// ── Text Composition ────────────────────────────────────────────────
+
+/**
+ * Compose a rich text representation from book + index data for embedding.
+ * This text captures the semantic essence of the book.
+ */
+function composeEmbeddingText(book, indexData) {
+  const parts = [];
+
+  // Title and author (always available)
+  parts.push(`${book.display_title || book.title || 'Untitled'} by ${book.author || 'Unknown'}`);
+
+  if (book.language) parts.push(`Language: ${book.language}`);
+  if (book.published) parts.push(`Published: ${book.published}`);
+
+  // Enrichment data (from book_indexes)
+  if (indexData) {
+    // Book summary — the richest semantic signal
+    if (indexData.bookSummary?.detailed) {
+      parts.push(indexData.bookSummary.detailed);
+    } else if (indexData.bookSummary?.brief) {
+      parts.push(indexData.bookSummary.brief);
+    } else if (indexData.bookSummary?.abstract) {
+      parts.push(indexData.bookSummary.abstract);
+    }
+
+    // Section summaries — chapter-level context
+    if (indexData.sectionSummaries?.length > 0) {
+      const sections = indexData.sectionSummaries
+        .map(s => s.title || s.summary)
+        .filter(Boolean)
+        .slice(0, 15); // cap to avoid over-long text
+      if (sections.length > 0) {
+        parts.push(`Chapters: ${sections.join('; ')}`);
+      }
+    }
+
+    // Vocabulary/index entries — topical keywords
+    if (indexData.entries?.length > 0) {
+      const terms = indexData.entries
+        .sort((a, b) => (b.pages?.length || 0) - (a.pages?.length || 0))
+        .slice(0, 50) // top 50 by page frequency
+        .map(e => e.term);
+      parts.push(`Topics: ${terms.join(', ')}`);
+    }
+
+    // Named entities
+    if (indexData.people?.length > 0) {
+      const names = indexData.people.slice(0, 30).map(p => p.name);
+      parts.push(`People: ${names.join(', ')}`);
+    }
+    if (indexData.places?.length > 0) {
+      const names = indexData.places.slice(0, 20).map(p => p.name);
+      parts.push(`Places: ${names.join(', ')}`);
+    }
+    if (indexData.concepts?.length > 0) {
+      const names = indexData.concepts.slice(0, 30).map(c => c.name);
+      parts.push(`Concepts: ${names.join(', ')}`);
+    }
+  }
+
+  // Fallback fields from book document
+  if (book.description && !indexData?.bookSummary) {
+    parts.push(book.description);
+  }
+  if (book.summary && !indexData?.bookSummary) {
+    parts.push(book.summary);
+  }
+  if (book.reading_summary?.overview && !indexData?.bookSummary) {
+    parts.push(book.reading_summary.overview);
+  }
+  if (book.categories?.length > 0) {
+    parts.push(`Categories: ${book.categories.join(', ')}`);
+  }
+
+  // Truncate to ~8000 chars to stay well within Gemini token limits
+  const text = parts.join('\n').slice(0, 8000);
+  return text;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  const mongo = new MongoClient(MONGODB_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  console.log('Connected to MongoDB and Supabase');
+
+  // Build filter
+  const bookFilter = {
+    visible: true,
+    pages_count: { $gt: 0 },
+  };
+  if (BOOK_ID) bookFilter.id = BOOK_ID;
+
+  // Get books
+  const bookProjection = {
+    id: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1,
+    description: 1, summary: 1, categories: 1, quality_score: 1,
+    'reading_summary.overview': 1,
+    'index.bookSummary': 1, // legacy inline fallback
+  };
+
+  const books = await db.collection('books')
+    .find(bookFilter)
+    .project(bookProjection)
+    .toArray();
+
+  console.log(`Found ${books.length} visible books`);
+
+  // If incremental, filter out books already in Supabase
+  let bookIds = books.map(b => b.id);
+  if (INCREMENTAL && !BOOK_ID) {
+    // Fetch all existing book_ids from Supabase in batches
+    const existingIds = new Set();
+    let offset = 0;
+    const pageSize = 1000;
+    while (true) {
+      const { data } = await supabase
+        .from('book_embeddings')
+        .select('book_id')
+        .range(offset, offset + pageSize - 1);
+      if (!data || data.length === 0) break;
+      data.forEach(d => existingIds.add(d.book_id));
+      offset += pageSize;
+      if (data.length < pageSize) break;
+    }
+    console.log(`Supabase has ${existingIds.size} existing embeddings`);
+    bookIds = bookIds.filter(id => !existingIds.has(id));
+    console.log(`${bookIds.length} books need embedding`);
+  }
+
+  if (LIMIT > 0) bookIds = bookIds.slice(0, LIMIT);
+
+  // Load all book_indexes in bulk
+  console.log('Loading book_indexes...');
+  const indexDocs = await db.collection('book_indexes')
+    .find(
+      BOOK_ID ? { book_id: BOOK_ID } : {},
+      { maxTimeMS: 60000 }
+    )
+    .toArray();
+  const indexMap = new Map(indexDocs.map(d => [d.book_id, d]));
+  console.log(`Loaded ${indexMap.size} book_indexes entries`);
+
+  const bookMap = new Map(books.map(b => [b.id, b]));
+
+  if (DRY_RUN) {
+    let withIndex = 0, withoutIndex = 0;
+    for (const bookId of bookIds) {
+      if (indexMap.has(bookId)) withIndex++;
+      else withoutIndex++;
+    }
+    console.log(`\nDry run summary:`);
+    console.log(`  ${bookIds.length} books to embed`);
+    console.log(`  ${withIndex} with book_indexes (rich embedding)`);
+    console.log(`  ${withoutIndex} without (fallback: title+desc+categories)`);
+    await mongo.close();
+    return;
+  }
+
+  // Process in batches
+  let embedded = 0, skipped = 0, errors = 0;
+  const startTime = Date.now();
+
+  for (let i = 0; i < bookIds.length; i += BATCH_SIZE) {
+    const batchIds = bookIds.slice(i, i + BATCH_SIZE);
+    const batchTexts = [];
+    const batchBooks = [];
+
+    for (const bookId of batchIds) {
+      const book = bookMap.get(bookId);
+      if (!book) continue;
+
+      const indexData = indexMap.get(bookId) || book.index || null;
+      const text = composeEmbeddingText(book, indexData);
+
+      if (text.length < 10) {
+        skipped++;
+        continue;
+      }
+
+      batchTexts.push(text);
+      batchBooks.push({ book, text, indexData });
+    }
+
+    if (batchTexts.length === 0) continue;
+
+    const embeddings = await embedBatch(batchTexts);
+    if (!embeddings) {
+      errors += batchTexts.length;
+      console.error(`  Failed to embed batch at offset ${i}`);
+      continue;
+    }
+
+    // Upsert to Supabase
+    const rows = batchBooks.map((item, idx) => {
+      const book = item.book;
+      const yearMatch = (book.published || '').match(/\d{3,4}/);
+      return {
+        book_id: book.id,
+        title: book.display_title || book.title || '',
+        author: book.author || '',
+        year: yearMatch ? parseInt(yearMatch[0]) : null,
+        language: book.language || null,
+        summary_text: item.text,
+        embedding: JSON.stringify(embeddings[idx]),
+        metadata: {
+          has_index: !!item.indexData,
+          categories: book.categories || [],
+          quality_score: book.quality_score || null,
+          entity_counts: item.indexData ? {
+            people: item.indexData.people?.length || 0,
+            places: item.indexData.places?.length || 0,
+            concepts: item.indexData.concepts?.length || 0,
+            terms: item.indexData.entries?.length || 0,
+          } : null,
+        },
+        updated_at: new Date().toISOString(),
+      };
+    });
+
+    const { error } = await supabase.from('book_embeddings').upsert(rows, {
+      onConflict: 'book_id',
+    });
+
+    if (error) {
+      console.error(`  Supabase upsert error: ${error.message}`);
+      errors += rows.length;
+    } else {
+      embedded += rows.length;
+    }
+
+    // Progress
+    const elapsed = (Date.now() - startTime) / 1000;
+    const rate = embedded / elapsed;
+    const remaining = ((bookIds.length - i - BATCH_SIZE) / rate) || 0;
+    process.stdout.write(
+      `\r  ${embedded}/${bookIds.length} embedded (${rate.toFixed(1)}/s, ~${Math.ceil(remaining / 60)}min left, ${errors} errors, ${skipped} skipped)`
+    );
+
+    // Gentle rate limiting
+    await sleep(200);
+  }
+
+  console.log(`\n\nDone!`);
+  console.log(`  Embedded: ${embedded}`);
+  console.log(`  Skipped: ${skipped}`);
+  console.log(`  Errors: ${errors}`);
+  console.log(`  Time: ${((Date.now() - startTime) / 1000).toFixed(0)}s`);
+
+  await mongo.close();
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/migration/backfill-book-embeddings.mjs
+++ b/scripts/migration/backfill-book-embeddings.mjs
@@ -236,39 +236,46 @@ async function main() {
 
   if (LIMIT > 0) bookIds = bookIds.slice(0, LIMIT);
 
-  // Load all book_indexes in bulk
-  console.log('Loading book_indexes...');
-  const indexDocs = await db.collection('book_indexes')
-    .find(
-      BOOK_ID ? { book_id: BOOK_ID } : {},
-      { maxTimeMS: 60000 }
-    )
-    .toArray();
-  const indexMap = new Map(indexDocs.map(d => [d.book_id, d]));
-  console.log(`Loaded ${indexMap.size} book_indexes entries`);
+  // Only project the fields we need from book_indexes (skip pageSummaries which are huge)
+  const INDEX_PROJECTION = {
+    book_id: 1,
+    bookSummary: 1,
+    sectionSummaries: { $slice: 15 },
+    'entries.term': 1, 'entries.pages': 1,
+    people: { $slice: 30 },
+    places: { $slice: 20 },
+    concepts: { $slice: 30 },
+  };
 
   const bookMap = new Map(books.map(b => [b.id, b]));
 
   if (DRY_RUN) {
-    let withIndex = 0, withoutIndex = 0;
-    for (const bookId of bookIds) {
-      if (indexMap.has(bookId)) withIndex++;
-      else withoutIndex++;
-    }
+    // For dry run, just count which books have indexes (lightweight query)
+    const indexCount = await db.collection('book_indexes')
+      .countDocuments(BOOK_ID ? { book_id: BOOK_ID } : {}, { maxTimeMS: 30000 });
     console.log(`\nDry run summary:`);
     console.log(`  ${bookIds.length} books to embed`);
-    console.log(`  ${withIndex} with book_indexes (rich embedding)`);
-    console.log(`  ${withoutIndex} without (fallback: title+desc+categories)`);
+    console.log(`  ${indexCount} with book_indexes (rich embedding)`);
+    console.log(`  ${bookIds.length - indexCount} without (fallback: title+desc+categories)`);
     await mongo.close();
     return;
   }
 
-  // Process in batches
+  // Process in batches — fetch book_indexes per batch to avoid OOM
   let embedded = 0, skipped = 0, errors = 0;
   const startTime = Date.now();
 
   for (let i = 0; i < bookIds.length; i += BATCH_SIZE) {
     const batchIds = bookIds.slice(i, i + BATCH_SIZE);
+
+    // Fetch indexes for this batch only
+    const indexDocs = await db.collection('book_indexes')
+      .find({ book_id: { $in: batchIds } })
+      .project(INDEX_PROJECTION)
+      .maxTimeMS(15000)
+      .toArray();
+    const indexMap = new Map(indexDocs.map(d => [d.book_id, d]));
+
     const batchTexts = [];
     const batchBooks = [];
 

--- a/scripts/migration/book-embeddings-schema.sql
+++ b/scripts/migration/book-embeddings-schema.sql
@@ -73,3 +73,45 @@ BEGIN
   LIMIT match_count;
 END;
 $$;
+
+-- RPC: scoped page-level semantic search within specific books (step 2)
+-- Scans only pages belonging to the given book_ids — instant for 200-500 pages.
+CREATE OR REPLACE FUNCTION match_pages_in_books(
+  query_embedding vector(768),
+  book_ids TEXT[],
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 10
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.page_id,
+    p.book_id,
+    p.page_number,
+    p.translation,
+    p.book_title,
+    p.book_author,
+    p.book_language,
+    p.book_year,
+    1 - (p.embedding <=> query_embedding) AS similarity
+  FROM page_translations p
+  WHERE p.book_id = ANY(book_ids)
+    AND p.embedding IS NOT NULL
+    AND 1 - (p.embedding <=> query_embedding) > match_threshold
+  ORDER BY p.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/scripts/migration/book-embeddings-schema.sql
+++ b/scripts/migration/book-embeddings-schema.sql
@@ -1,0 +1,75 @@
+-- Book-level semantic embeddings for fast discovery search.
+-- Model: gemini-embedding-2-preview (768 dims)
+-- Source: composed from book_indexes enrichment data (summaries, vocabulary, entities)
+-- Issue: #1158
+
+-- Ensure pgvector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Main table: one embedding per book, composed from enrichment data
+CREATE TABLE IF NOT EXISTS book_embeddings (
+  book_id TEXT PRIMARY KEY,
+  title TEXT,
+  author TEXT,
+  year INT,
+  language TEXT,
+  summary_text TEXT,              -- the composed text that was embedded
+  embedding vector(768) NOT NULL, -- gemini-embedding-2-preview
+  metadata JSONB DEFAULT '{}',    -- entity counts, categories, quality_score
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- HNSW index for fast cosine similarity search (~17K rows)
+-- m=16, ef_construction=64 is good for <100K vectors
+CREATE INDEX IF NOT EXISTS book_embeddings_embedding_idx
+  ON book_embeddings USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+-- Filter indexes for scoped searches
+CREATE INDEX IF NOT EXISTS book_embeddings_language_idx
+  ON book_embeddings (language);
+
+CREATE INDEX IF NOT EXISTS book_embeddings_year_idx
+  ON book_embeddings (year);
+
+-- RPC: semantic book discovery search
+CREATE OR REPLACE FUNCTION match_books_semantic(
+  query_embedding vector(768),
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 20,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL
+)
+RETURNS TABLE (
+  book_id TEXT,
+  title TEXT,
+  author TEXT,
+  year INT,
+  language TEXT,
+  summary_text TEXT,
+  metadata JSONB,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    b.book_id,
+    b.title,
+    b.author,
+    b.year,
+    b.language,
+    b.summary_text,
+    b.metadata,
+    1 - (b.embedding <=> query_embedding) AS similarity
+  FROM book_embeddings b
+  WHERE 1 - (b.embedding <=> query_embedding) > match_threshold
+    AND (filter_language IS NULL OR b.language = filter_language)
+    AND (filter_year_min IS NULL OR b.year >= filter_year_min)
+    AND (filter_year_max IS NULL OR b.year <= filter_year_max)
+  ORDER BY b.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -37,6 +37,7 @@
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { logUsage as logUsageToSupabase } from './lib/supabase-usage-logger.mjs';
+import { createClient } from '@supabase/supabase-js';
 
 /** Trigger on-demand revalidation for a book page after enrichment completes. */
 async function revalidateBookPage(bookId) {
@@ -135,6 +136,120 @@ async function markFailed(db, bookId, reason, retries) {
       },
     },
   );
+}
+
+// ── Book embedding upsert (issue #1158) ──
+// After generating book_indexes, compose + embed + upsert to Supabase book_embeddings.
+// Non-blocking: failures are logged but don't fail enrichment.
+
+const SUPABASE_URL = (process.env.SUPABASE_URL || '').trim();
+const SUPABASE_SERVICE_KEY = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+const supabaseClient = SUPABASE_URL && SUPABASE_SERVICE_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, { auth: { persistSession: false } })
+  : null;
+
+const EMBED_MODEL = 'gemini-embedding-2-preview';
+const EMBED_DIMS = 768;
+
+function composeBookEmbeddingText(book, indexData) {
+  const parts = [];
+  parts.push(`${book.display_title || book.title || 'Untitled'} by ${book.author || 'Unknown'}`);
+  if (book.language) parts.push(`Language: ${book.language}`);
+  if (book.published) parts.push(`Published: ${book.published}`);
+
+  if (indexData?.bookSummary?.detailed) {
+    parts.push(indexData.bookSummary.detailed);
+  } else if (indexData?.bookSummary?.brief) {
+    parts.push(indexData.bookSummary.brief);
+  }
+
+  if (indexData?.sectionSummaries?.length > 0) {
+    const sections = indexData.sectionSummaries.map(s => s.title || s.summary).filter(Boolean).slice(0, 15);
+    if (sections.length > 0) parts.push(`Chapters: ${sections.join('; ')}`);
+  }
+
+  if (indexData?.entries?.length > 0) {
+    const terms = indexData.entries
+      .sort((a, b) => (b.pages?.length || 0) - (a.pages?.length || 0))
+      .slice(0, 50).map(e => e.term);
+    parts.push(`Topics: ${terms.join(', ')}`);
+  }
+
+  if (indexData?.people?.length > 0) parts.push(`People: ${indexData.people.slice(0, 30).map(p => p.name).join(', ')}`);
+  if (indexData?.places?.length > 0) parts.push(`Places: ${indexData.places.slice(0, 20).map(p => p.name).join(', ')}`);
+  if (indexData?.concepts?.length > 0) parts.push(`Concepts: ${indexData.concepts.slice(0, 30).map(c => c.name).join(', ')}`);
+
+  if (book.categories?.length > 0) parts.push(`Categories: ${book.categories.join(', ')}`);
+
+  return parts.join('\n').slice(0, 8000);
+}
+
+async function upsertBookEmbedding(book, indexData) {
+  if (!supabaseClient) return;
+
+  const geminiKey = API_KEYS[0];
+  if (!geminiKey) return;
+
+  const text = composeBookEmbeddingText(book, indexData);
+  if (text.length < 10) return;
+
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${EMBED_MODEL}:batchEmbedContents?key=${geminiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          requests: [{
+            model: `models/${EMBED_MODEL}`,
+            content: { parts: [{ text }] },
+            outputDimensionality: EMBED_DIMS,
+          }],
+        }),
+        signal: AbortSignal.timeout(10000),
+      }
+    );
+
+    if (!res.ok) {
+      console.warn(`    [embed] Gemini ${res.status} — skipping book embedding`);
+      return;
+    }
+
+    const data = await res.json();
+    const embedding = data?.embeddings?.[0]?.values;
+    if (!embedding) return;
+
+    const yearMatch = (book.published || '').match(/\d{3,4}/);
+    const { error } = await supabaseClient.from('book_embeddings').upsert({
+      book_id: book.id,
+      title: book.display_title || book.title || '',
+      author: book.author || '',
+      year: yearMatch ? parseInt(yearMatch[0]) : null,
+      language: book.language || null,
+      summary_text: text,
+      embedding: JSON.stringify(embedding),
+      metadata: {
+        has_index: true,
+        categories: book.categories || [],
+        quality_score: book.quality_score || null,
+        entity_counts: {
+          people: indexData?.people?.length || 0,
+          places: indexData?.places?.length || 0,
+          concepts: indexData?.concepts?.length || 0,
+          terms: indexData?.entries?.length || 0,
+        },
+      },
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'book_id' });
+
+    if (error) {
+      console.warn(`    [embed] Supabase upsert failed: ${error.message}`);
+    } else {
+      console.log(`    [embed] Book embedding upserted`);
+    }
+  } catch (err) {
+    console.warn(`    [embed] Failed: ${err.message}`);
+  }
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -963,6 +1078,11 @@ async function enrichBook(db, book) {
   // Sync entities (non-blocking)
   syncBookEntities(db, bookId, bookTitle, bookAuthor, conceptIndex, book.year || null).catch(err => {
     console.error(`    Entity sync failed:`, err.message);
+  });
+
+  // Upsert book embedding to Supabase (non-blocking, issue #1158)
+  upsertBookEmbedding(book, index).catch(err => {
+    console.warn(`    [embed] Book embedding failed: ${err.message}`);
   });
 
   console.log(`    Done — ${batchExtractions.length} batches, ${groundedBatchQuotes.length} quotes, ${sectionSummaries.length} sections`);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -4,7 +4,7 @@ import { Book } from '@/lib/types';
 import type { SearchResult, SearchResponse } from '@/lib/api-client/types/search';
 import { buildPageSearchStage } from '@/lib/atlas-search';
 import { searchBookIds } from '@/lib/books-catalog';
-import { semanticPageSearch } from '@/lib/semantic-search';
+import { semanticBookSearch } from '@/lib/semantic-search';
 
 export const preferredRegion = 'fra1';
 
@@ -223,10 +223,19 @@ export async function GET(request: NextRequest) {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          return await semanticPageSearch(query, MAX_PAGE_RESULTS, {
-            keywordWeight: 0.3,
-            semanticWeight: 0.7,
-          });
+          const books = await semanticBookSearch(query, MAX_PAGE_RESULTS);
+          // Map book results to page-shaped results for merge compatibility
+          return books.map(b => ({
+            page_id: '',
+            book_id: b.book_id,
+            page_number: 0,
+            snippet: (b.summary_text || '').slice(0, 300),
+            score: b.similarity,
+            book_title: b.title,
+            book_author: b.author,
+            book_language: b.language,
+            book_year: b.year,
+          }));
         } catch {
           return [];
         }

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -1,111 +1,45 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
-import { getQueryEmbedding } from '@/lib/semantic-search';
+import { semanticBookSearch } from '@/lib/semantic-search';
 
 export const dynamic = 'force-dynamic';
 
 /**
- * GET /api/search/semantic?q=how+to+transmute+metals&limit=20
+ * GET /api/search/semantic?q=transmutation+of+metals&limit=20
  *
- * Hybrid semantic + keyword search across translated pages.
- * Uses pgvector (semantic similarity) + tsvector (keyword matching)
- * in a single Supabase query for ranked results.
+ * Book-level semantic search via book_embeddings table (HNSW, ~17K vectors).
+ * Replaces the broken hybrid_search on 3M+ page_translations (issue #1158).
  *
  * Query params:
- *   q      — search query (required)
- *   limit  — max results (default 20, max 50)
- *   kw     — keyword weight 0-1 (default 0.4)
- *   sem    — semantic weight 0-1 (default 0.6)
+ *   q        — search query (required)
+ *   limit    — max results (default 20, max 50)
+ *   language — filter by language
+ *   year_min — filter by minimum year
+ *   year_max — filter by maximum year
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const query = searchParams.get('q')?.trim();
   const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 50);
-  const keywordWeight = Math.max(0, Math.min(1, parseFloat(searchParams.get('kw') || '0.4')));
-  const semanticWeight = Math.max(0, Math.min(1, parseFloat(searchParams.get('sem') || '0.6')));
+  const language = searchParams.get('language') || undefined;
+  const yearMin = searchParams.get('year_min') ? parseInt(searchParams.get('year_min')!, 10) : undefined;
+  const yearMax = searchParams.get('year_max') ? parseInt(searchParams.get('year_max')!, 10) : undefined;
 
   if (!query || query.length < 2) {
     return NextResponse.json({ results: [], query: '' });
   }
 
   try {
-    // Generate query embedding server-side
-    const queryEmbedding = await getQueryEmbedding(query);
-
-    if (!queryEmbedding) {
-      // Fall back to keyword-only search if embedding fails
-      return keywordOnlySearch(query, limit);
-    }
-
-    // Call hybrid search function
-    const { data, error } = await supabase.rpc('hybrid_search', {
-      query_text: query,
-      query_embedding: JSON.stringify(queryEmbedding),
-      match_count: limit,
-      keyword_weight: keywordWeight,
-      semantic_weight: semanticWeight,
+    const books = await semanticBookSearch(query, limit, {
+      language,
+      yearMin,
+      yearMax,
     });
 
-    if (error) {
-      console.error('[semantic-search] Supabase error:', error.message);
-      return keywordOnlySearch(query, limit);
-    }
-
-    // Group by book for better UX
-    interface PageResult {
-      page_id: string;
-      page_number: number;
-      snippet: string;
-      score: number;
-      keyword_rank: number;
-      semantic_distance: number;
-    }
-
-    interface BookGroup {
-      book_id: string;
-      book_title: string;
-      book_author: string | null;
-      book_language: string | null;
-      book_year: number | null;
-      pages: PageResult[];
-      best_score: number;
-    }
-
-    const bookGroups = new Map<string, BookGroup>();
-
-    for (const row of (data || [])) {
-      const group: BookGroup = bookGroups.get(row.book_id) || {
-        book_id: row.book_id,
-        book_title: row.book_title,
-        book_author: row.book_author,
-        book_language: row.book_language,
-        book_year: row.book_year,
-        pages: [],
-        best_score: 0,
-      };
-
-      group.pages.push({
-        page_id: row.page_id,
-        page_number: row.page_number,
-        snippet: row.translation || '',
-        score: Number(row.score) || 0,
-        keyword_rank: Number(row.keyword_rank) || 0,
-        semantic_distance: Number(row.semantic_distance) || 1,
-      });
-
-      group.best_score = Math.max(group.best_score, Number(row.score) || 0);
-      bookGroups.set(row.book_id, group);
-    }
-
-    // Sort books by best page score
-    const results = Array.from(bookGroups.values())
-      .sort((a, b) => b.best_score - a.best_score);
-
     return NextResponse.json({
-      results,
+      results: books,
       query,
-      total: data?.length || 0,
-      mode: 'hybrid',
+      total: books.length,
+      mode: 'semantic',
     }, {
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
     });
@@ -116,37 +50,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-}
-
-/**
- * Fallback: keyword-only search via tsvector
- */
-async function keywordOnlySearch(query: string, limit: number) {
-  const { data, error } = await supabase
-    .from('page_translations')
-    .select('page_id, book_id, page_number, translation, book_title, book_author, book_language, book_year')
-    .textSearch('tsv', query, { type: 'websearch' })
-    .limit(limit);
-
-  if (error) {
-    return NextResponse.json({ results: [], query, error: error.message }, { status: 500 });
-  }
-
-  return NextResponse.json({
-    results: (data || []).map(r => ({
-      book_id: r.book_id,
-      book_title: r.book_title,
-      book_author: r.book_author,
-      pages: [{
-        page_id: r.page_id,
-        page_number: r.page_number,
-        snippet: (r.translation || '').slice(0, 500),
-        score: 1,
-      }],
-      best_score: 1,
-    })),
-    query,
-    total: data?.length || 0,
-    mode: 'keyword',
-  });
 }

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -4,7 +4,7 @@ import { supabase } from '@/lib/supabase';
 import type { BookSearchFilters } from '@/lib/atlas-search';
 import type { SearchResult } from '@/lib/api-client/types/search';
 import { searchBookIds } from '@/lib/books-catalog';
-import { semanticPageSearch } from '@/lib/semantic-search';
+import { semanticBookSearch } from '@/lib/semantic-search';
 
 // CLIP server on Hetzner for visual text→image search
 const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
@@ -99,9 +99,8 @@ export async function GET(request: NextRequest) {
       title: string;
       author: string | null;
       language: string | null;
-      snippet: string;
-      page_number: number;
-      score: number;
+      summary_snippet: string;
+      similarity: number;
     }
     const emptySemanticBooks = { results: [] as SemanticBookResult[], total: 0 };
 
@@ -116,24 +115,17 @@ export async function GET(request: NextRequest) {
       ),
       withTimeout(searchGallery(db, query, queryRegex, galleryLimit), emptyGallery, 'gallery'),
       withTimeout(searchVisual(query, galleryLimit), emptyGallery, 'visual', 5000),
-      // Semantic search: conceptual matches that keyword search misses
+      // Semantic search: book-level discovery via book_embeddings (HNSW, ~17K rows)
       withTimeout(
-        semanticPageSearch(query, 8, { keywordWeight: 0.3, semanticWeight: 0.7 })
-          .then(pages => {
-            // Dedupe by book, keep best page per book
-            const byBook = new Map<string, typeof pages[0]>();
-            for (const p of pages) {
-              const existing = byBook.get(p.book_id);
-              if (!existing || p.score > existing.score) byBook.set(p.book_id, p);
-            }
-            const results = Array.from(byBook.values()).map(p => ({
-              book_id: p.book_id,
-              title: p.book_title,
-              author: p.book_author,
-              language: p.book_language,
-              snippet: p.snippet,
-              page_number: p.page_number,
-              score: p.score,
+        semanticBookSearch(query, 8)
+          .then(books => {
+            const results = books.map(b => ({
+              book_id: b.book_id,
+              title: b.title,
+              author: b.author,
+              language: b.language,
+              summary_snippet: (b.summary_text || '').slice(0, 300),
+              similarity: b.similarity,
             }));
             return { results, total: results.length };
           })

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -293,66 +293,41 @@ async function executeSearchCollection(query: string, searchBooks = true): Promi
 async function executeSearchSemantic(query: string): Promise<
   Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>
 > {
-  // Use book-level semantic search (issue #1158) — fast HNSW on ~17K vectors
-  const { semanticBookSearch } = await import('@/lib/semantic-search');
+  // Two-step search (issue #1158):
+  // Step 1: book discovery via book_embeddings (HNSW, ~17K vectors, instant)
+  // Step 2: page drill-down via match_pages_in_books (scoped to found books)
+  const { semanticBookSearch, semanticPageSearchScoped } = await import('@/lib/semantic-search');
   try {
     const books = await semanticBookSearch(query, 8);
-    return books.map(b => ({
-      book_id: b.book_id,
-      bookTitle: b.title || 'Unknown',
-      bookAuthor: b.author || 'Unknown',
-      bookSlug: undefined,
-      page_number: 0,
-      snippet: (b.summary_text || '').slice(0, 500),
-      score: b.similarity,
-    }));
+    if (books.length === 0) return [];
+
+    // Step 2: get best page citations from top books
+    const bookIds = books.map(b => b.book_id);
+    const pages = await semanticPageSearchScoped(query, bookIds, 8);
+
+    // Build a map of best page per book
+    const bestPageByBook = new Map<string, typeof pages[0]>();
+    for (const p of pages) {
+      const existing = bestPageByBook.get(p.book_id);
+      if (!existing || p.score > existing.score) bestPageByBook.set(p.book_id, p);
+    }
+
+    // Return book results, enriched with page citations where available
+    return books.map(b => {
+      const page = bestPageByBook.get(b.book_id);
+      return {
+        book_id: b.book_id,
+        bookTitle: b.title || 'Unknown',
+        bookAuthor: b.author || 'Unknown',
+        bookSlug: undefined,
+        page_number: page?.page_number || 0,
+        snippet: page?.snippet || (b.summary_text || '').slice(0, 500),
+        score: b.similarity,
+      };
+    });
   } catch {
     return [];
   }
-}
-
-// Legacy embedding-based search (kept for reference, unused)
-async function _legacyExecuteSearchSemantic(query: string): Promise<
-  Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>
-> {
-  const embedUrl = process.env.EMBED_URL || 'http://46.224.122.120:3456';
-  let queryEmbedding: number[] | null = null;
-  try {
-    const res = await fetch(`${embedUrl}/embed`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ texts: [query], task: 'query' }),
-      signal: AbortSignal.timeout(3000),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      queryEmbedding = data?.embeddings?.[0] || null;
-    }
-  } catch { /* embedding server unavailable */ }
-
-  if (!queryEmbedding) {
-    const { data } = await supabase
-      .from('page_translations')
-      .select('page_id, book_id, page_number, translation, book_title, book_author')
-      .textSearch('tsv', query, { type: 'websearch' })
-      .limit(8);
-    return (data || []).map(r => ({
-      book_id: r.book_id, bookTitle: r.book_title || 'Unknown', bookAuthor: r.book_author || 'Unknown',
-      page_number: r.page_number, snippet: (r.translation || '').slice(0, 500), score: 1,
-    }));
-  }
-
-  const { data } = await supabase.rpc('hybrid_search', {
-    query_text: query, query_embedding: JSON.stringify(queryEmbedding),
-    match_count: 8, keyword_weight: 0.3, semantic_weight: 0.7,
-  });
-
-  return (data || []).map((r: Record<string, unknown>) => ({
-    book_id: r.book_id as string, bookTitle: (r.book_title as string) || 'Unknown',
-    bookAuthor: (r.book_author as string) || 'Unknown', bookSlug: undefined,
-    page_number: r.page_number as number, snippet: ((r.translation as string) || '').slice(0, 500),
-    score: Number(r.score) || 0,
-  }));
 }
 
 async function executeSearchWikipedia(query: string): Promise<{ title: string; summary: string; url: string } | null> {

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -293,6 +293,28 @@ async function executeSearchCollection(query: string, searchBooks = true): Promi
 async function executeSearchSemantic(query: string): Promise<
   Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>
 > {
+  // Use book-level semantic search (issue #1158) — fast HNSW on ~17K vectors
+  const { semanticBookSearch } = await import('@/lib/semantic-search');
+  try {
+    const books = await semanticBookSearch(query, 8);
+    return books.map(b => ({
+      book_id: b.book_id,
+      bookTitle: b.title || 'Unknown',
+      bookAuthor: b.author || 'Unknown',
+      bookSlug: undefined,
+      page_number: 0,
+      snippet: (b.summary_text || '').slice(0, 500),
+      score: b.similarity,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// Legacy embedding-based search (kept for reference, unused)
+async function _legacyExecuteSearchSemantic(query: string): Promise<
+  Array<{ book_id: string; bookTitle: string; bookAuthor: string; bookSlug?: string; page_number: number; snippet: string; score: number }>
+> {
   const embedUrl = process.env.EMBED_URL || 'http://46.224.122.120:3456';
   let queryEmbedding: number[] | null = null;
   try {

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -2,7 +2,7 @@ import { supabase } from '@/lib/supabase';
 
 /**
  * Generate query embedding via Gemini embedding-2-preview.
- * Must use the same model as the backfill (embed-gemini.mjs).
+ * Must use the same model as the backfill (embed-gemini.mjs / backfill-book-embeddings.mjs).
  * Falls back to Hetzner e5-base if Gemini fails.
  */
 export async function getQueryEmbedding(query: string): Promise<number[] | null> {
@@ -50,6 +50,59 @@ export async function getQueryEmbedding(query: string): Promise<number[] | null>
   }
 }
 
+// ── Book-level semantic search (issue #1158) ────────────────────────
+
+export interface SemanticBookResult {
+  book_id: string;
+  title: string;
+  author: string | null;
+  year: number | null;
+  language: string | null;
+  summary_text: string | null;
+  metadata: Record<string, unknown> | null;
+  similarity: number;
+}
+
+/**
+ * Semantic book discovery via book_embeddings table (HNSW, ~17K rows).
+ * Replaces the broken hybrid_search on 3M+ page_translations.
+ */
+export async function semanticBookSearch(
+  query: string,
+  limit: number = 20,
+  opts?: { language?: string; yearMin?: number; yearMax?: number; threshold?: number }
+): Promise<SemanticBookResult[]> {
+  const queryEmbedding = await getQueryEmbedding(query);
+  if (!queryEmbedding) return [];
+
+  const { data, error } = await supabase.rpc('match_books_semantic', {
+    query_embedding: JSON.stringify(queryEmbedding),
+    match_threshold: opts?.threshold ?? 0.3,
+    match_count: limit,
+    filter_language: opts?.language ?? null,
+    filter_year_min: opts?.yearMin ?? null,
+    filter_year_max: opts?.yearMax ?? null,
+  });
+
+  if (error) {
+    console.error('[semantic-search] match_books_semantic error:', error.message);
+    return [];
+  }
+
+  return (data || []).map((row: any) => ({
+    book_id: row.book_id,
+    title: row.title,
+    author: row.author,
+    year: row.year,
+    language: row.language,
+    summary_text: row.summary_text,
+    metadata: row.metadata,
+    similarity: Number(row.similarity) || 0,
+  }));
+}
+
+// ── Page-level scoped search (step 2: within a book) ────────────────
+
 export interface SemanticPageResult {
   page_id: string;
   book_id: string;
@@ -63,42 +116,67 @@ export interface SemanticPageResult {
 }
 
 /**
- * Run hybrid semantic + keyword search on page_translations.
- * Returns flat page results (not grouped by book) for easy merging.
+ * Scoped page-level semantic search within specific books.
+ * Used as step 2 after book discovery — never searches all pages globally.
+ */
+export async function semanticPageSearchScoped(
+  query: string,
+  bookIds: string[],
+  limit: number = 10,
+): Promise<SemanticPageResult[]> {
+  if (bookIds.length === 0) return [];
+
+  const queryEmbedding = await getQueryEmbedding(query);
+  if (!queryEmbedding) return [];
+
+  // Use match_semantic RPC if available, otherwise direct query
+  const { data, error } = await supabase.rpc('match_semantic', {
+    query_embedding: JSON.stringify(queryEmbedding),
+    match_threshold: 0.3,
+    match_count: limit,
+  });
+
+  if (error) {
+    console.error('[semantic-search] match_semantic error:', error.message);
+    return [];
+  }
+
+  // Filter to requested books (RPC may not support book_id filter)
+  const bookIdSet = new Set(bookIds);
+  return (data || [])
+    .filter((row: any) => bookIdSet.has(row.book_id))
+    .map((row: any) => ({
+      page_id: row.page_id,
+      book_id: row.book_id,
+      page_number: row.page_number,
+      snippet: (row.translation || '').slice(0, 300),
+      score: Number(row.similarity) || 0,
+      book_title: row.book_title,
+      book_author: row.book_author,
+      book_language: row.book_language,
+      book_year: row.book_year,
+    }));
+}
+
+/**
+ * @deprecated Use semanticBookSearch instead. This hits the broken hybrid_search RPC.
  */
 export async function semanticPageSearch(
   query: string,
   limit: number = 20,
   opts?: { keywordWeight?: number; semanticWeight?: number }
 ): Promise<SemanticPageResult[]> {
-  const keywordWeight = opts?.keywordWeight ?? 0.3;
-  const semanticWeight = opts?.semanticWeight ?? 0.7;
-
-  const queryEmbedding = await getQueryEmbedding(query);
-  if (!queryEmbedding) return [];
-
-  const { data, error } = await supabase.rpc('hybrid_search', {
-    query_text: query,
-    query_embedding: JSON.stringify(queryEmbedding),
-    match_count: limit,
-    keyword_weight: keywordWeight,
-    semantic_weight: semanticWeight,
-  });
-
-  if (error) {
-    console.error('[semantic-search] Supabase hybrid_search error:', error.message);
-    return [];
-  }
-
-  return (data || []).map((row: any) => ({
-    page_id: row.page_id,
-    book_id: row.book_id,
-    page_number: row.page_number,
-    snippet: (row.translation || '').slice(0, 300),
-    score: Number(row.score) || 0,
-    book_title: row.book_title,
-    book_author: row.book_author,
-    book_language: row.book_language,
-    book_year: row.book_year,
+  // Redirect to book-level search, return best page per book
+  const books = await semanticBookSearch(query, limit);
+  return books.map(b => ({
+    page_id: '',
+    book_id: b.book_id,
+    page_number: 0,
+    snippet: (b.summary_text || '').slice(0, 300),
+    score: b.similarity,
+    book_title: b.title,
+    book_author: b.author,
+    book_language: b.language,
+    book_year: b.year,
   }));
 }

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -101,7 +101,7 @@ export async function semanticBookSearch(
   }));
 }
 
-// ── Page-level scoped search (step 2: within a book) ────────────────
+// ── Page-level scoped search (step 2: within specific books) ────────
 
 export interface SemanticPageResult {
   page_id: string;
@@ -117,6 +117,9 @@ export interface SemanticPageResult {
 
 /**
  * Scoped page-level semantic search within specific books.
+ * Uses match_pages_in_books RPC — scans only pages for the given book_ids
+ * (200-500 pages per book, instant without a global index).
+ *
  * Used as step 2 after book discovery — never searches all pages globally.
  */
 export async function semanticPageSearchScoped(
@@ -129,54 +132,27 @@ export async function semanticPageSearchScoped(
   const queryEmbedding = await getQueryEmbedding(query);
   if (!queryEmbedding) return [];
 
-  // Use match_semantic RPC if available, otherwise direct query
-  const { data, error } = await supabase.rpc('match_semantic', {
+  const { data, error } = await supabase.rpc('match_pages_in_books', {
     query_embedding: JSON.stringify(queryEmbedding),
+    book_ids: bookIds,
     match_threshold: 0.3,
     match_count: limit,
   });
 
   if (error) {
-    console.error('[semantic-search] match_semantic error:', error.message);
+    console.error('[semantic-search] match_pages_in_books error:', error.message);
     return [];
   }
 
-  // Filter to requested books (RPC may not support book_id filter)
-  const bookIdSet = new Set(bookIds);
-  return (data || [])
-    .filter((row: any) => bookIdSet.has(row.book_id))
-    .map((row: any) => ({
-      page_id: row.page_id,
-      book_id: row.book_id,
-      page_number: row.page_number,
-      snippet: (row.translation || '').slice(0, 300),
-      score: Number(row.similarity) || 0,
-      book_title: row.book_title,
-      book_author: row.book_author,
-      book_language: row.book_language,
-      book_year: row.book_year,
-    }));
-}
-
-/**
- * @deprecated Use semanticBookSearch instead. This hits the broken hybrid_search RPC.
- */
-export async function semanticPageSearch(
-  query: string,
-  limit: number = 20,
-  opts?: { keywordWeight?: number; semanticWeight?: number }
-): Promise<SemanticPageResult[]> {
-  // Redirect to book-level search, return best page per book
-  const books = await semanticBookSearch(query, limit);
-  return books.map(b => ({
-    page_id: '',
-    book_id: b.book_id,
-    page_number: 0,
-    snippet: (b.summary_text || '').slice(0, 300),
-    score: b.similarity,
-    book_title: b.title,
-    book_author: b.author,
-    book_language: b.language,
-    book_year: b.year,
+  return (data || []).map((row: any) => ({
+    page_id: row.page_id,
+    book_id: row.book_id,
+    page_number: row.page_number,
+    snippet: (row.translation || '').slice(0, 300),
+    score: Number(row.similarity) || 0,
+    book_title: row.book_title,
+    book_author: row.book_author,
+    book_language: row.book_language,
+    book_year: row.book_year,
   }));
 }


### PR DESCRIPTION
## Summary

Closes #1158

- Replaces broken `hybrid_search` RPC (timed out on 3M+ page rows) with **book-level embeddings** composed from enrichment data (summaries, vocabulary, entities)
- ~17K vectors instead of 3M — instant HNSW search, no timeouts
- Enrich-worker auto-upserts embedding after Phase 6 (incremental)
- All search routes updated: `/api/search/semantic`, `/api/search/unified`, `/api/search`, librarian

## What's included

| File | Change |
|------|--------|
| `scripts/migration/book-embeddings-schema.sql` | Table + HNSW index + `match_books_semantic` RPC |
| `scripts/migration/backfill-book-embeddings.mjs` | Bulk backfill from `book_indexes` → Gemini → Supabase |
| `src/lib/semantic-search.ts` | New `semanticBookSearch()` + scoped page search |
| `src/app/api/search/semantic/route.ts` | Rewritten to use book embeddings |
| `src/app/api/search/unified/route.ts` | Updated semantic lane |
| `src/app/api/search/route.ts` | Updated semantic merge |
| `src/lib/embassy/librarian.ts` | Updated to use book-level search |
| `scripts/workers/enrich-worker.mjs` | Auto-upsert embedding after Phase 6 |

## Deploy steps

1. Run schema migration: `node scripts/migration/run-supabase-sql.mjs scripts/migration/book-embeddings-schema.sql`
2. Run backfill on Hetzner: `node scripts/migration/backfill-book-embeddings.mjs` (~20 min, free tier)
3. Deploy to Vercel

## Test plan

- [ ] Run schema migration against Supabase
- [ ] Run backfill with `--dry-run` first to verify counts
- [ ] Run full backfill, verify ~17K rows in `book_embeddings`
- [ ] Test `/api/search/semantic?q=transmutation+of+metals` returns book results
- [ ] Test unified search includes semantic results
- [ ] Verify enrich-worker auto-embeds on next Phase 6 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)