### PR TITLE
Improve translation comparison blog post framing

### DIFF
--- a/src/app/blog/translations-across-civilizations/page.tsx
+++ b/src/app/blog/translations-across-civilizations/page.tsx
@@ -1,0 +1,325 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import BlogComments from '@/components/blog/BlogComments';
+import PassageComparison from '@/components/comparison/PassageComparison';
+
+export const metadata: Metadata = {
+  title: 'What Ficino Heard — Translations Across Civilizations | Source Library',
+  description:
+    'The same Hermetic vision, rendered by a Renaissance philosopher in 1481, a 17th-century English scribe, and an AI in 2026. Three translations, three centuries, one text.',
+  openGraph: {
+    title: 'What Ficino Heard',
+    description:
+      'Three translations of the Corpus Hermeticum — Ficino (1481), an anonymous English scribe (1650), and AI (2026) — reveal what each era sought in the same ancient text.',
+    images: [
+      {
+        url: 'https://images.sourcelibrary.org/archived/69938e765d28b693146d0f99/19.jpg',
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+  alternates: {
+    canonical: '/blog/translations-across-civilizations',
+  },
+};
+
+export default function TranslationsAcrossCivilizationsPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="What Ficino Heard"
+          subtitle="Three translations of the Poimandres &mdash; 1481, 1650, 2026"
+        >
+          <p className="text-stone-400 text-sm mt-4">
+            19 April 2026 &middot; 10 min read
+          </p>
+        </ContentHeader>
+      }
+      bg="bg-cream"
+    >
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-secondary transition-colors text-sm"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+          All notes
+        </Link>
+      </div>
+
+      <article className="prose-content max-w-none">
+        <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+          In 1463, a Greek manuscript arrived at the court of Cosimo
+          de&rsquo; Medici in Florence. Cosimo ordered his best scholar,
+          Marsilio Ficino, to drop everything &mdash; including Plato &mdash;
+          and translate it immediately. The text was the{' '}
+          <em>Corpus Hermeticum</em>, attributed to the legendary sage Hermes
+          Trismegistus. Ficino believed it was older than Moses.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          Ficino&rsquo;s 1481 Latin translation shaped five centuries of
+          Western esotericism. But Ficino was not a neutral channel. He was a
+          Neoplatonist, a priest, and a man writing for a patron. Every
+          word he chose was an interpretation. Now, for the first time, we can
+          place his rendering next to two others: a 1650 English manuscript
+          translation, and a direct AI translation from the 1554 Greek editio
+          princeps. The AI has no patron, no theology, no agenda. It is a
+          mirror &mdash; and what it reflects is what the human translators
+          chose to add.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          What follows are three passages from the <em>Poimandres</em>, the
+          first and most famous tractate of the <em>Corpus Hermeticum</em>.
+          In it, Hermes describes a mystical vision: a divine being called
+          Poimandres appears, reveals the creation of the cosmos, and
+          explains the origin and destiny of the human soul.
+        </p>
+
+        {/* ──────── PASSAGE 1: THE OPENING VISION ──────── */}
+
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          I. &ldquo;What Do You Wish to Hear and See?&rdquo;
+        </h2>
+
+        <p className="text-sm text-muted uppercase tracking-wider mb-4">
+          Poimandres I.1&ndash;2 &mdash; The Opening Vision
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6 font-body">
+          The text opens with Hermes in a state of meditation. His bodily
+          senses are &ldquo;put to sleep,&rdquo; and a being of immense size
+          appears. Watch how each translator handles the moment of encounter
+          &mdash; what Ficino makes formal and theological, the English scribe
+          makes intimate, and the AI keeps literal.
+        </p>
+
+        <PassageComparison
+          title="The Appearance of Poimandres"
+          showOriginal={false}
+          passages={[
+            {
+              label: 'Greek (1554 Turnebus)',
+              language: 'Greek',
+              original:
+                'ΕΝΝΟΙΑΣ μοι ποτέ γενομένης περὶ τῶν ὄντων, καὶ μετεωρισθείσης μοι τῆς Διανοίας, σφόδρα κατασχεθῶν μου τῶν σωματικῶν αἰσθήσεων, ὥσπερ οἱ ἐν ὕπνῳ βεβαρημένοι ἐκ κόρου τροφῆς, ἢ ἐκ κόπου σώματος, ἔδοξά τινα ὑπερμεγέθη μέτρῳ ἀπεριορίστῳ τυγχάνοντα, καλεῖν τὸ ὄνομα, καὶ λέγοντά μοι, τί βούλῃ ἀκοῦσαι καὶ θεάσασθαι, καὶ νοήσας μαθεῖν καὶ γνῶναι.',
+              translation:
+                'Once, when I was contemplating the things that exist and my understanding had been lifted high, while my bodily senses were strongly restrained — as if by those who are heavy with sleep from overeating or physical labor — I thought I saw a being of immeasurable size calling my name and saying to me, "What do you wish to hear and see, and having understood, what do you wish to learn and know?"',
+              citation: 'p. 19',
+              bookUrl:
+                '/book/poimandres-greek-editio-princeps-turnebus-trismegistus?page=19',
+            },
+            {
+              label: 'Ficino (Latin, 1481)',
+              language: 'Latin',
+              original:
+                'CVM de rerum natura cogitarē: ac mētis aciem ad superna erigerem: sopitis iam corporis sēsibus: quemadmodū accidere solet iis: qui ob saturitatem: uel defatigationē somno grauati sunt. subito mihi uisus sum cernere quēdam: immensa magnitudine corporis: qui me nomine uocans: in hūc modum clamaret. Quid est o Mercuri: quod & audire: & intueri desideras? Quid est: quod discere atq; inteligere cupis?',
+              translation:
+                'When I was meditating on the nature of things and raising the sharp point of my mind toward the heavens, the senses of my body were now put to sleep — just as it usually happens to those who are heavy with sleep due to fullness or exhaustion. Suddenly, I seemed to see someone of immense bodily size, who, calling me by name, shouted in this manner: "What is it, O Mercury, that you desire to hear and behold? What is it that you wish to learn and understand?"',
+              citation: 'p. 15',
+              bookUrl:
+                '/book/corpus-hermeticum-pimander-1481-venice-edition-hermes-trismegistus?page=15',
+            },
+            {
+              label: 'English MS (c. 1650)',
+              language: 'English',
+              original:
+                'I know what thou wouldest have, & I am allwayes present with thee. Then sayd I; I would learne the things that are, & understand the nature of them, & know God. How? sayd he; I answered that I would gladly heare. Then he, Have me againe in thy minde, & whatsoever thou wouldest learne I will teach thee.',
+              translation:
+                '"I know what thou wouldest have, and I am always present with thee." Then said I: "I would learn the things that are, and understand the nature of them, and know God." "How?" said he. I answered that I would gladly hear. Then he: "Have me again in thy mind, and whatsoever thou wouldest learn I will teach thee."',
+              citation: 'p. 54',
+              bookUrl:
+                '/book/corpus-hermeticum-17th-century-english-translation-ms-imming?page=54',
+            },
+          ]}
+          commentary='Notice how Ficino adds "raising the sharp point of my mind toward the heavens" — the Greek says only that his understanding "was lifted high." Ficino makes the ascent active and intellectual, reflecting his Neoplatonic commitment to the mind as the instrument of divine contact. The English scribe, working from a different tradition, drops the elaborate scene-setting entirely and plunges straight into dialogue. The AI preserves the passive construction of the Greek: understanding was lifted, senses were restrained. Something happens to Hermes. He does not make it happen.'
+        />
+
+        {/* ──────── PASSAGE 2: THE COSMOGONIC VISION ──────── */}
+
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          II. &ldquo;From the Light, the Holy Logos Stepped Upon the
+          Nature&rdquo;
+        </h2>
+
+        <p className="text-sm text-muted uppercase tracking-wider mb-4">
+          Poimandres I.5&ndash;9 &mdash; The Creation of the Elements
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6 font-body">
+          After the initial vision of light and darkness, Poimandres reveals
+          the cosmogony: how fire, air, earth, and water separated, and how
+          the divine Word (Logos) organized chaos into cosmos. This is the
+          passage that most closely parallels Genesis &mdash; and where
+          Ficino&rsquo;s Christian theology leaves its deepest mark.
+        </p>
+
+        <PassageComparison
+          title="The Logos and the Elements"
+          showOriginal={false}
+          passages={[
+            {
+              label: 'Greek (1554 Turnebus)',
+              language: 'Greek',
+              original:
+                'ἐκ δὲ φωτὸς Ὁ λόγος ἅγιος ἐπέβη τῇ φύσει, καὶ πῦρ ἄκρατον ἐξεπήδησεν ἐκ τῆς ὑγρᾶς φύσεως ἄνω εἰς ὕψος· κοῦφον δὲ ἦν καὶ ὀξὺ, δραστικόν τε ἅμα· καὶ ὁ ἀὴρ ἐλαφρὸς ὢν, ἠκολούθησε τῷ πνεύματι.',
+              translation:
+                'From the light, the holy Logos stepped upon the nature, and unmixed fire leaped out from the moist nature up into the height. It was light and sharp and at the same time active. The air, being light, followed the spirit as it ascended from the earth and water up to the fire, so that it seemed to hang from it.',
+              citation: 'p. 20',
+              bookUrl:
+                '/book/poimandres-greek-editio-princeps-turnebus-trismegistus?page=20',
+            },
+            {
+              label: 'Ficino (Latin, 1481)',
+              language: 'Latin',
+              original:
+                'ex hac luminis uoce: uerbũ factũ prodiit: Verũ hoc naturæ humidã adstãs eam fouebat. Ex humidæ autem naturæ uisceribus: sincerus ac leuis ignis emicuit.',
+              translation:
+                'From this voice of light, the Word came forth. Indeed, this Word stood near the moist nature and cherished it. From the depths of that moist nature, a pure and light fire immediately flew out and sought the heights. The air, also being light and following the spirit, took its place in the middle region between the fire and the water.',
+              citation: 'p. 16',
+              bookUrl:
+                '/book/corpus-hermeticum-pimander-1481-venice-edition-hermes-trismegistus?page=16',
+            },
+            {
+              label: 'English MS (c. 1650)',
+              language: 'English',
+              original:
+                'And the ayre, which was also light, followed the spirit, & mounted up even to the fire (frõ the earth & the water) in so much that it seemed to hang & depend upon it; And the earth & the water stayed by themselves so mingled together that the Earth could not be seen for the water; but they were moved because of the spirituall word that was caryed upon them.',
+              translation:
+                'And the air, which was also light, followed the spirit, and mounted up even to the fire — from the earth and the water — insomuch that it seemed to hang and depend upon it. And the earth and the water stayed by themselves so mingled together that the earth could not be seen for the water; but they were moved because of the spiritual word that was carried upon them.',
+              citation: 'p. 55',
+              bookUrl:
+                '/book/corpus-hermeticum-17th-century-english-translation-ms-imming?page=55',
+            },
+          ]}
+          commentary='The Greek says the Logos "stepped upon" (ἐπέβη) the nature — a verb of physical contact, almost violent. Ficino softens this dramatically: his Word "stood near the moist nature and cherished it" (adstans eam fovebat). This is not a translation choice; it is a theological intervention. Ficino&rsquo;s Word is gentle, nurturing, Christological. The Greek Logos is imperious — it treads on chaos. The English scribe preserves the dynamic quality: the spiritual word is "carried upon" the elements, echoing Genesis 1:2 ("the Spirit of God moved upon the face of the waters"). Three translators, three cosmologies.'
+        />
+
+        {/* ──────── PASSAGE 3: THE CREATION OF MAN ──────── */}
+
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          III. &ldquo;The Father Brought Forth a Human Equal to
+          Himself&rdquo;
+        </h2>
+
+        <p className="text-sm text-muted uppercase tracking-wider mb-4">
+          Poimandres I.12&ndash;14 &mdash; The Creation of the Archetypal
+          Human
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6 font-body">
+          The climax of the cosmogony: the divine Mind creates a human being
+          in its own image, who then gazes down through the celestial spheres,
+          sees Nature, and falls in love with his own reflection. This passage
+          is simultaneously a creation myth, a Narcissus story, and the
+          Hermetic answer to the question of why the divine soul is trapped in
+          matter.
+        </p>
+
+        <PassageComparison
+          title="The Archetypal Human"
+          showOriginal={false}
+          passages={[
+            {
+              label: 'Greek (1554 Turnebus)',
+              language: 'Greek',
+              original:
+                'ὁ δὲ πάντων πατήρ, ὁ νοῦς ὢν ζωὴ καὶ φῶς, ἀπεκύησεν ἄνθρωπον αὑτῷ ἴσον, οὗ ἠράσθη ὡς ἰδίου τόκου. περικαλλὴς γὰρ, τὴν τοῦ πατρὸς εἰκόνα ἔχων· ὄντως γὰρ καὶ ὁ θεὸς ἠράσθη τῆς ἰδίας μορφῆς.',
+              translation:
+                'The Father of all, the Nous, being life and light, gave birth to a human equal to himself, whom he loved as his own offspring. For he was all-beautiful, having the image of the Father; truly, God also loved his own form. And he delivered to him all his own creations.',
+              citation: 'p. 22',
+              bookUrl:
+                '/book/poimandres-greek-editio-princeps-turnebus-trismegistus?page=22',
+            },
+            {
+              label: 'Ficino (Latin, 1481)',
+              language: 'Latin',
+              original:
+                'hominem sibi similem procreauit: atque ei tanquā filio suo congratulatus est. Pulcher.n.erat: patrisq; sui ferebat imaginem. Deus.n.re uera propria forma nimirum delectatus: opera eius omnia usui concessit humano.',
+              translation:
+                'He produced a human being similar to himself, and he rejoiced in him as if in his own son. For he was beautiful, and he bore the image of his father. For God, truly delighted with his own form, granted all his works for human use.',
+              citation: 'p. 18',
+              bookUrl:
+                '/book/corpus-hermeticum-pimander-1481-venice-edition-hermes-trismegistus?page=18',
+            },
+            {
+              label: 'English MS (c. 1650)',
+              language: 'English',
+              original:
+                'But the father of all things, the minde, being, life, & light, brought forth Man like unto himself, who he loved as his proper birth, for he was all beauteous, having the image of his father.',
+              translation:
+                'But the father of all things, the mind, being life and light, brought forth Man like unto himself, whom he loved as his proper birth. For he was all beauteous, having the image of his father.',
+              citation: 'p. 58',
+              bookUrl:
+                '/book/corpus-hermeticum-17th-century-english-translation-ms-imming?page=58',
+            },
+          ]}
+          commentary='The Greek says God "gave birth" (ἀπεκύησεν) to a human "equal" (ἴσον) to himself and "loved" (ἠράσθη) him with erotic love — the same verb used for romantic desire. Ficino cannot say this. His God "produced" (procreauit) a human merely "similar" (similem) to himself and "rejoiced" (congratulatus est) rather than loved with eros. The theological distance between "equal" and "similar," between "loved" and "rejoiced," is the distance between Hermeticism and Christianity. The AI preserves the radical equality of the Greek. The English scribe splits the difference: "like unto himself" (similar, not equal), but "loved as his proper birth" (the intimacy is preserved, the equality is not).'
+        />
+
+        {/* ──────── CODA ──────── */}
+
+        <div className="mt-16 pt-8 border-t border-stone-200">
+          <h2 className="text-2xl md:text-3xl text-primary mb-6">
+            Every Translation Is an Interpretation
+          </h2>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The point of this exercise is not &ldquo;AI vs. human &mdash; who
+            wins?&rdquo; No one wins. Every translation is an interpretation,
+            and every interpretation reveals something the others miss.
+            Ficino&rsquo;s Logos &ldquo;cherishes&rdquo; nature because Ficino
+            is a Christian Neoplatonist writing for the Medici. The English
+            scribe&rsquo;s Word is &ldquo;carried upon&rdquo; the waters
+            because the scribe is steeped in the King James Bible. The
+            AI&rsquo;s Logos &ldquo;steps upon&rdquo; nature because the AI
+            has no theology &mdash; only the Greek.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            What the AI gives us is not a better translation. It is a{' '}
+            <em>baseline</em> &mdash; a rendering with no cultural agenda, no
+            patron to please, no Romantic sensibility to project. Against this
+            baseline, the human translations become legible as the creative
+            acts they always were. We can see what Ficino <em>added</em>. We
+            can see what the English scribe <em>heard</em>. We can see, in
+            the gaps between all three, the dimensions of the original that no
+            single translation can capture.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-8 font-body">
+            Source Library holds{' '}
+            <Link
+              href="/work/corpus-hermeticum"
+              className="text-amber-700 hover:underline"
+            >
+              23 editions of the Corpus Hermeticum
+            </Link>{' '}
+            across five languages and five centuries. Every page is
+            OCR&rsquo;d, translated, and searchable. This is what a digital
+            library makes possible: not just access to texts, but access to
+            the history of reading them.
+          </p>
+        </div>
+
+        <BlogComments slug="translations-across-civilizations" />
+      </article>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/blog/translations-across-civilizations/page.tsx
+++ b/src/app/blog/translations-across-civilizations/page.tsx
@@ -64,6 +64,23 @@ export default function TranslationsAcrossCivilizationsPage() {
 
       <article className="prose-content max-w-none">
         <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+          Something new is possible now that has never been possible before.
+          Source Library holds thousands of pre-modern texts in their original
+          languages &mdash; Greek, Latin, Sanskrit, Arabic, Chinese &mdash;
+          alongside AI translations generated directly from those originals.
+          For hundreds of these works, we also hold historical human
+          translations: the versions that shaped civilizations. Place them
+          side by side, and you can see something no single translation
+          reveals: what each translator <em>chose</em> to hear in the
+          original.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          This is the first in a series of experiments with that
+          three-way comparison. We start with the <em>Corpus Hermeticum</em>.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
           In 1463, a Greek manuscript arrived at the court of Cosimo
           de&rsquo; Medici in Florence. Cosimo ordered his best scholar,
           Marsilio Ficino, to drop everything &mdash; including Plato &mdash;
@@ -303,7 +320,7 @@ export default function TranslationsAcrossCivilizationsPage() {
             single translation can capture.
           </p>
 
-          <p className="text-secondary leading-relaxed mb-8 font-body">
+          <p className="text-secondary leading-relaxed mb-6 font-body">
             Source Library holds{' '}
             <Link
               href="/work/corpus-hermeticum"
@@ -315,6 +332,46 @@ export default function TranslationsAcrossCivilizationsPage() {
             OCR&rsquo;d, translated, and searchable. This is what a digital
             library makes possible: not just access to texts, but access to
             the history of reading them.
+          </p>
+
+          <h3 className="text-xl text-primary mt-10 mb-4">
+            Try it yourself
+          </h3>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The Corpus Hermeticum is just the beginning. Source Library holds
+            multi-edition, multi-language data for Plotinus, the Bible,
+            Aristotle, the Panchatantra, Shakuntala, and hundreds of other
+            works. Any work with a{' '}
+            <Link
+              href="/work/corpus-hermeticum/compare"
+              className="text-amber-700 hover:underline"
+            >
+              Compare translations
+            </Link>{' '}
+            button can be explored this way.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            Pick a work you know. Find two editions in different languages.
+            Open them side by side and read the same passage through different
+            centuries, different cultures, different agendas. You will notice
+            things that no single translation could show you &mdash; because
+            every translation is a theory about what the original means, and
+            theories are most visible when you can compare them.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-8 font-body">
+            If you find a comparison that reveals something surprising,{' '}
+            <Link
+              href="https://x.com/SourceLibrary_"
+              className="text-amber-700 hover:underline"
+              target="_blank"
+              rel="noopener"
+            >
+              we&rsquo;d love to hear about it
+            </Link>
+            .
           </p>
         </div>
 

--- a/src/app/work/[id]/compare/CompareClient.tsx
+++ b/src/app/work/[id]/compare/CompareClient.tsx
@@ -1,0 +1,365 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+
+interface Chapter {
+  title: string;
+  titleEn?: string;
+  pageNumber: number;
+  level: number;
+}
+
+interface Edition {
+  id: string;
+  slug: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  published: string;
+  language: string;
+  pages_count: number;
+  pages_translated: number;
+  chapters: Chapter[];
+}
+
+interface PageText {
+  page_number: number;
+  ocr?: string;
+  translation?: string;
+}
+
+interface CompareClientProps {
+  editions: Edition[];
+  allEditions: Edition[];
+  workId: string;
+}
+
+export default function CompareClient({ editions, allEditions, workId }: CompareClientProps) {
+  // Default: pick the first two translated editions
+  const [selectedIds, setSelectedIds] = useState<string[]>(() =>
+    editions.slice(0, Math.min(2, editions.length)).map((e) => e.id)
+  );
+  const [showPicker, setShowPicker] = useState(false);
+  const [chapterIndex, setChapterIndex] = useState(0);
+  const [pageTexts, setPageTexts] = useState<Record<string, PageText[]>>({});
+  const [loading, setLoading] = useState(false);
+  const [showOriginal, setShowOriginal] = useState(false);
+
+  const selectedEditions = editions.filter((e) => selectedIds.includes(e.id));
+
+  // Use the first selected edition's chapter list as the navigation source
+  const primaryEdition = selectedEditions[0];
+  const chapters = primaryEdition?.chapters || [];
+  const currentChapter = chapters[chapterIndex];
+
+  // Fetch chapter text for all selected editions
+  const fetchTexts = useCallback(async () => {
+    if (!currentChapter || selectedIds.length === 0) return;
+    setLoading(true);
+
+    const results: Record<string, PageText[]> = {};
+
+    await Promise.all(
+      selectedIds.map(async (bookId) => {
+        const edition = editions.find((e) => e.id === bookId);
+        if (!edition) return;
+
+        // Find the matching chapter in this edition
+        const matchIdx = findMatchingChapter(edition.chapters, currentChapter);
+        const chapter = matchIdx >= 0 ? edition.chapters[matchIdx] : null;
+
+        if (!chapter) {
+          results[bookId] = [];
+          return;
+        }
+
+        // Determine page range for this chapter
+        const nextChapter = edition.chapters[matchIdx + 1];
+        const fromPage = chapter.pageNumber;
+        const toPage = nextChapter
+          ? nextChapter.pageNumber - 1
+          : Math.min(fromPage + 15, edition.pages_count); // cap at 15 pages
+
+        try {
+          const res = await fetch(
+            `/api/books/${bookId}/text?content=both&from=${fromPage}&to=${toPage}&format=json`
+          );
+          if (res.ok) {
+            const data = await res.json();
+            results[bookId] = (data.pages || []).map((p: { page_number: number; ocr?: string; translation?: string }) => ({
+              page_number: p.page_number,
+              ocr: p.ocr,
+              translation: p.translation,
+            }));
+          } else {
+            results[bookId] = [];
+          }
+        } catch {
+          results[bookId] = [];
+        }
+      })
+    );
+
+    setPageTexts(results);
+    setLoading(false);
+  }, [selectedIds, currentChapter, editions]);
+
+  useEffect(() => {
+    fetchTexts();
+  }, [fetchTexts]);
+
+  const toggleEdition = (id: string) => {
+    setSelectedIds((prev) => {
+      if (prev.includes(id)) {
+        return prev.length > 1 ? prev.filter((x) => x !== id) : prev;
+      }
+      if (prev.length >= 4) return prev; // max 4
+      return [...prev, id];
+    });
+  };
+
+  return (
+    <div className="prose-content max-w-none">
+      {/* Controls bar */}
+      <div className="flex flex-wrap items-center gap-4 mb-8">
+        {/* Edition picker toggle */}
+        <button
+          onClick={() => setShowPicker(!showPicker)}
+          className="text-sm border border-stone-300 rounded-lg px-3 py-1.5 text-stone-600 hover:border-stone-400 transition-colors"
+        >
+          {selectedEditions.length} edition{selectedEditions.length !== 1 ? 's' : ''} selected
+          <span className="ml-1 text-stone-400">{showPicker ? '▲' : '▼'}</span>
+        </button>
+
+        {/* Chapter navigator */}
+        {chapters.length > 0 && (
+          <select
+            value={chapterIndex}
+            onChange={(e) => setChapterIndex(Number(e.target.value))}
+            className="text-sm border border-stone-300 rounded-lg px-3 py-1.5 text-stone-600 bg-white max-w-md truncate"
+          >
+            {chapters.map((ch, i) => (
+              <option key={i} value={i}>
+                {ch.titleEn || ch.title}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {/* Original toggle */}
+        <button
+          onClick={() => setShowOriginal(!showOriginal)}
+          className="ml-auto text-xs text-stone-400 hover:text-stone-600 transition-colors border border-stone-200 rounded-full px-3 py-1"
+        >
+          {showOriginal ? 'Hide original' : 'Show original'}
+        </button>
+
+        {/* Back link */}
+        <Link
+          href={`/work/${workId}`}
+          className="text-xs text-stone-400 hover:text-stone-600 transition-colors"
+        >
+          Back to work
+        </Link>
+      </div>
+
+      {/* Edition picker panel */}
+      {showPicker && (
+        <div className="mb-8 p-4 border border-stone-200 rounded-xl bg-white">
+          <p className="text-xs text-stone-400 mb-3">
+            Select up to 4 editions to compare (at least 1 required)
+          </p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {allEditions.map((edition) => {
+              const isSelected = selectedIds.includes(edition.id);
+              const hasTranslation = edition.pages_translated > 0;
+              return (
+                <button
+                  key={edition.id}
+                  onClick={() => hasTranslation && toggleEdition(edition.id)}
+                  disabled={!hasTranslation}
+                  className={`text-left p-3 rounded-lg border transition-colors ${
+                    isSelected
+                      ? 'border-amber-700/40 bg-amber-50/50'
+                      : hasTranslation
+                        ? 'border-stone-200 hover:border-stone-300'
+                        : 'border-stone-100 opacity-40 cursor-not-allowed'
+                  }`}
+                >
+                  <div className="text-sm font-medium text-stone-700 truncate">
+                    {edition.display_title || edition.title}
+                  </div>
+                  <div className="text-xs text-stone-400 mt-0.5">
+                    {edition.language} &middot; {edition.published}
+                    {!hasTranslation && ' · not yet translated'}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Chapter title */}
+      {currentChapter && (
+        <h2 className="text-lg font-medium text-stone-700 mb-6">
+          {currentChapter.titleEn || currentChapter.title}
+        </h2>
+      )}
+
+      {/* Loading state */}
+      {loading && (
+        <div className="text-center py-12 text-stone-400 text-sm">
+          Loading passages...
+        </div>
+      )}
+
+      {/* Comparison columns */}
+      {!loading && (
+        <div
+          className={`grid gap-4 ${
+            selectedEditions.length === 2
+              ? 'md:grid-cols-2'
+              : selectedEditions.length === 3
+                ? 'lg:grid-cols-3'
+                : selectedEditions.length === 4
+                  ? 'lg:grid-cols-2 xl:grid-cols-4'
+                  : ''
+          }`}
+        >
+          {selectedEditions.map((edition) => {
+            const pages = pageTexts[edition.id] || [];
+            const combinedTranslation = pages
+              .map((p) => p.translation)
+              .filter(Boolean)
+              .join('\n\n');
+            const combinedOcr = pages
+              .map((p) => p.ocr)
+              .filter(Boolean)
+              .join('\n\n');
+            const cleanText = (text: string) =>
+              text.replace(/<[^>]+>/g, '').replace(/^(Continuity from.*?\n)/gm, '').trim();
+            const pageRange = pages.length > 0
+              ? `pp. ${pages[0].page_number}–${pages[pages.length - 1].page_number}`
+              : '';
+
+            return (
+              <div
+                key={edition.id}
+                className="border border-stone-200 rounded-xl p-5 bg-white"
+              >
+                {/* Edition header */}
+                <div className="text-xs text-stone-400 uppercase tracking-wider mb-3 flex items-center justify-between">
+                  <span>
+                    {edition.language} ({edition.published})
+                  </span>
+                  {pageRange && (
+                    <Link
+                      href={`/book/${edition.slug}?page=${pages[0]?.page_number || 1}`}
+                      className="text-amber-700/60 hover:text-amber-700 transition-colors normal-case tracking-normal"
+                    >
+                      {pageRange} &rarr;
+                    </Link>
+                  )}
+                </div>
+
+                {/* Edition title */}
+                <div className="text-xs text-stone-500 mb-3 truncate">
+                  {edition.display_title || edition.title}
+                </div>
+
+                {/* Original text */}
+                {showOriginal && combinedOcr && (
+                  <div className="mb-4 pb-4 border-b border-stone-100">
+                    <p className="text-sm leading-relaxed text-stone-500 font-serif whitespace-pre-line max-h-96 overflow-y-auto">
+                      {cleanText(combinedOcr).substring(0, 3000)}
+                    </p>
+                  </div>
+                )}
+
+                {/* Translation */}
+                {combinedTranslation ? (
+                  <p className="text-sm leading-relaxed text-stone-700 font-body whitespace-pre-line max-h-96 overflow-y-auto">
+                    {cleanText(combinedTranslation).substring(0, 3000)}
+                  </p>
+                ) : (
+                  <p className="text-sm text-stone-400 italic">
+                    No matching chapter found in this edition
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Chapter navigation */}
+      {chapters.length > 1 && (
+        <div className="flex justify-between mt-8">
+          <button
+            onClick={() => setChapterIndex(Math.max(0, chapterIndex - 1))}
+            disabled={chapterIndex === 0}
+            className="text-sm text-stone-500 hover:text-stone-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            &larr; Previous chapter
+          </button>
+          <span className="text-xs text-stone-400">
+            {chapterIndex + 1} / {chapters.length}
+          </span>
+          <button
+            onClick={() => setChapterIndex(Math.min(chapters.length - 1, chapterIndex + 1))}
+            disabled={chapterIndex === chapters.length - 1}
+            className="text-sm text-stone-500 hover:text-stone-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            Next chapter &rarr;
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Find the best-matching chapter in a target edition's chapter list.
+ * Uses normalized title comparison (case-insensitive, ignoring numbering).
+ */
+function findMatchingChapter(targetChapters: Chapter[], sourceChapter: Chapter): number {
+  if (targetChapters.length === 0) return -1;
+
+  const normalize = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/^(chapter|tractate|tractatus|book|sermon|discourse)\s*[\divxlc.:]+\s*/i, '')
+      .replace(/[^a-z\s]/g, '')
+      .trim();
+
+  const sourceTitle = normalize(sourceChapter.titleEn || sourceChapter.title);
+
+  let bestIdx = -1;
+  let bestScore = 0;
+
+  for (let i = 0; i < targetChapters.length; i++) {
+    const targetTitle = normalize(targetChapters[i].titleEn || targetChapters[i].title);
+    const score = jaccardSimilarity(sourceTitle, targetTitle);
+    if (score > bestScore) {
+      bestScore = score;
+      bestIdx = i;
+    }
+  }
+
+  // Require at least 0.3 similarity to count as a match
+  return bestScore >= 0.3 ? bestIdx : -1;
+}
+
+/**
+ * Jaccard similarity on word sets.
+ */
+function jaccardSimilarity(a: string, b: string): number {
+  const setA = new Set(a.split(/\s+/).filter(Boolean));
+  const setB = new Set(b.split(/\s+/).filter(Boolean));
+  if (setA.size === 0 && setB.size === 0) return 1;
+  const intersection = new Set([...setA].filter((x) => setB.has(x)));
+  const union = new Set([...setA, ...setB]);
+  return intersection.size / union.size;
+}

--- a/src/app/work/[id]/compare/page.tsx
+++ b/src/app/work/[id]/compare/page.tsx
@@ -1,0 +1,123 @@
+import { Metadata } from 'next';
+import { getReadDb } from '@/lib/mongodb';
+import { notFound } from 'next/navigation';
+import type { Book } from '@/lib/types';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import CompareClient from './CompareClient';
+
+export const revalidate = false;
+export const dynamicParams = true;
+export async function generateStaticParams() {
+  return [];
+}
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+interface EditionForCompare {
+  id: string;
+  slug: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  published: string;
+  language: string;
+  pages_count: number;
+  pages_translated: number;
+  chapters: Array<{
+    title: string;
+    titleEn?: string;
+    pageNumber: number;
+    level: number;
+  }>;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+}
+
+function workTitle(workId: string): string {
+  return workId
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+async function getEditionsForCompare(workId: string): Promise<EditionForCompare[]> {
+  const db = await getReadDb();
+  const editions = await db
+    .collection('books')
+    .find(
+      { work_id: workId, visible: true },
+      {
+        projection: {
+          id: 1,
+          slug: 1,
+          title: 1,
+          display_title: 1,
+          author: 1,
+          published: 1,
+          language: 1,
+          pages_count: 1,
+          pages_translated: 1,
+          chapters: 1,
+          thumbnail: 1,
+          thumbnail_blob: 1,
+        },
+        sort: { published: 1 },
+      }
+    )
+    .toArray();
+  return editions.map((e) => ({
+    id: (e.id || e._id?.toString()) as string,
+    slug: e.slug as string,
+    title: e.title as string,
+    display_title: e.display_title as string | undefined,
+    author: e.author as string,
+    published: e.published as string,
+    language: e.language as string,
+    pages_count: (e.pages_count || 0) as number,
+    pages_translated: (e.pages_translated || 0) as number,
+    chapters: ((e.chapters || []) as Array<{ title: string; titleEn?: string; pageNumber: number; level: number; endPage?: number }>).map((ch) => ({
+      title: ch.title,
+      titleEn: ch.titleEn,
+      pageNumber: ch.pageNumber,
+      level: ch.level,
+    })),
+    thumbnail: e.thumbnail as string | undefined,
+    thumbnail_blob: e.thumbnail_blob as string | undefined,
+  }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const title = workTitle(id);
+  return {
+    title: `Compare Translations — ${title} | Source Library`,
+    description: `Compare translations across editions of ${title}. View original language texts alongside AI and human translations side by side.`,
+    robots: { index: true, follow: true },
+    alternates: { canonical: `/work/${id}/compare` },
+  };
+}
+
+export default async function CompareWorkPage({ params }: PageProps) {
+  const { id } = await params;
+  const editions = await getEditionsForCompare(id);
+  if (editions.length < 2) notFound();
+
+  const title = workTitle(id);
+  const translatedEditions = editions.filter((e) => e.pages_translated > 0);
+
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title={`Compare: ${title}`}
+          subtitle={`${editions.length} editions, ${new Set(editions.map((e) => e.language)).size} languages`}
+        />
+      }
+      bg="bg-cream"
+    >
+      <CompareClient editions={translatedEditions} workId={id} allEditions={editions} />
+    </ContentPageLayout>
+  );
+}

--- a/src/app/work/[id]/page.tsx
+++ b/src/app/work/[id]/page.tsx
@@ -90,7 +90,7 @@ export default async function WorkPage({ params }: PageProps) {
     >
       <div className="prose-content max-w-none">
         {/* Stats bar */}
-        <div className="flex flex-wrap gap-6 text-sm text-stone-500 mb-10">
+        <div className="flex flex-wrap items-center gap-6 text-sm text-stone-500 mb-10">
           {earliest && latest && earliest !== latest && (
             <span>{earliest} &ndash; {latest}</span>
           )}
@@ -98,6 +98,14 @@ export default async function WorkPage({ params }: PageProps) {
           {languages.length > 0 && <span>{languages.join(', ')}</span>}
           <span>{totalPages.toLocaleString()} pages</span>
           <span>{editions.length} editions</span>
+          {editions.filter(e => (e.pages_translated || 0) > 0).length >= 2 && (
+            <Link
+              href={`/work/${id}/compare`}
+              className="ml-auto text-xs border border-stone-300 hover:border-stone-400 rounded-full px-3 py-1 text-stone-600 hover:text-stone-800 transition-colors"
+            >
+              Compare translations
+            </Link>
+          )}
         </div>
 
         {/* Editions grid */}

--- a/src/components/comparison/PassageComparison.tsx
+++ b/src/components/comparison/PassageComparison.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+export interface Passage {
+  label: string;
+  original?: string;
+  translation: string;
+  citation?: string;
+  bookUrl?: string;
+  language?: string;
+}
+
+interface PassageComparisonProps {
+  passages: Passage[];
+  commentary?: string;
+  title?: string;
+  showOriginal?: boolean;
+}
+
+const SCRIPT_FONTS: Record<string, string> = {
+  Greek: 'font-serif',
+  Latin: 'font-serif italic',
+  Arabic: 'font-serif',
+  Sanskrit: 'font-serif',
+  Hebrew: 'font-serif',
+};
+
+export default function PassageComparison({
+  passages,
+  commentary,
+  title,
+  showOriginal: initialShowOriginal = false,
+}: PassageComparisonProps) {
+  const [showOriginal, setShowOriginal] = useState(initialShowOriginal);
+  const hasOriginals = passages.some((p) => p.original);
+
+  return (
+    <div className="my-12">
+      {/* Header */}
+      {(title || hasOriginals) && (
+        <div className="flex items-baseline justify-between mb-4 gap-4 flex-wrap">
+          {title && (
+            <h3 className="text-lg font-medium text-stone-700">{title}</h3>
+          )}
+          {hasOriginals && (
+            <button
+              onClick={() => setShowOriginal(!showOriginal)}
+              className="text-xs text-stone-400 hover:text-stone-600 transition-colors border border-stone-200 rounded-full px-3 py-1"
+            >
+              {showOriginal ? 'Hide original' : 'Show original'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Passage cards */}
+      <div
+        className={`grid gap-4 ${
+          passages.length === 2
+            ? 'md:grid-cols-2'
+            : passages.length === 3
+              ? 'lg:grid-cols-3'
+              : 'md:grid-cols-2'
+        }`}
+      >
+        {passages.map((passage, i) => (
+          <div
+            key={i}
+            className="border border-stone-200 rounded-xl p-5 bg-white"
+          >
+            {/* Label */}
+            <div className="text-xs text-stone-400 uppercase tracking-wider mb-3 flex items-center justify-between">
+              <span>{passage.label}</span>
+              {passage.bookUrl && passage.citation && (
+                <Link
+                  href={passage.bookUrl}
+                  className="text-amber-700/60 hover:text-amber-700 transition-colors normal-case tracking-normal"
+                >
+                  {passage.citation} &rarr;
+                </Link>
+              )}
+            </div>
+
+            {/* Original text */}
+            {showOriginal && passage.original && (
+              <div className="mb-4 pb-4 border-b border-stone-100">
+                <p
+                  className={`text-sm leading-relaxed text-stone-500 ${
+                    SCRIPT_FONTS[passage.language || ''] || 'font-serif'
+                  }`}
+                  dir={passage.language === 'Arabic' || passage.language === 'Hebrew' ? 'rtl' : 'ltr'}
+                >
+                  {passage.original}
+                </p>
+              </div>
+            )}
+
+            {/* Translation */}
+            <p className="text-sm leading-relaxed text-stone-700 font-body">
+              {passage.translation}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Commentary */}
+      {commentary && (
+        <div className="mt-6 text-sm text-stone-500 leading-relaxed font-body border-l-2 border-amber-700/20 pl-4">
+          {commentary}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Lead with the opportunity: explain the three-way comparison (original + human + AI) upfront before the Ficino narrative
- Frame as "first in a series" of translation experiments
- Add "Try it yourself" closing section with links to compare page and Twitter invitation

## Test plan
- [ ] Visit `/blog/translations-across-civilizations` — verify new opening paragraph, "Try it yourself" section with working links

🤖 Generated with [Claude Code](https://claude.com/claude-code)