### PR TITLE
Make /artwork pages public

### DIFF
--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
-import { isInnerCircle } from '@/lib/auth-helpers';
 import { Book } from '@/lib/types';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
@@ -84,8 +83,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${artwork.display_title || artwork.title} — ${artwork.author} — Source Library`,
     description: (artwork as any).commons_description?.slice(0, 200) || `${artwork.title} by ${artwork.author}`,
-    // Artwork pages are admin-only (non-admin gets redirected) — don't index
-    robots: { index: false, follow: true },
+    robots: { index: true, follow: true },
     openGraph: {
       title: `${artwork.display_title || artwork.title} by ${artwork.author}`,
       images: [artwork.thumbnail_blob || artwork.thumbnail || ''],
@@ -94,9 +92,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ArtworkPage({ params }: PageProps) {
-  const admin = await isInnerCircle();
-  if (!admin) redirect('/');
-
   const { slug } = await params;
   const data = await getArtwork(slug);
   if (!data) notFound();

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
-import { isInnerCircle } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -99,15 +98,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${data.name} — Source Library Visual Art`,
     description: `${data.artworks.length} works by ${data.name} in Source Library.`,
-    // Artist pages are admin-only (non-admin gets redirected) — don't index
-    robots: { index: false, follow: true },
+    robots: { index: true, follow: true },
   };
 }
 
 export default async function ArtistPage({ params }: PageProps) {
-  const admin = await isInnerCircle();
-  if (!admin) redirect('/');
-
   const { slug } = await params;
   const data = await getArtist(slug);
   if (!data) notFound();

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -1,9 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { redirect } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
-import { isInnerCircle } from '@/lib/auth-helpers';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { sanitizeThumbnail } from '@/lib/collections-utils';
 
@@ -40,9 +38,6 @@ async function getData() {
 }
 
 export default async function ArtworkLandingPage() {
-  const admin = await isInnerCircle();
-  if (!admin) redirect('/');
-
   const { collections, totalCount } = await getData();
 
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -29,7 +29,7 @@ export default function robots(): MetadataRoute.Robots {
           '/reading-history',
           '/highlights',
           '/favorites',
-          '/artwork/',
+          // '/artwork/' — now public (2026-04-19)
         ],
       },
 


### PR DESCRIPTION
## Summary
- Remove `isInnerCircle()` gate from `/artwork`, `/artwork/[slug]`, and `/artwork/artist/[slug]`
- Enable search engine indexing (`robots: { index: true }`)
- Remove `/artwork/` from `robots.txt` disallow list
- The visual art wing now has 10,900+ artworks across 28 collections — ready for public access

## Test plan
- [ ] Visit `/artwork` logged out — should render collections grid
- [ ] Visit `/artwork/courtesan-with-a-client` — should render artwork detail
- [ ] Visit `/artwork/artist/Aubrey-Beardsley` — should render artist page
- [ ] Check `/robots.txt` — `/artwork/` no longer disallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)