### PR TITLE
Fix site-wide RSC cache corruption

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -86,6 +86,10 @@ const nextConfig: NextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
+          // Prevent Cloudflare from serving RSC flight data as HTML.
+          // Next.js uses these headers for client-side navigation — without Vary,
+          // CF caches the RSC payload and serves it to fresh page loads as raw text.
+          { key: 'Vary', value: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
         ],
       },
       // CDN-Cache-Control for Cloudflare edge caching.


### PR DESCRIPTION
## Summary
- **499/500 sampled book pages were broken** — serving raw React Server Components flight data instead of rendered HTML
- Cloudflare was caching RSC responses (`text/x-component`) under the same cache key as HTML, then serving the RSC payload to fresh page loads
- Adds `Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch` header to all routes so CF keeps separate cache entries
- Full CF cache has been purged; this deploy prevents re-corruption

## Test plan
- [ ] Verify `/book/*` pages render HTML (not raw RSC text) after deploy
- [ ] Verify client-side navigation still works (RSC responses still served for SPA transitions)
- [ ] Check `cf-cache-status` header shows HIT after second visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)