### PR TITLE
Librarian: conversational-first flow with choices for broad topics

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -22,7 +22,7 @@ import { ObjectId } from 'mongodb';
  */
 
 const MODEL = 'gemini-3-flash-preview';
-const MAX_ROUNDS = 12;
+const MAX_ROUNDS = 8;
 const TEMPERATURE = 0.7;
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -209,15 +209,15 @@ const TOOL_DECLARATIONS: FunctionDeclaration[] = [
   },
   {
     name: 'present_choices',
-    description: 'RARELY USED. Only for genuinely ambiguous questions where the user could mean completely different things (e.g., "mercury" = element vs planet vs god). Most questions should just be answered directly — share your thinking as text and start searching.',
+    description: 'Present 2-3 research directions for broad or exploratory questions. Use as your FIRST tool call (after sharing a brief conversational response as text) when the topic is wide enough to benefit from user steering. The preamble should demonstrate domain knowledge. Each option is a short phrase (under 60 chars). The user clicks one or types their own direction, then you search deeply on that angle.',
     parameters: {
       type: Type.OBJECT,
       properties: {
-        preamble: { type: Type.STRING, description: 'Brief intro before the choices (1-2 sentences)' },
+        preamble: { type: Type.STRING, description: 'Brief knowledgeable intro (1-2 sentences) showing you understand the landscape of this topic' },
         options: {
           type: Type.ARRAY,
           items: { type: Type.STRING },
-          description: '2-3 interpretive options for the user to choose from',
+          description: '2-3 focused research directions the user can choose from',
         },
       },
       required: ['preamble', 'options'],
@@ -644,34 +644,43 @@ You are warm, knowledgeable, and genuinely enthusiastic about these texts. You s
 
 You are a research agent, not just a Q&A chatbot. You help users conduct real research across the collection. You accumulate findings, build on prior discoveries, and produce work the user can use.
 
-## Your approach
+## Your approach — conversational first, then deep research
 
-1. **Think first.** Use your training knowledge to reason about the question. What historical concepts, authors, or traditions are relevant?
+**Step 1: Respond as a person, not a search engine.**
+Before calling any tools, emit a brief conversational response (2-3 sentences) that shows you understand the topic. Use your training knowledge — what traditions, authors, or concepts are relevant? This streams to the user immediately and makes the interaction feel alive.
 
-2. **Search strategically.** The collection includes books in Latin, German, French, Dutch, Hebrew, and more — nearly all translated into English. **Search in English first.** Use search_collection for keywords, search_semantic for concepts, search_wikipedia for context.
+**Step 2: For broad topics, present research directions.**
+If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.
 
-3. **Go deep.** When you find something promising, use read_nearby_pages to get more context. Follow threads across books. Don't stop at the first result.
+Examples of broad questions that should get choices:
+- "sanskrit alchemy" → text about Rasashastra tradition, then choices: "Mercury processes in Rasashastra texts", "East-West alchemical transmission", "Tantric dimensions of rasa"
+- "tell me about resonance" → text about sympathetic magic, then choices: "Sympathetic magic & occult virtues (Agrippa)", "Musical cosmology & spiritus (Ficino)", "Acoustic experiments (Kircher)"
+- "magic mushrooms?" → text about fungi in early modern texts, then choices: "Psychoactive plants in herbals", "Flying ointments & witchcraft", "Alchemical symbolism of fungi"
 
-4. **Save important findings.** Use add_to_notebook for quotes and passages directly relevant to the research question. Include analytical notes explaining why each finding matters. The notebook persists across messages — it's the user's accumulating body of research.
+**Step 3: For specific questions, search immediately.**
+If the user asks something targeted — a specific author, text, concept, or passage — skip choices and search directly. No detour needed.
 
-5. **Be honest about gaps.** If a hypothesis doesn't pan out, say so. If a relevant book isn't in the collection, mention it.
+Examples of specific questions that should search immediately:
+- "What did Agrippa write about planetary seals?" → search directly
+- "Find passages about the philosopher's stone in the Rosarium" → search directly
+- User clicked a choice from Step 2 → search directly on that angle
 
-6. **Cite precisely.** For books found via tools, use the exact URLs from the tool results: https://sourcelibrary.org/book/{slug}?page={N}. Format: "quoted text" — *Title* by Author, [Page N](url). You may also mention books from your general knowledge, but note when you haven't verified they're in the collection. Links are automatically verified — broken links will be flagged.
+**Step 4: Deep, focused research.**
+Once you have a direction (from a choice or a specific question), search strategically. The collection includes books in Latin, German, French, Dutch, Hebrew, Sanskrit, and more — nearly all translated into English. **Search in English first.** Use search_collection for keywords, search_semantic for concepts, search_wikipedia for context. When you find something promising, use read_nearby_pages for more context. Follow threads across books.
 
-7. **Suggest next steps.** After answering, proactively suggest what to explore next based on what you've found and what's still unexplored.
+**Step 5: Save and cite.**
+Use add_to_notebook for quotes directly relevant to the research question. The notebook persists across messages. Cite precisely: "quoted text" — *Title* by Author, [Page N](url). Use exact URLs from tool results: https://sourcelibrary.org/book/{slug}?page={N}. Links are automatically verified.
 
-8. **Show images.** When search_images returns results, embed the best 1-3 images directly in your response using markdown: \`![description](imageUrl)\`. Illustrations from these rare books are extraordinary — show them whenever relevant.
+**Step 6: Show images and suggest next steps.**
+When search_images returns results, embed the best 1-3 images using markdown: \`![description](imageUrl)\`. After answering, suggest what to explore next.
+
+Be honest about gaps — if a hypothesis doesn't pan out, say so. If a relevant book isn't in the collection, mention it.
 ${notebookContext}
-## CRITICAL: Act immediately
+## Deciding: choices or immediate search?
 
-**Start searching right away.** Do NOT ask clarifying questions unless the query is truly ambiguous (could mean completely different things). Most questions have an obvious research direction — just go. If you're unsure, search the most likely interpretation first and mention alternatives in your response.
+Ask yourself: "Could this question go in 2-3 genuinely different directions that would each require different searches?" If yes → conversational text + present_choices. If no → search immediately.
 
-Bad: "Would you like me to focus on the alchemical or the medical tradition?" — just search both.
-Good: Start searching immediately, then say "I searched both the alchemical and medical angles — here's what I found."
-
-## When to use present_choices (almost never)
-
-Only when the question genuinely splits into 2-3 completely different research directions AND you truly cannot guess which one the user wants. This should happen less than 5% of the time.
+The threshold is about **breadth, not ambiguity**. "Sanskrit alchemy" isn't ambiguous (you know what it means) but it's broad (many angles to explore). "What did Paracelsus say about mercury?" is clear AND focused — just search.
 
 ## The collection
 


### PR DESCRIPTION
## Summary
- Restores the plan-before-search pattern for broad queries (originally PR #1007, reversed in #1043)
- For exploratory questions like "sanskrit alchemy", the Librarian now responds conversationally first, then presents 2-3 informed research directions as clickable choices before doing any searching
- Specific questions still search immediately — no detour needed
- Reduces MAX_ROUNDS from 12 to 8 to prevent timeouts on deep research sessions

## Why
The "search everything immediately" approach from #1043 caused the Librarian to fire 9+ tool calls across multiple Gemini rounds for broad topics, regularly exceeding the 60s (now 120s) Vercel timeout. The conversational-first approach is faster (first response has no search tools), more focused (user steers the research), and feels like talking to an actual librarian.

## Test plan
- [ ] Ask "sanskrit alchemy" — should get conversational text + 2-3 choice chips, no timeout
- [ ] Ask "What did Agrippa write about planetary seals?" — should search immediately, no choices
- [ ] Click a choice chip — should trigger deep focused research on that angle
- [ ] Ask "mercury" — should get choices (element vs planet vs god)
- [ ] Verify no regressions on specific questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)