### PR TITLE
Fix voice agent permission denied error message

### DIFF
--- a/src/app/reading-room/voice/VoiceAgentClient.tsx
+++ b/src/app/reading-room/voice/VoiceAgentClient.tsx
@@ -176,7 +176,14 @@ function VoiceAgentInner() {
         return [...prev, entry];
       });
     },
-    onError: (message: string) => { console.error('[voice-agent]', message); setErrorMsg(message || 'Connection error'); setAppStatus('error'); },
+    onError: (message: string) => {
+      console.error('[voice-agent]', message);
+      const msg = message || 'Connection error';
+      if (msg.includes('Permission') || msg.includes('NotAllowed') || msg.includes('permission'))
+        setErrorMsg('Microphone access needed. Your browser should prompt you — if not, click the lock icon in the address bar and allow microphone access.');
+      else setErrorMsg(msg);
+      setAppStatus('error');
+    },
     onStatusChange: ({ status }: { status: string }) => {
       if (status === 'connected') setAppStatus('connected');
       else if (status === 'connecting') setAppStatus('connecting');


### PR DESCRIPTION
## Summary
- The "Permission denied" error from browser mic access was arriving via the ElevenLabs SDK's `onError` callback, which showed the raw message
- The friendly "Microphone access needed..." message only triggered in the `start()` catch block, not the async callback
- Now both paths show the same user-friendly message

## Test plan
- [ ] Open `/reading-room/voice`, deny microphone permission — should show friendly message instead of raw "Permission denied"

🤖 Generated with [Claude Code](https://claude.com/claude-code)