### PR TITLE
Podcast landing page + site navigation

### DIFF
--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -1,0 +1,233 @@
+import { connectToDatabase } from '@/lib/mongodb';
+import SiteHeader from '@/components/layout/SiteHeader';
+import Link from 'next/link';
+
+export const revalidate = 3600; // 1h ISR
+
+export const metadata = {
+  title: 'Source Library Deep Dive — Podcast',
+  description: 'AI-generated scholarly podcasts exploring rare books from the 15th-18th centuries. Alchemy, Hermetica, Kabbalah, and the Western esoteric tradition — grounded in primary sources.',
+};
+
+interface PodcastEpisode {
+  threadId: string;
+  title: string;
+  topic: string;
+  creatorName: string;
+  audioUrl: string;
+  format: string;
+  findingCount: number;
+  generatedAt: string;
+  bookIds: string[];
+}
+
+async function getEpisodes(): Promise<PodcastEpisode[]> {
+  try {
+    const { db } = await connectToDatabase();
+
+    // Find all threads with podcasts
+    const threads = await db.collection('embassy_threads')
+      .find({
+        $or: [
+          { 'podcasts.deep-dive': { $exists: true } },
+          { 'podcast': { $exists: true } },
+        ],
+      })
+      .sort({ 'podcasts.deep-dive.generatedAt': -1, 'podcast.generatedAt': -1 })
+      .limit(50)
+      .project({ _id: 1, title: 1, creatorName: 1, podcasts: 1, podcast: 1 })
+      .toArray();
+
+    const episodes: PodcastEpisode[] = [];
+
+    for (const thread of threads) {
+      const formats = ['deep-dive', 'brief', 'critique', 'guided-reading'];
+      for (const format of formats) {
+        const p = thread.podcasts?.[format];
+        if (p?.audioUrl) {
+          episodes.push({
+            threadId: thread._id.toString(),
+            title: thread.title || p.topic,
+            topic: p.topic,
+            creatorName: thread.creatorName || 'Anonymous',
+            audioUrl: p.audioUrl,
+            format,
+            findingCount: p.findingCount || 0,
+            generatedAt: p.generatedAt,
+            bookIds: [],
+          });
+        }
+      }
+      // Legacy single podcast
+      if (thread.podcast?.audioUrl && !thread.podcasts?.['deep-dive']) {
+        episodes.push({
+          threadId: thread._id.toString(),
+          title: thread.title || thread.podcast.topic,
+          topic: thread.podcast.topic,
+          creatorName: thread.creatorName || 'Anonymous',
+          audioUrl: thread.podcast.audioUrl,
+          format: 'deep-dive',
+          findingCount: thread.podcast.findingCount || 0,
+          generatedAt: thread.podcast.generatedAt,
+          bookIds: [],
+        });
+      }
+    }
+
+    // Load notebook finding counts for book thumbnails
+    const threadIds = [...new Set(episodes.map(e => e.threadId))];
+    const notebooks = await db.collection('research_notebooks')
+      .find({ threadId: { $in: threadIds.map(id => new (require('mongodb').ObjectId)(id)) } })
+      .project({ threadId: 1, findings: 1 })
+      .toArray();
+
+    const notebookMap = new Map(notebooks.map(n => [
+      n.threadId.toString(),
+      [...new Set((n.findings || []).map((f: { source: { bookId: string } }) => f.source.bookId))],
+    ]));
+
+    for (const ep of episodes) {
+      ep.bookIds = (notebookMap.get(ep.threadId) || []) as string[];
+    }
+
+    return episodes.sort((a, b) =>
+      new Date(b.generatedAt).getTime() - new Date(a.generatedAt).getTime()
+    );
+  } catch (err) {
+    console.error('[podcast] Failed to load episodes:', err);
+    return [];
+  }
+}
+
+const FORMAT_LABELS: Record<string, string> = {
+  'deep-dive': 'Deep Dive',
+  'brief': 'The Brief',
+  'critique': 'The Critique',
+  'guided-reading': 'Guided Reading',
+};
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+export default async function PodcastPage() {
+  const episodes = await getEpisodes();
+
+  return (
+    <div className="min-h-screen bg-[#fdfcf9]">
+      <SiteHeader variant="light" breadcrumbs={[{ label: 'Podcast', href: '/podcast' }]} />
+
+      <div className="max-w-[720px] mx-auto px-6 py-10 md:py-16">
+        {/* Header */}
+        <div className="text-center mb-12">
+          <h1
+            className="text-3xl md:text-4xl font-serif text-[#1a1612] mb-3"
+            style={{ fontWeight: 400 }}
+          >
+            Source Library Deep Dive
+          </h1>
+          <p className="text-[15px] font-body text-[#6b6560] max-w-lg mx-auto leading-relaxed">
+            AI-generated scholarly podcasts grounded in primary sources from
+            the 15th-18th centuries. Two hosts explore alchemy, Hermetica, death rites,
+            celestial beings, and the hidden connections between ancient traditions.
+          </p>
+          <div className="mt-4 flex items-center justify-center gap-4 text-[12px] font-sans text-[#8a8480]">
+            <a
+              href="/api/podcast/feed.xml"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-[#9e4a3a] hover:underline"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12.75 19.5v-.75a7.5 7.5 0 00-7.5-7.5H4.5m0-6.75h.75c7.87 0 14.25 6.38 14.25 14.25v.75M6 18.75a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+              </svg>
+              RSS Feed
+            </a>
+            <span>{episodes.length} episode{episodes.length !== 1 ? 's' : ''}</span>
+          </div>
+        </div>
+
+        {/* Episodes */}
+        {episodes.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-[#8a8480] font-body">No episodes yet. Research a topic in the Reading Room to generate one.</p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {episodes.map((ep, i) => (
+              <article
+                key={`${ep.threadId}-${ep.format}-${i}`}
+                className="p-5 bg-white rounded-xl border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors"
+              >
+                {/* Book cover thumbnails */}
+                {ep.bookIds.length > 0 && (
+                  <div className="flex gap-1.5 mb-3 overflow-hidden">
+                    {ep.bookIds.slice(0, 5).map(bid => (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        key={bid}
+                        src={`https://sourcelibrary.org/api/image?url=https://images.sourcelibrary.org/covers/${bid}.jpg&w=60&q=75`}
+                        alt=""
+                        className="w-8 h-12 object-cover rounded flex-shrink-0 bg-[#f0ece4]"
+                        loading="lazy"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                      />
+                    ))}
+                    {ep.bookIds.length > 5 && (
+                      <span className="text-[10px] text-[#8a8480] font-sans self-end mb-1">+{ep.bookIds.length - 5}</span>
+                    )}
+                  </div>
+                )}
+
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div>
+                    <Link
+                      href={`/reading-room/thread/${ep.threadId}`}
+                      className="text-[16px] font-serif text-[#1a1612] leading-snug hover:text-[#9e4a3a] transition-colors"
+                      style={{ fontWeight: 400 }}
+                    >
+                      {ep.title}
+                    </Link>
+                    <p className="text-[11px] text-[#8a8480] font-sans mt-1">
+                      {FORMAT_LABELS[ep.format] || 'Deep Dive'} &middot; {ep.findingCount} sources &middot; {formatDate(ep.generatedAt)}
+                    </p>
+                  </div>
+                </div>
+
+                <audio
+                  controls
+                  src={ep.audioUrl}
+                  className="w-full"
+                  preload="metadata"
+                />
+
+                <div className="mt-2 flex items-center justify-between">
+                  <Link
+                    href={`/reading-room/thread/${ep.threadId}`}
+                    className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
+                  >
+                    View sources & transcript
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+        {/* CTA */}
+        <div className="mt-12 pt-8 border-t border-[#e8e4dc] text-center">
+          <p className="text-[#6b6560] text-sm font-body mb-3">
+            Want to create your own episode?
+          </p>
+          <Link
+            href="/reading-room"
+            className="inline-block px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors"
+          >
+            Research a topic in the Reading Room
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -556,6 +556,15 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
             </svg>
             Try voice conversation
           </Link>
+          <Link
+            href="/podcast"
+            className="inline-flex items-center gap-2 mt-2 px-4 py-2 bg-white/10 hover:bg-white/20 text-white/80 hover:text-white text-sm rounded-lg backdrop-blur-sm border border-white/10 transition-all"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.114 5.636a9 9 0 010 12.728M16.463 8.288a5.25 5.25 0 010 7.424M6.75 8.25l4.72-4.72a.75.75 0 011.28.53v15.88a.75.75 0 01-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.01 9.01 0 012.25 12c0-.83.112-1.633.322-2.396C2.806 8.756 3.63 8.25 4.51 8.25H6.75z" />
+            </svg>
+            Listen to Deep Dives
+          </Link>
 
           {featuredPassage && (
             <div className="mt-8 max-w-[560px]">

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -13,6 +13,7 @@ const NAV_LINKS = [
   { label: 'Timeline', href: '/timeline' },
   { label: 'Libraries', href: '/libraries' },
   { label: 'Reading Room', href: '/reading-room' },
+  { label: 'Podcast', href: '/podcast' },
 ];
 
 interface Breadcrumb {


### PR DESCRIPTION
## Summary
New `/podcast` page listing all generated episodes, plus navigation links.

### Podcast page (`/podcast`)
- Lists all threads with generated podcasts
- Book cover thumbnails from cited sources
- Inline audio player per episode
- Format label (Deep Dive, Brief, etc.), source count, date
- Link to thread page for full transcript, source cards, and interactive mode
- RSS feed link at top
- CTA at bottom: "Research a topic in the Reading Room"

### Navigation
- "Podcast" added to main site nav in SiteHeader (appears after "Reading Room")
- "Listen to Deep Dives" button added to Reading Room hero alongside "Try voice conversation"

## Test plan
- [ ] Visit https://sourcelibrary.org/podcast — verify both episodes appear
- [ ] Verify audio plays inline
- [ ] Verify book cover thumbnails load
- [ ] Click "View sources & transcript" — verify links to thread page
- [ ] Check nav bar shows "Podcast" link
- [ ] Check Reading Room hero shows "Listen to Deep Dives" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)