### PR TITLE
Reading room fixes: voice rename, loading states, transcripts, thumbnails

### DIFF
--- a/src/app/api/embassy/threads/[id]/podcast/route.ts
+++ b/src/app/api/embassy/threads/[id]/podcast/route.ts
@@ -68,13 +68,15 @@ export async function POST(
     }
   } catch { /* default format */ }
 
-  // Verify thread ownership
+  // Verify thread exists and user owns it
   const thread = await db.collection('embassy_threads').findOne({
     _id: new ObjectId(id),
-    creatorId: session.user.id,
   });
   if (!thread) {
     return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+  }
+  if (thread.creatorId !== session.user.id) {
+    return NextResponse.json({ error: 'Only the thread creator can generate podcasts' }, { status: 403 });
   }
 
   // Load notebook
@@ -139,13 +141,15 @@ export async function PATCH(
     return NextResponse.json({ error: 'Invalid format' }, { status: 400 });
   }
 
-  // Verify thread ownership
+  // Verify thread exists and user owns it
   const thread = await db.collection('embassy_threads').findOne({
     _id: new ObjectId(id),
-    creatorId: session.user.id,
   });
   if (!thread) {
     return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
+  }
+  if (thread.creatorId !== session.user.id) {
+    return NextResponse.json({ error: 'Only the thread creator can publish podcasts' }, { status: 403 });
   }
 
   // Update published status

--- a/src/app/podcast/TranscriptToggle.tsx
+++ b/src/app/podcast/TranscriptToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+function formatTranscript(script: string): { speaker: string; text: string }[] {
+  return script
+    .split('\n')
+    .filter(line => line.includes(':'))
+    .map(line => {
+      const colonIdx = line.indexOf(':');
+      const speaker = line.slice(0, colonIdx).trim();
+      const text = line.slice(colonIdx + 1).trim()
+        .replace(/\[(laughs|whispers|enthusiasm|thoughtful|determination)\]/gi, '');
+      return { speaker, text };
+    })
+    .filter(entry => entry.text.length > 0);
+}
+
+export default function TranscriptToggle({ script }: { script: string }) {
+  const [open, setOpen] = useState(false);
+  const entries = formatTranscript(script);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={() => setOpen(!open)}
+        className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
+      >
+        {open ? 'Hide transcript' : 'Show transcript'}
+      </button>
+      {open && (
+        <div className="mt-3 pt-3 border-t border-[#e0d9cc] space-y-2 max-h-[400px] overflow-y-auto">
+          {entries.map((entry, i) => (
+            <p key={i} className="text-[13px] font-body leading-relaxed text-[#333]">
+              <span className="font-semibold text-[#1a1612]">{entry.speaker}:</span>{' '}
+              {entry.text}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -2,6 +2,7 @@ import { connectToDatabase } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import Link from 'next/link';
+import TranscriptToggle from './TranscriptToggle';
 
 export const revalidate = 3600; // 1h ISR
 
@@ -20,6 +21,8 @@ interface PodcastEpisode {
   findingCount: number;
   generatedAt: string;
   bookIds: string[];
+  bookThumbnails: string[];
+  script: string | null;
 }
 
 async function getEpisodes(): Promise<PodcastEpisode[]> {
@@ -56,6 +59,8 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
             findingCount: p.findingCount || 0,
             generatedAt: p.generatedAt,
             bookIds: [],
+            bookThumbnails: [],
+            script: p.script || null,
           });
         }
       }
@@ -71,6 +76,8 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
           findingCount: thread.podcast.findingCount || 0,
           generatedAt: thread.podcast.generatedAt,
           bookIds: [],
+          bookThumbnails: [],
+          script: thread.podcast.script || null,
         });
       }
     }
