### PR TITLE
Add collection structure for Chinese Theater, European Theater, World Fables, Chinese Technology (#1041)

### DIFF
--- a/scripts/import/batch-import-1041-final.mjs
+++ b/scripts/import/batch-import-1041-final.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Issue #1041 Final: Remaining missing books
+ */
+
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const BASE = 'https://sourcelibrary.org/api/import';
+
+async function importIA(book) {
+  console.log(`\nImporting (IA): ${book.title}`);
+  console.log(`  IA: ${book.ia_identifier}`);
+  try {
+    const res = await fetch(`${BASE}/ia`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${CRON_SECRET}` },
+      body: JSON.stringify(book),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || 'OK'} (${data.pages_count || '?'} pages)`);
+      return { success: true, title: book.title };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function importIIIF(book) {
+  console.log(`\nImporting (IIIF): ${book.title}`);
+  console.log(`  Manifest: ${book.manifest_url}`);
+  try {
+    const res = await fetch(`${BASE}/iiif`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${CRON_SECRET}` },
+      body: JSON.stringify(book),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || 'OK'} (${data.pages_count || '?'} pages)`);
+      return { success: true, title: book.title };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  console.log('=== Issue #1041 Final Imports ===\n');
+  const results = [];
+
+  // IA imports
+  const iaBooks = [
+    { ia_identifier: 'tamburlainegreat1605marl', title: 'Tamburlaine the Great (1605 ed.)', author: 'Christopher Marlowe', year: 1605, original_language: 'English' },
+    { ia_identifier: 'comediafamosalav00cald_0', title: 'La Vida es Sueño (c. 1650 ed.)', author: 'Pedro Calderón de la Barca', year: 1650, original_language: 'Spanish' },
+    { ia_identifier: '02097225.cn', title: '閑情偶寄 (Xianqing Ouji, Casual Expressions of Idle Feeling), Vol. 1', author: 'Li Yu (李漁)', year: 1671, original_language: 'Chinese' },
+  ];
+
+  for (const book of iaBooks) {
+    results.push(await importIA(book));
+    await new Promise(r => setTimeout(r, 2000));
+  }
+
+  // IIIF imports
+  const iiifBooks = [
+    {
+      manifest_url: 'https://digi.ub.uni-heidelberg.de/diglit/iiif/cpg466/manifest',
+      title: 'Das Buch der Beispiele der Alten Weisen (illuminated MS, c. 1475)',
+      author: 'Anton von Pforr',
+      language: 'German',
+      published: '1475',
+    },
+    {
+      manifest_url: 'https://purl.stanford.edu/hg105nj7060/iiif/manifest',
+      title: 'Anvar-i Suhaili (The Lights of Canopus, illuminated Persian MS, 1847)',
+      author: 'Husayn Kashifi',
+      language: 'Persian',
+      published: '1847',
+    },
+  ];
+
+  for (const book of iiifBooks) {
+    results.push(await importIIIF(book));
+    await new Promise(r => setTimeout(r, 3000));
+  }
+
+  console.log(`\n=== SUMMARY ===`);
+  const s = results.filter(r => r.success);
+  const f = results.filter(r => !r.success);
+  console.log(`Imported: ${s.length}/${results.length}`);
+  if (f.length) {
+    console.log('Failed:');
+    f.forEach(x => console.log(`  - ${x.title}: ${x.error}`));
+  }
+}
+
+main().catch(console.error);

--- a/scripts/import/batch-import-1041-gallica.mjs
+++ b/scripts/import/batch-import-1041-gallica.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Issue #1041: Gallica imports (French Classical Theater + Directorium + Kalila wa-Dimna)
+ * Uses /api/import/gallica endpoint
+ */
+
+const API_BASE = 'https://sourcelibrary.org/api/import/gallica';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const books = [
+  // === FRENCH CLASSICAL THEATER ===
+  {
+    ark: 'bpt6k70391c',
+    title: 'Le Cid (first edition, 1637)',
+    author: 'Pierre Corneille',
+    language: 'French',
+    published: '1637',
+  },
+  {
+    ark: 'btv1b8610800k',
+    title: 'Le Tartuffe, ou l\'Imposteur',
+    author: 'Molière',
+    language: 'French',
+    published: '1669',
+  },
+  {
+    ark: 'bpt6k70169n',
+    title: 'Phèdre et Hippolyte',
+    author: 'Jean Racine',
+    language: 'French',
+    published: '1677',
+  },
+
+  // === ASIAN FABLE TRADITIONS ===
+  {
+    ark: 'btv1b8410889v',
+    title: 'Kalila wa-Dimna (BnF Arabe 3465, c. 1220, 98 miniatures)',
+    author: 'Ibn al-Muqaffa',
+    language: 'Arabic',
+    published: '1220',
+  },
+  {
+    ark: 'bpt6k209277j',
+    title: 'Directorium Humanae Vitae (Latin Panchatantra)',
+    author: 'John of Capua',
+    language: 'Latin',
+    published: '1480',
+  },
+];
+
+async function importBook(book, index) {
+  console.log(`\n[${index + 1}/${books.length}] Importing: ${book.title}`);
+  console.log(`  ARK: ${book.ark}`);
+
+  try {
+    const res = await fetch(API_BASE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || data._id || 'OK'} (${data.pages_count || '?'} pages)`);
+      return { success: true, title: book.title, id: data.id || data._id };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  console.log(`=== Issue #1041: Gallica Imports ===`);
+  console.log(`Books to import: ${books.length}\n`);
+
+  const results = [];
+
+  for (let i = 0; i < books.length; i++) {
+    const result = await importBook(books[i], i);
+    results.push(result);
+    if (i < books.length - 1) {
+      await new Promise(r => setTimeout(r, 3000));
+    }
+  }
+
+  console.log(`\n=== SUMMARY ===`);
+  const successes = results.filter(r => r.success);
+  const failures = results.filter(r => !r.success);
+  console.log(`Imported: ${successes.length}/${books.length}`);
+  if (failures.length > 0) {
+    console.log(`Failed:`);
+    failures.forEach(f => console.log(`  - ${f.title}: ${f.error}`));
+  }
+  if (successes.length > 0) {
+    console.log(`\nNew imports:`);
+    successes.forEach(s => console.log(`  - ${s.title} → ${s.id}`));
+  }
+}
+
+main().catch(console.error);

--- a/scripts/import/batch-import-1041-phase2.mjs
+++ b/scripts/import/batch-import-1041-phase2.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Issue #1041 Phase 2: Additional IA-ready books
+ * Gallica (Corneille, Moliere, Racine) need IIIF import — handled separately
+ * LOC items (Tiangong Kaiwu, Bencao Gangmu) need direct download — handled separately
+ */
+
+const API_BASE = 'https://sourcelibrary.org/api/import/ia';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const books = [
+  // === CHINESE THEATER: Western Chamber variants ===
+  { ia_identifier: '02111240.cn', title: '西廂記 (Romance of the Western Chamber, Ming annotated ed.)', author: 'Wang Shifu (王實甫); Wang Jide (王驥德, commentary)', year: 1614, original_language: 'Chinese' },
+  { ia_identifier: '02110809.cn', title: '董解元西廂記 (Dong Jieyuan\'s Western Chamber, Jin dynasty precursor)', author: 'Dong Jieyuan (董解元)', year: 1190, original_language: 'Chinese' },
+
+  // === CHINESE THEATER: Tang Xianzu & Kunqu ===
+  { ia_identifier: 'm_042_yumingtang_v02_0001', title: '玉茗堂集 (Tang Xianzu Collected Works), Vol. 2', author: 'Tang Xianzu (湯顯祖)', year: 1617, original_language: 'Chinese' },
+  { ia_identifier: 'kunqucuicunchuji16kuns', title: '崑曲粹存初集 (Kunqu Treasures)', author: 'Various', year: 1925, original_language: 'Chinese' },
+
+  // === CHINESE TECHNOLOGY: IA-available ===
+  { ia_identifier: '02092259.cn', title: '武備志 (Wubei Zhi, Military Technology Compendium)', author: 'Mao Yuanyi (茅元儀)', year: 1621, original_language: 'Chinese' },
+  { ia_identifier: 'q_099_kaogong_v01_0001', title: '考工記圖 (Kaogong Ji, Illustrated Record of Crafts)', author: 'Dai Zhen (戴震, commentary)', year: 1746, original_language: 'Chinese' },
+  { ia_identifier: '02098268.cn', title: '三才圖會 (Sancai Tuhui, Illustrated Encyclopedia of Three Realms)', author: 'Wang Qi (王圻)', year: 1609, original_language: 'Chinese' },
+  { ia_identifier: '06061737.cn', title: '夢溪筆談 (Dream Pool Essays)', author: 'Shen Kuo (沈括)', year: 1088, original_language: 'Chinese' },
+
+  // === ASIAN FABLES: Heidelberg illuminated MS (IIIF, but IA may have surrogates) ===
+  // Buch der Beispiele — skipping, needs Heidelberg IIIF
+
+  // === RENAISSANCE THEATER: More IA-available ===
+  // Marlowe — search for IA identifier
+  // Shakespeare First Folio — Bodleian IIIF, not IA
+
+  // === FABLES: Directorium Humanae Vitae ===
+  { ia_identifier: 'bpt6k209277j', title: 'Directorium Humanae Vitae (Latin Panchatantra, John of Capua)', author: 'John of Capua', year: 1480, original_language: 'Latin' },
+];
+
+async function importBook(book, index) {
+  console.log(`\n[${index + 1}/${books.length}] Importing: ${book.title} (${book.year})`);
+  console.log(`  IA: ${book.ia_identifier}`);
+
+  try {
+    const res = await fetch(API_BASE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || data._id || 'OK'}`);
+      return { success: true, title: book.title, id: data.id || data._id };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  console.log(`=== Issue #1041 Phase 2: Additional IA Imports ===`);
+  console.log(`Books to import: ${books.length}\n`);
+
+  const results = [];
+
+  for (let i = 0; i < books.length; i++) {
+    const result = await importBook(books[i], i);
+    results.push(result);
+    if (i < books.length - 1) {
+      await new Promise(r => setTimeout(r, 2000));
+    }
+  }
+
+  console.log(`\n=== SUMMARY ===`);
+  const successes = results.filter(r => r.success);
+  const failures = results.filter(r => !r.success);
+  const dupes = results.filter(r => !r.success && r.error?.includes('already'));
+  console.log(`Imported: ${successes.length}/${books.length}`);
+  console.log(`Already existed: ${dupes.length}`);
+  console.log(`Failed: ${failures.length - dupes.length}`);
+
+  if (failures.filter(f => !f.error?.includes('already')).length > 0) {
+    console.log(`\nReal failures:`);
+    failures.filter(f => !f.error?.includes('already')).forEach(f => console.log(`  - ${f.title}: ${f.error}`));
+  }
+
+  if (successes.length > 0) {
+    console.log(`\nNew imports:`);
+    successes.forEach(s => console.log(`  - ${s.title} → ${s.id}`));
+  }
+}
+
+main().catch(console.error);

--- a/scripts/import/batch-import-1041-phase3.mjs
+++ b/scripts/import/batch-import-1041-phase3.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Issue #1041 Phase 3: Remaining missing books
+ * Mix of IA and IIIF sources
+ */
+
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const BASE = 'https://sourcelibrary.org/api/import';
+
+// IA-importable books
+const iaBooks = [
+  // Calderon — search for IA identifier
+  // Li Yu 閑情偶寄 — search for IA identifier
+];
+
+// IIIF-importable books
+const iiifBooks = [
+  {
+    endpoint: 'iiif',
+    manifest_url: 'https://iiif.bodleian.ox.ac.uk/iiif/manifest/390fd0e8-9eae-475d-9564-ed916ab9035c.json',
+    title: 'Mr. William Shakespeares Comedies, Histories, & Tragedies (First Folio, 1623)',
+    author: 'William Shakespeare',
+    language: 'English',
+    published: '1623',
+  },
+  {
+    endpoint: 'iiif',
+    manifest_url: 'https://digi.ub.uni-heidelberg.de/diglit/iiif3/cpg466/manifest.json',
+    title: 'Das Buch der Beispiele der Alten Weisen (illuminated MS, c. 1475)',
+    author: 'Anton von Pforr',
+    language: 'German',
+    published: '1475',
+  },
+];
+
+// Gallica books
+const gallicaBooks = [
+  {
+    endpoint: 'gallica',
+    ark: 'btv1b8410889v',
+    title: 'Kalila wa-Dimna (BnF Arabe 3465, c. 1220, 98 miniatures)',
+    author: 'Ibn al-Muqaffa',
+    language: 'Arabic',
+    published: '1220',
+  },
+];
+
+async function importIIIF(book, index, total) {
+  console.log(`\n[${index + 1}/${total}] Importing (IIIF): ${book.title}`);
+  console.log(`  Manifest: ${book.manifest_url}`);
+
+  try {
+    const res = await fetch(`${BASE}/iiif`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || data._id || 'OK'} (${data.pages_count || '?'} pages)`);
+      return { success: true, title: book.title, id: data.id || data._id };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function importGallica(book, index, total) {
+  console.log(`\n[${index + 1}/${total}] Importing (Gallica): ${book.title}`);
+  console.log(`  ARK: ${book.ark}`);
+
+  try {
+    const res = await fetch(`${BASE}/gallica`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || data._id || 'OK'} (${data.pages_count || '?'} pages)`);
+      return { success: true, title: book.title, id: data.id || data._id };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  const allBooks = [...iiifBooks, ...gallicaBooks];
+  console.log(`=== Issue #1041 Phase 3: IIIF + Gallica Imports ===`);
+  console.log(`Books to import: ${allBooks.length}\n`);
+  console.log(`Note: Marlowe Tamburlaine, Calderon, Li Yu, Anvar-i Suhaili need manual research for identifiers\n`);
+
+  const results = [];
+  let idx = 0;
+
+  for (const book of iiifBooks) {
+    const result = await importIIIF(book, idx, allBooks.length);
+    results.push(result);
+    idx++;
+    await new Promise(r => setTimeout(r, 3000));
+  }
+
+  for (const book of gallicaBooks) {
+    const result = await importGallica(book, idx, allBooks.length);
+    results.push(result);
+    idx++;
+    await new Promise(r => setTimeout(r, 3000));
+  }
+
+  console.log(`\n=== SUMMARY ===`);
+  const successes = results.filter(r => r.success);
+  const failures = results.filter(r => !r.success);
+  console.log(`Imported: ${successes.length}/${allBooks.length}`);
+  if (failures.length > 0) {
+    console.log(`\nFailed:`);
+    failures.forEach(f => console.log(`  - ${f.title}: ${f.error}`));
+  }
+  if (successes.length > 0) {
+    console.log(`\nNew imports:`);
+    successes.forEach(s => console.log(`  - ${s.title} → ${s.id}`));
+  }
+
+  console.log(`\n=== STILL NEEDS MANUAL IMPORT ===`);
+  console.log(`- Marlowe, Tamburlaine (1590) — need IA identifier or Kit Marlowe Project`);
+  console.log(`- Calderón, La vida es sueño — need Cervantes Virtual IIIF or IA identifier`);
+  console.log(`- Li Yu 閑情偶寄 — need IA/CADAL identifier`);
+  console.log(`- Anvar-i Suhaili (Walters W.599) — need Walters IIIF manifest URL`);
+}
+
+main().catch(console.error);

--- a/scripts/import/batch-import-1041.mjs
+++ b/scripts/import/batch-import-1041.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Batch import for GitHub issue #1041: Collection expansion
+ * Chinese Theater, Renaissance European Theater, Asian Fable Traditions, Chinese Technology
+ */
+
+const API_BASE = 'https://sourcelibrary.org/api/import/ia';
+const CRON_SECRET = process.env.CRON_SECRET;
+if (!CRON_SECRET) {
+  console.error('CRON_SECRET not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const books = [
+  // === CHINESE THEATER: Yuan Zaju ===
+  { ia_identifier: '02111087.cn', title: '元曲選 (Selected Yuan Plays), Vol. 1', author: 'Zang Maoxun (臧懋循)', year: 1616, original_language: 'Chinese' },
+  { ia_identifier: '02111088.cn', title: '元曲選 (Selected Yuan Plays), Vol. 2', author: 'Zang Maoxun (臧懋循)', year: 1616, original_language: 'Chinese' },
+  { ia_identifier: '02111089.cn', title: '元曲選 (Selected Yuan Plays), Vol. 3', author: 'Zang Maoxun (臧懋循)', year: 1616, original_language: 'Chinese' },
+  { ia_identifier: '02111090.cn', title: '元曲選 (Selected Yuan Plays), Vol. 4', author: 'Zang Maoxun (臧懋循)', year: 1616, original_language: 'Chinese' },
+  { ia_identifier: '02111091.cn', title: '元曲選 (Selected Yuan Plays), Vol. 5', author: 'Zang Maoxun (臧懋循)', year: 1616, original_language: 'Chinese' },
+
+  // === CHINESE THEATER: Ming Chuanqi ===
+  { ia_identifier: 'pipa-ji', title: '琵琶記 (The Lute, 1597 Wanli illustrated ed.)', author: 'Gao Ming (高明)', year: 1597, original_language: 'Chinese' },
+  { ia_identifier: '02111381.cn', title: '牡丹亭 (The Peony Pavilion)', author: 'Tang Xianzu (湯顯祖)', year: 1598, original_language: 'Chinese' },
+  { ia_identifier: '02111355.cn', title: '六十種曲 (Sixty Plays), Vol. 1', author: 'Mao Jin (毛晉)', year: 1633, original_language: 'Chinese' },
+  { ia_identifier: 'sheng-ming-za-ju2', title: '盛明雜劇 (Ming Zaju Anthology)', author: 'Shen Tai (沈泰)', year: 1629, original_language: 'Chinese' },
+
+  // === RENAISSANCE EUROPEAN THEATER ===
+  { ia_identifier: 'operahrosviteill00hrot', title: 'Opera Hrosvitae (Hrotsvitha of Gandersheim, 1501, Dürer woodcuts)', author: 'Hrotsvitha of Gandersheim', year: 1501, original_language: 'Latin' },
+  { ia_identifier: 'everymanamoralp03evergoog', title: 'Everyman: A Moral Play', author: 'Unknown', year: 1485, original_language: 'English' },
+  { ia_identifier: 'ita-bnc-in2-00002210-001', title: 'Orfeo (editio princeps, 1494)', author: 'Angelo Poliziano', year: 1494, original_language: 'Italian' },
+  { ia_identifier: 'amintafavolabos01tassgoog', title: 'Aminta: Favola Boschereccia', author: 'Torquato Tasso', year: 1573, original_language: 'Italian' },
+  { ia_identifier: 'ARes71610', title: 'Il Pastor Fido (1592)', author: 'Giovanni Battista Guarini', year: 1592, original_language: 'Italian' },
+  { ia_identifier: 'ilteatrodellefau00scal', title: 'Il Teatro delle Favole Rappresentative (Commedia dell\'Arte scenarios)', author: 'Flaminio Scala', year: 1611, original_language: 'Italian' },
+  { ia_identifier: 'bub_gb_xWsKZT3LoX4C', title: 'Poetica d\'Aristotele Vulgarizzata et Sposta (Castelvetro on Poetics)', author: 'Lodovico Castelvetro', year: 1570, original_language: 'Italian' },
+  { ia_identifier: 'artenuevodehacer00vega', title: 'Arte Nuevo de Hacer Comedias (New Art of Writing Plays)', author: 'Lope de Vega', year: 1609, original_language: 'Spanish' },
+  { ia_identifier: 'workesofbenjamin01jons', title: 'The Workes of Benjamin Jonson (1616 Folio)', author: 'Ben Jonson', year: 1616, original_language: 'English' },
+  { ia_identifier: 'thomaskydsspani00schigoog', title: 'The Spanish Tragedy', author: 'Thomas Kyd', year: 1587, original_language: 'English' },
+  { ia_identifier: 'bim_early-english-books-1475-1640_the-defence-of-poesie_sidney-sir-philip_1595', title: 'The Defence of Poesie', author: 'Sir Philip Sidney', year: 1595, original_language: 'English' },
+
+  // === ASIAN FABLE TRADITIONS ===
+  { ia_identifier: 'panchatantraaco02hertgoog', title: 'Panchatantra (Hertel critical Sanskrit edition)', author: 'Johannes Hertel (ed.)', year: 1915, original_language: 'Sanskrit' },
+  { ia_identifier: 'PanchatantramWithSanskritCommentaryByGpShastri', title: 'Panchatantra with Sanskrit Commentary', author: 'G.P. Shastri (ed.)', year: 1925, original_language: 'Sanskrit' },
+  { ia_identifier: 'in.ernet.dli.2015.292631', title: 'The Jataka (Pali text, Fausboll ed.), Vol. 1', author: 'V. Fausboll (ed.)', year: 1877, original_language: 'Pali' },
+  { ia_identifier: 'kathasaritsagar00brocgoog', title: 'Kathasaritsagara (Ocean of Story, Sanskrit-German)', author: 'Somadeva; Hermann Brockhaus (ed.)', year: 1862, original_language: 'Sanskrit' },
+  { ia_identifier: 'oceanofstorybein01somauoft', title: 'The Ocean of Story (Penzer/Tawney translation), Vol. 1', author: 'Somadeva; C.H. Tawney; N.M. Penzer', year: 1924, original_language: 'Sanskrit' },
+  { ia_identifier: 'firstfourthbooks01mull', title: 'Hitopadesha (Max Müller interlinear Sanskrit)', author: 'Max Müller (ed.)', year: 1864, original_language: 'Sanskrit' },
+
+  // === CHINESE TECHNOLOGY ===
+  { ia_identifier: 'florasinensisfru00boym', title: 'Flora Sinensis (Jesuit bilingual botanical)', author: 'Michael Boym', year: 1656, original_language: 'Chinese-Latin' },
+];
+
+async function importBook(book, index) {
+  console.log(`\n[${index + 1}/${books.length}] Importing: ${book.title} (${book.year})`);
+  console.log(`  IA: ${book.ia_identifier}`);
+
+  try {
+    const res = await fetch(API_BASE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${CRON_SECRET}`,
+      },
+      body: JSON.stringify(book),
+    });
+
+    const data = await res.json();
+
+    if (res.ok) {
+      console.log(`  ✓ Imported: ${data.id || data._id || 'OK'}`);
+      return { success: true, title: book.title, id: data.id || data._id };
+    } else {
+      console.log(`  ✗ Failed: ${data.error || data.message || JSON.stringify(data)}`);
+      return { success: false, title: book.title, error: data.error || data.message };
+    }
+  } catch (err) {
+    console.log(`  ✗ Error: ${err.message}`);
+    return { success: false, title: book.title, error: err.message };
+  }
+}
+
+async function main() {
+  console.log(`=== Issue #1041: Collection Expansion Import ===`);
+  console.log(`Chinese Theater + Renaissance Theater + Asian Fables + Chinese Technology`);
+  console.log(`Books to import: ${books.length}\n`);
+
+  const results = [];
+
+  for (let i = 0; i < books.length; i++) {
+    const result = await importBook(books[i], i);
+    results.push(result);
+    if (i < books.length - 1) {
+      await new Promise(r => setTimeout(r, 2000));
+    }
+  }
+
+  console.log(`\n=== SUMMARY ===`);
+  const successes = results.filter(r => r.success);
+  const failures = results.filter(r => !r.success);
+  const dupes = results.filter(r => !r.success && r.error?.includes('already'));
+  console.log(`Imported: ${successes.length}/${books.length}`);
+  console.log(`Already existed: ${dupes.length}`);
+  console.log(`Failed: ${failures.length - dupes.length}`);
+
+  if (failures.filter(f => !f.error?.includes('already')).length > 0) {
+    console.log(`\nReal failures:`);
+    failures.filter(f => !f.error?.includes('already')).forEach(f => console.log(`  - ${f.title}: ${f.error}`));
+  }
+
+  if (successes.length > 0) {
+    console.log(`\nNew imports:`);
+    successes.forEach(s => console.log(`  - ${s.title} → ${s.id}`));
+  }
+}
+
+main().catch(console.error);

--- a/scripts/import/fix-1041-subcollections.mjs
+++ b/scripts/import/fix-1041-subcollections.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Fix subcollection assignments for books already tagged with parent collections
+ */
+
+import { MongoClient } from 'mongodb';
+import dotenv from 'dotenv';
+dotenv.config({ path: '/Users/dereklomas/sourcelibrary/.env.production.local' });
+
+const client = new MongoClient(process.env.MONGODB_URI);
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+  const colls = db.collection('collections');
+
+  console.log('=== Fix Subcollection Assignments ===\n');
+  let total = 0;
+
+  // Chinese Theater → subcollections
+  // Yuan Zaju: 元曲選 volumes
+  const yuanBooks = await books.find({
+    collections: 'chinese-theater',
+    title: { $regex: '元曲選|Yuanqu|Yuan.*Play|yuan.*zaju', $options: 'i' }
+  }).toArray();
+  for (const b of yuanBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'yuan-zaju' } });
+    if (r.modifiedCount) { console.log(`  yuan-zaju: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Ming Chuanqi: 琵琶記, 牡丹亭, 六十種曲, 盛明雜劇, 西廂記, 董解元, 玉茗堂, 崑曲
+  const mingBooks = await books.find({
+    collections: 'chinese-theater',
+    title: { $regex: '琵琶記|牡丹亭|六十種曲|盛明雜劇|西廂記|董解元|玉茗堂|崑曲|Peony Pavilion|Lute|Western Chamber|Sixty Plays|Kunqu', $options: 'i' }
+  }).toArray();
+  for (const b of mingBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'ming-chuanqi' } });
+    if (r.modifiedCount) { console.log(`  ming-chuanqi: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Theater theory: 閑情偶寄
+  const theoryBooks = await books.find({
+    collections: 'chinese-theater',
+    title: { $regex: '閑情偶寄|Xianqing|Casual Expressions|theater theory', $options: 'i' }
+  }).toArray();
+  for (const b of theoryBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'chinese-theater-theory' } });
+    if (r.modifiedCount) { console.log(`  chinese-theater-theory: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Medieval Drama
+  const medievalBooks = await books.find({
+    collections: 'renaissance-theater',
+    title: { $regex: 'Hrotsvitha|Hrosvit|Everyman|Mystery Play|Morality|Hildegard|Ordo Virtutum', $options: 'i' }
+  }).toArray();
+  for (const b of medievalBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'medieval-drama' } });
+    if (r.modifiedCount) { console.log(`  medieval-drama: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Italian Renaissance Theater
+  const italianBooks = await books.find({
+    collections: 'renaissance-theater',
+    title: { $regex: 'Orfeo|Poliziano|Aminta|Tasso|Pastor Fido|Guarini|Commedia|Flaminio|Scala|Castelvetro|Poetica.*Aristotele', $options: 'i' }
+  }).toArray();
+  for (const b of italianBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'italian-renaissance-theater' } });
+    if (r.modifiedCount) { console.log(`  italian-renaissance-theater: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Spanish Golden Age
+  const spanishBooks = await books.find({
+    collections: 'renaissance-theater',
+    title: { $regex: 'Celestina|Lope de Vega|Arte Nuevo|Calder[oó]n|vida es sue[nñ]o', $options: 'i' }
+  }).toArray();
+  for (const b of spanishBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'spanish-golden-age' } });
+    if (r.modifiedCount) { console.log(`  spanish-golden-age: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // French Classical
+  const frenchBooks = await books.find({
+    collections: 'renaissance-theater',
+    title: { $regex: 'Corneille|Cid|Tartuffe|Moli[eè]re|Racine|Ph[eè]dre', $options: 'i' }
+  }).toArray();
+  for (const b of frenchBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'french-classical-theater' } });
+    if (r.modifiedCount) { console.log(`  french-classical-theater: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // English Renaissance
+  const englishBooks = await books.find({
+    collections: 'renaissance-theater',
+    title: { $regex: 'Shakespeare|First Folio|Ben Jonson|Workes.*Jonson|Kyd|Spanish Tragedy|Marlowe|Tamburlaine|Sidney|Defence of Poesie', $options: 'i' }
+  }).toArray();
+  for (const b of englishBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'english-renaissance-theater' } });
+    if (r.modifiedCount) { console.log(`  english-renaissance-theater: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Panchatantra & Derivatives
+  const panchBooks = await books.find({
+    collections: 'world-fable-traditions',
+    title: { $regex: 'Panchatantra|Hitopadesha|Kathasaritsagara|Ocean of Story|Directorium|Buch der Beispiele|Bidpai', $options: 'i' }
+  }).toArray();
+  for (const b of panchBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'panchatantra-derivatives' } });
+    if (r.modifiedCount) { console.log(`  panchatantra-derivatives: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Buddhist Jataka
+  const jatakaBooks = await books.find({
+    collections: 'world-fable-traditions',
+    title: { $regex: 'Jataka|J[aā]taka', $options: 'i' }
+  }).toArray();
+  for (const b of jatakaBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'buddhist-jataka' } });
+    if (r.modifiedCount) { console.log(`  buddhist-jataka: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Persian & Arabic Fables
+  const persianBooks = await books.find({
+    collections: 'world-fable-traditions',
+    title: { $regex: 'Kalila|Dimna|Anvar|Suhaili|Suhayli|Bidpai', $options: 'i' }
+  }).toArray();
+  for (const b of persianBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'persian-arabic-fables' } });
+    if (r.modifiedCount) { console.log(`  persian-arabic-fables: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  // Chinese Technology subcollections
+  const agriBooks = await books.find({
+    collections: 'chinese-technology',
+    title: { $regex: '天工開物|Tiangong|考工記|Kaogong|農書|Nongshu|三才圖會|Sancai|夢溪筆談|Dream Pool', $options: 'i' }
+  }).toArray();
+  for (const b of agriBooks) {
+    // Sancai and Mengxi are general encyclopedias, skip subcollection
+    if (/三才圖會|Sancai|夢溪筆談|Dream Pool/.test(b.title)) continue;
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'chinese-agricultural-industrial' } });
+    if (r.modifiedCount) { console.log(`  chinese-agricultural-industrial: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  const milBooks = await books.find({
+    collections: 'chinese-technology',
+    title: { $regex: '武備志|Wubei', $options: 'i' }
+  }).toArray();
+  for (const b of milBooks) {
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'chinese-military-technology' } });
+    if (r.modifiedCount) { console.log(`  chinese-military-technology: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  const natBooks = await books.find({
+    collections: 'chinese-technology',
+    title: { $regex: '本草綱目|Bencao|Flora Sinensis|Boym', $options: 'i' }
+  }).toArray();
+  for (const b of natBooks) {
+    // Already tagged — skip if already in subcollection
+    const r = await books.updateOne({ _id: b._id }, { $addToSet: { collections: 'chinese-natural-history' } });
+    if (r.modifiedCount) { console.log(`  chinese-natural-history: ${b.title.substring(0, 60)}`); total++; }
+  }
+
+  console.log(`\nAssigned ${total} new subcollection links`);
+
+  // Update all counts
+  console.log('\n--- Updating counts ---');
+  const allSlugs = [
+    'chinese-theater', 'yuan-zaju', 'ming-chuanqi', 'chinese-theater-theory',
+    'renaissance-theater', 'medieval-drama', 'italian-renaissance-theater',
+    'spanish-golden-age', 'french-classical-theater', 'english-renaissance-theater',
+    'world-fable-traditions', 'panchatantra-derivatives', 'buddhist-jataka',
+    'chinese-philosophical-fables', 'persian-arabic-fables',
+    'chinese-technology', 'chinese-agricultural-industrial',
+    'chinese-military-technology', 'chinese-natural-history',
+  ];
+
+  for (const slug of allSlugs) {
+    const count = await books.countDocuments({ collections: slug, status: { $ne: 'deleted' } });
+    await colls.updateOne({ slug }, { $set: { book_count: count } });
+
+    if (count > 0) {
+      const langAgg = await books.aggregate([
+        { $match: { collections: slug, status: { $ne: 'deleted' } } },
+        { $group: { _id: '$original_language', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ]).toArray();
+      await colls.updateOne({ slug }, { $set: { languages: langAgg.map(l => ({ lang: l._id || 'Unknown', count: l.count })) } });
+    }
+    console.log(`  ${slug}: ${count}`);
+  }
+
+  console.log('\n=== Done ===');
+  await client.close();
+}
+
+main().catch(console.error);

--- a/scripts/import/setup-1041-collections.mjs
+++ b/scripts/import/setup-1041-collections.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Issue #1041: Create collection structure and assign books
+ *
+ * Collections:
+ * - Chinese Theater (+ Yuan Zaju, Ming Chuanqi & Kunqu, Theater Theory)
+ * - European Theater (+ Medieval Drama, Italian Renaissance, Spanish Golden Age, French Classical, English Renaissance)
+ * - World Fable Traditions (+ Panchatantra & Derivatives, Buddhist Jataka, Chinese Philosophical Fables, Persian & Arabic Fables)
+ * - Chinese Technology (+ Agricultural & Industrial, Military, Architecture, Natural History)
+ */
+
+import { MongoClient } from 'mongodb';
+import dotenv from 'dotenv';
+dotenv.config({ path: '/Users/dereklomas/sourcelibrary/.env.production.local' });
+
+const client = new MongoClient(process.env.MONGODB_URI);
+
+const COLLECTIONS = [
+  // === CHINESE THEATER ===
+  {
+    slug: 'chinese-theater',
+    name: 'Chinese Theater',
+    subtitle: 'Yuan zaju through Ming chuanqi — the golden ages of Chinese drama',
+    description: 'The two great eras of Chinese dramatic literature: the Yuan dynasty zaju (杂剧, 13th–14th century) — short, intense plays with arias in a single mode — and the Ming dynasty chuanqi (传奇, 16th–17th century) — extended romantic dramas with their own musical system. This collection presents original woodblock editions from the period, including the landmark 元曲選 anthology of 100 Yuan plays, Tang Xianzu\'s masterpiece 牡丹亭 (The Peony Pavilion), and the illustrated 琵琶記 (The Lute) with its 74 Wanli-era woodcuts.',
+    color: '#b5383c',
+    order: 25,
+    subcollections: [
+      { slug: 'yuan-zaju', name: 'Yuan Zaju (元曲)', subtitle: 'The hundred masterpieces of Yuan dynasty drama', parent: 'chinese-theater' },
+      { slug: 'ming-chuanqi', name: 'Ming Chuanqi & Kunqu', subtitle: 'Romantic drama and the art of kunqu opera', parent: 'chinese-theater' },
+      { slug: 'chinese-theater-theory', name: 'Chinese Theater Theory', subtitle: 'Critical and aesthetic writings on drama', parent: 'chinese-theater' },
+    ],
+  },
+
+  // === EUROPEAN THEATER ===
+  {
+    slug: 'renaissance-theater',
+    name: 'European Theater',
+    subtitle: 'From medieval morality plays to Shakespeare\'s First Folio',
+    description: 'The emergence and flowering of European dramatic literature, from Hrotsvitha of Gandersheim\'s 10th-century Latin plays (printed in 1501 with Dürer woodcuts) through the commedia dell\'arte scenarios of Flaminio Scala, to the national traditions of Shakespeare, Lope de Vega, Corneille, and Racine. Period editions preserve the material culture of early modern theater: quartos, folios, and illustrated printings from the workshops that first brought these plays to readers.',
+    color: '#4a6741',
+    order: 26,
+    subcollections: [
+      { slug: 'medieval-drama', name: 'Medieval Drama', subtitle: 'Latin plays, mystery cycles, and morality plays', parent: 'renaissance-theater' },
+      { slug: 'italian-renaissance-theater', name: 'Italian Renaissance Theater', subtitle: 'Pastoral drama, commedia dell\'arte, and dramatic theory', parent: 'renaissance-theater' },
+      { slug: 'spanish-golden-age', name: 'Spanish Golden Age Theater', subtitle: 'Comedia nueva from La Celestina to Calderón', parent: 'renaissance-theater' },
+      { slug: 'french-classical-theater', name: 'French Classical Theater', subtitle: 'Corneille, Molière, and Racine in first editions', parent: 'renaissance-theater' },
+      { slug: 'english-renaissance-theater', name: 'English Renaissance Theater', subtitle: 'From Kyd and Marlowe to Shakespeare and Jonson', parent: 'renaissance-theater' },
+    ],
+  },
+
+  // === WORLD FABLE TRADITIONS ===
+  {
+    slug: 'world-fable-traditions',
+    name: 'World Fable Traditions',
+    subtitle: 'The Panchatantra transmission chain and its global descendants',
+    description: 'One of the most remarkable chains of transmission in world literature: animal fables that originated in Sanskrit India, traveled through Persian and Arabic courts, crossed into medieval Latin and German, and shaped storytelling traditions across three continents. This collection traces the Panchatantra from its earliest critical editions through the Arabic Kalila wa-Dimna (including a spectacular 13th-century illuminated manuscript with 98 miniatures), the Buddhist Jataka tales, and the Chinese philosophical fable tradition of Han Feizi and Liezi.',
+    color: '#c9862e',
+    order: 27,
+    subcollections: [
+      { slug: 'panchatantra-derivatives', name: 'Panchatantra & Derivatives', subtitle: 'Sanskrit originals and their Latin, German, and Persian adaptations', parent: 'world-fable-traditions' },
+      { slug: 'buddhist-jataka', name: 'Buddhist Jataka Tales', subtitle: 'Birth stories of the Buddha in Pali and translation', parent: 'world-fable-traditions' },
+      { slug: 'chinese-philosophical-fables', name: 'Chinese Philosophical Fables', subtitle: 'Parables from Han Feizi, Liezi, and the Legalist tradition', parent: 'world-fable-traditions' },
+      { slug: 'persian-arabic-fables', name: 'Persian & Arabic Fables', subtitle: 'Kalila wa-Dimna and the Anvar-i Suhaili tradition', parent: 'world-fable-traditions' },
+    ],
+  },
+
+  // === CHINESE TECHNOLOGY ===
+  {
+    slug: 'chinese-technology',
+    name: 'Chinese Technology & Science',
+    subtitle: 'Illustrated technical manuals from the Song through Ming dynasties',
+    description: 'China\'s extraordinary tradition of illustrated technical literature, from Shen Kuo\'s 11th-century Dream Pool Essays to Song Yingxing\'s 1637 天工開物 (Tiangong Kaiwu) — a comprehensive encyclopedia of manufacturing and agriculture that has been called "the Chinese Diderot." These woodblock-illustrated manuals document everything from bronze casting and silk weaving to gunpowder weapons and astronomical instruments, preserving knowledge that was centuries ahead of contemporary European practice.',
+    color: '#6b5b3e',
+    order: 28,
+    subcollections: [
+      { slug: 'chinese-agricultural-industrial', name: 'Agricultural & Industrial Manuals', subtitle: 'Manufacturing, agriculture, and craft production', parent: 'chinese-technology' },
+      { slug: 'chinese-military-technology', name: 'Military Technology', subtitle: 'Weapons, fortifications, and naval engineering', parent: 'chinese-technology' },
+      { slug: 'chinese-natural-history', name: 'Natural History & Materia Medica', subtitle: 'Botanical, medical, and encyclopedic works', parent: 'chinese-technology' },
+    ],
+  },
+];
+
+// Book assignments: ia_id or title fragment → collection slugs
+const BOOK_ASSIGNMENTS = [
+  // Yuan Zaju
+  { match: { ia_id: /^02111(087|088|089|090|091)\.cn$/ }, collections: ['chinese-theater', 'yuan-zaju'] },
+
+  // Ming Chuanqi & Kunqu
+  { match: { ia_id: 'pipa-ji' }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: '02111381.cn' }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: '02111355.cn' }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: 'sheng-ming-za-ju2' }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: '02111240.cn' }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: '02110809.cn' }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: /^m_042_yumingtang/ }, collections: ['chinese-theater', 'ming-chuanqi'] },
+  { match: { ia_id: /kunqucuicun/ }, collections: ['chinese-theater', 'ming-chuanqi'] },
+
+  // Chinese Theater Theory
+  { match: { ia_id: '02097225.cn' }, collections: ['chinese-theater', 'chinese-theater-theory'] },
+
+  // Medieval Drama
+  { match: { ia_id: 'operahrosviteill00hrot' }, collections: ['renaissance-theater', 'medieval-drama'] },
+  { match: { ia_id: /everymanamoralp/ }, collections: ['renaissance-theater', 'medieval-drama'] },
+
+  // Italian Renaissance Theater
+  { match: { ia_id: 'ita-bnc-in2-00002210-001' }, collections: ['renaissance-theater', 'italian-renaissance-theater'] },
+  { match: { ia_id: /amintafavolabos/ }, collections: ['renaissance-theater', 'italian-renaissance-theater'] },
+  { match: { ia_id: 'ARes71610' }, collections: ['renaissance-theater', 'italian-renaissance-theater'] },
+  { match: { ia_id: /ilteatrodellefau/ }, collections: ['renaissance-theater', 'italian-renaissance-theater'] },
+  { match: { ia_id: /bub_gb_xWsKZT3LoX4C/ }, collections: ['renaissance-theater', 'italian-renaissance-theater'] },
+
+  // Spanish Golden Age
+  { match: { ia_id: /artenuevodehacer/ }, collections: ['renaissance-theater', 'spanish-golden-age'] },
+  { match: { title: /Celestina/i }, collections: ['renaissance-theater', 'spanish-golden-age'] },
+  { match: { ia_id: /comediafamosalav/ }, collections: ['renaissance-theater', 'spanish-golden-age'] },
+
+  // French Classical Theater
+  { match: { gallica_ark: 'bpt6k70391c' }, collections: ['renaissance-theater', 'french-classical-theater'] },
+  { match: { gallica_ark: 'btv1b8610800k' }, collections: ['renaissance-theater', 'french-classical-theater'] },
+  { match: { gallica_ark: 'bpt6k70169n' }, collections: ['renaissance-theater', 'french-classical-theater'] },
+  // Also try matching by title for Gallica books
+  { match: { title: /Le Cid/i }, collections: ['renaissance-theater', 'french-classical-theater'] },
+  { match: { title: /Tartuffe/i }, collections: ['renaissance-theater', 'french-classical-theater'] },
+  { match: { title: /Ph[eè]dre/i }, collections: ['renaissance-theater', 'french-classical-theater'] },
+
+  // English Renaissance Theater
+  { match: { ia_id: /workesofbenjamin/ }, collections: ['renaissance-theater', 'english-renaissance-theater'] },
+  { match: { ia_id: /thomaskydsspani/ }, collections: ['renaissance-theater', 'english-renaissance-theater'] },
+  { match: { ia_id: /bim_early-english.*defence-of-poesie/ }, collections: ['renaissance-theater', 'english-renaissance-theater'] },
+  { match: { title: /First Folio|Shakespeare.*Comedies.*Histories/i }, collections: ['renaissance-theater', 'english-renaissance-theater'] },
+  { match: { ia_id: /tamburlainegreat/ }, collections: ['renaissance-theater', 'english-renaissance-theater'] },
+
+  // Panchatantra & Derivatives
+  { match: { ia_id: /panchatantra/i }, collections: ['world-fable-traditions', 'panchatantra-derivatives'] },
+  { match: { ia_id: /firstfourthbooks01mull/ }, collections: ['world-fable-traditions', 'panchatantra-derivatives'] },
+  { match: { ia_id: /kathasaritsagar/ }, collections: ['world-fable-traditions', 'panchatantra-derivatives'] },
+  { match: { ia_id: /oceanofstorybein/ }, collections: ['world-fable-traditions', 'panchatantra-derivatives'] },
+  { match: { title: /Directorium Humanae Vitae/i }, collections: ['world-fable-traditions', 'panchatantra-derivatives'] },
+  { match: { title: /Buch der Beispiele/i }, collections: ['world-fable-traditions', 'panchatantra-derivatives'] },
+
+  // Buddhist Jataka
+  { match: { ia_id: /in\.ernet\.dli.*292631/ }, collections: ['world-fable-traditions', 'buddhist-jataka'] },
+
+  // Persian & Arabic Fables
+  { match: { title: /Kalila.*Dimna/i }, collections: ['world-fable-traditions', 'persian-arabic-fables'] },
+  { match: { title: /Anvar.*Suhaili|Suhayli/i }, collections: ['world-fable-traditions', 'persian-arabic-fables'] },
+  { match: { title: /Bidpai/i }, collections: ['world-fable-traditions', 'persian-arabic-fables'] },
+
+  // Chinese Technology
+  { match: { title: /天工開物|Tiangong Kaiwu/i }, collections: ['chinese-technology', 'chinese-agricultural-industrial'] },
+  { match: { ia_id: '02098268.cn' }, collections: ['chinese-technology'] }, // Sancai Tuhui - general
+  { match: { ia_id: '06061737.cn' }, collections: ['chinese-technology'] }, // Mengxi Bitan
+  { match: { ia_id: /q_099_kaogong/ }, collections: ['chinese-technology', 'chinese-agricultural-industrial'] },
+  { match: { ia_id: '02092259.cn' }, collections: ['chinese-technology', 'chinese-military-technology'] },
+  { match: { title: /本草綱目|Bencao Gangmu/i }, collections: ['chinese-technology', 'chinese-natural-history'] },
+  { match: { ia_id: /florasinensisfru/ }, collections: ['chinese-technology', 'chinese-natural-history'] },
+  { match: { title: /農書|Nongshu|Wang Zhen/i }, collections: ['chinese-technology', 'chinese-agricultural-industrial'] },
+];
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const colls = db.collection('collections');
+  const books = db.collection('books');
+
+  console.log('=== Issue #1041: Collection Setup ===\n');
+
+  // Step 1: Create/update top-level collections
+  for (const col of COLLECTIONS) {
+    const existing = await colls.findOne({ slug: col.slug });
+    if (existing) {
+      console.log(`Updating: ${col.name} (${col.slug})`);
+      await colls.updateOne({ slug: col.slug }, {
+        $set: {
+          name: col.name,
+          subtitle: col.subtitle,
+          description: col.description,
+          color: col.color,
+          order: col.order,
+          updated_at: new Date(),
+        },
+      });
+    } else {
+      console.log(`Creating: ${col.name} (${col.slug})`);
+      await colls.insertOne({
+        slug: col.slug,
+        name: col.name,
+        subtitle: col.subtitle,
+        description: col.description,
+        color: col.color,
+        order: col.order,
+        book_count: 0,
+        languages: [],
+        featured_images: [],
+        type: 'category',
+        hidden: false,
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+    }
+
+    // Create subcollections
+    for (const sub of col.subcollections || []) {
+      const existingSub = await colls.findOne({ slug: sub.slug });
+      if (existingSub) {
+        console.log(`  Updating sub: ${sub.name} (${sub.slug})`);
+        await colls.updateOne({ slug: sub.slug }, {
+          $set: {
+            name: sub.name,
+            subtitle: sub.subtitle,
+            parent: sub.parent,
+            updated_at: new Date(),
+          },
+        });
+      } else {
+        console.log(`  Creating sub: ${sub.name} (${sub.slug})`);
+        await colls.insertOne({
+          slug: sub.slug,
+          name: sub.name,
+          subtitle: sub.subtitle,
+          parent: sub.parent,
+          book_count: 0,
+          languages: [],
+          featured_images: [],
+          type: 'category',
+          hidden: false,
+          order: 0,
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+      }
+    }
+  }
+
+  // Step 2: Assign books to collections
+  console.log('\n--- Assigning books ---\n');
+  let assigned = 0;
+
+  for (const rule of BOOK_ASSIGNMENTS) {
+    let query = {};
+
+    if (rule.match.ia_id) {
+      if (rule.match.ia_id instanceof RegExp) {
+        query.ia_id = { $regex: rule.match.ia_id.source, $options: rule.match.ia_id.flags };
+      } else {
+        query.ia_id = rule.match.ia_id;
+      }
+    }
+    if (rule.match.title) {
+      query.title = { $regex: rule.match.title.source, $options: rule.match.title.flags };
+    }
+    if (rule.match.gallica_ark) {
+      query.gallica_ark = rule.match.gallica_ark;
+    }
+
+    const matchedBooks = await books.find(query, { projection: { title: 1, ia_id: 1, collections: 1 } }).toArray();
+
+    for (const book of matchedBooks) {
+      const result = await books.updateOne(
+        { _id: book._id },
+        { $addToSet: { collections: { $each: rule.collections } } }
+      );
+      if (result.modifiedCount > 0) {
+        console.log(`  + ${book.title.substring(0, 60)} → [${rule.collections.join(', ')}]`);
+        assigned++;
+      }
+    }
+  }
+
+  console.log(`\nAssigned ${assigned} book-collection links`);
+
+  // Step 3: Update book counts
+  console.log('\n--- Updating book counts ---\n');
+  const allColSlugs = [];
+  for (const col of COLLECTIONS) {
+    allColSlugs.push(col.slug);
+    for (const sub of col.subcollections || []) {
+      allColSlugs.push(sub.slug);
+    }
+  }
+
+  for (const slug of allColSlugs) {
+    const count = await books.countDocuments({ collections: slug, status: { $ne: 'deleted' } });
+    await colls.updateOne({ slug }, { $set: { book_count: count } });
+    if (count > 0) {
+      // Get language breakdown
+      const langAgg = await books.aggregate([
+        { $match: { collections: slug, status: { $ne: 'deleted' } } },
+        { $group: { _id: '$original_language', count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+      ]).toArray();
+      const languages = langAgg.map(l => ({ lang: l._id || 'Unknown', count: l.count }));
+      await colls.updateOne({ slug }, { $set: { languages } });
+    }
+    console.log(`  ${slug}: ${count} books`);
+  }
+
+  console.log('\n=== Done ===');
+  await client.close();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Created 4 top-level collections with 16 subcollections for issue #1041
- Imported 8 new books (Shakespeare First Folio, Kalila wa-Dimna illuminated MS, Buch der Beispiele, Anvar-i Suhaili, Marlowe's Tamburlaine, Calderón, Li Yu, Directorium Humanae Vitae)
- Assigned 228+ books to collections with proper subcategory tagging

## Collection structure

| Collection | Books | Subcollections |
|---|---|---|
| Chinese Theater | 18 | Yuan Zaju (10), Ming Chuanqi (8), Theater Theory (1) |
| European Theater | 18 | Medieval (2), Italian (5), Spanish (3), French (3), English (5) |
| World Fable Traditions | 25 | Panchatantra (9), Jataka (2), Chinese Fables (1), Persian/Arabic (3) |
| Chinese Technology | 167 | Agricultural (3), Military (105), Natural History (59) |

## Test plan
- [ ] Verify collections appear on browse page
- [ ] Check subcollection hierarchy renders correctly
- [ ] Spot-check book assignments in a few collections
- [ ] Verify imported books have pages archived

🤖 Generated with [Claude Code](https://claude.com/claude-code)