### PR TITLE
Pin homepage row 2: Hermetica, Alchemy, Mysticism, Kabbalah

### DIFF
--- a/src/lib/collections-utils.ts
+++ b/src/lib/collections-utils.ts
@@ -6,10 +6,16 @@
 // ---------- Pinned collection ordering ----------
 
 export const PINNED_COLLECTION_SLUGS = [
+  // Row 1
   'natural-philosophy',
   'classical-philosophy',
   'renaissance-philosophy',
   'sacred-texts',
+  // Row 2
+  'hermetica',
+  'alchemy',
+  'mysticism',
+  'kabbalah',
 ];
 
 /** Pin specific collections first, shuffle the rest. */


### PR DESCRIPTION
## Summary
- Pins Hermetica, Alchemy, Mysticism, and Kabbalah to the second row of the homepage collections grid
- Row 1 was already pinned (Natural Philosophy, Classical Philosophy, Renaissance Philosophy, Sacred Texts)
- Row 3+ remains randomly shuffled from remaining collections

## Test plan
- [ ] Verify homepage shows the 4 pinned collections in row 2 on desktop (4-col grid)
- [ ] Verify mobile layout (2-col) still looks correct with 8 pinned items

🤖 Generated with [Claude Code](https://claude.com/claude-code)