### PR TITLE
Fix search fallback: stopwords + zero-only trigger

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -162,13 +162,13 @@ export async function GET(request: NextRequest) {
         }
 
         // Metadata fallback: search categories/subject_keywords/language in MongoDB
-        // when Supabase trigram returns sparse results
-        if (books.length < limit) {
-          const words = query.trim().split(/\s+/).filter((w: string) => w.length >= 2);
+        // Only fires when Supabase found nothing (avoids slow regex on common queries)
+        if (books.length === 0) {
+          const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
+          const words = query.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
           if (words.length >= 2) {
-            const seenIds = new Set(books.map((b: any) => b.id));
             const wordRegexes = words.map((w: string) => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
-            const fallbackBooks = await db.collection('books')
+            books = await db.collection('books')
               .find({
                 $and: wordRegexes.map(rx => ({
                   $or: [
@@ -183,14 +183,8 @@ export async function GET(request: NextRequest) {
               })
               .project(bookProjection)
               .limit(limit)
-              .maxTimeMS(5000)
+              .maxTimeMS(3000)
               .toArray();
-
-            for (const fb of fallbackBooks) {
-              if (!seenIds.has(fb.id)) {
-                books.push(fb);
-              }
-            }
           }
         }
         return books;

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -232,11 +232,11 @@ async function searchBooks(
 
   // Metadata fallback: search categories, subject_keywords, and language in MongoDB
   // Catches queries like "sanskrit alchemy" where words match metadata fields
-  // that Supabase trigram doesn't cover. Fires when results are sparse.
-  if (books.length < limit) {
-    const words = query.trim().split(/\s+/).filter(w => w.length >= 2);
+  // that Supabase trigram doesn't cover. Only fires when Supabase found nothing.
+  if (books.length === 0) {
+    const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
+    const words = query.trim().split(/\s+/).filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
     if (words.length >= 2) {
-      const seenIds = new Set(books.map((b: any) => b.id));
       const wordRegexes = words.map(w => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
       const fallbackFilter: Record<string, unknown> = {
         $and: wordRegexes.map(rx => ({
@@ -255,19 +255,12 @@ async function searchBooks(
       if (searchFilters.category) fallbackFilter.categories = searchFilters.category;
       if (library) fallbackFilter['image_source.provider'] = library;
 
-      const fallbackBooks = await db.collection('books')
+      books = await db.collection('books')
         .find(fallbackFilter)
         .project(bookProjection)
         .limit(limit + 1)
-        .maxTimeMS(5000)
+        .maxTimeMS(3000)
         .toArray();
-
-      for (const fb of fallbackBooks) {
-        if (!seenIds.has(fb.id)) {
-          books.push(fb);
-          seenIds.add(fb.id);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- **Bug:** The metadata fallback from #1243 fired on every query with < limit results, causing 500 errors on queries like "school of athens" (word "of" matched thousands of titles via regex, overwhelming MongoDB)
- **Fix:** Only fire fallback when Supabase returns exactly 0 results, filter stopwords (of/the/in/etc.), require words ≥ 3 chars, reduce timeout to 3s

## Test plan
- [x] "school of athens" no longer 500s
- [x] "sanskrit alchemy" still works (both words pass stopword filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)