### PR TITLE
Add Cellulae research blog post

### DIFF
--- a/docs/blog-cellulae-research.md
+++ b/docs/blog-cellulae-research.md
@@ -1,0 +1,132 @@
+# Cellulae: What Two Pages of a Medieval Manuscript Reveal About Biology, Law, and the Dangers of Careful Reasoning
+
+*A research report drawn from the holdings of [Source Library](https://sourcelibrary.org)*
+
+---
+
+We were reading a fifteenth-century manuscript of the *Secretum Secretorum* --- the most widely copied text of the medieval period, framed as a letter from Aristotle to Alexander the Great on how to rule, eat, and live. Somewhere around [page 32](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5), the text describes the anatomy of the womb:
+
+> "It has seven cells [*cellulas*], impressed with the human figure like a coin-mold. It is for this reason that a woman can bear seven children in a single birth, but no more."
+
+The word caught our attention. *Cellulas* --- small chambers. The same Latin word that Robert Hooke would use in 1665 when he looked at cork through a microscope and saw "a great many little Boxes," launching the concept that would become the foundation of modern biology.
+
+But then we turned the page. And what followed the *cellulae* was far darker than etymology.
+
+---
+
+## I. The Seven Chambers
+
+The doctrine that the uterus contained seven chambers --- three on the right producing males, three on the left producing females, one in the center producing hermaphrodites --- was a widespread medieval medical belief. It first appears in the pseudo-Galenic *De Spermate*, a twelfth-century Latin compilation that circulated under Galen's name. It entered the European medical canon through figures like Michael Scot (c. 1180--1250), scientific advisor to Emperor Frederick II, and persisted through Mondino de Luzzi's influential *Anathomia* of 1316 into at least the seventeenth century, when cadaver dissection by Leonardo da Vinci and Vesalius finally demonstrated a single uterine cavity.
+
+The word *cellula* --- diminutive of *cella*, a small room --- was already standard anatomical terminology before Hooke ever touched a microscope. Medieval physicians spoke of the three *cellae* of the brain (the ventricles, each housing a cognitive faculty: imagination in the front, reason in the middle, memory in the rear), the *cellulae* of the colon, and the *cellulae* of the seminal vesicle. In a 2024 paper in the Royal Society's *Notes and Records*, Winfried S. Peters argues that when Hooke described the "cells" of cork, he was not thinking of monks' rooms at all --- he was drawing on this existing anatomical vocabulary, where *cellulae* meant linearly arranged compartments for the storage, modification, and transport of materials.
+
+If Peters is right, the word "cell" in biology descends not from monastery architecture but from exactly this tradition of medieval anatomy --- the tradition that produced the *cellulae* in our manuscript. The seven chambers of the womb, the three chambers of the brain, the compartments of cork: it is the same word doing the same conceptual work across five centuries.
+
+> **Source:** [*Aristotelis Secretum Secretorum*](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle), 15th century. The *cellulae* passage appears on [page 32](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5).
+
+---
+
+## II. Turn the Page
+
+The *cellulae* passage is part of a longer dialogue on reproduction, structured as a series of questions from a Disciple to a Philosopher. On the same page, the Disciple asks why prostitutes rarely conceive. The Philosopher explains that conception requires pleasure --- the emission of female "seed" --- and prostitutes "experience no pleasure in the act but are moved only by the fee, so they emit nothing."
+
+Then the Disciple raises an objection. If pleasure is required for conception, what about rape?
+
+> "Even if the act is displeasing at first to those who are seized, at the end it nonetheless becomes pleasing through the friction of the flesh."
+
+The Philosopher distinguishes two kinds of will: the *voluntas rationis* (rational will) and the *delectatio carnis* (delight of the flesh). Even in rape, he argues, the body experiences its own involuntary pleasure, independent of consent. And since conception requires female seed, and female seed requires pleasure, any pregnancy that results from rape proves that pleasure --- and therefore a kind of consent --- was present.
+
+The argument is circular. It protects the two-seed theory from falsification by asserting that the counterevidence (pregnancy from rape) actually confirms the theory, because pleasure must have been secretly present. But the text contains its own contradiction: just a few lines later, the Philosopher notes that wives who have intercourse "with great pleasure" with their husbands also frequently never conceive. If pleasure were truly sufficient for conception, this should not happen. The text simply moves on.
+
+> **Source:** The rape argument spans [pages 32--33](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5). The infertility discussion that undermines it is on [page 33](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c6).
+
+---
+
+## III. A Most Harmful Doctrine
+
+The argument in our manuscript did not stay in our manuscript. The medical claim that conception requires female pleasure, and therefore that pregnancy from rape implies consent, entered European law and stayed there for centuries.
+
+The chain of transmission runs through **Galen** (2nd century CE), who argued in *De Semine* that both men and women produce generative seed and that the emission of female seed is accompanied by pleasure. The **Salernitan medical school** (12th--13th century) transmitted these ideas through scholastic question-and-answer texts that circulated across the universities. **Henry de Bracton**, writing English law around 1235, codified the principle:
+
+> "If, however, the woman should have conceived at the time, it abates the appeal, for without the will of the woman she could not conceive."
+
+--- Bracton, *De Legibus et Consuetudinibus Angliae*, Book III, on the appeal of rape
+
+This effectively made pregnancy a defense against a rape charge. The doctrine persisted in English common law through the early modern period. While Blackstone (1765) did not repeat it in exactly the same terms, the structural assumptions --- that the female body is a reliable witness to consent --- remained embedded in how rape was prosecuted and how juries were instructed.
+
+The echo reached 2012, when U.S. Representative Todd Akin stated that in cases of "legitimate rape, the female body has ways to try to shut that whole thing down." The American College of Obstetricians and Gynecologists immediately refuted the claim. Historians recognized it as a direct descendant of the medieval two-seed theory --- the same theory articulated in our manuscript, on the page after the *cellulae*.
+
+> **Key scholarship:** Joan Cadden, *Meanings of Sex Difference in the Middle Ages: Medicine, Science, and Culture* (Cambridge University Press, 1993); Fridolf Kudlien, "The Seven Cells of the Uterus: The Doctrine and Its Roots," *Bulletin of the History of Medicine* 39, no. 5 (1965).
+
+---
+
+## IV. Not Aristotle --- and Not the *Secretum*
+
+When we checked the passage against the other copies of the *Secretum Secretorum* in Source Library --- [seven copies in total](https://sourcelibrary.org/search?q=secretum+secretorum), spanning Latin, Arabic, and German --- we discovered something unexpected. The *cellulae* passage, the rape argument, the infertility discussion: **none of it appears in any other copy.**
+
+The reason is that our sixty-eight-page manuscript is a **composite codex**. The *Secretum Secretorum* proper --- pseudo-Aristotle's advice to Alexander on governance, diet, and astrology --- ends on [page 26](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446bf) with a colophon. What follows, without announcement, is a different text entirely: the *Philosophia Mundi* of **William of Conches** (c. 1125), a twelfth-century natural philosopher from the Cathedral School of Chartres.
+
+The Disciple/Philosopher dialogue format is William's signature. He was not hiding behind Aristotle's name or claiming ancient authority. He was writing openly as a contemporary thinker, synthesizing Galen, Plato's *Timaeus*, and Salernitan medicine into a systematic account of the natural world. The *cellulae*, the two-seed theory, the rape argument --- these are the work of a named twelfth-century author doing what he believed was rigorous natural philosophy.
+
+Which makes the passage not "ancient wisdom gone wrong" but something arguably worse: **a smart man following correct logical form from wrong premises to a monstrous conclusion.** William of Conches was not being cynical. The body/will distinction (*delectatio carnis* versus *voluntas rationis*) is genuinely sophisticated --- it anticipates later mind-body debates by centuries. He was recognizing that the flesh has responses independent of rational consent. But the legal system did not preserve the nuance. It took "pleasure was present" and made it a rule of evidence.
+
+The accident of bookbinding --- William's *Philosophia Mundi* stitched into a codex alongside the most popular text of the Middle Ages --- was the transmission vector. A Chartres schoolmaster's thought experiment traveled under Aristotle's authority across Europe.
+
+---
+
+## V. What the Arabic Actually Says
+
+Source Library holds an [Arabic manuscript of the *Kitāb Sirr al-Asrār*](https://sourcelibrary.org/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle) --- the original text from which the Latin *Secretum Secretorum* was translated. It is a copy of the University of Pennsylvania's LJS 459, dated **1193 CE** and written in Mosul, Iraq, making it one of the earliest surviving copies of the work, produced roughly two centuries after the Arabic original was composed.
+
+An exhaustive search of all 265 pages confirmed what the cross-copy comparison suggested: **the Arabic contains none of the reproductive material found in the Latin manuscript.** No seven chambers of the womb. No rape argument. No infertility discussion. No menstrual theory. No gender determination. The word for rape (*ghaṣb*) appears zero times. The word for barrenness (*ʿuqm*) appears zero times.
+
+What the Arabic does contain, in the same conceptual space, is [Neoplatonic cosmology](https://sourcelibrary.org/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle/page/69ae674a4b74f168e0c159d0):
+
+> "The Universal Soul is a spiritual power that flowed from the Intellect by the permission of God, may His majesty be glorified. Know that it has two powers that circulate through all bodies, just as the power of the sun circulates through all parts of the air... perfected with seven powers: the attractive power, the retentive power, the digestive power, the assimilative power, the formative power, and the growth power. When these powers act upon the composition of the human body, upon the arrival of the semen in the womb and its management for months..."
+
+The number seven appears in both traditions --- but in the Arabic, it describes powers of the cosmic soul emanating from the divine Intellect. In the Latin (William of Conches, not the *Secretum*), it describes physical compartments of a uterus. The entire register shifted: from metaphysics to gynecology, from emanation to anatomy, from the soul's descent into matter to the mechanics of where sperm lands.
+
+The Arabic text is fundamentally a political-cosmological work. The soul progresses through stages --- sensation, perception, reason --- and after death, "if the soul has been completed and perfected before parting from the body, the power of the Universal Soul descends and ascends with it to the Higher Assembly... If it has not been completed, it is returned to the lowest of the low." This is theology, not medicine. The Latin tradition turned it into something else entirely.
+
+> **Compare:** Arabic [page 170](https://sourcelibrary.org/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle/page/69ae674a4b74f168e0c159d0) (Universal Soul) vs. Latin [page 32](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5) (seven *cellulae*).
+
+---
+
+## VI. Between the Horror and the Beauty
+
+There is one more passage worth noting. Two pages after the *cellulae*, two pages after the rape argument, on [page 34](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c7), William of Conches writes:
+
+> "In this, man differs from the other animals: because they possess only the present, but man has, along with the present, the memory of things past and the conjecture of things future."
+
+It is a striking formulation of what cognitive scientists now call "mental time travel" --- the capacity to project consciousness backward and forward in time, which many researchers consider the defining feature of human cognition. William uses it to explain why pregnant humans still desire sex while other animals do not: because we can remember past pleasure and anticipate future pleasure, desire persists beyond its reproductive function.
+
+The passage is beautiful, and it sits two pages from the rape argument. The same mind that could articulate the temporal structure of human consciousness could also reason its way into a doctrine that would harm women for eight centuries. This is not a contradiction. It is what careful reasoning looks like when the framework is wrong. The logic is valid; the premises are catastrophic.
+
+---
+
+## VII. What a Library Makes Possible
+
+None of these findings required a research grant, a plane ticket, or a reading room appointment. They required a digital library with multiple copies of the same text, machine-readable translations from the original Latin and Arabic, and the ability to search across them.
+
+Source Library holds [seven copies of the *Secretum Secretorum*](https://sourcelibrary.org/search?q=secretum+secretorum) spanning Latin, Arabic, and German, dated from the twelfth to the sixteenth century. By searching all seven for the same passages, we could determine that the *cellulae* and the rape argument appear in only one --- and that the one is a composite codex binding two different texts together. By reading the Arabic original page by page, we could confirm that the entire reproductive dialogue was a Latin-world addition, absent from the Islamic philosophical tradition that produced the *Sirr al-Asrār*.
+
+The word *cellula* traveled from William of Conches' womb chambers through five centuries of anatomical usage to Robert Hooke's microscope, and from there to Schleiden and Schwann and the foundation of modern biology. The rape argument traveled from the same pages through Bracton and English common law to a Missouri congressman in 2012. Both journeys began in the same manuscript, on adjacent pages, written by a man in twelfth-century Chartres who thought he was doing science.
+
+The texts are there to read. The *cellulae* are on [page 32](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5). The horror is on [page 33](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c6). The beauty is on [page 34](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c7). All translated, all open, all waiting for the next reader to notice something we missed.
+
+---
+
+## Sources and Further Reading
+
+**Primary sources in Source Library:**
+- [*Aristotelis Secretum Secretorum*](https://sourcelibrary.org/book/the-secret-of-secrets-manuscript-pseudo-aristotle) (15th-century Latin manuscript, including William of Conches' *Philosophia Mundi*)
+- [*Sirr al-Asrār*](https://sourcelibrary.org/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle) (Arabic, UPenn LJS 459, 1193 CE, Mosul)
+
+**Secondary scholarship:**
+- Cadden, Joan. *Meanings of Sex Difference in the Middle Ages: Medicine, Science, and Culture.* Cambridge University Press, 1993.
+- Kudlien, Fridolf. "The Seven Cells of the Uterus: The Doctrine and Its Roots." *Bulletin of the History of Medicine* 39, no. 5 (1965): 415--423.
+- Peters, Winfried S. "The Cells of Robert Hooke: Wombs, Brains and Ammonites." *Notes and Records: The Royal Society Journal of the History of Science* (2024). doi:10.1098/rsnr.2023.0081.
+- Williams, Steven J. *The Secret of Secrets: The Scholarly Career of a Pseudo-Aristotelian Text in the Latin Middle Ages.* University of Michigan Press, 2003.
+- Greenblatt, Samuel H. "Where Did the Ventricular Localization of Mental Faculties Come From?" *Journal of the History of the Behavioral Sciences* 39, no. 2 (2003): 131--142.
+- Merisalo, Outi. "The Early Tradition of the Pseudo-Galenic *De Spermate* (Twelfth--Thirteenth Centuries)." Academia.edu.
+- Lawn, Brian. *The Prose Salernitan Questions.* Oxford University Press, 1979.

--- a/src/app/blog/cellulae/page.tsx
+++ b/src/app/blog/cellulae/page.tsx
@@ -1,0 +1,527 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import BlogComments from '@/components/blog/BlogComments';
+
+export const metadata: Metadata = {
+  title: 'Cellulae: What Two Pages of a Medieval Manuscript Reveal About Biology, Law, and the Dangers of Careful Reasoning - Source Library',
+  description:
+    'A word on page 32 of a medieval manuscript launched modern biology. The argument on page 33 helped criminalize rape victims for eight centuries. They were written by the same man.',
+  openGraph: {
+    title: 'Cellulae: Biology, Law, and the Dangers of Careful Reasoning',
+    description: 'A word on page 32 launched modern biology. The argument on page 33 helped criminalize rape victims for eight centuries. Written by the same man, in the same manuscript.',
+  },
+  alternates: {
+    canonical: '/blog/cellulae',
+  },
+};
+
+export default function CellulaePage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Cellulae"
+          subtitle="What two pages of a medieval manuscript reveal about biology, law, and the dangers of careful reasoning"
+        >
+          <p className="text-stone-400 text-sm mt-4">16 April 2026 &middot; 12 min read</p>
+        </ContentHeader>
+      }
+      bg="bg-cream"
+    >
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-secondary transition-colors text-sm"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All notes
+        </Link>
+      </div>
+
+      <article className="prose-content max-w-none">
+        {/* Lede */}
+        <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+          We were reading a fifteenth-century manuscript of the <em>Secretum Secretorum</em> &mdash; the most
+          widely copied text of the medieval period, framed as a letter from Aristotle to Alexander the Great
+          on how to rule, eat, and live. Somewhere around{' '}
+          <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5" className="text-accent-rust hover:text-accent-rust underline">
+            page 32
+          </Link>
+          , the text describes the anatomy of the womb:
+        </p>
+
+        <div className="border-l-4 border-accent-rust pl-6 my-10">
+          <p className="text-lg text-secondary italic font-body leading-relaxed">
+            &ldquo;It has seven cells [<em>cellulas</em>], impressed with the human figure like a coin-mold.
+            It is for this reason that a woman can bear seven children in a single birth, but no more.&rdquo;
+          </p>
+        </div>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          The word caught our attention. <em>Cellulas</em> &mdash; small chambers. The same Latin word
+          that Robert Hooke would use in 1665 when he looked at cork through a microscope and saw
+          &ldquo;a great many little Boxes,&rdquo; launching the concept that would become the foundation
+          of modern biology.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          But then we turned the page. And what followed the <em>cellulae</em> was far darker than etymology.
+        </p>
+
+        <hr className="border-border-light my-12" />
+
+        {/* I. The Seven Chambers */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            I. The Seven Chambers
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The doctrine that the uterus contained seven chambers &mdash; three on the right producing
+            males, three on the left producing females, one in the center producing hermaphrodites &mdash;
+            was a widespread medieval medical belief. It first appears in the pseudo-Galenic{' '}
+            <em>De Spermate</em>, a twelfth-century Latin compilation that circulated under Galen&apos;s name.
+            It entered the European medical canon through figures like Michael Scot (c. 1180&ndash;1250),
+            scientific advisor to Emperor Frederick II, and persisted through Mondino de Luzzi&apos;s
+            influential <em>Anathomia</em> of 1316 into at least the seventeenth century, when cadaver
+            dissection by Leonardo da Vinci and Vesalius finally demonstrated a single uterine cavity.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The word <em>cellula</em> &mdash; diminutive of <em>cella</em>, a small room &mdash; was already
+            standard anatomical terminology before Hooke ever touched a microscope. Medieval physicians
+            spoke of the three <em>cellae</em> of the brain (the ventricles, each housing a cognitive
+            faculty: imagination in the front, reason in the middle, memory in the rear), the{' '}
+            <em>cellulae</em> of the colon, and the <em>cellulae</em> of the seminal vesicle.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            In a 2024 paper in the Royal Society&apos;s <em>Notes and Records</em>, Winfried S. Peters
+            argues that when Hooke described the &ldquo;cells&rdquo; of cork, he was not thinking of
+            monks&apos; rooms at all &mdash; he was drawing on this existing anatomical vocabulary, where{' '}
+            <em>cellulae</em> meant linearly arranged compartments for the storage, modification, and
+            transport of materials.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            If Peters is right, the word &ldquo;cell&rdquo; in biology descends not from monastery
+            architecture but from exactly this tradition of medieval anatomy &mdash; the tradition that
+            produced the <em>cellulae</em> in our manuscript. The seven chambers of the womb, the three
+            chambers of the brain, the compartments of cork: it is the same word doing the same conceptual
+            work across five centuries.
+          </p>
+
+          <p className="text-sm text-muted mt-8 font-body">
+            <strong>Source:</strong>{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle" className="text-accent-rust hover:text-accent-rust underline">
+              <em>Aristotelis Secretum Secretorum</em>
+            </Link>, 15th century. The <em>cellulae</em> passage appears on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5" className="text-accent-rust hover:text-accent-rust underline">
+              page 32
+            </Link>.
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* II. Turn the Page */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            II. Turn the Page
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The <em>cellulae</em> passage is part of a longer dialogue on reproduction, structured as a
+            series of questions from a Disciple to a Philosopher. On the same page, the Disciple asks
+            why prostitutes rarely conceive. The Philosopher explains that conception requires pleasure &mdash;
+            the emission of female &ldquo;seed&rdquo; &mdash; and prostitutes &ldquo;experience no pleasure
+            in the act but are moved only by the fee, so they emit nothing.&rdquo;
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            Then the Disciple raises an objection. If pleasure is required for conception, what about rape?
+          </p>
+
+          <div className="border-l-4 border-stone-300 pl-6 my-10">
+            <p className="text-lg text-secondary italic font-body leading-relaxed">
+              &ldquo;Even if the act is displeasing at first to those who are seized, at the end it
+              nonetheless becomes pleasing through the friction of the flesh.&rdquo;
+            </p>
+          </div>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The Philosopher distinguishes two kinds of will: the <em>voluntas rationis</em> (rational will)
+            and the <em>delectatio carnis</em> (delight of the flesh). Even in rape, he argues, the body
+            experiences its own involuntary pleasure, independent of consent. And since conception requires
+            female seed, and female seed requires pleasure, any pregnancy that results from rape proves
+            that pleasure &mdash; and therefore a kind of consent &mdash; was present.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The argument is circular. It protects the two-seed theory from falsification by asserting
+            that the counterevidence (pregnancy from rape) actually confirms the theory, because pleasure
+            must have been secretly present. But the text contains its own contradiction: just a few lines
+            later, the Philosopher notes that wives who have intercourse &ldquo;with great pleasure&rdquo;
+            with their husbands also frequently never conceive. If pleasure were truly sufficient for
+            conception, this should not happen. The text simply moves on.
+          </p>
+
+          <p className="text-sm text-muted mt-8 font-body">
+            <strong>Source:</strong> The rape argument spans{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5" className="text-accent-rust hover:text-accent-rust underline">
+              pages 32&ndash;33
+            </Link>. The infertility discussion that undermines it is on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c6" className="text-accent-rust hover:text-accent-rust underline">
+              page 33
+            </Link>.
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* III. A Most Harmful Doctrine */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            III. A Most Harmful Doctrine
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The argument in our manuscript did not stay in our manuscript. The medical claim that
+            conception requires female pleasure, and therefore that pregnancy from rape implies consent,
+            entered European law and stayed there for centuries.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The chain of transmission runs through <strong>Galen</strong> (2nd century CE), who argued
+            in <em>De Semine</em> that both men and women produce generative seed and that the emission
+            of female seed is accompanied by pleasure. The <strong>Salernitan medical school</strong>{' '}
+            (12th&ndash;13th century) transmitted these ideas through scholastic question-and-answer texts
+            that circulated across the universities. <strong>Henry de Bracton</strong>, writing English
+            law around 1235, codified the principle:
+          </p>
+
+          <div className="border-l-4 border-stone-300 pl-6 my-10">
+            <p className="text-lg text-secondary italic font-body leading-relaxed">
+              &ldquo;If, however, the woman should have conceived at the time, it abates the appeal,
+              for without the will of the woman she could not conceive.&rdquo;
+            </p>
+            <p className="text-sm text-muted mt-3 not-italic font-body">
+              &mdash; Bracton, <em>De Legibus et Consuetudinibus Angliae</em>, Book III, on the appeal of rape
+            </p>
+          </div>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            This effectively made pregnancy a defense against a rape charge. The doctrine persisted
+            in English common law through the early modern period. While Blackstone (1765) did not
+            repeat it in exactly the same terms, the structural assumptions &mdash; that the female body
+            is a reliable witness to consent &mdash; remained embedded in how rape was prosecuted and how
+            juries were instructed.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The echo reached 2012, when U.S. Representative Todd Akin stated that in cases of
+            &ldquo;legitimate rape, the female body has ways to try to shut that whole thing down.&rdquo;
+            The American College of Obstetricians and Gynecologists immediately refuted the claim.
+            Historians recognized it as a direct descendant of the medieval two-seed theory &mdash; the
+            same theory articulated in our manuscript, on the page after the <em>cellulae</em>.
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* IV. Not Aristotle */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            IV. Not Aristotle &mdash; and Not the <em>Secretum</em>
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            When we checked the passage against the other copies of the <em>Secretum Secretorum</em> in
+            Source Library &mdash;{' '}
+            <Link href="/search?q=secretum+secretorum" className="text-accent-rust hover:text-accent-rust underline">
+              seven copies in total
+            </Link>, spanning Latin, Arabic, and German &mdash; we discovered something unexpected. The{' '}
+            <em>cellulae</em> passage, the rape argument, the infertility discussion: none of it appears
+            in any other copy.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The reason is that our sixty-eight-page manuscript is a <strong>composite codex</strong>. The{' '}
+            <em>Secretum Secretorum</em> proper &mdash; pseudo-Aristotle&apos;s advice to Alexander on
+            governance, diet, and astrology &mdash; ends on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446bf" className="text-accent-rust hover:text-accent-rust underline">
+              page 26
+            </Link>{' '}
+            with a colophon. What follows, without announcement, is a different text entirely: the{' '}
+            <em>Philosophia Mundi</em> of <strong>William of Conches</strong> (c. 1125), a twelfth-century
+            natural philosopher from the Cathedral School of Chartres.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The Disciple/Philosopher dialogue format is William&apos;s signature. He was not hiding behind
+            Aristotle&apos;s name or claiming ancient authority. He was writing openly as a contemporary
+            thinker, synthesizing Galen, Plato&apos;s <em>Timaeus</em>, and Salernitan medicine into a
+            systematic account of the natural world. The <em>cellulae</em>, the two-seed theory, the rape
+            argument &mdash; these are the work of a named twelfth-century author doing what he believed
+            was rigorous natural philosophy.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            Which makes the passage not &ldquo;ancient wisdom gone wrong&rdquo; but something arguably
+            worse: <strong>a smart man following correct logical form from wrong premises to a monstrous
+            conclusion</strong>. William of Conches was not being cynical. The body/will distinction
+            (<em>delectatio carnis</em> versus <em>voluntas rationis</em>) is genuinely sophisticated &mdash;
+            it anticipates later mind-body debates by centuries. He was recognizing that the flesh has
+            responses independent of rational consent. But the legal system did not preserve the nuance.
+            It took &ldquo;pleasure was present&rdquo; and made it a rule of evidence.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The accident of bookbinding &mdash; William&apos;s <em>Philosophia Mundi</em> stitched into
+            a codex alongside the most popular text of the Middle Ages &mdash; was the transmission vector.
+            A Chartres schoolmaster&apos;s thought experiment traveled under Aristotle&apos;s authority
+            across Europe.
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* V. What the Arabic Actually Says */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            V. What the Arabic Actually Says
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            Source Library holds an{' '}
+            <Link href="/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle" className="text-accent-rust hover:text-accent-rust underline">
+              Arabic manuscript of the <em>Kit&#x101;b Sirr al-Asr&#x101;r</em>
+            </Link>{' '}
+            &mdash; the original text from which the Latin <em>Secretum Secretorum</em> was translated.
+            It is a copy of the University of Pennsylvania&apos;s LJS 459, dated 1193 CE and written in
+            Mosul, Iraq, making it one of the earliest surviving copies of the work, produced roughly two
+            centuries after the Arabic original was composed.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            An exhaustive search of all 265 pages confirmed what the cross-copy comparison suggested:{' '}
+            <strong>the Arabic contains none of the reproductive material found in the Latin
+            manuscript</strong>. No seven chambers of the womb. No rape argument. No infertility discussion.
+            No menstrual theory. No gender determination. The Arabic word for rape (<em>gha&#x1E63;b</em>)
+            appears zero times. The word for barrenness (<em>&#x02BF;uqm</em>) appears zero times.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            What the Arabic does contain, in the same conceptual space, is{' '}
+            <Link href="/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle/page/69ae674a4b74f168e0c159d0" className="text-accent-rust hover:text-accent-rust underline">
+              Neoplatonic cosmology
+            </Link>:
+          </p>
+
+          <div className="border-l-4 border-accent-rust pl-6 my-10">
+            <p className="text-lg text-secondary italic font-body leading-relaxed">
+              &ldquo;The Universal Soul is a spiritual power that flowed from the Intellect by the
+              permission of God, may His majesty be glorified. Know that it has two powers that
+              circulate through all bodies, just as the power of the sun circulates through all parts
+              of the air&hellip; perfected with seven powers: the attractive power, the retentive power,
+              the digestive power, the assimilative power, the formative power, and the growth
+              power.&rdquo;
+            </p>
+            <p className="text-sm text-muted mt-3 not-italic font-body">
+              &mdash; <em>Sirr al-Asr&#x101;r</em>, UPenn LJS 459 (1193 CE),{' '}
+              <Link href="/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle/page/69ae674a4b74f168e0c159d0" className="text-accent-rust hover:text-accent-rust not-italic underline">
+                page 170
+              </Link>
+            </p>
+          </div>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The number seven appears in both traditions &mdash; but in the Arabic, it describes powers
+            of the cosmic soul emanating from the divine Intellect. In the Latin (William of Conches,
+            not the <em>Secretum</em>), it describes physical compartments of a uterus. The entire
+            register shifted: from metaphysics to gynecology, from emanation to anatomy, from the
+            soul&apos;s descent into matter to the mechanics of where sperm lands.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The Arabic text is fundamentally a political-cosmological work. The soul progresses through
+            stages &mdash; sensation, perception, reason &mdash; and after death, &ldquo;if the soul
+            has been completed and perfected before parting from the body, the power of the Universal
+            Soul descends and ascends with it to the Higher Assembly&hellip; If it has not been completed,
+            it is returned to the lowest of the low.&rdquo; This is theology, not medicine. The Latin
+            tradition turned it into something else entirely.
+          </p>
+
+          <p className="text-sm text-muted mt-8 font-body">
+            <strong>Compare:</strong> Arabic{' '}
+            <Link href="/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle/page/69ae674a4b74f168e0c159d0" className="text-accent-rust hover:text-accent-rust underline">
+              page 170
+            </Link>{' '}
+            (Universal Soul) vs. Latin{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5" className="text-accent-rust hover:text-accent-rust underline">
+              page 32
+            </Link>{' '}
+            (seven <em>cellulae</em>).
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* VI. Between the Horror and the Beauty */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            VI. Between the Horror and the Beauty
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            There is one more passage worth noting. Two pages after the <em>cellulae</em>, two pages
+            after the rape argument, on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c7" className="text-accent-rust hover:text-accent-rust underline">
+              page 34
+            </Link>, William of Conches writes:
+          </p>
+
+          <div className="border-l-4 border-accent-rust pl-6 my-10">
+            <p className="text-lg text-secondary italic font-body leading-relaxed">
+              &ldquo;In this, man differs from the other animals: because they possess only the present,
+              but man has, along with the present, the memory of things past and the conjecture of things
+              future.&rdquo;
+            </p>
+          </div>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            It is a striking formulation of what cognitive scientists now call &ldquo;mental time
+            travel&rdquo; &mdash; the capacity to project consciousness backward and forward in time,
+            which many researchers consider the defining feature of human cognition. William uses it
+            to explain why pregnant humans still desire sex while other animals do not: because we can
+            remember past pleasure and anticipate future pleasure, desire persists beyond its reproductive
+            function.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The passage is beautiful, and it sits two pages from the rape argument. The same mind that
+            could articulate the temporal structure of human consciousness could also reason its way into
+            a doctrine that would harm women for eight centuries. This is not a contradiction. It is what
+            careful reasoning looks like when the framework is wrong. The logic is valid; the premises are
+            catastrophic.
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* VII. What a Library Makes Possible */}
+        <section className="mb-16">
+          <h2 className="font-serif text-3xl text-primary mb-6">
+            VII. What a Library Makes Possible
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            None of these findings required a research grant, a plane ticket, or a reading room
+            appointment. They required a digital library with multiple copies of the same text,
+            machine-readable translations from the original Latin and Arabic, and the ability to search
+            across them.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            Source Library holds{' '}
+            <Link href="/search?q=secretum+secretorum" className="text-accent-rust hover:text-accent-rust underline">
+              seven copies of the <em>Secretum Secretorum</em>
+            </Link>{' '}
+            spanning Latin, Arabic, and German, dated from the twelfth to the sixteenth century. By
+            searching all seven for the same passages, we could determine that the <em>cellulae</em> and
+            the rape argument appear in only one &mdash; and that the one is a composite codex binding
+            two different texts together. By reading the Arabic original page by page, we could confirm
+            that the entire reproductive dialogue was a Latin-world addition, absent from the Islamic
+            philosophical tradition that produced the <em>Sirr al-Asr&#x101;r</em>.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The word <em>cellula</em> traveled from William of Conches&apos; womb chambers through five
+            centuries of anatomical usage to Robert Hooke&apos;s microscope, and from there to Schleiden
+            and Schwann and the foundation of modern biology. The rape argument traveled from the same
+            pages through Bracton and English common law to a Missouri congressman in 2012. Both journeys
+            began in the same manuscript, on adjacent pages, written by a man in twelfth-century Chartres
+            who thought he was doing science.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The texts are there to read. The <em>cellulae</em> are on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c5" className="text-accent-rust hover:text-accent-rust underline">
+              page 32
+            </Link>. The horror is on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c6" className="text-accent-rust hover:text-accent-rust underline">
+              page 33
+            </Link>. The beauty is on{' '}
+            <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle/page/6952306aab34727b1f0446c7" className="text-accent-rust hover:text-accent-rust underline">
+              page 34
+            </Link>. All translated, all open, all waiting for the next reader to notice something we missed.
+          </p>
+        </section>
+
+        <hr className="border-border-light my-12" />
+
+        {/* Sources */}
+        <section className="mb-16">
+          <h2 className="font-serif text-2xl text-primary mb-6">
+            Sources and Further Reading
+          </h2>
+
+          <h3 className="font-serif text-lg text-primary mb-4 mt-8">Primary sources in Source Library</h3>
+          <ul className="list-disc list-inside space-y-2 text-secondary font-body">
+            <li>
+              <Link href="/book/the-secret-of-secrets-manuscript-pseudo-aristotle" className="text-accent-rust hover:text-accent-rust underline">
+                <em>Aristotelis Secretum Secretorum</em>
+              </Link>{' '}
+              (15th-century Latin manuscript, including William of Conches&apos; <em>Philosophia Mundi</em>)
+            </li>
+            <li>
+              <Link href="/book/sirr-al-asrar-secret-of-secrets-pseudo-aristotle" className="text-accent-rust hover:text-accent-rust underline">
+                <em>Sirr al-Asr&#x101;r</em>
+              </Link>{' '}
+              (Arabic, UPenn LJS 459, 1193 CE, Mosul)
+            </li>
+          </ul>
+
+          <h3 className="font-serif text-lg text-primary mb-4 mt-8">Secondary scholarship</h3>
+          <ul className="list-disc list-inside space-y-2 text-secondary font-body text-sm">
+            <li>
+              Cadden, Joan. <em>Meanings of Sex Difference in the Middle Ages: Medicine, Science, and Culture.</em>{' '}
+              Cambridge University Press, 1993.
+            </li>
+            <li>
+              Kudlien, Fridolf. &ldquo;The Seven Cells of the Uterus: The Doctrine and Its Roots.&rdquo;{' '}
+              <em>Bulletin of the History of Medicine</em> 39, no. 5 (1965): 415&ndash;423.
+            </li>
+            <li>
+              Peters, Winfried S. &ldquo;The Cells of Robert Hooke: Wombs, Brains and Ammonites.&rdquo;{' '}
+              <em>Notes and Records: The Royal Society Journal of the History of Science</em> (2024).
+            </li>
+            <li>
+              Williams, Steven J. <em>The Secret of Secrets: The Scholarly Career of a Pseudo-Aristotelian
+              Text in the Latin Middle Ages.</em> University of Michigan Press, 2003.
+            </li>
+            <li>
+              Greenblatt, Samuel H. &ldquo;Where Did the Ventricular Localization of Mental Faculties
+              Come From?&rdquo; <em>Journal of the History of the Behavioral Sciences</em> 39, no. 2
+              (2003): 131&ndash;142.
+            </li>
+            <li>
+              Lawn, Brian. <em>The Prose Salernitan Questions.</em> Oxford University Press, 1979.
+            </li>
+          </ul>
+        </section>
+
+        <BlogComments slug="cellulae" />
+      </article>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -25,6 +25,15 @@ interface BlogPost {
 
 const posts: BlogPost[] = [
   {
+    slug: 'cellulae',
+    title: 'Cellulae',
+    subtitle: 'A word on page 32 of a medieval manuscript launched modern biology. The argument on page 33 helped criminalize rape victims for eight centuries. They were written by the same man.',
+    date: '16 April 2026',
+    readTime: '12 min read',
+    tag: 'Deep dive',
+    tagColor: 'bg-accent-rust/10 text-accent-rust',
+  },
+  {
     slug: '10000-books',
     title: '10,000 Books',
     subtitle: 'Source Library passes 10,000 translated historical texts. The symbolic 10,000th: a 1517 Renaissance encyclopedia from the BPH, in English for the first time.',


### PR DESCRIPTION
## Summary
- New blog post at `/blog/cellulae` tracing two threads from a medieval manuscript: the word "cellulae" forward to Hooke and modern cell biology, and the rape/pleasure doctrine forward to Bracton and English common law
- Discovered the passage is William of Conches' *Philosophia Mundi* (c. 1125), not the *Secretum Secretorum* — confirmed by cross-searching 7 copies in the library and 265 pages of the Arabic original
- All claims link to specific pages in Source Library

## Test plan
- [ ] Preview deploy renders `/blog/cellulae` correctly
- [ ] All internal links to book pages resolve
- [ ] Blog index at `/blog` shows the new post at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)