### PR TITLE
Remove duplicate download/stats bar from book page

### DIFF
--- a/scripts/import-met-artworks.mjs
+++ b/scripts/import-met-artworks.mjs
@@ -308,9 +308,17 @@ async function main() {
       harvested_at: new Date(),
     };
 
-    await books.insertOne(doc);
-    console.log(`  ✓ ${slug} — ${artist} — ${title.substring(0, 50)} (${obj.objectDate || '?'})`);
-    totalImported++;
+    try {
+      await books.insertOne(doc);
+      console.log(`  ✓ ${slug} — ${artist} — ${title.substring(0, 50)} (${obj.objectDate || '?'})`);
+      totalImported++;
+    } catch (err) {
+      if (err.code === 11000) {
+        totalSkipped++;
+        return;
+      }
+      throw err;
+    }
   }
 
   // ─── Explicit object IDs mode ───────────────────────────────────────────────

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -882,11 +882,11 @@ async function BookInfo({ id }: { id: string }) {
           if (membersOnlyUntil && new Date(membersOnlyUntil) > new Date()) {
             return (
               <EarlyAccessGate membersOnlyUntil={membersOnlyUntil}>
-                <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} totalPagesOcr={book.pages_ocr} totalPagesTranslated={book.pages_translated} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />
+                <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />
               </EarlyAccessGate>
             );
           }
-          return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} totalPagesOcr={book.pages_ocr} totalPagesTranslated={book.pages_translated} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
+          return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
         })()}
         <AuthCheck role="admin">
           <BookHistory bookId={book.id} />

--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -8,10 +8,7 @@ import type { ActionType } from './ProcessingPanel';
 import { prompts as promptsApi, jobs, books } from '@/lib/api-client';
 import { queueBooks } from '@/lib/api-client/queues';
 import { getPageThumbUrl } from '@/lib/utils';
-import { AuthCheck } from '@/components/auth/AuthCheck';
-import BookPagesStats from './BookPagesStats';
 import JobStatusBanner from './JobStatusBanner';
-import DownloadButton from '@/components/ui/DownloadButton';
 import PagesGrid from './PagesGrid';
 
 interface BookPagesSectionProps {
@@ -19,14 +16,12 @@ interface BookPagesSectionProps {
   bookTitle?: string;
   pages: Page[];
   totalPageCount?: number;
-  totalPagesOcr?: number;
-  totalPagesTranslated?: number;
   displayBrightness?: number;
 }
 
 const PAGES_PER_LOAD = 24; // 2 rows on 12-col grid
 
-export default function BookPagesSection({ bookId, bookTitle, pages: initialPages, totalPageCount, totalPagesOcr, totalPagesTranslated, displayBrightness }: BookPagesSectionProps) {
+export default function BookPagesSection({ bookId, bookTitle, pages: initialPages, totalPageCount, displayBrightness }: BookPagesSectionProps) {
   const [pages, setPages] = useState(initialPages);
   const [allPagesFetched, setAllPagesFetched] = useState(
     !totalPageCount || initialPages.length >= totalPageCount
@@ -127,21 +122,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
 
   const lastSelectedIndexRef = useRef<number | null>(null);
 
-  // Use book-level cached counts when available (page array may be truncated to first 100)
-  const pagesWithOcr = totalPagesOcr ?? pages.filter(p => p.ocr?.updated_at).length;
-  const pagesWithTranslation = totalPagesTranslated ?? pages.filter(p => p.translation?.updated_at).length;
   const totalPages = totalPageCount || pages.length;
-
-  // Calculate last activity dates
-  const lastOcrDate = pages
-    .filter(p => p.ocr?.updated_at)
-    .map(p => new Date(p.ocr!.updated_at!))
-    .sort((a, b) => b.getTime() - a.getTime())[0];
-
-  const lastTranslationDate = pages
-    .filter(p => p.translation?.updated_at)
-    .map(p => new Date(p.translation!.updated_at!))
-    .sort((a, b) => b.getTime() - a.getTime())[0];
 
   // Fetch current job on mount
   useEffect(() => {
@@ -510,26 +491,6 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
 
   return (
     <div className="space-y-6">
-      {/* Stats Bar — inner_circle only */}
-      <AuthCheck role="inner_circle">
-        <div className="bg-white rounded-xl border border-stone-200 p-4">
-          <div className="flex items-center justify-between">
-            <BookPagesStats
-              pagesWithOcr={pagesWithOcr}
-              pagesWithTranslation={pagesWithTranslation}
-              totalPages={totalPages}
-              lastOcrDate={lastOcrDate}
-              lastTranslationDate={lastTranslationDate}
-            />
-            <DownloadButton
-              bookId={bookId}
-              hasTranslations={pagesWithTranslation > 0}
-              hasOcr={pagesWithOcr > 0}
-            />
-          </div>
-        </div>
-      </AuthCheck>
-
       {/* Job Status Banner */}
       {currentJob && (
         <JobStatusBanner


### PR DESCRIPTION
## Summary
- Remove the redundant stats bar (OCR count, translation count, download button) from BookPagesSection — this info is already in the header utility bar
- Clean up unused imports (BookPagesStats, DownloadButton, AuthCheck) and props (totalPagesOcr, totalPagesTranslated)
- Handle duplicate key errors gracefully in Met artwork import script

## Test plan
- [ ] Visit any book page — verify download button still works in header
- [ ] Verify the stats bar no longer appears below "Pages" heading
- [ ] Confirm no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)