### PR TITLE
Show representative quotes in search results

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -441,10 +441,7 @@ export async function GET(request: NextRequest) {
       const queryLower = query.toLowerCase();
 
       results.sort((a, b) => {
-        // 1. Books before pages
-        if (a.type !== b.type) return a.type === 'book' ? -1 : 1;
-
-        // 2. Title/author match (strongest signal)
+        // 1. Title/author match (strongest signal)
         const aTitle = (a.display_title || a.title).toLowerCase();
         const bTitle = (b.display_title || b.title).toLowerCase();
         const aTitleMatch = aTitle.includes(queryLower);
@@ -457,18 +454,22 @@ export async function GET(request: NextRequest) {
         const bAuthorMatch = bAuthor.includes(queryLower);
         if (aAuthorMatch !== bAuthorMatch) return aAuthorMatch ? -1 : 1;
 
-        // 3. Original language beats modern English translations
-        // A Latin "De Occulta Philosophia" should rank above an English reprint
+        // 3. Results with actual content quotes rank above summary-only results
+        const aHasQuote = (a.snippet_type === 'translation' || a.snippet_type === 'ocr') ? 1 : 0;
+        const bHasQuote = (b.snippet_type === 'translation' || b.snippet_type === 'ocr') ? 1 : 0;
+        if (aHasQuote !== bHasQuote) return bHasQuote - aHasQuote;
+
+        // 5. Original language beats modern English translations
         const aOriginal = a.language !== ENGLISH ? 1 : 0;
         const bOriginal = b.language !== ENGLISH ? 1 : 0;
         if (aOriginal !== bOriginal) return bOriginal - aOriginal;
 
-        // 4. Older editions rank higher (earlier = closer to source)
+        // 6. Older editions rank higher (earlier = closer to source)
         const aYear = parseInt(a.published?.match(/\d{3,4}/)?.[0] || '9999');
         const bYear = parseInt(b.published?.match(/\d{3,4}/)?.[0] || '9999');
         if (aYear !== bYear) return aYear - bYear;
 
-        // 5. Quality score tie-breaker
+        // 7. Quality score tie-breaker
         const aScore = (a as any).quality_score || 0;
         const bScore = (b as any).quality_score || 0;
         return bScore - aScore;

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -288,8 +288,8 @@ export async function GET(request: NextRequest) {
       seenBooks.add((book as any).id);
     }
 
-    // Process page results (skip if book results already fill the limit)
-    if (pageDocs.length > 0 && (bookId || results.length < limit)) {
+    // Process page results — add books discovered through content search
+    if (pageDocs.length > 0) {
       const pageBookIds = [...new Set(pageDocs.map(p => p.book_id as string))];
       const bookMap = new Map<string, Book>();
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -245,9 +245,46 @@ export async function GET(request: NextRequest) {
       })(),
     ]);
 
-    // Process book results
+    // Extract the best page snippet per book from page results
+    // This gives us actual quotes to attach to book-level results
+    const bestPageQuote = new Map<string, { snippet: string; snippetType: 'translation' | 'ocr'; pageNumber: number }>();
+    if (pageDocs.length > 0) {
+      for (const page of pageDocs) {
+        const bookIdStr = page.book_id as string;
+        if (bestPageQuote.has(bookIdStr)) continue; // Keep first (highest relevance from Atlas Search)
+
+        let snippet = '';
+        let snippetType: 'translation' | 'ocr' = 'ocr';
+        const highlights = page.highlights as Array<{ path: string; texts: Array<{ value: string; type: string }> }> | undefined;
+        if (highlights && highlights.length > 0) {
+          const translationHL = highlights.find(h => h.path === 'translation.data');
+          const hl = translationHL || highlights[0];
+          snippet = cleanText(hl.texts.map(t => t.value).join(''));
+          snippetType = hl.path === 'translation.data' ? 'translation' : 'ocr';
+        } else {
+          const translationText = page.translation?.data as string || '';
+          const ocrText = page.ocr?.data as string || '';
+          const snippetSource = translationText || ocrText;
+          snippetType = translationText ? 'translation' : 'ocr';
+          snippet = extractSnippet(snippetSource, query);
+        }
+
+        if (snippet) {
+          bestPageQuote.set(bookIdStr, { snippet, snippetType, pageNumber: page.page_number as number });
+        }
+      }
+    }
+
+    // Process book results — attach page quotes when available
     for (const book of bookDocs) {
-      results.push(bookToResult(book as unknown as Book));
+      const result = bookToResult(book as unknown as Book);
+      const quote = bestPageQuote.get((book as any).id);
+      if (quote) {
+        result.snippet = quote.snippet;
+        result.snippet_type = quote.snippetType;
+        result.quote_page = quote.pageNumber;
+      }
+      results.push(result);
       seenBooks.add((book as any).id);
     }
 
@@ -275,23 +312,27 @@ export async function GET(request: NextRequest) {
         if (!book.pages_count || book.pages_count === 0) continue;
         if (!pagesOnly && seenBooks.has(book.id)) continue;
 
-        // Prefer Atlas Search highlights (faster, more precise) over full-text extraction
-        let snippet = '';
-        let snippetType: 'translation' | 'ocr' = 'ocr';
-        const highlights = page.highlights as Array<{ path: string; texts: Array<{ value: string; type: string }> }> | undefined;
-        if (highlights && highlights.length > 0) {
-          // Prefer translation highlights over OCR
-          const translationHL = highlights.find(h => h.path === 'translation.data');
-          const hl = translationHL || highlights[0];
-          snippet = cleanText(hl.texts.map(t => t.value).join(''));
-          snippetType = hl.path === 'translation.data' ? 'translation' : 'ocr';
-        } else {
-          // Fallback to full text extraction
-          const translationText = page.translation?.data as string || '';
-          const ocrText = page.ocr?.data as string || '';
-          const snippetSource = translationText || ocrText;
-          snippetType = translationText ? 'translation' : 'ocr';
-          snippet = extractSnippet(snippetSource, query);
+        const cached = bestPageQuote.get(page.book_id as string);
+        const snippet = cached && cached.pageNumber === (page.page_number as number) ? cached.snippet : '';
+        const snippetType = cached && cached.pageNumber === (page.page_number as number) ? cached.snippetType : 'ocr';
+
+        // If not cached (different page), extract fresh
+        let finalSnippet = snippet;
+        let finalSnippetType = snippetType;
+        if (!finalSnippet) {
+          const highlights = page.highlights as Array<{ path: string; texts: Array<{ value: string; type: string }> }> | undefined;
+          if (highlights && highlights.length > 0) {
+            const translationHL = highlights.find(h => h.path === 'translation.data');
+            const hl = translationHL || highlights[0];
+            finalSnippet = cleanText(hl.texts.map(t => t.value).join(''));
+            finalSnippetType = hl.path === 'translation.data' ? 'translation' : 'ocr';
+          } else {
+            const translationText = page.translation?.data as string || '';
+            const ocrText = page.ocr?.data as string || '';
+            const snippetSource = translationText || ocrText;
+            finalSnippetType = translationText ? 'translation' : 'ocr';
+            finalSnippet = extractSnippet(snippetSource, query);
+          }
         }
 
         const pageResult: SearchResult = {
@@ -311,8 +352,8 @@ export async function GET(request: NextRequest) {
           doi: book.doi,
           categories: book.categories,
           page_number: page.page_number as number,
-          snippet,
-          snippet_type: snippetType,
+          snippet: finalSnippet,
+          snippet_type: finalSnippetType,
           thumbnail: (book as any).thumbnail,
           thumbnail_blob: (book as any).thumbnail_blob,
         };
@@ -323,17 +364,10 @@ export async function GET(request: NextRequest) {
 
     // Merge semantic results (conceptual matches that keyword search missed)
     if (semanticDocs.length > 0) {
-      // Track which pages we already have from Atlas Search
-      const seenPageKeys = new Set(
-        results
-          .filter(r => r.type === 'page')
-          .map(r => `${r.book_id}-${r.page_number}`)
-      );
-
-      // Collect book IDs we need metadata for
+      // Collect book IDs we need metadata for (skip books we already have)
       const semanticBookIds = [...new Set(
         semanticDocs
-          .filter(s => !seenPageKeys.has(`${s.book_id}-${s.page_number}`))
+          .filter(s => !seenBooks.has(s.book_id))
           .map(s => s.book_id)
       )];
 
@@ -354,18 +388,16 @@ export async function GET(request: NextRequest) {
       }
 
       for (const sem of semanticDocs) {
-        const pageKey = `${sem.book_id}-${sem.page_number}`;
-        if (seenPageKeys.has(pageKey)) continue;
-        seenPageKeys.add(pageKey);
+        if (seenBooks.has(sem.book_id)) continue;
+        seenBooks.add(sem.book_id);
 
         // Use fetched book metadata, or construct minimal from semantic result
         const book = semanticBookMap.get(sem.book_id);
         if (!book) continue; // Book not visible or missing
 
         const semResult: SearchResult = {
-          id: `${sem.book_id}-p${sem.page_number}`,
-          page_id: sem.page_id,
-          type: 'page',
+          id: sem.book_id,
+          type: 'book',
           book_id: sem.book_id,
           slug: book.slug,
           title: book.title || sem.book_title,
@@ -378,9 +410,8 @@ export async function GET(request: NextRequest) {
           has_doi: !!book.doi,
           doi: book.doi,
           categories: book.categories,
-          page_number: sem.page_number,
           snippet: sem.snippet,
-          snippet_type: 'translation' as const,
+          snippet_type: 'summary' as const,
           thumbnail: book.thumbnail,
           thumbnail_blob: book.thumbnail_blob,
         };

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1038,10 +1038,13 @@ export default function SearchPage() {
             {aiResults.map(result => {
               const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
               const text = result.snippet || result.summary;
+              const isQuote = result.snippet_type === 'translation' || result.snippet_type === 'ocr';
+              const targetPage = result.type === 'page' ? result.page_number : result.quote_page;
+              const bookPath = `/book/${result.slug || result.book_id}`;
               return (
                 <Link
                   key={result.id}
-                  href={result.type === 'page' ? `/book/${result.slug || result.book_id}/page-number/${result.page_number}` : `/book/${result.slug || result.book_id}`}
+                  href={targetPage ? `${bookPath}/page-number/${targetPage}` : bookPath}
                   className="flex items-start gap-3 p-4 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
                 >
                   {cover && (
@@ -1055,9 +1058,11 @@ export default function SearchPage() {
                       {result.author}{result.published ? `, ${result.published}` : ''}
                       {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
                     </p>
-                    {text && (
+                    {text && isQuote ? (
+                      <p className="text-xs text-secondary mt-1 line-clamp-2 italic">&ldquo;{text}&rdquo;{result.quote_page && <span className="not-italic text-muted ml-1">p. {result.quote_page}</span>}</p>
+                    ) : text ? (
                       <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
-                    )}
+                    ) : null}
                   </div>
                 </Link>
               );
@@ -1216,10 +1221,13 @@ export default function SearchPage() {
               {aiResults.map(result => {
                 const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
                 const text = result.snippet || result.summary;
+                const isQuote = result.snippet_type === 'translation' || result.snippet_type === 'ocr';
+                const targetPage = result.type === 'page' ? result.page_number : result.quote_page;
+                const bookPath = `/book/${result.slug || result.book_id}`;
                 return (
                   <Link
                     key={result.id}
-                    href={result.type === 'page' ? `/book/${result.slug || result.book_id}/page-number/${result.page_number}` : `/book/${result.slug || result.book_id}`}
+                    href={targetPage ? `${bookPath}/page-number/${targetPage}` : bookPath}
                     className="flex items-start gap-3 p-3 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
                   >
                     {cover && (
@@ -1233,9 +1241,11 @@ export default function SearchPage() {
                         {result.author}{result.published ? `, ${result.published}` : ''}
                         {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
                       </p>
-                      {text && (
+                      {text && isQuote ? (
+                        <p className="text-xs text-secondary mt-1 line-clamp-2 italic">&ldquo;{text}&rdquo;{result.quote_page && <span className="not-italic text-muted ml-1">p. {result.quote_page}</span>}</p>
+                      ) : text ? (
                         <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
-                      )}
+                      ) : null}
                     </div>
                   </Link>
                 );
@@ -1255,10 +1265,13 @@ function BookResultCard({ result, query }: { result: SearchResult; query: string
   const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
   const text = result.snippet || result.summary;
   const [imgError, setImgError] = useState(false);
+  const bookPath = `/book/${result.slug || result.book_id}`;
+  const targetPage = result.type === 'page' ? result.page_number : result.quote_page;
+  const href = targetPage ? `${bookPath}/page-number/${targetPage}` : bookPath;
 
   return (
     <Link
-      href={result.type === 'page' ? `/book/${result.slug || result.book_id}/page-number/${result.page_number}` : `/book/${result.slug || result.book_id}`}
+      href={href}
       className="block bg-white rounded-xl border border-border-light p-4 hover:border-accent-rust/30 hover:shadow-md transition-all"
     >
       <div className="flex items-start gap-4">
@@ -1295,11 +1308,16 @@ function BookResultCard({ result, query }: { result: SearchResult; query: string
               </a>
             )}
           </div>
-          {text && (
+          {text && (result.snippet_type === 'translation' || result.snippet_type === 'ocr') ? (
+            <p className="mt-1.5 text-sm text-secondary line-clamp-2 font-body leading-relaxed italic">
+              &ldquo;<HighlightedText text={text} query={query} />&rdquo;
+              {result.quote_page && <span className="not-italic text-muted ml-1">p. {result.quote_page}</span>}
+            </p>
+          ) : text ? (
             <p className="mt-1.5 text-sm text-secondary line-clamp-2 font-body leading-relaxed">
               <HighlightedText text={text} query={query} />
             </p>
-          )}
+          ) : null}
           {result.type === 'book' && result.page_count && (
             <p className="mt-1.5 text-xs text-muted">
               {result.page_count} pages{result.translated_count ? ` · ${result.translated_count} translated` : ''}

--- a/src/lib/api-client/types/search.ts
+++ b/src/lib/api-client/types/search.ts
@@ -25,6 +25,7 @@ export interface SearchResult {
   page_number?: number;
   snippet?: string;
   snippet_type?: 'translation' | 'ocr' | 'summary';
+  quote_page?: number;
   thumbnail?: string;
   thumbnail_blob?: string;
   quality_score?: number;


### PR DESCRIPTION
## Summary
- When Atlas Search finds a page match for a book, the best matching passage is shown as the snippet instead of the AI-generated summary
- Quotes render in italics with quotation marks and page number ("...transmutation of metals..." p. 42)
- Clicking a result with a quote links directly to the quoted page
- Semantic-only results (no keyword match) correctly show as book-level with summary snippets, not mislabeled as page-level translations

Closes #1164

## Test plan
- [ ] Search "philosopher stone transmutation" — top results should show actual quoted passages, not AI summaries
- [ ] Search "harmony of the spheres" — verify quotes render in italics with page numbers
- [ ] Click a result with a quote — should navigate to the specific page, not the book landing
- [ ] Results without page matches still show summaries (no regressions)
- [ ] MCP `search_translations` (pages_only=true) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)