### PR TITLE
Fix numeric book IDs returning 500 and stale search test

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -29,13 +29,12 @@ test.describe('Search', () => {
     await measurePerf(page, 'search: result cards link to books');
   });
 
-  test('search results heading appears', async ({ page }) => {
+  test('search results summary appears', async ({ page }) => {
     await page.goto(`/search?q=${SEARCH.query}`);
 
-    // Wait for results heading (indicates search completed and found results)
-    // The heading shows "{N} results" in the unified view
-    const resultsHeading = page.getByRole('heading', { name: /results/i });
-    await expect(resultsHeading).toBeVisible({ timeout: SEARCH_TIMEOUT });
-    await measurePerf(page, 'search: results heading appears');
+    // In the unified "All" view, results show as accordion sections like "Books (5)"
+    const booksSection = page.getByText(/books\s*\(\d+\)/i);
+    await expect(booksSection.first()).toBeVisible({ timeout: SEARCH_TIMEOUT });
+    await measurePerf(page, 'search: results summary appears');
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -194,8 +194,9 @@ export function proxy(request: NextRequest) {
 
     // Non-slug IDs → redirect to canonical slug URL.
     // Slugs contain hyphens and are >24 chars. ObjectIds are exactly 24 hex chars.
-    // Custom IDs are shorter hex strings. Both lack hyphens.
-    const looksLikeId = /^[0-9a-f]{24}$/.test(segment) || (!segment.includes('-') && /^[0-9a-f]+$/.test(segment));
+    // Custom IDs are shorter hex strings with at least one hex letter (a-f).
+    // Pure numeric strings (e.g. "13") are not valid IDs and should 404 normally.
+    const looksLikeId = /^[0-9a-f]{24}$/.test(segment) || (!segment.includes('-') && /^[0-9a-f]+$/.test(segment) && /[a-f]/.test(segment));
     if (looksLikeId) {
       const url = request.nextUrl.clone();
       url.pathname = '/api/redirect/book-slug';


### PR DESCRIPTION
## Summary
- **Proxy fix:** Pure numeric URLs like `/book/13` were matched as hex IDs by the proxy regex, routed to the slug-redirect handler, and returned 500 when no book was found. Now requires at least one hex letter (a-f) so pure numbers fall through to 404 normally.
- **E2E fix:** Search test expected a heading with "results" but the unified search UI uses accordion sections like "Books (5)". Updated selector to match current UI.

## Test plan
- [x] Full e2e suite: 61/61 passing (was 59/61)
- [x] Regex logic verified: `13`, `16`, `999` no longer match; `abc`, `a1b2c3`, full ObjectIds still match
- [ ] Verify `/book/13` returns 404 (not 500) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)