### PR TITLE
Add artwork search coverage to MCP + reader header metadata

### DIFF
--- a/src/app/api/artwork/search/route.ts
+++ b/src/app/api/artwork/search/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+
+/**
+ * GET /api/artwork/search?q=...&limit=...
+ *
+ * Search artwork items (paintings, prints, sculptures) stored in the books collection.
+ * These are distinct from gallery_images (extracted illustrations from book pages).
+ * Artworks are identified by having R2 artwork/ thumbnail URLs.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q');
+  const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 50);
+
+  if (!query) {
+    return NextResponse.json({ error: 'q parameter required' }, { status: 400 });
+  }
+
+  const db = await getReadDb();
+  const pattern = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const artworks = await db.collection('books')
+    .find({
+      thumbnail: { $regex: /^https:\/\/images\.sourcelibrary\.org\/artwork\// },
+      visible: true,
+      $or: [
+        { title: { $regex: pattern, $options: 'i' } },
+        { artist: { $regex: pattern, $options: 'i' } },
+        { author: { $regex: pattern, $options: 'i' } },
+      ],
+    }, {
+      projection: {
+        _id: 0, id: 1, title: 1, artist: 1, author: 1, year: 1,
+        thumbnail: 1, thumbnail_blob: 1, slug: 1, medium: 1,
+        collections: 1,
+      },
+    })
+    .limit(limit)
+    .toArray();
+
+  const items = artworks.map(art => ({
+    id: art.id,
+    title: art.title,
+    artist: art.artist || art.author,
+    year: art.year,
+    medium: art.medium,
+    image_url: art.thumbnail_blob || art.thumbnail,
+    thumbnail_url: art.thumbnail,
+    url: `https://sourcelibrary.org/book/${art.slug || art.id}`,
+    collections: art.collections,
+  }));
+
+  return NextResponse.json({
+    total: items.length,
+    items,
+  }, {
+    headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },
+  });
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -169,19 +169,43 @@ async function searchImages(args: Record<string, unknown>) {
   if (args.year_to) params.set('yearEnd', String(args.year_to));
   if (args.book_id) params.set('bookId', String(args.book_id));
   if (args.min_quality !== undefined) params.set('minQuality', String(args.min_quality));
-  params.set('limit', String(Math.min(Number(args.limit) || 20, 50)));
+  const limit = Math.min(Number(args.limit) || 20, 50);
+  params.set('limit', String(limit));
 
-  const result = await apiGet('/gallery', params) as Record<string, unknown>;
+  // Search both gallery illustrations AND artworks (paintings/prints) in parallel
+  const artworkParams = new URLSearchParams();
+  if (args.query) artworkParams.set('q', String(args.query));
+  artworkParams.set('limit', String(limit));
+
+  const [galleryResult, artworkResult] = await Promise.all([
+    apiGet('/gallery', params) as Promise<Record<string, unknown>>,
+    args.query
+      ? (apiGet('/artwork/search', artworkParams) as Promise<Record<string, unknown>>).catch(() => ({ items: [] }))
+      : Promise.resolve({ items: [] }),
+  ]);
+
+  const galleryImages = (galleryResult.items as Array<Record<string, unknown>>)?.map((item) => ({
+    description: item.description, type: item.type, quality: item.galleryQuality,
+    book: { title: item.bookTitle, author: item.author, year: item.year },
+    page: item.pageNumber, image_url: item.imageUrl,
+    url: `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
+    book_url: item.bookId ? `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}` : undefined,
+  })) || [];
+
+  const artworks = (artworkResult.items as Array<Record<string, unknown>>)?.map((item) => ({
+    description: item.title, type: 'artwork',
+    artist: item.artist, medium: item.medium,
+    year: item.year, image_url: item.image_url,
+    url: item.url,
+  })) || [];
+
+  // Artworks first (exact matches), then gallery illustrations
+  const allImages = [...artworks, ...galleryImages].slice(0, limit);
+
   return {
-    total: result.total,
-    showing: (result.items as unknown[])?.length || 0,
-    images: (result.items as Array<Record<string, unknown>>)?.map((item) => ({
-      description: item.description, type: item.type, quality: item.galleryQuality,
-      book: { title: item.bookTitle, author: item.author, year: item.year },
-      page: item.pageNumber, image_url: item.imageUrl,
-      url: `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
-      book_url: item.bookId ? `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}` : undefined,
-    })),
+    total: (galleryResult.total as number || 0) + artworks.length,
+    showing: allImages.length,
+    images: allImages,
   };
 }
 
@@ -300,7 +324,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'search_images',
-    description: 'Search 50,000+ historical illustrations, emblems, engravings, and diagrams. Filter by type, subject, figure, symbol, year.',
+    description: 'Search 50,000+ historical illustrations, emblems, engravings, diagrams, AND 7,500+ artworks (paintings, prints, sculptures). Filter by type, subject, figure, symbol, year.',
     annotations: { title: 'Search Images', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -832,6 +832,11 @@ export default function TranslationEditor({
                 <h1 className="text-sm sm:text-base font-medium truncate" style={{ color: 'var(--text-primary)' }}>
                   {book.display_title || book.title}
                 </h1>
+                {(book.author || book.published) && (
+                  <p className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
+                    {book.author}{book.author && book.published ? ' · ' : ''}{book.published}
+                  </p>
+                )}
               </a>
             </div>
 
@@ -1551,6 +1556,11 @@ export default function TranslationEditor({
               <h1 className="text-base sm:text-xl font-medium truncate" style={{ color: 'var(--text-primary)' }}>
                 {book.display_title || book.title}
               </h1>
+              {(book.author || book.published) && (
+                <p className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
+                  {book.author}{book.author && book.published ? ' · ' : ''}{book.published}
+                </p>
+              )}
             </a>
           </div>
 


### PR DESCRIPTION
## Summary
- **New `/api/artwork/search` endpoint** — searches paintings, prints, and sculptures stored in the books collection (7,500+ items). Separate from `gallery_images` so artworks don't get confused with book illustrations.
- **MCP `search_images` now searches both lanes** — gallery illustrations AND artworks, in parallel. Artworks returned with distinct `type: 'artwork'` so consumers can handle them appropriately.
- **Reader header shows author + year** — lightweight `Author · 1509` line below the title in both read and edit modes, so readers have context without needing to visit the book overview.

## Test plan
- [ ] MCP `search_images` for "School of Athens" returns the Raphael artwork
- [ ] MCP `search_images` for "ouroboros" still returns gallery illustrations as before
- [ ] `/api/artwork/search?q=raphael` returns artwork results
- [ ] Reader page shows author and year below title
- [ ] No regression on gallery page or gallery API

🤖 Generated with [Claude Code](https://claude.com/claude-code)