### PR TITLE
Fix search: revert Supabase cross-field, metadata-only MongoDB fallback

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -162,21 +162,21 @@ export async function GET(request: NextRequest) {
         }
 
         // Metadata fallback: search categories/subject_keywords/language in MongoDB
-        // Only fires when Supabase found nothing (avoids slow regex on common queries)
-        if (books.length === 0) {
+        // Catches queries like "sanskrit alchemy" where words match metadata fields.
+        // Stopwords filtered. Only searches metadata fields (not title — Supabase handles that).
+        if (books.length < limit) {
           const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
           const words = query.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
           if (words.length >= 2) {
+            const seenIds = new Set(books.map((b: any) => b.id));
             const wordRegexes = words.map((w: string) => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
-            books = await db.collection('books')
+            const fallbackBooks = await db.collection('books')
               .find({
                 $and: wordRegexes.map(rx => ({
                   $or: [
                     { categories: rx },
                     { subject_keywords: rx },
                     { language: rx },
-                    { title: rx },
-                    { display_title: rx },
                   ],
                 })),
                 ...bookFilters,
@@ -185,6 +185,12 @@ export async function GET(request: NextRequest) {
               .limit(limit)
               .maxTimeMS(3000)
               .toArray();
+
+            for (const fb of fallbackBooks) {
+              if (!seenIds.has(fb.id)) {
+                books.push(fb);
+              }
+            }
           }
         }
         return books;

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -232,11 +232,12 @@ async function searchBooks(
 
   // Metadata fallback: search categories, subject_keywords, and language in MongoDB
   // Catches queries like "sanskrit alchemy" where words match metadata fields
-  // that Supabase trigram doesn't cover. Only fires when Supabase found nothing.
-  if (books.length === 0) {
+  // that Supabase trigram doesn't cover. Stopwords filtered to avoid broad scans.
+  if (books.length < limit) {
     const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
     const words = query.trim().split(/\s+/).filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
     if (words.length >= 2) {
+      const seenIds = new Set(books.map((b: any) => b.id));
       const wordRegexes = words.map(w => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
       const fallbackFilter: Record<string, unknown> = {
         $and: wordRegexes.map(rx => ({
@@ -244,8 +245,6 @@ async function searchBooks(
             { categories: rx },
             { subject_keywords: rx },
             { language: rx },
-            { title: rx },
-            { display_title: rx },
           ],
         })),
         visible: true,
@@ -255,12 +254,19 @@ async function searchBooks(
       if (searchFilters.category) fallbackFilter.categories = searchFilters.category;
       if (library) fallbackFilter['image_source.provider'] = library;
 
-      books = await db.collection('books')
+      const fallbackBooks = await db.collection('books')
         .find(fallbackFilter)
         .project(bookProjection)
         .limit(limit + 1)
         .maxTimeMS(3000)
         .toArray();
+
+      for (const fb of fallbackBooks) {
+        if (!seenIds.has(fb.id)) {
+          books.push(fb);
+          seenIds.add(fb.id);
+        }
+      }
     }
   }
 

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -317,9 +317,7 @@ export async function searchBookIds(
 
   // Build OR filter: exact phrase match + word-level AND matches
   // "mathematical magick" should match "Mathematicall Magick" by matching each word
-  const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
   const words = text.trim().split(/\s+/).filter(w => w.length >= 2);
-  const contentWords = words.filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
   // Only ilike on indexed/short fields — summary_text and description cause
   // full-table scans and Supabase statement timeouts (no trigram indexes)
   const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`;
@@ -330,19 +328,6 @@ export async function searchBookIds(
     const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');
     orFilter += `,and(${titleAnds}),and(${displayAnds})`;
-
-    // Cross-field AND: each content word must appear in SOME searchable field
-    // Catches queries like "sanskrit alchemy" where "sanskrit" matches language
-    // and "alchemy" matches title. Stopwords filtered to avoid broad scans.
-    if (contentWords.length >= 2) {
-      const crossFieldAnd = contentWords.map(w =>
-        `or(title.ilike.%${w}%,display_title.ilike.%${w}%,author.ilike.%${w}%,language.ilike.%${w}%)`
-      ).join(',');
-      orFilter += `,and(${crossFieldAnd})`;
-    }
-  } else {
-    // Single word: also match against language (e.g. "Sanskrit", "Arabic")
-    orFilter += `,language.ilike.%${text}%`;
   }
 
   let query = supabase


### PR DESCRIPTION
## Summary
- Reverted `searchBookIds` cross-field AND (was causing latency on all queries)
- MongoDB fallback now only searches metadata fields (categories, subject_keywords, language) — not title/display_title
- Fires when results < limit, with stopword filtering and 3s timeout
- Fixes both "sanskrit alchemy" (finds books) and "school of athens" (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)