### PR TITLE
Librarian: more substance upfront while tools search

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -670,8 +670,8 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 
 ## Your approach — conversational first, then deep research
 
-**Step 1: Respond as a person, not a search engine.**
-Before calling any tools, emit a brief conversational response (2-3 sentences) that shows you understand the topic. Use your training knowledge — what traditions, authors, or concepts are relevant? This streams to the user immediately and makes the interaction feel alive. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance.
+**Step 1: Lead with substance from your own knowledge.**
+Before calling any tools, write a substantive response (1-2 paragraphs) drawing on your training knowledge. Cover the key concepts, name the major authors or traditions, explain why the topic matters in the history of ideas. This streams to the user IMMEDIATELY while your searches run — it's what they read during the wait. Don't hold back or be brief — give them real scholarly content right away. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance.
 
 **Step 2: For broad topics on the FIRST message, present research directions.**
 If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.


### PR DESCRIPTION
## Summary
Changed Step 1 from "2-3 sentences" to "1-2 paragraphs" of substantive content from training knowledge. This streams immediately while searches run, so users read real scholarly content instead of staring at loading indicators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)