### PR TITLE
Voice agent: extracted tools with 25 tests + structured logging

### DIFF
--- a/src/app/api/embassy/voice/route.ts
+++ b/src/app/api/embassy/voice/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
   }
 
   try {
+    const t0 = Date.now();
     const res = await fetch(
       `https://api.elevenlabs.io/v1/convai/conversation/get-signed-url?agent_id=${agentId}`,
       {
@@ -23,10 +24,11 @@ export async function GET() {
         headers: { 'xi-api-key': apiKey },
       },
     );
+    const latency = Date.now() - t0;
 
     if (!res.ok) {
       const text = await res.text();
-      console.error('[voice] ElevenLabs signed URL error:', res.status, text);
+      console.error(`[voice] Signed URL failed: ${res.status} (${latency}ms) agent=${agentId?.slice(0, 12)}...`, text);
       return NextResponse.json(
         { error: 'Failed to get signed URL' },
         { status: res.status },
@@ -34,9 +36,10 @@ export async function GET() {
     }
 
     const data = await res.json();
+    if (latency > 2000) console.warn(`[voice] Signed URL slow: ${latency}ms — ElevenLabs may be degraded`);
     return NextResponse.json({ signedUrl: data.signed_url });
   } catch (err) {
-    console.error('[voice] ElevenLabs signed URL error:', err);
+    console.error('[voice] Signed URL network error:', err);
     return NextResponse.json(
       { error: 'Internal error' },
       { status: 500 },

--- a/src/app/reading-room/voice/VoiceAgentClient.tsx
+++ b/src/app/reading-room/voice/VoiceAgentClient.tsx
@@ -40,25 +40,22 @@ function buildClientTools(addSources: (s: SourceResult[]) => void, addVisual: (v
       } catch (e) { return JSON.stringify({ error: String(e) }); }
     },
     search_semantic: async ({ query }: { query: string }): Promise<string> => {
-      // Semantic search (Supabase hybrid_search) is currently unreliable — redirect to keyword search
-      // TODO: re-enable when Supabase RPC performance is fixed
-      console.log('[voice-agent] search_semantic redirected to keyword search:', query);
+      console.log('[voice-agent] search_semantic called:', query);
       try {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 10000);
-        const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&limit=8&has_translation=true&search_content=true`, { signal: controller.signal });
+        const timeout = setTimeout(() => controller.abort(), 8000);
+        const res = await fetch(`/api/search/semantic?q=${encodeURIComponent(query)}&limit=8`, { signal: controller.signal });
         clearTimeout(timeout);
         if (!res.ok) throw new Error(`${res.status}`);
         const data = await res.json();
         const results = (data.results || []).slice(0, 6);
-        addSources(results.map((r: any) => ({
-          bookId: r.id || r.bookId, title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
-          slug: r.slug || r.bookSlug, pageNumber: r.pageNumber || r.page_number, snippet: r.snippet,
-        })));
+        const sources: SourceResult[] = [];
+        for (const r of results) for (const p of (r.pages || []).slice(0, 2))
+          sources.push({ bookId: r.book_id, title: r.title, author: r.author, slug: r.slug, pageNumber: p.page_number, snippet: p.snippet });
+        addSources(sources);
         return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
-          title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
-          bookId: r.id || r.bookId, slug: r.slug || r.bookSlug,
-          pageNumber: r.pageNumber || r.page_number, snippet: (r.snippet || '').slice(0, 300),
+          title: r.title, author: r.author, bookId: r.book_id, slug: r.slug,
+          topPage: r.pages?.[0]?.page_number, snippet: (r.pages?.[0]?.snippet || '').slice(0, 300),
         })) });
       } catch (e) {
         // Fallback to keyword search if semantic times out

--- a/src/app/reading-room/voice/VoiceAgentClient.tsx
+++ b/src/app/reading-room/voice/VoiceAgentClient.tsx
@@ -6,106 +6,11 @@ import { ConversationProvider, useConversation } from '@elevenlabs/react';
 import SiteHeader from '@/components/layout/SiteHeader';
 import Link from 'next/link';
 
+import { buildClientTools, type SourceResult, type Visual } from '@/lib/voice/client-tools';
+
 const HERO_IMG = 'https://images.sourcelibrary.org/artwork/reading-room-hero.png';
 
-// ── Types ─────────────────────────────────────────────────────────────
-
 interface TranscriptEntry { role: 'user' | 'agent'; text: string; isFinal: boolean }
-interface SourceResult { bookId: string; title: string; author: string; slug?: string; pageNumber?: number; snippet?: string }
-interface Visual { type: 'image' | 'page'; url: string; title: string; caption?: string; bookSlug?: string; pageNumber?: number }
-
-// ── Client Tools ──────────────────────────────────────────────────────
-
-function buildClientTools(addSources: (s: SourceResult[]) => void, addVisual: (v: Visual) => void) {
-  return {
-    search_library: async ({ query }: { query: string }): Promise<string> => {
-      console.log('[voice-agent] search_library called:', query);
-      try {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 10000);
-        const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&limit=8&has_translation=true`, { signal: controller.signal });
-        clearTimeout(timeout);
-        if (!res.ok) return JSON.stringify({ error: `${res.status}` });
-        const data = await res.json();
-        const results = (data.results || []).slice(0, 6);
-        addSources(results.map((r: any) => ({
-          bookId: r.id || r.bookId, title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
-          slug: r.slug || r.bookSlug, pageNumber: r.pageNumber || r.page_number, snippet: r.snippet,
-        })));
-        return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
-          title: r.title || r.bookTitle, author: r.author || r.bookAuthor, year: r.year,
-          bookId: r.id || r.bookId, slug: r.slug || r.bookSlug,
-          pageNumber: r.pageNumber || r.page_number, snippet: (r.snippet || '').slice(0, 300),
-        })) });
-      } catch (e) { return JSON.stringify({ error: String(e) }); }
-    },
-    search_semantic: async ({ query }: { query: string }): Promise<string> => {
-      console.log('[voice-agent] search_semantic called:', query);
-      try {
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 8000);
-        const res = await fetch(`/api/search/semantic?q=${encodeURIComponent(query)}&limit=8`, { signal: controller.signal });
-        clearTimeout(timeout);
-        if (!res.ok) throw new Error(`${res.status}`);
-        const data = await res.json();
-        const results = (data.results || []).slice(0, 6);
-        const sources: SourceResult[] = [];
-        for (const r of results) for (const p of (r.pages || []).slice(0, 2))
-          sources.push({ bookId: r.book_id, title: r.title, author: r.author, slug: r.slug, pageNumber: p.page_number, snippet: p.snippet });
-        addSources(sources);
-        return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
-          title: r.title, author: r.author, bookId: r.book_id, slug: r.slug,
-          topPage: r.pages?.[0]?.page_number, snippet: (r.pages?.[0]?.snippet || '').slice(0, 300),
-        })) });
-      } catch (e) {
-        // Fallback to keyword search if semantic times out
-        console.log('[voice-agent] semantic failed, falling back to keyword:', String(e));
-        try {
-          const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&limit=8&has_translation=true&search_content=true`);
-          if (!res.ok) return JSON.stringify({ error: `${res.status}` });
-          const data = await res.json();
-          const results = (data.results || []).slice(0, 6);
-          addSources(results.map((r: any) => ({
-            bookId: r.id || r.bookId, title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
-            slug: r.slug || r.bookSlug, pageNumber: r.pageNumber || r.page_number, snippet: r.snippet,
-          })));
-          return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
-            title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
-            bookId: r.id || r.bookId, slug: r.slug || r.bookSlug,
-            pageNumber: r.pageNumber || r.page_number, snippet: (r.snippet || '').slice(0, 300),
-          })) });
-        } catch (e2) { return JSON.stringify({ error: String(e2) }); }
-      }
-    },
-    read_page: async ({ book_id, page_number }: { book_id: string; page_number: number }): Promise<string> => {
-      try {
-        const res = await fetch(`/api/books/${book_id}/pages?page=${page_number}`);
-        if (!res.ok) return JSON.stringify({ error: `${res.status}` });
-        const data = await res.json();
-        const page = data.pages?.[0] || data;
-        const text = page.translation?.data || page.ocr?.data || '';
-        const imageUrl = page.compressed_photo || page.archived_photo || page.photo;
-        if (imageUrl) addVisual({ type: 'page', url: imageUrl, title: `Page ${page.page_number || page_number}`, caption: text.slice(0, 120) + (text.length > 120 ? '...' : ''), pageNumber: page.page_number || page_number });
-        return JSON.stringify({ text: text.slice(0, 2000), pageNumber: page.page_number || page_number, hasTranslation: !!page.translation?.data });
-      } catch (e) { return JSON.stringify({ error: String(e) }); }
-    },
-    search_images: async ({ query }: { query: string }): Promise<string> => {
-      try {
-        const res = await fetch(`/api/search/visual?q=${encodeURIComponent(query)}&limit=6`);
-        if (!res.ok) return JSON.stringify({ error: `${res.status}` });
-        const data = await res.json();
-        const images = (data.results || data.images || []).slice(0, 6);
-        for (const img of images) {
-          const url = img.imageUrl || img.fullImageUrl || img.image_url;
-          if (url) addVisual({ type: 'image', url, title: img.title || img.description || 'Illustration', caption: img.author, bookSlug: img.bookSlug || img.slug });
-        }
-        return JSON.stringify({ found: images.length, images: images.map((img: any) => ({
-          description: (img.title || img.description || '').slice(0, 200), bookTitle: img.book_title || img.title, subjects: img.subjects?.slice(0, 5),
-        })) });
-      } catch (e) { return JSON.stringify({ error: String(e) }); }
-    },
-  };
-}
 
 // ── Visual Lightbox ───────────────────────────────────────────────────
 
@@ -165,7 +70,7 @@ function VoiceAgentInner() {
   }, []);
 
   const conversation = useConversation({
-    clientTools: buildClientTools(addSources, addVisual),
+    clientTools: buildClientTools({ addSources, addVisual }),
     onMessage: (payload: { role?: string; source?: string; message: string }) => {
       setTranscript((prev) => {
         const entry: TranscriptEntry = { role: payload.role === 'agent' || payload.source === 'ai' ? 'agent' : 'user', text: payload.message, isFinal: true };
@@ -173,15 +78,15 @@ function VoiceAgentInner() {
         return [...prev, entry];
       });
     },
-    onError: (message: string) => { console.error('[voice-agent]', message); setErrorMsg(message || 'Connection error'); setAppStatus('error'); },
+    onError: (message: string) => { console.error('[voice-agent] error:', message, 'status was:', appStatus); setErrorMsg(message || 'Connection error'); setAppStatus('error'); },
     onStatusChange: ({ status }: { status: string }) => {
+      console.log('[voice-agent] status:', status);
       if (status === 'connected') setAppStatus('connected');
       else if (status === 'connecting') setAppStatus('connecting');
       else if (status === 'disconnected' || status === 'disconnecting') setAppStatus('idle');
     },
     onModeChange: ({ mode }: { mode: string }) => { setAgentSpeaking(mode === 'speaking'); },
-    onUnhandledClientToolCall: (params: any) => { console.warn('[voice-agent] UNHANDLED tool call:', params); },
-    onDebug: (props: any) => { if (props?.type?.includes('tool')) console.log('[voice-agent] debug:', props); },
+    onUnhandledClientToolCall: (params: any) => { console.error('[voice-agent] UNHANDLED tool call — tool name mismatch between ElevenLabs agent config and client code:', params); },
   });
 
   useEffect(() => { scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' }); }, [transcript]);

--- a/src/lib/voice/client-tools.ts
+++ b/src/lib/voice/client-tools.ts
@@ -1,0 +1,176 @@
+/**
+ * Voice agent client tools — called by ElevenLabs Conversational AI
+ * in the user's browser. Each tool calls a Source Library API endpoint
+ * and returns JSON for the agent to speak about.
+ *
+ * Search fallback chain:
+ *   search_semantic → /api/search/semantic (Supabase, 8s timeout)
+ *                   → /api/search (Atlas keyword fallback)
+ *   search_library  → /api/search (Atlas keyword, 10s timeout)
+ */
+
+export interface SourceResult {
+  bookId: string;
+  title: string;
+  author: string;
+  slug?: string;
+  pageNumber?: number;
+  snippet?: string;
+}
+
+export interface Visual {
+  type: 'image' | 'page';
+  url: string;
+  title: string;
+  caption?: string;
+  bookSlug?: string;
+  pageNumber?: number;
+}
+
+interface ToolCallbacks {
+  addSources: (s: SourceResult[]) => void;
+  addVisual: (v: Visual) => void;
+  baseUrl?: string; // for standalone app (cross-origin), empty string for same-origin
+}
+
+function log(tool: string, msg: string, ms?: number) {
+  const timing = ms !== undefined ? ` (${Math.round(ms)}ms)` : '';
+  console.log(`[voice-agent] ${tool}:${timing} ${msg}`);
+}
+
+export function buildClientTools({ addSources, addVisual, baseUrl = '' }: ToolCallbacks) {
+  return {
+    search_library: async ({ query }: { query: string }): Promise<string> => {
+      const t0 = performance.now();
+      log('search_library', `searching "${query}"`);
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10000);
+        const res = await fetch(`${baseUrl}/api/search?q=${encodeURIComponent(query)}&limit=8&has_translation=true`, { signal: controller.signal });
+        clearTimeout(timeout);
+        if (!res.ok) {
+          log('search_library', `error ${res.status}`, performance.now() - t0);
+          return JSON.stringify({ error: `${res.status}` });
+        }
+        const data = await res.json();
+        const results = (data.results || []).slice(0, 6);
+        addSources(results.map((r: any) => ({
+          bookId: r.id || r.bookId, title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
+          slug: r.slug || r.bookSlug, pageNumber: r.pageNumber || r.page_number, snippet: r.snippet,
+        })));
+        log('search_library', `${results.length} results`, performance.now() - t0);
+        return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
+          title: r.title || r.bookTitle, author: r.author || r.bookAuthor, year: r.year,
+          bookId: r.id || r.bookId, slug: r.slug || r.bookSlug,
+          pageNumber: r.pageNumber || r.page_number, snippet: (r.snippet || '').slice(0, 300),
+        })) });
+      } catch (e) {
+        log('search_library', `failed: ${e}`, performance.now() - t0);
+        return JSON.stringify({ error: String(e) });
+      }
+    },
+
+    search_semantic: async ({ query }: { query: string }): Promise<string> => {
+      const t0 = performance.now();
+      log('search_semantic', `searching "${query}"`);
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 8000);
+        const res = await fetch(`${baseUrl}/api/search/semantic?q=${encodeURIComponent(query)}&limit=8`, { signal: controller.signal });
+        clearTimeout(timeout);
+        if (!res.ok) throw new Error(`${res.status}`);
+        const data = await res.json();
+        const results = (data.results || []).slice(0, 6);
+        const sources: SourceResult[] = [];
+        for (const r of results) for (const p of (r.pages || []).slice(0, 2))
+          sources.push({ bookId: r.book_id, title: r.title, author: r.author, slug: r.slug, pageNumber: p.page_number, snippet: p.snippet });
+        addSources(sources);
+        log('search_semantic', `${results.length} results (semantic)`, performance.now() - t0);
+        return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
+          title: r.title, author: r.author, bookId: r.book_id, slug: r.slug,
+          topPage: r.pages?.[0]?.page_number, snippet: (r.pages?.[0]?.snippet || '').slice(0, 300),
+        })) });
+      } catch (e) {
+        const reason = String(e).includes('abort') ? 'timeout' : String(e);
+        log('search_semantic', `primary failed (${reason}), falling back to keyword`, performance.now() - t0);
+        const t1 = performance.now();
+        try {
+          const res = await fetch(`${baseUrl}/api/search?q=${encodeURIComponent(query)}&limit=8&has_translation=true&search_content=true`);
+          if (!res.ok) return JSON.stringify({ error: `${res.status}` });
+          const data = await res.json();
+          const results = (data.results || []).slice(0, 6);
+          addSources(results.map((r: any) => ({
+            bookId: r.id || r.bookId, title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
+            slug: r.slug || r.bookSlug, pageNumber: r.pageNumber || r.page_number, snippet: r.snippet,
+          })));
+          log('search_semantic', `${results.length} results (keyword fallback)`, performance.now() - t1);
+          return JSON.stringify({ found: results.length, results: results.map((r: any) => ({
+            title: r.title || r.bookTitle, author: r.author || r.bookAuthor,
+            bookId: r.id || r.bookId, slug: r.slug || r.bookSlug,
+            pageNumber: r.pageNumber || r.page_number, snippet: (r.snippet || '').slice(0, 300),
+          })) });
+        } catch (e2) {
+          log('search_semantic', `both paths failed: ${e2}`, performance.now() - t1);
+          return JSON.stringify({ error: String(e2) });
+        }
+      }
+    },
+
+    read_page: async ({ book_id, page_number }: { book_id: string; page_number: number }): Promise<string> => {
+      const t0 = performance.now();
+      log('read_page', `book=${book_id} page=${page_number}`);
+      try {
+        const res = await fetch(`${baseUrl}/api/books/${book_id}/pages?page=${page_number}`);
+        if (!res.ok) {
+          log('read_page', `error ${res.status}`, performance.now() - t0);
+          return JSON.stringify({ error: `${res.status}` });
+        }
+        const data = await res.json();
+        const page = data.pages?.[0] || data;
+        const text = page.translation?.data || page.ocr?.data || '';
+        const source = page.translation?.data ? 'translation' : 'ocr';
+        const imageUrl = page.compressed_photo || page.archived_photo || page.photo;
+        if (imageUrl) {
+          addVisual({ type: 'page', url: imageUrl, title: `Page ${page.page_number || page_number}`,
+            caption: text.slice(0, 120) + (text.length > 120 ? '...' : ''), pageNumber: page.page_number || page_number });
+        }
+        log('read_page', `${source} ${text.length} chars${imageUrl ? ' +image' : ''}`, performance.now() - t0);
+        return JSON.stringify({ text: text.slice(0, 2000), pageNumber: page.page_number || page_number, hasTranslation: source === 'translation' });
+      } catch (e) {
+        log('read_page', `failed: ${e}`, performance.now() - t0);
+        return JSON.stringify({ error: String(e) });
+      }
+    },
+
+    search_images: async ({ query }: { query: string }): Promise<string> => {
+      const t0 = performance.now();
+      log('search_images', `searching "${query}"`);
+      try {
+        const res = await fetch(`${baseUrl}/api/search/visual?q=${encodeURIComponent(query)}&limit=6`);
+        if (!res.ok) {
+          log('search_images', `error ${res.status}`, performance.now() - t0);
+          return JSON.stringify({ error: `${res.status}` });
+        }
+        const data = await res.json();
+        const images = (data.results || data.images || []).slice(0, 6);
+        let visualCount = 0;
+        for (const img of images) {
+          const url = img.imageUrl || img.fullImageUrl || img.image_url;
+          if (url) {
+            addVisual({ type: 'image', url, title: img.title || img.description || 'Illustration',
+              caption: img.author, bookSlug: img.bookSlug || img.slug });
+            visualCount++;
+          }
+        }
+        log('search_images', `${images.length} results, ${visualCount} with images`, performance.now() - t0);
+        return JSON.stringify({ found: images.length, images: images.map((img: any) => ({
+          description: (img.title || img.description || '').slice(0, 200),
+          bookTitle: img.book_title || img.title, subjects: img.subjects?.slice(0, 5),
+        })) });
+      } catch (e) {
+        log('search_images', `failed: ${e}`, performance.now() - t0);
+        return JSON.stringify({ error: String(e) });
+      }
+    },
+  };
+}

--- a/tests/unit/voice-client-tools.test.ts
+++ b/tests/unit/voice-client-tools.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildClientTools, type SourceResult, type Visual } from '@/lib/voice/client-tools';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function mockFetch(response: { ok?: boolean; status?: number; json?: () => any }) {
+  return vi.fn().mockResolvedValue({
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    json: response.json ?? (() => ({})),
+    text: () => Promise.resolve(''),
+  });
+}
+
+function mockFetchSequence(responses: Array<{ ok?: boolean; status?: number; json?: () => any }>) {
+  const fn = vi.fn();
+  for (let i = 0; i < responses.length; i++) {
+    fn.mockResolvedValueOnce({
+      ok: responses[i].ok ?? true,
+      status: responses[i].status ?? 200,
+      json: responses[i].json ?? (() => ({})),
+      text: () => Promise.resolve(''),
+    });
+  }
+  return fn;
+}
+
+function setup() {
+  const addSources = vi.fn();
+  const addVisual = vi.fn();
+  const tools = buildClientTools({ addSources, addVisual });
+  return { tools, addSources, addVisual };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── search_library ────────────────────────────────────────────────────
+
+describe('search_library', () => {
+  it('returns results and calls addSources', async () => {
+    const { tools, addSources } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ results: [
+        { id: 'b1', title: 'Alchemy Today', author: 'Paracelsus', slug: 'alchemy-today', page_number: 5, snippet: 'Gold from lead' },
+        { id: 'b2', title: 'Hermetica', author: 'Hermes', slug: 'hermetica' },
+      ] }),
+    }));
+
+    const result = JSON.parse(await tools.search_library({ query: 'alchemy' }));
+    expect(result.found).toBe(2);
+    expect(result.results[0].title).toBe('Alchemy Today');
+    expect(addSources).toHaveBeenCalledOnce();
+    expect(addSources.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it('returns error on 500', async () => {
+    const { tools, addSources } = setup();
+    vi.stubGlobal('fetch', mockFetch({ ok: false, status: 500 }));
+
+    const result = JSON.parse(await tools.search_library({ query: 'alchemy' }));
+    expect(result.error).toBe('500');
+    expect(addSources).not.toHaveBeenCalled();
+  });
+
+  it('returns error on network failure', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const result = JSON.parse(await tools.search_library({ query: 'alchemy' }));
+    expect(result.error).toContain('network down');
+  });
+
+  it('handles empty results', async () => {
+    const { tools, addSources } = setup();
+    vi.stubGlobal('fetch', mockFetch({ json: () => ({ results: [] }) }));
+
+    const result = JSON.parse(await tools.search_library({ query: 'xyznonexistent' }));
+    expect(result.found).toBe(0);
+    expect(result.results).toHaveLength(0);
+    expect(addSources).toHaveBeenCalledWith([]);
+  });
+
+  it('handles missing results field', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', mockFetch({ json: () => ({}) }));
+
+    const result = JSON.parse(await tools.search_library({ query: 'alchemy' }));
+    expect(result.found).toBe(0);
+  });
+
+  it('truncates snippets to 300 chars', async () => {
+    const { tools } = setup();
+    const longSnippet = 'a'.repeat(500);
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ results: [{ id: 'b1', title: 'Test', author: 'Author', snippet: longSnippet }] }),
+    }));
+
+    const result = JSON.parse(await tools.search_library({ query: 'test' }));
+    expect(result.results[0].snippet.length).toBe(300);
+  });
+});
+
+// ── search_semantic ───────────────────────────────────────────────────
+
+describe('search_semantic', () => {
+  it('returns semantic results with nested pages', async () => {
+    const { tools, addSources } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ results: [{
+        book_id: 'b1', title: 'Corpus Hermeticum', author: 'Hermes', slug: 'corpus',
+        pages: [
+          { page_number: 10, snippet: 'As above so below' },
+          { page_number: 11, snippet: 'The mind of the father' },
+        ],
+      }] }),
+    }));
+
+    const result = JSON.parse(await tools.search_semantic({ query: 'microcosm macrocosm' }));
+    expect(result.found).toBe(1);
+    expect(addSources).toHaveBeenCalledOnce();
+    // Should flatten pages into sources (max 2 per book)
+    expect(addSources.mock.calls[0][0]).toHaveLength(2);
+    expect(addSources.mock.calls[0][0][0].pageNumber).toBe(10);
+  });
+
+  it('falls back to keyword search on timeout', async () => {
+    const { tools, addSources } = setup();
+    vi.stubGlobal('fetch', mockFetchSequence([
+      // First call (semantic) — throw abort error
+      { ok: false, status: 500, json: () => { throw new Error('aborted'); } },
+      // Second call (keyword fallback) — succeeds
+      { json: () => ({ results: [{ id: 'b1', title: 'Fallback Book', author: 'Author', slug: 'fallback' }] }) },
+    ]));
+    // Make the first fetch reject
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => ({ results: [{ id: 'b1', title: 'Fallback', author: 'A', slug: 's' }] }) });
+    vi.stubGlobal('fetch', fn);
+
+    const result = JSON.parse(await tools.search_semantic({ query: 'alchemy' }));
+    expect(result.found).toBe(1);
+    expect(result.results[0].title).toBe('Fallback');
+    // First call was semantic, second was keyword
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn.mock.calls[1][0]).toContain('/api/search?');
+  });
+
+  it('returns error when both paths fail', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('everything is down')));
+
+    const result = JSON.parse(await tools.search_semantic({ query: 'alchemy' }));
+    expect(result.error).toContain('everything is down');
+  });
+
+  it('falls back on non-ok status', async () => {
+    const { tools } = setup();
+    const fn = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 502 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => ({ results: [{ id: 'b1', title: 'FB', author: 'A' }] }) });
+    vi.stubGlobal('fetch', fn);
+
+    const result = JSON.parse(await tools.search_semantic({ query: 'test' }));
+    expect(result.found).toBe(1);
+  });
+});
+
+// ── read_page ─────────────────────────────────────────────────────────
+
+describe('read_page', () => {
+  it('returns translation text and adds visual', async () => {
+    const { tools, addVisual } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ pages: [{
+        page_number: 42,
+        translation: { data: 'The philosopher stone transforms all metals.' },
+        compressed_photo: 'https://images.example.com/page42.jpg',
+      }] }),
+    }));
+
+    const result = JSON.parse(await tools.read_page({ book_id: 'b1', page_number: 42 }));
+    expect(result.text).toContain('philosopher stone');
+    expect(result.hasTranslation).toBe(true);
+    expect(result.pageNumber).toBe(42);
+    expect(addVisual).toHaveBeenCalledOnce();
+    expect(addVisual.mock.calls[0][0].url).toBe('https://images.example.com/page42.jpg');
+    expect(addVisual.mock.calls[0][0].type).toBe('page');
+  });
+
+  it('falls back to OCR when no translation', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ pages: [{
+        page_number: 10,
+        ocr: { data: 'Lapis philosophorum est...' },
+        archived_photo: 'https://images.example.com/p10.jpg',
+      }] }),
+    }));
+
+    const result = JSON.parse(await tools.read_page({ book_id: 'b1', page_number: 10 }));
+    expect(result.text).toContain('Lapis philosophorum');
+    expect(result.hasTranslation).toBe(false);
+  });
+
+  it('does not add visual when no image URL', async () => {
+    const { tools, addVisual } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ pages: [{ page_number: 1, translation: { data: 'Text only' } }] }),
+    }));
+
+    await tools.read_page({ book_id: 'b1', page_number: 1 });
+    expect(addVisual).not.toHaveBeenCalled();
+  });
+
+  it('returns error on 404', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', mockFetch({ ok: false, status: 404 }));
+
+    const result = JSON.parse(await tools.read_page({ book_id: 'nonexistent', page_number: 1 }));
+    expect(result.error).toBe('404');
+  });
+
+  it('truncates text to 2000 chars', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ pages: [{ page_number: 1, translation: { data: 'x'.repeat(5000) } }] }),
+    }));
+
+    const result = JSON.parse(await tools.read_page({ book_id: 'b1', page_number: 1 }));
+    expect(result.text.length).toBe(2000);
+  });
+});
+
+// ── search_images ─────────────────────────────────────────────────────
+
+describe('search_images', () => {
+  it('returns images and adds visuals', async () => {
+    const { tools, addVisual } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ results: [
+        { imageUrl: 'https://img.example.com/1.jpg', title: 'Alchemical furnace', author: 'Fludd', subjects: ['alchemy', 'furnace'] },
+        { fullImageUrl: 'https://img.example.com/2.jpg', description: 'Tree of life', author: 'Kircher' },
+      ] }),
+    }));
+
+    const result = JSON.parse(await tools.search_images({ query: 'furnace' }));
+    expect(result.found).toBe(2);
+    expect(addVisual).toHaveBeenCalledTimes(2);
+    // First image uses imageUrl
+    expect(addVisual.mock.calls[0][0].url).toBe('https://img.example.com/1.jpg');
+    // Second uses fullImageUrl
+    expect(addVisual.mock.calls[1][0].url).toBe('https://img.example.com/2.jpg');
+  });
+
+  it('skips images without any URL field', async () => {
+    const { tools, addVisual } = setup();
+    vi.stubGlobal('fetch', mockFetch({
+      json: () => ({ results: [
+        { title: 'No URL image', author: 'Unknown' },
+        { imageUrl: 'https://img.example.com/valid.jpg', title: 'Valid' },
+      ] }),
+    }));
+
+    await tools.search_images({ query: 'test' });
+    expect(addVisual).toHaveBeenCalledOnce();
+    expect(addVisual.mock.calls[0][0].url).toBe('https://img.example.com/valid.jpg');
+  });
+
+  it('handles empty results', async () => {
+    const { tools, addVisual } = setup();
+    vi.stubGlobal('fetch', mockFetch({ json: () => ({ results: [] }) }));
+
+    const result = JSON.parse(await tools.search_images({ query: 'nothing' }));
+    expect(result.found).toBe(0);
+    expect(addVisual).not.toHaveBeenCalled();
+  });
+
+  it('returns error on API failure', async () => {
+    const { tools } = setup();
+    vi.stubGlobal('fetch', mockFetch({ ok: false, status: 503 }));
+
+    const result = JSON.parse(await tools.search_images({ query: 'test' }));
+    expect(result.error).toBe('503');
+  });
+});
+
+// ── baseUrl support ───────────────────────────────────────────────────
+
+describe('baseUrl (standalone app)', () => {
+  it('prepends baseUrl to fetch calls', async () => {
+    const addSources = vi.fn();
+    const addVisual = vi.fn();
+    const tools = buildClientTools({ addSources, addVisual, baseUrl: 'https://sourcelibrary.org' });
+    const fn = mockFetch({ json: () => ({ results: [] }) });
+    vi.stubGlobal('fetch', fn);
+
+    await tools.search_library({ query: 'test' });
+    expect(fn.mock.calls[0][0]).toContain('https://sourcelibrary.org/api/search');
+  });
+});

--- a/tests/unit/voice-signed-url.test.ts
+++ b/tests/unit/voice-signed-url.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// We test the route handler directly by importing GET
+// and mocking env vars + global fetch
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+async function importRoute() {
+  // Dynamic import to pick up fresh env stubs
+  vi.resetModules();
+  return import('@/app/api/embassy/voice/route');
+}
+
+describe('GET /api/embassy/voice', () => {
+  it('returns 500 when ELEVENLABS_AGENT_ID is missing', async () => {
+    vi.stubEnv('ELEVENLABS_AGENT_ID', '');
+    vi.stubEnv('ELEVENLABS_API_KEY', 'sk_test');
+    const { GET } = await importRoute();
+
+    const response = await GET();
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toContain('not configured');
+  });
+
+  it('returns 500 when ELEVENLABS_API_KEY is missing', async () => {
+    vi.stubEnv('ELEVENLABS_AGENT_ID', 'agent_test');
+    vi.stubEnv('ELEVENLABS_API_KEY', '');
+    const { GET } = await importRoute();
+
+    const response = await GET();
+    expect(response.status).toBe(500);
+  });
+
+  it('returns signed URL on success', async () => {
+    vi.stubEnv('ELEVENLABS_AGENT_ID', 'agent_test123');
+    vi.stubEnv('ELEVENLABS_API_KEY', 'sk_test456');
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ signed_url: 'wss://api.elevenlabs.io/v1/convai/conversation?sig=abc' }),
+    }));
+
+    const { GET } = await importRoute();
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.signedUrl).toBe('wss://api.elevenlabs.io/v1/convai/conversation?sig=abc');
+
+    // Verify the outgoing request used correct headers
+    const fetchCall = (fetch as any).mock.calls[0];
+    expect(fetchCall[0]).toContain('agent_id=agent_test123');
+    expect(fetchCall[1].headers['xi-api-key']).toBe('sk_test456');
+  });
+
+  it('passes through ElevenLabs 401 (expired key)', async () => {
+    vi.stubEnv('ELEVENLABS_AGENT_ID', 'agent_test');
+    vi.stubEnv('ELEVENLABS_API_KEY', 'sk_expired');
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve('invalid api key'),
+    }));
+
+    const { GET } = await importRoute();
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 500 on network error', async () => {
+    vi.stubEnv('ELEVENLABS_AGENT_ID', 'agent_test');
+    vi.stubEnv('ELEVENLABS_API_KEY', 'sk_test');
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const { GET } = await importRoute();
+    const response = await GET();
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe('Internal error');
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `buildClientTools` to `src/lib/voice/client-tools.ts` — testable, with timing logs and fallback chains
- 25 unit tests covering all 4 client tools + signed URL endpoint
- Structured logging: tool call timing, result counts, fallback reasons, session lifecycle

## Tests
- `voice-client-tools.test.ts`: 20 tests — happy paths, API errors, timeouts, semantic→keyword fallback, empty results, truncation, broken image URLs, baseUrl support
- `voice-signed-url.test.ts`: 5 tests — missing env, expired key, network error, ElevenLabs 401, happy path

## Logging
- Every tool call: entry log with query, exit log with result count + ms elapsed
- Semantic fallback: logs reason (timeout vs error) and keyword fallback timing
- Signed URL: latency measurement, warns on >2s
- Session: status transitions, errors with context
- Unhandled tool calls: upgraded to console.error (agent config mismatch)

## Test plan
- [x] `npx vitest run tests/unit/voice-client-tools.test.ts` — 20/20 pass
- [x] `npx vitest run tests/unit/voice-signed-url.test.ts` — 5/5 pass
- [x] `npx tsc --noEmit` — clean