### PR TITLE
Fix art collections showing 0 works

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -63,6 +63,7 @@ export async function GET(
       const { books: sbBooks, total } = await browseBooks({
         collection: id,
         hasTranslation: !skipTranslationFilter,
+        hasPages: isArtCollection ? false : undefined,
         sort: sbSort,
         limit: 1000, // manifest wants everything
         exactCount: true,
@@ -88,6 +89,7 @@ export async function GET(
     const { books: sbBooks, total } = await browseBooks({
       collection: id,
       hasTranslation: !skipTranslationFilter,
+      hasPages: isArtCollection ? false : undefined,
       language: language || undefined,
       search: q || undefined,
       sort: sbSort,
@@ -111,6 +113,7 @@ export async function GET(
     const { books: highlightBooks } = await browseBooks({
       collection: id,
       hasTranslation: !skipTranslationFilter,
+      hasPages: isArtCollection ? false : undefined,
       sort: 'quality',
       limit: 5,
     });

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -276,6 +276,7 @@ async function fetchCollectionData(id: string) {
         sort: 'popular',
         limit: COMPACT_LIMIT,
         skipCount: true, // collection.book_count is cached — skip expensive Supabase count
+        hasPages: isArtCollection ? false : undefined,
       });
       return sbBooks.map(b => ({
         id: b.id, slug: b.slug, title: b.title, display_title: b.display_title,


### PR DESCRIPTION
## Summary
- Art collection pages (e.g. `/collections/haarlem-mannerists`) showed "0 works" because `browseBooks()` defaults to filtering `pages_count > 0`
- Artworks have `pages_count=0` (they're visual works, not books with pages), so all 7,449 artworks were excluded
- Pass `hasPages: false` for `visual_art` collections in both the SSR page component and the client-side API route
- Also fixed DB: updated `book_count` and `visible` flags for all 19 art collections

## Test plan
- [ ] Visit `/collections/haarlem-mannerists` — should show 1,179 works
- [ ] Visit `/artwork` — should show all 19 collections with correct counts
- [ ] Check client-side pagination/search within an art collection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)