@@ -84,11 +91,30 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
 
     const notebookMap = new Map(notebooks.map(n => [
       n.threadId.toString(),
-      [...new Set((n.findings || []).map((f: { source: { bookId: string } }) => f.source.bookId))],
+      [...new Set((n.findings || []).map((f: { source: { bookId: string } }) => f.source?.bookId).filter(Boolean))],
     ]));
 
     for (const ep of episodes) {
       ep.bookIds = (notebookMap.get(ep.threadId) || []) as string[];
+    }
+
+    // Look up actual thumbnails for referenced books
+    const allBookIds = [...new Set(episodes.flatMap(e => e.bookIds))];
+    if (allBookIds.length > 0) {
+      const validIds = allBookIds.filter(id => ObjectId.isValid(id));
+      const books = await db.collection('books')
+        .find({ _id: { $in: validIds.map(id => new ObjectId(id)) } })
+        .project({ _id: 1, thumbnail: 1, thumbnail_blob: 1 })
+        .toArray();
+      const thumbMap = new Map(books.map(b => [
+        b._id.toString(),
+        b.thumbnail || b.thumbnail_blob || null,
+      ]));
+      for (const ep of episodes) {
+        ep.bookThumbnails = ep.bookIds
+          .map(id => thumbMap.get(id))
+          .filter(Boolean) as string[];
+      }
     }
 
     return episodes.sort((a, b) =>
@@ -162,20 +188,20 @@ export default async function PodcastPage() {
                 className="p-5 bg-white rounded-xl border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors"
               >
                 {/* Book cover thumbnails */}
-                {ep.bookIds.length > 0 && (
+                {ep.bookThumbnails.length > 0 && (
                   <div className="flex gap-1.5 mb-3 overflow-hidden">
-                    {ep.bookIds.slice(0, 5).map(bid => (
+                    {ep.bookThumbnails.slice(0, 5).map((url, idx) => (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
-                        key={bid}
-                        src={`https://sourcelibrary.org/api/image?url=https://images.sourcelibrary.org/covers/${bid}.jpg&w=60&q=75`}
+                        key={idx}
+                        src={`/api/image?url=${encodeURIComponent(url)}&w=60&q=75`}
                         alt=""
                         className="w-8 h-12 object-cover rounded flex-shrink-0 bg-[#f0ece4]"
                         loading="lazy"
                       />
                     ))}
-                    {ep.bookIds.length > 5 && (
-                      <span className="text-[10px] text-[#8a8480] font-sans self-end mb-1">+{ep.bookIds.length - 5}</span>
+                    {ep.bookThumbnails.length > 5 && (
+                      <span className="text-[10px] text-[#8a8480] font-sans self-end mb-1">+{ep.bookThumbnails.length - 5}</span>
                     )}
                   </div>
                 )}
@@ -207,8 +233,9 @@ export default async function PodcastPage() {
                     href={`/reading-room/thread/${ep.threadId}`}
                     className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
                   >
-                    View sources & transcript
+                    View research &amp; sources
                   </Link>
+                  {ep.script && <TranscriptToggle script={ep.script} />}
                 </div>
               </article>
             ))}

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -398,7 +398,7 @@ function AskWhileListening({ threadId }: { threadId: string }) {
 
 // ── Podcast Player ────────────────────────────────────────────────────
 
-function PodcastPlayer({ threadId }: { threadId: string }) {
+function PodcastPlayer({ threadId, isCreator }: { threadId: string; isCreator: boolean }) {
   const [podcasts, setPodcasts] = useState<Record<string, PodcastData>>({});
   const [selectedFormat, setSelectedFormat] = useState<PodcastFormat>('deep-dive');
   const [generating, setGenerating] = useState(false);
@@ -565,28 +565,34 @@ function PodcastPlayer({ threadId }: { threadId: string }) {
           <p className="text-[13px] text-[#6b6560] font-body mb-3">
             {FORMAT_OPTIONS.find(f => f.value === selectedFormat)?.desc}
           </p>
-          <button
-            onClick={handleGenerate}
-            disabled={generating}
-            className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {generating ? (
-              <>
-                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
-                Elena &amp; Marcus are writing...
-              </>
-            ) : (
-              'Generate'
-            )}
-          </button>
-          {generating && (
-            <p className="text-[11px] text-[#8a8480] font-sans mt-2">This usually takes 30–60 seconds</p>
-          )}
-          {error && (
-            <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
+          {isCreator ? (
+            <>
+              <button
+                onClick={handleGenerate}
+                disabled={generating}
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {generating ? (
+                  <>
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Elena &amp; Marcus are writing...
+                  </>
+                ) : (
+                  'Generate'
+                )}
+              </button>
+              {generating && (
+                <p className="text-[11px] text-[#8a8480] font-sans mt-2">This usually takes 30–60 seconds</p>
+              )}
+              {error && (
+                <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
+              )}
+            </>
+          ) : (
+            <p className="text-[12px] text-[#8a8480] font-sans">Not yet generated</p>
           )}
         </div>
       )}
@@ -739,7 +745,7 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
         </div>
 
         {/* Podcast section */}
-        <PodcastPlayer threadId={id} />
+        <PodcastPlayer threadId={id} isCreator={session?.user?.id === thread.creatorId} />
 
         {/* Source books used in this research */}
         <SourceCards threadId={id} />

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -373,7 +373,7 @@ function AskWhileListening({ threadId }: { threadId: string }) {
       <audio ref={audioRef} className="hidden" />
       {loading && (
         <p className="mt-2 text-[12px] text-[#8a8480] font-sans animate-pulse">
-          Elena and Marcus are thinking...
+          Elena and Marcus are thinking... <span className="opacity-60">(~15 seconds)</span>
         </p>
       )}
       {exchanges.map((ex, i) => (
@@ -576,12 +576,15 @@ function PodcastPlayer({ threadId }: { threadId: string }) {
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
-                Generating...
+                Elena &amp; Marcus are writing...
               </>
             ) : (
               'Generate'
             )}
           </button>
+          {generating && (
+            <p className="text-[11px] text-[#8a8480] font-sans mt-2">This usually takes 30–60 seconds</p>
+          )}
           {error && (
             <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
           )}

--- a/src/app/reading-room/voice/VoiceAgentClient.tsx
+++ b/src/app/reading-room/voice/VoiceAgentClient.tsx
@@ -254,7 +254,7 @@ function VoiceAgentInner() {
 
         <div className="relative max-w-[1200px] mx-auto px-6 md:px-12 pt-14 sm:pt-20 pb-16 flex flex-col items-center text-center">
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-display mb-3 drop-shadow-lg" style={{ fontWeight: 500 }}>
-            Hermes
+            Thoth
           </h1>
           <p className="text-white/60 text-base sm:text-lg font-body leading-relaxed max-w-[520px] mb-8">
             Voice research across 10,000 rare books &mdash; alchemy, Daoist texts, Sanskrit philosophy, Sufi mysticism, Kabbalah, and more.
@@ -284,7 +284,7 @@ function VoiceAgentInner() {
               >
                 <div className={`flex flex-col items-center ${holding ? 'text-[#0e0c0a]' : pttMode && !agentSpeaking ? 'text-white/70' : 'text-[#0e0c0a]'}`}>
                   {holding ? (<><MicIcon /><span className="text-xs mt-1 font-sans font-medium">Speaking</span></>)
-                    : agentSpeaking ? (<><SpeakerIcon /><span className="text-xs mt-1 font-sans opacity-70">Hermes</span></>)
+                    : agentSpeaking ? (<><SpeakerIcon /><span className="text-xs mt-1 font-sans opacity-70">Thoth</span></>)
                       : pttMode ? (<><MicIcon /><span className="text-xs mt-1 font-sans opacity-70">Hold to talk</span></>)
                         : (<><MicIcon /><span className="text-xs mt-1 font-sans opacity-70">Listening</span></>)}
                 </div>
@@ -323,12 +323,12 @@ function VoiceAgentInner() {
                   <div className="text-center py-10">
                     <img src="/brand/png/icon-only--black-on-transparent--96h.png" alt="" className="w-10 h-10 mx-auto mb-3 opacity-30" />
                     <p className="text-[#8a8480] text-sm font-body max-w-[360px] mx-auto leading-relaxed">
-                      Hermes searches the collection as you speak &mdash; alchemy, philosophy, sacred texts, manuscripts from every tradition.
+                      Thoth searches the collection as you speak &mdash; alchemy, philosophy, sacred texts, manuscripts from every tradition.
                     </p>
                   </div>
                 )}
                 {transcript.length === 0 && appStatus === 'connected' && (
-                  <div className="text-center py-10 animate-pulse"><p className="text-[#b0a89c] text-sm font-body">Hermes is here...</p></div>
+                  <div className="text-center py-10 animate-pulse"><p className="text-[#b0a89c] text-sm font-body">Thoth is here...</p></div>
                 )}
                 {transcript.map((entry, i) => (
                   <div key={i} className={`flex gap-3 ${entry.role === 'user' ? 'justify-end' : ''}`}>
@@ -361,7 +361,7 @@ function VoiceAgentInner() {
               <p className="text-[11px] text-[#8a8480] tracking-[0.15em] uppercase font-sans">Sources found</p>
               {sources.length === 0 ? (
                 <div className="bg-white rounded-lg border border-[#e8e4dc] p-5 text-center shadow-sm">
-                  <p className="text-[#b0a89c] text-sm font-body leading-relaxed">Sources will appear here as Hermes searches the collection.</p>
+                  <p className="text-[#b0a89c] text-sm font-body leading-relaxed">Sources will appear here as Thoth searches the collection.</p>
                 </div>
               ) : (
                 <div className="space-y-2 max-h-[60vh] overflow-y-auto">
@@ -374,7 +374,7 @@ function VoiceAgentInner() {
                       </Link>
                       {appStatus === 'connected' && (
                         <button onClick={() => pushContext(`The user is now looking at "${s.title}" by ${s.author}${s.pageNumber ? `, page ${s.pageNumber}` : ''}. ${s.snippet ? `Passage: "${s.snippet.slice(0, 150)}"` : ''}`)}
-                          className="mt-2 text-[10px] text-[#c9a86c] hover:text-[#a88a4c] font-sans tracking-wide uppercase">Tell Hermes</button>
+                          className="mt-2 text-[10px] text-[#c9a86c] hover:text-[#a88a4c] font-sans tracking-wide uppercase">Tell Thoth</button>
                       )}
                     </div>
                   ))}

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -647,10 +647,12 @@ function DecadeBar({
     <div
       ref={barRef}
       className="flex-1 relative cursor-pointer group"
-      style={{ minWidth: 8, height: '100%' }}
+      style={{ minWidth: 10, height: '100%' }}
       onClick={onClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={() => setTooltipPos(null)}
+      onTouchStart={handleMouseEnter}
+      onTouchEnd={() => setTimeout(() => setTooltipPos(null), 2000)}
     >
       {/* Tooltip — fixed position to escape overflow:hidden */}
       {tooltipPos && (

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -670,8 +670,8 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 
 ## Your approach — conversational first, then deep research
 
-**Step 1: Lead with substance from your own knowledge.**
-Before calling any tools, write a substantive response (1-2 paragraphs) drawing on your training knowledge. Cover the key concepts, name the major authors or traditions, explain why the topic matters in the history of ideas. This streams to the user IMMEDIATELY while your searches run — it's what they read during the wait. Don't hold back or be brief — give them real scholarly content right away. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance.
+**Step 1: Lead with substance — briefly.**
+Before calling any tools, write 1-3 sentences (max 50 words) that show you know the topic. Name the key tradition, author, or concept. This streams immediately while searches run. Keep it SHORT — the user wants results, not a lecture. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance.
 
 **Step 2: For broad topics on the FIRST message, present research directions.**
 If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.


### PR DESCRIPTION
## Summary
- **#1246** — Rename Hermes → Thoth in voice agent UI + shorten Librarian initial response (max 50 words)
- **#1247** — "Elena & Marcus are writing..." with 30-60s time estimate on Generate, ~15s on interactive ask
- **#1248** — Fix "Thread not found": separate ownership check from lookup, gate Generate behind `isCreator`
- **#1249** — Add `TranscriptToggle` component to /podcast page with speaker-attributed lines
- **#1250** — Fix broken thumbnails: fetch actual `book.thumbnail` from DB instead of guessing R2 cover paths
- **#1255** — Timeline: touch tooltip support for mobile histogram bars

## Not code fixes
- **#1251** — Investigated: NOT hallucinated. Cyrano de Bergerac page had truncated OCR but translation correctly captured full text from image.

## Test plan
- [ ] Visit `/reading-room/voice` — title should say "Thoth"
- [ ] Start a new Librarian thread — initial response should be brief (1-3 sentences)
- [ ] Click Generate on a podcast format — should show "Elena & Marcus are writing..." + time estimate
- [ ] Visit `/podcast` — thumbnails should load, "Show transcript" toggle should appear
- [ ] Visit a public thread as non-creator — Generate button should not appear
- [ ] Visit `/timeline` on mobile — tap histogram bars for tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)