### PR TITLE
Fix private threads, add delete, bump chat timeout to 120s

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -168,9 +168,10 @@ export async function POST(request: NextRequest) {
       await send({ type: 'done' });
       await writer.close();
     } catch (err) {
-      console.error('[Embassy] Agentic stream error:', err);
+      const errMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
+      console.error('[Embassy] Agentic stream error:', errMsg);
       try {
-        await send({ type: 'error', message: 'The Librarian was interrupted. Please try again.' });
+        await send({ type: 'error', message: 'The Librarian was interrupted. Please try again.', debug: errMsg });
         await writer.close();
       } catch { /* already closed */ }
     }

--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -7,7 +7,7 @@ import { streamAgenticResponse, type LibrarianStep, type SourceCard } from '@/li
 import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 60;
+export const maxDuration = 120;
 
 const messageSchema = z.object({
   role: z.enum(['user', 'assistant']),

--- a/src/app/api/embassy/threads/[id]/route.ts
+++ b/src/app/api/embassy/threads/[id]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getReadDb } from '@/lib/mongodb';
+import { getReadDb, getDb } from '@/lib/mongodb';
+import { auth } from '@/lib/auth';
 import { ObjectId } from 'mongodb';
 
 /**
  * GET /api/embassy/threads/[id] — Get a single thread with all messages.
- * Public threads visible to everyone; private threads require auth.
+ * Public threads visible to everyone; private threads require creator auth.
  */
 export async function GET(
   request: NextRequest,
@@ -26,9 +27,12 @@ export async function GET(
     return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
   }
 
-  // For now, only public threads are accessible without auth
+  // Private threads require auth from the creator
   if (thread.visibility !== 'public') {
-    return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+    const session = await auth();
+    if (!session?.user?.id || thread.creatorId !== session.user.id) {
+      return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+    }
   }
 
   const messages = await db.collection('embassy_messages')
@@ -42,6 +46,7 @@ export async function GET(
       type: thread.type,
       title: thread.title,
       creatorName: thread.creatorName,
+      creatorId: thread.creatorId,
       visibility: thread.visibility,
       messageCount: thread.messageCount,
       createdAt: thread.createdAt,
@@ -56,4 +61,46 @@ export async function GET(
       createdAt: m.createdAt,
     })),
   });
