### PR TITLE
Gallery illustrations in podcast source cards

### DIFF
--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -114,8 +114,19 @@ interface SourceFinding {
   };
 }
 
+interface GalleryImage {
+  id: string;
+  imageUrl: string;
+  bookTitle: string;
+  bookSlug?: string;
+  pageNumber: number;
+  description?: string;
+  type?: string;
+}
+
 function SourceCards({ threadId }: { threadId: string }) {
   const [findings, setFindings] = useState<SourceFinding[]>([]);
+  const [galleryImages, setGalleryImages] = useState<GalleryImage[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
@@ -123,7 +134,25 @@ function SourceCards({ threadId }: { threadId: string }) {
     fetch(`/api/embassy/threads/${threadId}/notebook?format=json`)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
-        if (data?.notebook?.findings) setFindings(data.notebook.findings);
+        if (data?.notebook?.findings) {
+          setFindings(data.notebook.findings);
+          // Fetch gallery images from cited books
+          const bookIds = [...new Set(data.notebook.findings.map((f: SourceFinding) => f.source.bookId))];
+          // Fetch gallery images for each book (in parallel, up to 4 per book)
+          Promise.all(
+            bookIds.map(bid =>
+              fetch(`/api/gallery?bookId=${bid}&limit=4`)
+                .then(r => r.ok ? r.json() : null)
+                .then(d => (d?.images || []).map((img: { id: string; imageUrl: string; bookTitle: string; bookSlug?: string; pageNumber: number; description?: string; type?: string }) => ({
+                  ...img, bookId: bid,
+                })))
+                .catch(() => [])
+            )
+          ).then(results => {
+            const all = results.flat().slice(0, 12);
+            setGalleryImages(all);
+          });
+        }
         setLoaded(true);
       })
       .catch(() => setLoaded(true));
@@ -202,46 +231,40 @@ function SourceCards({ threadId }: { threadId: string }) {
             );
           })}
 
-          {/* Page images from cited sources */}
-          {findings.length > 0 && (
+          {/* Gallery images from cited books */}
+          {galleryImages.length > 0 && (
             <div className="mt-4 pt-4 border-t border-[#e8e4dc]">
               <p className="text-[11px] text-[#6b6560] font-sans tracking-wide uppercase mb-3">
-                Pages cited in this episode
+                Illustrations from these sources
               </p>
               <div className="grid grid-cols-3 gap-2">
-                {findings.slice(0, 9).map((f, i) => {
-                  const pageNum = String(f.source.pageNumber).padStart(4, '0');
-                  const pageImgUrl = `https://images.sourcelibrary.org/pages/${f.source.bookId}/${pageNum}.jpg`;
-                  const pageUrl = `https://sourcelibrary.org/book/${f.source.bookSlug || f.source.bookId}?page=${f.source.pageNumber}`;
-                  return (
-                    <a
-                      key={`${f.source.bookId}-${f.source.pageNumber}-${i}`}
-                      href={pageUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group relative aspect-[3/4] overflow-hidden rounded-lg bg-[#f0ece4]"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={`https://sourcelibrary.org/api/image?url=${encodeURIComponent(pageImgUrl)}&w=300&q=75`}
-                        alt={`${f.source.bookTitle}, page ${f.source.pageNumber}`}
-                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                        loading="lazy"
-                        onError={e => { (e.target as HTMLImageElement).src = `https://sourcelibrary.org/api/image?url=https://images.sourcelibrary.org/covers/${f.source.bookId}.jpg&w=300&q=75`; }}
-                      />
-                      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
-                        <div className="absolute bottom-0 left-0 right-0 p-2">
-                          <p className="text-[10px] text-white font-sans leading-tight line-clamp-2">
-                            {f.source.bookTitle}
-                          </p>
-                          <p className="text-[9px] text-white/70 font-sans">
-                            Page {f.source.pageNumber}
-                          </p>
-                        </div>
+                {galleryImages.map((img, i) => (
+                  <a
+                    key={img.id || i}
+                    href={`https://sourcelibrary.org/gallery/image/${img.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group relative aspect-square overflow-hidden rounded-lg bg-[#f0ece4]"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`https://sourcelibrary.org/api/image?url=${encodeURIComponent(img.imageUrl)}&w=300&q=75`}
+                      alt={img.description || ''}
+                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                      loading="lazy"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className="absolute bottom-0 left-0 right-0 p-2">
+                        <p className="text-[10px] text-white font-sans leading-tight line-clamp-2">
+                          {img.description || img.bookTitle}
+                        </p>
+                        {img.type && (
+                          <p className="text-[9px] text-white/70 font-sans capitalize">{img.type}</p>
+                        )}
                       </div>
-                    </a>
-                  );
-                })}
+                    </div>
+                  </a>
+                ))}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
Replaces raw page scans with extracted gallery illustrations (woodcuts, engravings, diagrams) in the podcast Sources section. Fetches up to 4 images per cited book, 12 total.

The Shan Hai Jing episode now shows the actual woodcut illustrations — nine-headed phoenix, pierced-chest people, mermen, headless Xingtian — instead of full manuscript pages.

Books without gallery extractions (text-only like Enoch, Bruno) gracefully show nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)