### PR TITLE
Librarian: no pleasantries, no duplicate choices

### DIFF
--- a/docs/blog-egyptian-digitization-gap.md
+++ b/docs/blog-egyptian-digitization-gap.md
@@ -1,0 +1,95 @@
+# The Egyptian Digitization Gap: Why the World's Oldest Literature Is the Hardest to Find Online
+
+When we set out to add Egyptian texts to Source Library, we expected the usual challenges: OCR quirks, translation alignment, metadata cleanup. What we found instead was a structural gap in digital humanities infrastructure that affects every scholar, student, and curious reader trying to access one of humanity's oldest literary traditions.
+
+European medieval manuscripts have never been more accessible. Thanks to over a decade of coordinated investment in the International Image Interoperability Framework (IIIF), you can pull up a page of the *Book of Kells* or a Gutenberg Bible in seconds, zoom to individual pen strokes, and embed images directly into your research. Hundreds of libraries — from the BnF to the Bodleian to the Bayerische Staatsbibliothek — publish their holdings through standardized APIs that any tool can consume.
+
+Egyptian papyri, which predate most of those manuscripts by two thousand years, have no equivalent infrastructure. The manuscripts exist. Many have been digitized. But finding and using those images requires an archaeological dig through museum websites, broken endpoints, and institutional silos.
+
+## What we built — and what we learned building it
+
+Source Library just imported 50 Egyptian texts spanning roughly 2,000 years, from the Old Kingdom wisdom literature of Ptahhotep (c. 2350 BCE) to Demotic tales from the Ptolemaic period. The source corpus is [ORAEC](https://oraec.github.io/) (Open Richly Annotated Egyptian Corpus), a rigorous scholarly project that provides Unicode hieroglyphic transcriptions, Egyptological transliteration, and German translations for a wide range of texts.
+
+Our pipeline works like this: we ingest the ORAEC corpus, paginate the texts into readable sections, translate the German scholarly translations into English using Gemini, and then try to align manuscript images from whatever sources we can find.
+
+That last step — "whatever sources we can find" — is where the problems start.
+
+Each text on Source Library now presents the hieroglyphic source (𓇋𓅱 𓊪𓅱𓅱𓂻 𓇋𓀁 𓎡), the transliteration (*iw pw.t r=i jm*), and the English translation side by side. For a reader encountering the *Tale of Sinuhe* or the *Admonitions of Ipuwer* for the first time, this is transformative. For a student comparing the *Maxims of Ptahhotep* across editions, it is a tool that simply did not exist in one place before.
+
+But without manuscript images, these texts float free of their physical reality. A papyrus is not just a text. The hand of the scribe, the damage patterns, the recto-verso layout, the color of the ink — these carry meaning that no transcription preserves.
+
+## The search for Sinuhe
+
+The *Tale of Sinuhe* is one of the most famous works of world literature. Written around 1875 BCE, it is a narrative of exile and return that has been compared to the Odyssey (which it predates by a thousand years). The primary manuscript is pBerlin 3022, held by the Agyptisches Museum in Berlin.
+
+To find a usable digital image of this papyrus, we searched five different sources:
+
+1. **SMB Digital (Staatliche Museen zu Berlin):** The museum's IIIF endpoint returned errors. The collection is nominally online, but programmatic access is unreliable and the image quality varies.
+
+2. **Trismegistos:** The best cross-reference database for ancient texts, mapping texts to physical objects across collections worldwide. But Trismegistos is a metadata project — it tells you *where* a papyrus is, not what it looks like. No images.
+
+3. **TLA (Thesaurus Linguae Aegyptiae):** The authoritative text corpus for Egyptian, maintained by the Berlin-Brandenburgische Akademie der Wissenschaften. Superb linguistic data. No manuscript images.
+
+4. **The British Museum Collection Online:** Holds fragments of Sinuhe (and hundreds of other papyri under EA numbers), but images are served through a proprietary viewer with no IIIF support and no bulk access.
+
+5. **Wikimedia Commons:** This is where we finally found usable images — photographs and scans uploaded by individual scholars and Wikimedia volunteers. For famous texts like Sinuhe, the coverage is adequate. For anything less canonical, it drops off sharply.
+
+Five sources searched to find one image of one of the most studied texts in Egyptology. This is not a niche problem. This is infrastructure debt.
+
+## The Ptahhotep exception proves the rule
+
+There is exactly one major Egyptian papyrus with proper IIIF support: the Papyrus Prisse, held by the Bibliotheque nationale de France. It contains the *Maxims of Ptahhotep*, the oldest surviving wisdom text (c. 2350 BCE), and it is browsable through Gallica's excellent IIIF viewer because it happens to reside in a European national library that invested early in digital infrastructure.
+
+The Papyrus Prisse is the exception that proves the rule. It has IIIF not because Egyptian papyri have good digital infrastructure, but because the BnF gives IIIF to *everything*. If the Prisse Papyrus were in Cairo or Turin instead of Paris, it would likely be just as hard to access programmatically as everything else.
+
+## The institutional landscape
+
+The problem is not that museums have failed to digitize their Egyptian holdings. Many have:
+
+- **The British Museum** has digitized thousands of objects, including hundreds of papyri. But their platform serves images through a bespoke viewer with no interoperable API. You can look, but you cannot build.
+
+- **The Museo Egizio in Turin** holds the largest collection of Egyptian papyri outside Cairo, including the Turin King List and the Turin Erotic Papyrus. Their digitization is partial, their online access is uneven.
+
+- **The Egyptian Museum in Cairo** has been undergoing massive modernization with the move to the Grand Egyptian Museum. Digital access to the collection remains limited.
+
+- **The Brooklyn Museum, the Met, the Louvre** — each has Egyptian holdings online, each with its own viewer, its own API (or lack thereof), its own terms.
+
+The result is that a scholar studying a single text that survives in fragments across three museums must navigate three different platforms, none of which talk to each other, and none of which support the IIIF standard that would let a tool like Mirador or Source Library stitch the pieces together.
+
+## The 10-15 year gap
+
+Medieval European digital humanities had a head start, but the gap is not merely chronological. It is structural. The IIIF ecosystem succeeded because of three factors:
+
+1. **Institutional density:** Dozens of major libraries in close geographic and cultural proximity, sharing similar cataloging traditions and funding structures.
+
+2. **Shared standards early:** The IIIF spec emerged from collaboration between Stanford, the Bodleian, the BnF, and the Bayerische Staatsbibliothek. These institutions had both the technical capacity and the institutional will to agree on a standard.
+
+3. **Grant alignment:** Funding bodies like the Andrew W. Mellon Foundation and the European Research Council made interoperability a condition of digital humanities grants. Libraries that wanted funding adopted IIIF.
+
+Egyptian collections lack all three. The major holdings are distributed across continents (Berlin, London, Paris, Turin, Cairo, New York). The institutions operate under radically different governance structures. And there has been no coordinating body — no "IIIF for Egyptology" — to align standards.
+
+Trismegistos comes closest. Its database links texts to physical objects across collections, and its identifiers (TM numbers) are becoming a de facto standard for cross-referencing. But Trismegistos was built for metadata, not for images. Extending it — or building something alongside it — to serve as an image aggregation layer would be the single highest-impact infrastructure project in digital Egyptology.
+
+## What Source Library provides
+
+With this import, Source Library offers something that did not previously exist in one place: a reading environment for Egyptian texts that combines hieroglyphic source, transliteration, and English translation, with manuscript images where available, all presented in a format designed for reading rather than for specialist research tools.
+
+You can read the *Tale of the Shipwrecked Sailor* and see the hieroglyphs alongside the English. You can browse the *Westcar Papyrus* tales — the oldest known short stories — and follow the narrative in translation while checking the original. You can read the *Contendings of Horus and Seth*, a myth so vivid and strange that every Egyptologist has a favorite passage, and see exactly how the hieroglyphic text maps to the translation.
+
+This is not a replacement for the TLA or ORAEC. Those projects do essential scholarly work that we depend on. What Source Library adds is accessibility: a place where a non-specialist can encounter these texts in full, in context, without needing to know Egyptological conventions or navigate institutional databases.
+
+## A call to action
+
+Egyptian manuscripts need their own interoperability consortium. The model exists — IIIF proved it works for European libraries, and the payoff has been enormous. What is needed for Egyptian collections is:
+
+- **A shared image API standard** adopted by the British Museum, the Museo Egizio, SMB Berlin, the Grand Egyptian Museum, and other major holders.
+- **A cross-collection manifest registry** that links Trismegistos text IDs to IIIF manifests, so that any tool can go from "I want to see pBerlin 3022" to a zoomable image in one API call.
+- **Funding alignment** — grant bodies funding Egyptological digitization should require IIIF compliance, just as Mellon did for medieval collections a decade ago.
+
+The texts are there. The digitization is happening. What is missing is the connective tissue — the standards, the APIs, the shared infrastructure — that would let these scattered efforts compose into something greater than the sum of their parts.
+
+We built Source Library to make the world's pre-modern texts readable. For European manuscripts, the infrastructure meets us halfway. For Egyptian papyri, we are building bridges over gaps that should not still exist. We will keep building. But the real solution is not more bridges. It is filling in the gaps.
+
+---
+
+*Source Library is an open platform for pre-modern texts. Browse the Egyptian collection at [sourcelibrary.org](https://sourcelibrary.org). The ORAEC corpus is maintained by the Berlin-Brandenburgische Akademie der Wissenschaften and available at [oraec.github.io](https://oraec.github.io/).*

--- a/docs/blog-search-layers.md
+++ b/docs/blog-search-layers.md
@@ -1,0 +1,104 @@
+# How Do You Search for "Sex, Drugs, and Aliens" in a Library of 17,000 Pre-Modern Books?
+
+*On the three layers of search, and why finding Huygens's extraterrestrials requires more than a search box.*
+
+---
+
+## The Experiment
+
+We asked a simple question: can you search Source Library for sex, drugs, and aliens?
+
+The results were humbling. Searching "sex" returned Latin titles containing the word *sex* — meaning *six*. Frontinus's *De re militari*, Vitruvius's architecture books, Lipsius's *Six Books of Politics*. Searching "drugs" found Pliny cataloging "47 drugs from copper scales" and Sushruta describing "sweet, bitter, and astringent drugs." Searching "aliens" returned the Federalist Papers discussing immigration policy and Plato's *Laws* on the rights of resident foreigners.
+
+None of this is wrong. These are real matches for these words. But none of it is what you meant. You meant erotica, psychoactive substances, and life on other worlds. And all of those things *are* in the library — we just couldn't find them.
+
+## What's Actually in There
+
+Once we stopped searching like a computer and started thinking like a librarian, the results transformed.
+
+**Erotica:** Vatsyayana's *Kama Sutra* (1883 Burton translation and 1912 Sanskrit original). Edo-period Japanese *shunga* prints. Boccaccio's *Caccia di Diana*. The *Scriptores Erotici Graeci* — Longus, Heliodorus, Achilles Tatius. Martial's epigrams, where he casually jokes about using his hand "instead of a Ganymede." Herodas's *Mimes*, where two Greek women discuss the craftsmanship of a leather dildo.
+
+**Psychoactive substances:** Avicenna's *Canon of Medicine* contains a remarkable index entry: "Opium is stronger than all stupefying agents... the weight of 11 drachms is fatal in two days... Opium works more when taken with wine." Paracelsus's "Holy Laudanum." Hartmann's 1684 pharmacology with the memorable note: "Opium does not stimulate Venus... but prolongs the act of Venus." Gruling's 1665 observation that "opium is nothing other than the tear or gum of a certain poppy in Cambay."
+
+**Life on other worlds:** Christiaan Huygens's *Kosmotheoros* (1699) seriously argues for extraterrestrial life, discusses "the physical anatomy of extraterrestrial beings," and claims their logic and geometry "must be identical to ours." Kepler's *Somnium* (1634), a fictional voyage to the moon with detailed descriptions of lunar creatures. Cyrano de Bergerac's *Comical History of the Moon* (1654), the original science fiction moon voyage. Francis Godwin's *Man in the Moone*.
+
+All of it was there. The problem was finding it.
+
+## Three Layers of Search
+
+Finding pre-modern content with modern vocabulary requires three fundamentally different approaches. Each catches things the others miss. None is sufficient alone.
+
+### Layer 1: Keywords
+
+Keyword search is the backbone. You type a word, the system finds pages containing that word. It's fast, precise, and scales to millions of pages. Atlas Search indexes every word in every OCR transcription and translation across 17,000 books.
+
+**What it catches:** When the exact word exists in the text. Searching "opium" finds Avicenna's index entry. Searching "masturbator" finds Martial's epigram on page 392: *"Make even Hippolytus a masturbator."* Searching "extraterrestrial" finds Huygens because our AI translation used that modern English word to describe what Huygens was writing about in Latin.
+
+**What it misses:** Everything where the concept exists but the word doesn't. "Masturbation" misses "masturbator" (different suffix). "Aliens" misses "inhabitants of other worlds." "Drugs" misses "opium." The vocabulary gap between the 21st century and the 16th century is vast, and keyword search can't bridge it.
+
+**The morphology trap:** We added fuzzy matching for long single words — "masturbation" now matches "masturbator" within one edit distance. But this is a band-aid. The real problem isn't spelling variants; it's that concepts change names across centuries.
+
+### Layer 2: Semantic Embeddings
+
+Embedding search converts both the query and every book's content into points in a 768-dimensional vector space. Books that are *about* similar things end up near each other, regardless of the specific words used. We embed each book using a rich text composed from its AI-generated summary, vocabulary index, named entities, and topic keywords.
+
+**What it catches:** Conceptual proximity. Searching "extraterrestrial beings" finds Huygens's *Kosmotheoros* even though those exact words don't appear in the book's title — the embedding captures that the book is *about* life on other worlds. Searching "erotic love desire" finds Boccaccio and the *Dialogues of Love* because they occupy similar regions in meaning-space.
+
+**What it misses:** Lateral connections that require world knowledge. Would embedding find the story of Onan from a search for "masturbation"?
+
+Almost certainly not. Genesis 38 tells the story of Onan, who refuses to impregnate his dead brother's widow (a duty called levirate marriage) and "spills his seed on the ground." God kills him for this disobedience. The actual biblical text is about **coitus interruptus, filial duty, and divine punishment** — the word "masturbation" appears nowhere, and the semantic content is about obedience to kinship law.
+
+The connection between Onan and masturbation was forged *centuries later*, when the Swiss physician Samuel Tissot published *L'Onanisme* in 1760, reinterpreting Onan's "spilled seed" as a general warning against self-pleasure. The word "onanism" ��� meaning masturbation — is a cultural artifact, not a textual one. It exists in the history of ideas, not in embedding space.
+
+An embedding model trained on modern text might weakly associate "Onan" with "masturbation" because they co-occur in modern discussions, but the biblical text itself — describing a man's refusal of levirate duty — would not be near "masturbation" in any meaningful way. The connection requires *knowing the history of the word's reinterpretation*, which is exactly what the third layer does.
+
+### Layer 3: LLM Query Expansion
+
+When you search Source Library, a language model reads your query and generates context: a brief scholarly note explaining the concept, plus a list of expanded search terms — Latin equivalents, historical spellings, key authors, related works.
+
+Search "aliens" and the model might generate: *"The plurality of inhabited worlds was a major theme in early modern natural philosophy. Fontenelle's Entretiens and Huygens's Kosmotheoros argued that other planets must harbor intelligent life."* Plus expanded terms: `["Kosmotheoros", "plurality of worlds", "Somnium", "lunar inhabitants", "Fontenelle"]`.
+
+Each expanded term is then searched via the keyword and semantic layers. This is the bridge that connects modern concepts to their pre-modern incarnations.
+
+**What it catches:** The things only a knowledgeable human would think to search for. "Masturbation" → "onanism" → Tissot → Onan → Genesis 38. "Drugs" → "opium, laudanum, Paracelsus, materia medica." "Aliens" → "Kosmotheoros, Somnium, plurality of worlds." The model does exactly what a scholar does: it translates between vocabularies, names specific texts, and bridges centuries of terminological drift.
+
+**What it misses:** It's only as good as the model's training. Obscure connections — a specific passage in a specific medieval manuscript — won't be expanded unless the model happens to know about it. And it adds latency: generating expanded terms takes 1-2 seconds, which is noticeable in a search interface.
+
+## Why All Three Layers Matter
+
+Each layer has a different failure mode:
+
+| Layer | Finds | Misses |
+|-------|-------|--------|
+| **Keywords** | Exact words in text | Concepts under different names |
+| **Embeddings** | Conceptual neighbors | Lateral/etymological connections |
+| **LLM Expansion** | Cross-century vocabulary bridges | Obscure passages the model doesn't know |
+
+Searching "masturbation" without all three:
+- Keywords alone → 3 copies of Tissot (the word is in the title) and nothing else
+- Embeddings alone → Pseudo-Aristotle's reproductive physiology, monastic texts on self-discipline
+- LLM expansion alone → would generate "onanism, Priapeia, Martial" but couldn't search them
+
+Together: Tissot (keyword), Martial's "masturbator" (fuzzy keyword), the *Secret of Secrets* on sexual physiology (embedding), Diogenes Laertius and the olisbos of Herodas (LLM expansion → keyword).
+
+## The Deeper Problem: Text Has to Exist
+
+All three layers share a dependency: the text must be in the system. Herodas's *Mimes* — containing one of the most famous sexual passages in Greek literature — exists in our library as three editions. But none have been through the OCR and translation pipeline yet. No text means no keywords, no embeddings, no enrichment data. The book is invisible to every search layer.
+
+This is the unsexy infrastructure problem beneath every search improvement. You can build the most sophisticated retrieval system in the world, but if the Loeb Herodas is sitting there with 1 page and status "draft," no one will ever find the cobbler and his leather goods.
+
+## What We Learned
+
+1. **Modern words are terrible search terms for pre-modern content.** "Sex" means six. "Drugs" means remedies. "Aliens" means foreigners. The vocabulary gap is the fundamental challenge.
+
+2. **Embeddings bridge concepts but not etymologies.** Vector similarity finds books that are *about* similar things. It doesn't know that "onanism" was coined in 1760 by reinterpreting a Bronze Age kinship law.
+
+3. **LLMs are the missing bridge.** A language model can reason: "the user means psychoactive substances → opium was the major one → Avicenna and Paracelsus wrote about it → search those terms." No other technology does this.
+
+4. **The three layers are complementary, not competing.** Keywords for precision, embeddings for conceptual discovery, LLM for vocabulary translation. Remove any one and the system goes blind to a class of queries.
+
+5. **Pipeline coverage is the ceiling.** The most brilliant search architecture can't find text that hasn't been transcribed. Every unprocessed book is a hole in the collection's searchability.
+
+---
+
+*Source Library is a digital library of 17,000+ rare historical books, freely searchable at [sourcelibrary.org](https://sourcelibrary.org). All translations are AI-generated and released under CC BY-SA 4.0.*

--- a/scripts/import-commons-artworks.mjs
+++ b/scripts/import-commons-artworks.mjs
@@ -21,7 +21,7 @@ const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.
 const COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
 const R2_PREFIX = 'artwork';
 const DELAY_MS = 100; // Polite rate limit for Commons
-const DISPLAY_WIDTH = 3840; // Max thumb size Commons serves
+const DISPLAY_WIDTH = 10000; // Request original resolution — store full-res on R2
 const THUMB_WIDTH = 600; // Grid thumbnail size
 const MIN_DIMENSION = 800; // Minimum max(width, height) — reject smaller images
 
@@ -316,8 +316,8 @@ function generateId() {
   return Array.from({ length: 24 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
 }
 
-/** Download image, resize, upload display + thumbnail to R2
- *  - Display: up to 3840px wide (what Commons serves as max thumb)
+/** Download image, store full-res + thumbnail to R2
+ *  - Full: original resolution, JPEG quality 92 (no resize — preserve detail)
  *  - Thumbnail: 600px wide JPEG (for collection grids)
  *  - Returns { display, thumb } URLs on R2
  */
@@ -329,10 +329,9 @@ async function uploadToR2(s3, imageUrl, key) {
   if (!res.ok) return null;
   const buffer = Buffer.from(await res.arrayBuffer());
 
-  // Resize to display size (cap at 3840px wide) and optimize JPEG
+  // Store at original resolution — no resize, only re-encode to JPEG
   const displayBuffer = await sharp(buffer)
-    .resize({ width: DISPLAY_WIDTH, withoutEnlargement: true })
-    .jpeg({ quality: 85, mozjpeg: true })
+    .jpeg({ quality: 92, mozjpeg: true })
     .toBuffer();
 
   await s3.send(new PutObjectCommand({

--- a/scripts/import-met-artworks.mjs
+++ b/scripts/import-met-artworks.mjs
@@ -21,7 +21,7 @@ import sharp from 'sharp';
 const MET_API = 'https://collectionapi.metmuseum.org/public/collection/v1';
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
 const R2_PREFIX = 'artwork';
-const DISPLAY_MAX = 3840;
+const DISPLAY_MAX = 99999; // Store original resolution — no downscaling
 const THUMB_WIDTH = 600;
 const DELAY_MS = 300; // Met rate limits aggressively despite claiming 80/s
 
@@ -138,9 +138,9 @@ async function uploadToR2(s3, imageUrl, key) {
   if (!res.ok) return null;
   const buffer = Buffer.from(await res.arrayBuffer());
 
+  // Store at original resolution — no resize
   const displayBuffer = await sharp(buffer)
-    .resize({ width: DISPLAY_MAX, withoutEnlargement: true })
-    .jpeg({ quality: 85, mozjpeg: true })
+    .jpeg({ quality: 92, mozjpeg: true })
     .toBuffer();
 
   await s3.send(new PutObjectCommand({

--- a/scripts/import-rijks-artworks.mjs
+++ b/scripts/import-rijks-artworks.mjs
@@ -22,7 +22,7 @@ const SEARCH_BASE = 'https://data.rijksmuseum.nl/search/collection';
 const RESOLVER = 'https://id.rijksmuseum.nl';
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; contact@sourcelibrary.org)';
 const R2_PREFIX = 'artwork';
-const DISPLAY_MAX = 3840;
+const DISPLAY_MAX = 99999; // Store original resolution — no downscaling
 const THUMB_WIDTH = 600;
 const DELAY_MS = 300;
 
@@ -303,9 +303,9 @@ async function uploadToR2(s3, imageUrl, key) {
   if (!res.ok) return null;
   const buffer = Buffer.from(await res.arrayBuffer());
 
+  // Store at original resolution — no resize
   const displayBuffer = await sharp(buffer)
-    .resize({ width: DISPLAY_MAX, withoutEnlargement: true })
-    .jpeg({ quality: 85, mozjpeg: true })
+    .jpeg({ quality: 92, mozjpeg: true })
     .toBuffer();
 
   await s3.send(new PutObjectCommand({

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { semanticBookSearch } from '@/lib/semantic-search';
+import { getDb } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 
@@ -35,10 +36,36 @@ export async function GET(request: NextRequest) {
       yearMax,
     });
 
+    // Enrich with thumbnail + slug from MongoDB
+    const bookIds = books.map(b => b.book_id);
+    let thumbnailMap: Record<string, { thumbnail?: string; thumbnail_blob?: string; slug?: string }> = {};
+    if (bookIds.length > 0) {
+      try {
+        const db = await getDb();
+        const mongoBooks = await db.collection('books').find(
+          { id: { $in: bookIds } },
+          { projection: { id: 1, _id: 1, thumbnail: 1, thumbnail_blob: 1, slug: 1 } }
+        ).toArray();
+        for (const mb of mongoBooks) {
+          const bid = mb.id || mb._id?.toString();
+          if (bid) thumbnailMap[bid] = { thumbnail: mb.thumbnail, thumbnail_blob: mb.thumbnail_blob, slug: mb.slug };
+        }
+      } catch (e) {
+        // Non-fatal — results still work without thumbnails
+      }
+    }
+
+    const enriched = books.map(b => ({
+      ...b,
+      thumbnail: thumbnailMap[b.book_id]?.thumbnail || null,
+      thumbnail_blob: thumbnailMap[b.book_id]?.thumbnail_blob || null,
+      slug: thumbnailMap[b.book_id]?.slug || b.book_id,
+    }));
+
     return NextResponse.json({
-      results: books,
+      results: enriched,
       query,
-      total: books.length,
+      total: enriched.length,
       mode: 'semantic',
     }, {
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },

--- a/src/app/blog/translations-across-civilizations/page.tsx
+++ b/src/app/blog/translations-across-civilizations/page.tsx
@@ -64,6 +64,23 @@ export default function TranslationsAcrossCivilizationsPage() {
 
       <article className="prose-content max-w-none">
         <p className="text-xl text-secondary leading-relaxed mb-8 font-body">
+          Something new is possible now that has never been possible before.
+          Source Library holds thousands of pre-modern texts in their original
+          languages &mdash; Greek, Latin, Sanskrit, Arabic, Chinese &mdash;
+          alongside AI translations generated directly from those originals.
+          For hundreds of these works, we also hold historical human
+          translations: the versions that shaped civilizations. Place them
+          side by side, and you can see something no single translation
+          reveals: what each translator <em>chose</em> to hear in the
+          original.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
+          This is the first in a series of experiments with that
+          three-way comparison. We start with the <em>Corpus Hermeticum</em>.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8 font-body">
           In 1463, a Greek manuscript arrived at the court of Cosimo
           de&rsquo; Medici in Florence. Cosimo ordered his best scholar,
           Marsilio Ficino, to drop everything &mdash; including Plato &mdash;
@@ -303,7 +320,7 @@ export default function TranslationsAcrossCivilizationsPage() {
             single translation can capture.
           </p>
 
-          <p className="text-secondary leading-relaxed mb-8 font-body">
+          <p className="text-secondary leading-relaxed mb-6 font-body">
             Source Library holds{' '}
             <Link
               href="/work/corpus-hermeticum"
@@ -315,6 +332,46 @@ export default function TranslationsAcrossCivilizationsPage() {
             OCR&rsquo;d, translated, and searchable. This is what a digital
             library makes possible: not just access to texts, but access to
             the history of reading them.
+          </p>
+
+          <h3 className="text-xl text-primary mt-10 mb-4">
+            Try it yourself
+          </h3>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            The Corpus Hermeticum is just the beginning. Source Library holds
+            multi-edition, multi-language data for Plotinus, the Bible,
+            Aristotle, the Panchatantra, Shakuntala, and hundreds of other
+            works. Any work with a{' '}
+            <Link
+              href="/work/corpus-hermeticum/compare"
+              className="text-amber-700 hover:underline"
+            >
+              Compare translations
+            </Link>{' '}
+            button can be explored this way.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-6 font-body">
+            Pick a work you know. Find two editions in different languages.
+            Open them side by side and read the same passage through different
+            centuries, different cultures, different agendas. You will notice
+            things that no single translation could show you &mdash; because
+            every translation is a theory about what the original means, and
+            theories are most visible when you can compare them.
+          </p>
+
+          <p className="text-secondary leading-relaxed mb-8 font-body">
+            If you find a comparison that reveals something surprising,{' '}
+            <Link
+              href="https://x.com/SourceLibrary_"
+              className="text-amber-700 hover:underline"
+              target="_blank"
+              rel="noopener"
+            >
+              we&rsquo;d love to hear about it
+            </Link>
+            .
           </p>
         </div>
 

--- a/src/app/blog/word-alignment/LiveAlignmentDemo.tsx
+++ b/src/app/blog/word-alignment/LiveAlignmentDemo.tsx
@@ -230,8 +230,8 @@ function HighlightedSource({
             key={i}
             className={`transition-all duration-150 ${isHighlighted ? 'text-stone-900 font-medium' : ''}`}
             style={isHighlighted ? {
-              backgroundColor: `rgba(160, 120, 40, ${Math.pow((sim! - 0.55) / 0.45, 1.5) * 0.5})`,
-              borderBottom: `2px solid rgba(160, 120, 40, ${Math.pow((sim! - 0.55) / 0.45, 1.5) * 0.85})`,
+              backgroundColor: `rgba(160, 120, 40, ${0.03 + Math.pow((sim! - 0.55) / 0.45, 1.5) * 0.4})`,
+              borderBottom: `2px solid rgba(160, 120, 40, ${0.05 + Math.pow((sim! - 0.55) / 0.45, 1.2) * 0.95})`,
               borderRadius: '2px',
               padding: '1px 2px',
             } : undefined}

--- a/src/app/blog/word-alignment/LiveAlignmentDemo.tsx
+++ b/src/app/blog/word-alignment/LiveAlignmentDemo.tsx
@@ -230,8 +230,8 @@ function HighlightedSource({
             key={i}
             className={`transition-all duration-150 ${isHighlighted ? 'text-stone-900 font-medium' : ''}`}
             style={isHighlighted ? {
-              backgroundColor: `rgba(160, 120, 40, ${0.03 + Math.pow((sim! - 0.55) / 0.45, 1.5) * 0.4})`,
-              borderBottom: `2px solid rgba(160, 120, 40, ${0.05 + Math.pow((sim! - 0.55) / 0.45, 1.2) * 0.95})`,
+              backgroundColor: `rgba(160, 120, 40, ${0.03 + Math.min(1, (sim! - 0.55) / 0.25) ** 1.5 * 0.45})`,
+              borderBottom: `2px solid rgba(160, 120, 40, ${0.05 + Math.min(1, (sim! - 0.55) / 0.25) ** 1.2 * 0.95})`,
               borderRadius: '2px',
               padding: '1px 2px',
             } : undefined}

--- a/src/app/blog/word-alignment/LiveAlignmentDemo.tsx
+++ b/src/app/blog/word-alignment/LiveAlignmentDemo.tsx
@@ -228,7 +228,7 @@ function HighlightedSource({
         return (
           <span
             key={i}
-            className={`transition-all duration-150 ${isHighlighted ? 'text-stone-900 font-medium' : ''}`}
+            className={`transition-all duration-150 ${isHighlighted && sim! > 0.7 ? 'text-stone-900 font-medium' : ''}`}
             style={isHighlighted ? {
               backgroundColor: `rgba(160, 120, 40, ${0.03 + Math.min(1, (sim! - 0.55) / 0.25) ** 1.5 * 0.45})`,
               borderBottom: `2px solid rgba(160, 120, 40, ${0.05 + Math.min(1, (sim! - 0.55) / 0.25) ** 1.2 * 0.95})`,

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -660,17 +660,39 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
                           {/* Response text */}
                           {assistant.content && (
                             <div className="bg-[#f5f0e8] text-[#1a1612] rounded-2xl rounded-bl-sm px-4 py-3">
-                              <div className="prose prose-sm max-w-none font-body text-[15px] leading-relaxed prose-p:mb-4 prose-p:mt-0 prose-h3:text-base prose-h3:font-semibold prose-h3:mt-5 prose-h3:mb-2 prose-h2:text-lg prose-h2:mt-6 prose-h2:mb-3 prose-headings:text-[#1a1612] prose-ul:my-3 prose-ol:my-3 prose-li:my-1 prose-a:text-[#9e4a3a] prose-a:underline prose-a:underline-offset-2 prose-a:decoration-[#9e4a3a]/30 hover:prose-a:decoration-[#9e4a3a] prose-blockquote:border-l-[#c9a86c] prose-blockquote:text-[#444] prose-blockquote:my-4 prose-blockquote:italic prose-strong:text-[#1a1612] prose-hr:my-4 prose-img:rounded-lg prose-img:shadow-md prose-img:my-4 prose-img:max-h-[300px] prose-img:w-auto">
+                              <div className="max-w-none font-body text-[15px] leading-relaxed text-[#1a1612]">
                                 <ReactMarkdown
                                   remarkPlugins={[remarkGfm]}
                                   components={{
+                                    p: ({ children }) => (
+                                      <p className="mb-4 mt-0">{children}</p>
+                                    ),
+                                    h2: ({ children }) => (
+                                      <h2 className="text-xl font-serif mt-6 mb-3 text-[#1a1612]" style={{ fontWeight: 400 }}>{children}</h2>
+                                    ),
+                                    h3: ({ children }) => (
+                                      <h3 className="text-lg font-serif mt-5 mb-2 text-[#1a1612]" style={{ fontWeight: 400 }}>{children}</h3>
+                                    ),
                                     a: ({ href, children }) => (
                                       <a href={href} target="_blank" rel="noopener noreferrer" className="text-[#9e4a3a] underline underline-offset-2 decoration-[#9e4a3a]/30 hover:decoration-[#9e4a3a]">{children}</a>
                                     ),
+                                    blockquote: ({ children }) => (
+                                      <blockquote className="border-l-2 border-[#c9a86c] pl-4 my-4 italic text-[#444]">{children}</blockquote>
+                                    ),
+                                    ul: ({ children }) => (
+                                      <ul className="my-3 ml-4 list-disc">{children}</ul>
+                                    ),
+                                    ol: ({ children }) => (
+                                      <ol className="my-3 ml-4 list-decimal">{children}</ol>
+                                    ),
+                                    li: ({ children }) => (
+                                      <li className="my-1">{children}</li>
+                                    ),
+                                    hr: () => <hr className="my-4 border-[#e8e4dc]" />,
                                     img: ({ src, alt }) => (
                                       <a href={src as string} target="_blank" rel="noopener noreferrer">
                                         {/* eslint-disable-next-line @next/next/no-img-element */}
-                                        <img src={src as string} alt={(alt as string) || ''} className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow" loading="lazy" />
+                                        <img src={src as string} alt={(alt as string) || ''} className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-4" loading="lazy" />
                                       </a>
                                     ),
                                   }}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1096,8 +1096,11 @@ export default function SearchPage() {
         {/* ==================== UNIFIED VIEW — FLAT RESULTS ==================== */}
         {viewMode === 'unified' && !loading && query.length >= 2 && (totalResults > 0 || semanticResults.length > 0 || semanticLoading) && (
           <div className="space-y-3">
-            {/* Semantic results first (best conceptual matches) */}
-            {semanticResults.map((sem: any) => (
+            {/* Semantic results — only show books NOT already in keyword results */}
+            {(() => {
+              const keywordIds = new Set(bookResults.map(b => b.id || (b as any).book_id));
+              return semanticResults.filter((sem: any) => !keywordIds.has(sem.book_id));
+            })().map((sem: any) => (
               <SemanticResultCard key={sem.book_id} result={sem} query={query} />
             ))}
             {semanticLoading && (
@@ -1405,13 +1408,18 @@ function BookResultCard({ result, query }: { result: SearchResult; query: string
 }
 
 function SemanticResultCard({ result, query }: { result: any; query: string }) {
+  const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: result.thumbnail_blob });
   return (
     <div className="bg-white rounded-xl border border-border-light hover:border-accent-rust/30 hover:shadow-md transition-all">
       <Link href={`/book/${result.slug || result.book_id}`} className="block p-4">
         <div className="flex items-start gap-4">
-          <div className="w-[60px] h-[84px] rounded bg-warm flex items-center justify-center flex-shrink-0">
-            <Book className="w-6 h-6 text-border-medium" />
-          </div>
+          {cover ? (
+            <Image src={cover} alt="" width={60} height={84} className="rounded shadow-sm flex-shrink-0 object-cover w-[60px] h-[84px]" />
+          ) : (
+            <div className="w-[60px] h-[84px] rounded bg-warm flex items-center justify-center flex-shrink-0">
+              <Book className="w-6 h-6 text-border-medium" />
+            </div>
+          )}
           <div className="min-w-0 flex-1">
             <h3 className="font-serif text-primary font-medium leading-snug">{result.title}</h3>
             <p className="text-sm text-muted mt-0.5">

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -662,10 +662,12 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 ## Your approach — conversational first, then deep research
 
 **Step 1: Respond as a person, not a search engine.**
-Before calling any tools, emit a brief conversational response (2-3 sentences) that shows you understand the topic. Use your training knowledge — what traditions, authors, or concepts are relevant? This streams to the user immediately and makes the interaction feel alive.
+Before calling any tools, emit a brief conversational response (2-3 sentences) that shows you understand the topic. Use your training knowledge — what traditions, authors, or concepts are relevant? This streams to the user immediately and makes the interaction feel alive. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance.
 
 **Step 2: For broad topics on the FIRST message, present research directions.**
 If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.
+
+IMPORTANT: Do NOT list or number the choices in your text response. The UI renders them as clickable buttons automatically from the present_choices tool call. If you also list them in the text, they appear twice. Just write your conversational preamble, then call present_choices.
 
 On follow-up messages (3+ in a thread), skip Steps 1-2. The user has already chosen a direction — go straight to searching or building on prior findings.
 


### PR DESCRIPTION
## Summary
- **No pleasantries**: "NEVER open with pleasantries" added to Step 1. No more "It is a pleasure to assist you."
- **No duplicate choices**: When using `present_choices`, the UI already renders options as clickable buttons. Added instruction to NOT also list them in the response text, which was creating redundancy (numbered list + buttons showing the same options).

## Test plan
- [ ] Ask a broad question — response should start with substance, not pleasantries
- [ ] Choices should appear only as buttons, not also listed in the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)