### PR TITLE
Fuzzy page search for morphological variants

### DIFF
--- a/src/lib/atlas-search.ts
+++ b/src/lib/atlas-search.ts
@@ -98,9 +98,16 @@ export function buildBookSearchStage(query: string, filters: BookSearchFilters =
  * Optionally filters by book_id (single or array via $in).
  */
 export function buildPageSearchStage(query: string, bookIds?: string | string[]): Document {
+  // Use fuzzy matching for single long words to catch morphological variants
+  // (e.g. "masturbation" matches "masturbator", "extraterrestrial" matches "extraterrestrials")
+  const words = query.trim().split(/\s+/);
+  const fuzzy = words.length === 1 && words[0].length >= 6
+    ? { maxEdits: 1, prefixLength: 4 }
+    : undefined;
+
   const should: Document[] = [
-    { text: { query, path: 'translation.data', score: { boost: { value: 2 } } } },
-    { text: { query, path: 'ocr.data' } },
+    { text: { query, path: 'translation.data', score: { boost: { value: 2 } }, ...(fuzzy && { fuzzy }) } },
+    { text: { query, path: 'ocr.data', ...(fuzzy && { fuzzy }) } },
   ];
 
   const filter: Document[] = [];


### PR DESCRIPTION
## Summary
- Searching "masturbation" missed Martial's Epigrams p.392 which contains "masturbator" — Atlas Search wasn't matching morphological variants
- Single long words (≥6 chars) now use fuzzy matching (`maxEdits: 1, prefixLength: 4`)
- Multi-word queries and short terms are unaffected

## Test plan
- [ ] Search "masturbation" — verify Martial's Epigrams appears in page results
- [ ] Search "extraterrestrial" — verify "extraterrestrials" pages also match
- [ ] Search "philosopher's stone" — verify multi-word queries still work normally
- [ ] Search "sex" — verify short words don't get fuzzy (would match "six", "set", etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)