### PR TITLE
Fix librarian chat rendering + behavior

### DIFF
--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -26,12 +26,38 @@ function linkifySourceUrls(text: string): string {
 
 /**
  * Ensure proper markdown paragraph breaks.
- * Gemini's streaming often outputs single \n between paragraphs.
- * Standard markdown needs \n\n for a paragraph break.
- * This converts single \n to \n\n EXCEPT inside lists, blockquotes, and code blocks.
+ * Gemini often outputs single \n between paragraphs, but standard markdown
+ * needs \n\n for a visible paragraph break. Process line-by-line to avoid
+ * breaking lists, blockquotes, code blocks, and headings.
  */
 function ensureParagraphBreaks(text: string): string {
-  return text.replace(/([^\n])\n(?!\n)(?![-*>|`\d])/g, '$1\n\n');
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Track fenced code blocks
+    if (line.trimStart().startsWith('```')) inCodeBlock = !inCodeBlock;
+    result.push(line);
+
+    // Don't touch anything inside code blocks
+    if (inCodeBlock) continue;
+    // Last line — nothing to pad after
+    if (i === lines.length - 1) continue;
+
+    const next = lines[i + 1];
+    // Already has a blank line after this one
+    if (line === '' || next === '') continue;
+    // Next line is a list item, blockquote, heading, hr, or table — leave it
+    if (/^(\s*[-*+>|#\d]|---)/.test(next)) continue;
+    // Current line is a list item or blockquote continuing — leave it
+    if (/^(\s*[-*+>|#\d]|---)/.test(line)) continue;
+
+    // Insert blank line for paragraph break
+    result.push('');
+  }
+  return result.join('\n');
 }
 
 // ── Types ─────────────────────────────────────────────────────────────

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -17,7 +17,26 @@ function linkifySourceUrls(text: string): string {
 }
 
 function ensureParagraphBreaks(text: string): string {
-  return text.replace(/([^\n])\n(?!\n)(?![-*>|`\d])/g, '$1\n\n');
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trimStart().startsWith('```')) inCodeBlock = !inCodeBlock;
+    result.push(line);
+
+    if (inCodeBlock) continue;
+    if (i === lines.length - 1) continue;
+
+    const next = lines[i + 1];
+    if (line === '' || next === '') continue;
+    if (/^(\s*[-*+>|#\d]|---)/.test(next)) continue;
+    if (/^(\s*[-*+>|#\d]|---)/.test(line)) continue;
+
+    result.push('');
+  }
+  return result.join('\n');
 }
 
 interface ThreadMessage {

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -659,23 +659,31 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 6. **Cite precisely.** For books found via tools, use the exact URLs from the tool results: https://sourcelibrary.org/book/{slug}?page={N}. Format: "quoted text" — *Title* by Author, [Page N](url). You may also mention books from your general knowledge, but note when you haven't verified they're in the collection. Links are automatically verified — broken links will be flagged.
 
 7. **Suggest next steps.** After answering, proactively suggest what to explore next based on what you've found and what's still unexplored.
+
+8. **Show images.** When search_images returns results, embed the best 1-3 images directly in your response using markdown: \`![description](imageUrl)\`. Illustrations from these rare books are extraordinary — show them whenever relevant.
 ${notebookContext}
-## Share your thinking naturally
+## CRITICAL: Act immediately
 
-For broad or exploratory questions, share your initial thinking conversationally — what you know, what directions you could search. Then search immediately. Don't wait for permission.
+**Start searching right away.** Do NOT ask clarifying questions unless the query is truly ambiguous (could mean completely different things). Most questions have an obvious research direction — just go. If you're unsure, search the most likely interpretation first and mention alternatives in your response.
 
-## When to use present_choices (rarely)
+Bad: "Would you like me to focus on the alchemical or the medical tradition?" — just search both.
+Good: Start searching immediately, then say "I searched both the alchemical and medical angles — here's what I found."
 
-Only when the question genuinely splits into 2-3 completely different research directions. Most questions should just be answered directly.
+## When to use present_choices (almost never)
+
+Only when the question genuinely splits into 2-3 completely different research directions AND you truly cannot guess which one the user wants. This should happen less than 5% of the time.
 
 ## The collection
 
 Source Library has over 10,000 rare books from the 15th-18th centuries, many translated into English for the first time. Topics include alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, demonology, and related traditions.
 
-## Style
+## Formatting
 
+- Use markdown headers (## and ###) to organize longer responses
+- Use **bold** for key terms and *italics* for book titles
+- Use blockquotes (>) for important quotations from primary sources
+- Use paragraph breaks between distinct ideas — don't write walls of text
 - Conversational but substantive — a research conversation, not a lecture
-- Use markdown for readability
 - Cite 2-4 key passages rather than dumping everything
 - Make clear when speaking from general knowledge vs. specific texts`;
 }


### PR DESCRIPTION
## Summary
- **Paragraph breaks**: Rewrote `ensureParagraphBreaks` from a fragile one-line regex to a proper line-by-line processor that respects code blocks, lists, blockquotes, and headings. Fixed in both main chat and thread view.
- **Image embedding**: Added system prompt instruction telling Gemini to embed images via `![](url)` when `search_images` returns results — illustrations now appear inline.
- **Immediate action**: Strengthened prompt so Gemini searches immediately instead of asking clarifying questions. Added explicit good/bad examples. Clarifications should be <5% of interactions.
- **Formatting guidance**: Added explicit markdown formatting instructions (headers, bold, blockquotes, paragraph spacing) to the system prompt.

## Test plan
- [ ] Ask the librarian a question and verify paragraph breaks render correctly
- [ ] Ask about illustrations (e.g., "show me alchemical furnaces") and verify images appear inline
- [ ] Ask a broad question and verify Gemini starts searching immediately rather than asking for clarification
- [ ] Check thread view `/reading-room/thread/[id]` still renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)