+}
+
+/**
+ * DELETE /api/embassy/threads/[id] — Delete a thread and all its messages.
+ * Only the thread creator can delete.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  if (!ObjectId.isValid(id)) {
+    return NextResponse.json({ error: 'Invalid thread ID' }, { status: 400 });
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Sign in required' }, { status: 401 });
+  }
+
+  const db = await getDb();
+  const thread = await db.collection('embassy_threads').findOne({
+    _id: new ObjectId(id),
+  });
+
+  if (!thread) {
+    return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+  }
+
+  if (thread.creatorId !== session.user.id) {
+    return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+  }
+
+  const oid = new ObjectId(id);
+  await Promise.all([
+    db.collection('embassy_threads').deleteOne({ _id: oid }),
+    db.collection('embassy_messages').deleteMany({ threadId: oid }),
+    db.collection('research_notebooks').deleteMany({ threadId: oid }),
+  ]);
+
+  return NextResponse.json({ deleted: true });
 }

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -203,7 +203,7 @@ async function searchBooks(
     id: 1, slug: 1, title: 1, display_title: 1, author: 1, language: 1, published: 1,
     pages_count: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1,
     thumbnail: 1, thumbnail_blob: 1, doi: 1, categories: 1, quality_score: 1,
-    'reading_summary.overview': 1,
+    'reading_summary.overview': 1, work_id: 1,
   };
 
   // Supabase trigram search (fast, always warm — no cold-start penalty)
@@ -294,8 +294,17 @@ async function searchBooks(
     return (b.quality_score || 0) - (a.quality_score || 0);
   });
 
-  const hasMore = books.length > limit;
-  const truncated = hasMore ? books.slice(0, limit) : books;
+  // Work-level dedup: collapse editions of the same work (keep best-ranked)
+  const seenWorkIds = new Set<string>();
+  const deduped = books.filter((b: any) => {
+    if (!b.work_id) return true; // no work_id — always keep
+    if (seenWorkIds.has(b.work_id)) return false;
+    seenWorkIds.add(b.work_id);
+    return true;
+  });
+
+  const hasMore = deduped.length > limit;
+  const truncated = hasMore ? deduped.slice(0, limit) : deduped;
 
   return {
     results: truncated.map((b: any): SearchResult => {

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -451,6 +451,7 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
                   break;
 
                 case 'error':
+                  console.error('[Librarian error]', event.debug || event.message);
                   updateLastAssistant(m => ({ ...m, content: event.message || 'Something went wrong.' }));
                   break;
               }

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -26,12 +26,38 @@ function linkifySourceUrls(text: string): string {
 
 /**
  * Ensure proper markdown paragraph breaks.
- * Gemini's streaming often outputs single \n between paragraphs.
- * Standard markdown needs \n\n for a paragraph break.
- * This converts single \n to \n\n EXCEPT inside lists, blockquotes, and code blocks.
+ * Gemini often outputs single \n between paragraphs, but standard markdown
+ * needs \n\n for a visible paragraph break. Process line-by-line to avoid
+ * breaking lists, blockquotes, code blocks, and headings.
  */
 function ensureParagraphBreaks(text: string): string {
-  return text.replace(/([^\n])\n(?!\n)(?![-*>|`\d])/g, '$1\n\n');
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Track fenced code blocks
+    if (line.trimStart().startsWith('```')) inCodeBlock = !inCodeBlock;
+    result.push(line);
+
+    // Don't touch anything inside code blocks
+    if (inCodeBlock) continue;
+    // Last line — nothing to pad after
+    if (i === lines.length - 1) continue;
+
+    const next = lines[i + 1];
+    // Already has a blank line after this one
+    if (line === '' || next === '') continue;
+    // Next line is a list item, blockquote, heading, hr, or table — leave it
+    if (/^(\s*[-*+>|#\d]|---)/.test(next)) continue;
+    // Current line is a list item or blockquote continuing — leave it
+    if (/^(\s*[-*+>|#\d]|---)/.test(line)) continue;
+
+    // Insert blank line for paragraph break
+    result.push('');
+  }
+  return result.join('\n');
 }
 
 // ── Types ─────────────────────────────────────────────────────────────

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, use } from 'react';
+import { useSession } from 'next-auth/react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -51,6 +53,7 @@ interface ThreadData {
   id: string;
   title: string;
   creatorName: string;
+  creatorId?: string;
   messageCount: number;
   createdAt: string;
 }
@@ -431,10 +434,13 @@ function PodcastPlayer({ threadId }: { threadId: string }) {
 
 export default function ThreadPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
+  const { data: session } = useSession();
+  const router = useRouter();
   const [thread, setThread] = useState<ThreadData | null>(null);
   const [messages, setMessages] = useState<ThreadMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     fetch(`/api/embassy/threads/${id}`)
@@ -499,9 +505,28 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
           >
             {thread.title}
           </h1>
-          <p className="text-[12px] text-[#8a8480] font-sans">
-            {thread.creatorName} &middot; {formatDate(thread.createdAt)}
-          </p>
+          <div className="flex items-center gap-3">
+            <p className="text-[12px] text-[#8a8480] font-sans">
+              {thread.creatorName} &middot; {formatDate(thread.createdAt)}
+            </p>
+            {session?.user?.id && thread.creatorId === session.user.id && (
+              <button
+                onClick={async () => {
+                  if (!confirm('Delete this conversation? This cannot be undone.')) return;
+                  setDeleting(true);
+                  try {
+                    const res = await fetch(`/api/embassy/threads/${id}`, { method: 'DELETE' });
+                    if (res.ok) router.push('/reading-room');
+                    else setDeleting(false);
+                  } catch { setDeleting(false); }
+                }}
+                disabled={deleting}
+                className="text-[11px] text-[#b0a89c] hover:text-[#9e4a3a] font-sans transition-colors disabled:opacity-50"
+              >
+                {deleting ? 'Deleting...' : 'Delete'}
+              </button>
+            )}
+          </div>
         </div>
 
         <div className="space-y-6">

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -17,7 +17,26 @@ function linkifySourceUrls(text: string): string {
 }
 
 function ensureParagraphBreaks(text: string): string {
-  return text.replace(/([^\n])\n(?!\n)(?![-*>|`\d])/g, '$1\n\n');
+  const lines = text.split('\n');
+  const result: string[] = [];
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trimStart().startsWith('```')) inCodeBlock = !inCodeBlock;
+    result.push(line);
+
+    if (inCodeBlock) continue;
+    if (i === lines.length - 1) continue;
+
+    const next = lines[i + 1];
+    if (line === '' || next === '') continue;
+    if (/^(\s*[-*+>|#\d]|---)/.test(next)) continue;
+    if (/^(\s*[-*+>|#\d]|---)/.test(line)) continue;
+
+    result.push('');
+  }
+  return result.join('\n');
 }
 
 interface ThreadMessage {

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -659,23 +659,31 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 6. **Cite precisely.** For books found via tools, use the exact URLs from the tool results: https://sourcelibrary.org/book/{slug}?page={N}. Format: "quoted text" — *Title* by Author, [Page N](url). You may also mention books from your general knowledge, but note when you haven't verified they're in the collection. Links are automatically verified — broken links will be flagged.
 
 7. **Suggest next steps.** After answering, proactively suggest what to explore next based on what you've found and what's still unexplored.
+
+8. **Show images.** When search_images returns results, embed the best 1-3 images directly in your response using markdown: \`![description](imageUrl)\`. Illustrations from these rare books are extraordinary — show them whenever relevant.
 ${notebookContext}
-## Share your thinking naturally
+## CRITICAL: Act immediately
 
-For broad or exploratory questions, share your initial thinking conversationally — what you know, what directions you could search. Then search immediately. Don't wait for permission.
+**Start searching right away.** Do NOT ask clarifying questions unless the query is truly ambiguous (could mean completely different things). Most questions have an obvious research direction — just go. If you're unsure, search the most likely interpretation first and mention alternatives in your response.
 
-## When to use present_choices (rarely)
+Bad: "Would you like me to focus on the alchemical or the medical tradition?" — just search both.
+Good: Start searching immediately, then say "I searched both the alchemical and medical angles — here's what I found."
 
-Only when the question genuinely splits into 2-3 completely different research directions. Most questions should just be answered directly.
+## When to use present_choices (almost never)
+
+Only when the question genuinely splits into 2-3 completely different research directions AND you truly cannot guess which one the user wants. This should happen less than 5% of the time.
 
 ## The collection
 
 Source Library has over 10,000 rare books from the 15th-18th centuries, many translated into English for the first time. Topics include alchemy, Hermetica, Kabbalah, astrology, natural philosophy, Rosicrucianism, demonology, and related traditions.
 
-## Style
+## Formatting
 
+- Use markdown headers (## and ###) to organize longer responses
+- Use **bold** for key terms and *italics* for book titles
+- Use blockquotes (>) for important quotations from primary sources
+- Use paragraph breaks between distinct ideas — don't write walls of text
 - Conversational but substantive — a research conversation, not a lecture
-- Use markdown for readability
 - Cite 2-4 key passages rather than dumping everything
 - Make clear when speaking from general knowledge vs. specific texts`;
 }


### PR DESCRIPTION
## Summary
- **Private thread access**: Creator can now view their own private threads (was 404 for all private threads)
- **Thread delete**: `DELETE /api/embassy/threads/[id]` endpoint + "Delete" button on thread page. Removes thread, messages, and research notebook. Only visible to creator, requires confirmation.
- **Chat timeout**: Bumped `maxDuration` from 60s to 120s. With 4 parallel tool calls (collection + semantic + Wikipedia + images), 60s wasn't enough for Gemini to generate the response.

## Test plan
- [ ] Visit a private thread URL while signed in as creator — should load
- [ ] Visit same URL signed out — should show "Thread not found"
- [ ] Delete button visible on own threads, not on others'
- [ ] Delete removes thread and redirects to reading room
- [ ] Ask librarian a complex question — should complete within 120s instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)