### PR TITLE
Librarian v5: rich choice cards with descriptions

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -146,7 +146,7 @@ export async function POST(request: NextRequest) {
             break;
 
           case 'choices':
-            await send({ type: 'choices', text: step.text, options: step.options });
+            await send({ type: 'choices', text: step.text, options: step.options, descriptions: step.descriptions });
             break;
 
           case 'text':

--- a/src/app/reading-room/ReadingRoomClient.tsx
+++ b/src/app/reading-room/ReadingRoomClient.tsx
@@ -79,7 +79,7 @@ interface AssistantMessage {
   steps: SearchStep[];
   content: string;
   sources: SourceCard[];
-  choices?: { text: string; options: string[] };
+  choices?: { text: string; options: string[]; descriptions?: (string | undefined)[] };
   notebookCount?: number;
   notebookTopic?: string;
 }
@@ -409,7 +409,7 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
                 case 'choices':
                   updateLastAssistant(m => ({
                     ...m,
-                    choices: { text: event.text, options: event.options },
+                    choices: { text: event.text, options: event.options, descriptions: event.descriptions },
                   }));
                   break;
 
@@ -703,21 +703,35 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
 
                           {/* Research direction choices */}
                           {assistant.choices && (
-                            <div className="mt-4 space-y-2">
-                              {assistant.choices.options.map((opt) => (
-                                <button
-                                  key={opt}
-                                  onClick={() => handleChoiceClick(opt)}
-                                  className="w-full text-left group"
-                                >
-                                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-[#e0d9cc] bg-white hover:border-[#c9a86c] hover:bg-[#fdfcf9] transition-all">
-                                    <span className="flex-1 text-[14px] font-body text-[#1a1612] leading-snug">{opt}</span>
-                                    <span className="flex-shrink-0 text-[12px] font-sans text-[#9e4a3a] opacity-0 group-hover:opacity-100 transition-opacity">
-                                      Explore &rarr;
-                                    </span>
-                                  </div>
-                                </button>
-                              ))}
+                            <div className="mt-4 space-y-3">
+                              {assistant.choices.options.map((opt, idx) => {
+                                const desc = assistant.choices?.descriptions?.[idx];
+                                return (
+                                  <button
+                                    key={opt}
+                                    onClick={() => handleChoiceClick(opt)}
+                                    className="w-full text-left group"
+                                  >
+                                    <div className="px-4 py-3.5 rounded-xl border border-[#e0d9cc] bg-white hover:border-[#c9a86c] hover:bg-[#fdfcf9] transition-all">
+                                      {desc ? (
+                                        <>
+                                          <p className="text-[14px] font-body text-[#444] leading-relaxed mb-2.5">{desc}</p>
+                                          <span className="inline-flex items-center gap-1.5 text-[13px] font-sans font-medium text-[#9e4a3a] group-hover:underline">
+                                            {opt} <span className="text-[11px]">&rarr;</span>
+                                          </span>
+                                        </>
+                                      ) : (
+                                        <div className="flex items-center gap-3">
+                                          <span className="flex-1 text-[14px] font-body text-[#1a1612] leading-snug">{opt}</span>
+                                          <span className="flex-shrink-0 text-[12px] font-sans text-[#9e4a3a] opacity-0 group-hover:opacity-100 transition-opacity">
+                                            Explore &rarr;
+                                          </span>
+                                        </div>
+                                      )}
+                                    </div>
+                                  </button>
+                                );
+                              })}
                             </div>
                           )}
 
@@ -806,7 +820,7 @@ export default function ReadingRoomClient({ featuredPassage }: ReadingRoomClient
                           <span className="text-[9px]">{visibility === 'public' ? '(visible to others)' : '(only you)'}</span>
                         </button>
                       )}
-                      <span className="text-[9px] text-[#c0b8b0] font-mono">v4</span>
+                      <span className="text-[9px] text-[#c0b8b0] font-mono">v5</span>
                     </div>
                   </div>
 

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -68,6 +68,7 @@ export interface LibrarianStep {
   summary?: string;
   found?: number;
   options?: string[];
+  descriptions?: (string | undefined)[];
   sources?: SourceCard[];
   notebook?: { findingCount: number; topic?: string };
 }
@@ -209,18 +210,24 @@ const TOOL_DECLARATIONS: FunctionDeclaration[] = [
   },
   {
     name: 'present_choices',
-    description: 'Present 2-3 research directions for broad or exploratory questions. Use as your FIRST tool call (after sharing a brief conversational response as text) when the topic is wide enough to benefit from user steering. The preamble should demonstrate domain knowledge. Each option is a short phrase (under 60 chars). The user clicks one or types their own direction, then you search deeply on that angle.',
+    description: 'Present 2-3 research directions for broad or exploratory questions. Use as your FIRST tool call (after sharing a brief conversational response as text) when the topic is wide enough to benefit from user steering. Each option has a short label and a 1-2 sentence description explaining what that research angle covers. The user clicks one or types their own direction.',
     parameters: {
       type: Type.OBJECT,
       properties: {
-        preamble: { type: Type.STRING, description: 'Brief knowledgeable intro (1-2 sentences) showing you understand the landscape of this topic' },
         options: {
           type: Type.ARRAY,
-          items: { type: Type.STRING },
-          description: '2-3 focused research directions the user can choose from',
+          items: {
+            type: Type.OBJECT,
+            properties: {
+              label: { type: Type.STRING, description: 'Short label for the research direction (under 60 chars)' },
+              description: { type: Type.STRING, description: '1-2 sentence explanation of what this angle covers and why it is interesting' },
+            },
+            required: ['label', 'description'],
+          },
+          description: '2-3 focused research directions with explanations',
         },
       },
-      required: ['preamble', 'options'],
+      required: ['options'],
     },
   },
 ];
@@ -635,11 +642,13 @@ async function executeTool(
     }
 
     case 'present_choices': {
-      const preamble = args.preamble as string;
-      const options = args.options as string[];
+      const rawOptions = args.options as Array<{ label: string; description: string } | string>;
+      // Support both old string[] and new {label, description}[] formats
+      const options = rawOptions.map(o => typeof o === 'string' ? o : o.label);
+      const descriptions = rawOptions.map(o => typeof o === 'string' ? undefined : o.description);
       return {
         result: { status: 'choices_presented', note: 'The user will select an option. Wait for their response.' },
-        step: { type: 'choices', text: preamble, options },
+        step: { type: 'choices', options, descriptions },
       };
     }
 


### PR DESCRIPTION
## Summary
- `present_choices` tool now accepts `{label, description}` objects — each choice has a 1-2 sentence explanation
- Choice cards render description text followed by a rust-colored "Label →" button
- Falls back to old style for plain string options (backward compatible)
- Bumped version to v5

## Test plan
- [ ] Ask a broad question — choices should show description + labeled button
- [ ] Click a choice — should send the label as a message
- [ ] Version indicator shows "v5"

🤖 Generated with [Claude Code](https://claude.com/claude-code)