### PR TITLE
Fix librarian dropping newlines between paragraphs

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -788,7 +788,7 @@ export async function* streamAgenticResponse(
         allParts.push(p);
         if (p.functionCall) {
           functionCalls.push(p);
-        } else if (p.text?.trim()) {
+        } else if (p.text) {
           yield { type: 'text', text: p.text };
         }
       }


### PR DESCRIPTION
## Summary
Root cause of the "wall of text" in librarian chat: `p.text?.trim()` was used as a truthiness check when streaming Gemini chunks. Chunks that were only whitespace (like `"\n\n"` between paragraphs) got silently dropped, gluing paragraphs together.

**Fix:** Change `p.text?.trim()` to `p.text` — one character change.

## Test plan
- [ ] Ask the librarian a question — response should have visible paragraph spacing
- [ ] Headers (## / ###) should render at different sizes
- [ ] Blockquotes should be indented with a left border

🤖 Generated with [Claude Code](https://claude.com/claude-code)