### PR TITLE
Fix 4 UI bugs: podcast thumbnails, thread auth, map legend, librarian verbosity

### DIFF
--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -10,6 +10,11 @@ export const metadata = {
   description: 'AI-generated scholarly podcasts exploring rare books from the 15th-18th centuries. Alchemy, Hermetica, Kabbalah, and the Western esoteric tradition — grounded in primary sources.',
 };
 
+interface BookThumb {
+  id: string;
+  thumbnail: string | null;
+}
+
 interface PodcastEpisode {
   threadId: string;
   title: string;
@@ -20,6 +25,7 @@ interface PodcastEpisode {
   findingCount: number;
   generatedAt: string;
   bookIds: string[];
+  bookThumbs: BookThumb[];
 }
 
 async function getEpisodes(): Promise<PodcastEpisode[]> {
@@ -56,6 +62,7 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
             findingCount: p.findingCount || 0,
             generatedAt: p.generatedAt,
             bookIds: [],
+            bookThumbs: [],
           });
         }
       }
@@ -71,6 +78,7 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
           findingCount: thread.podcast.findingCount || 0,
           generatedAt: thread.podcast.generatedAt,
           bookIds: [],
+          bookThumbs: [],
         });
       }
     }
@@ -89,6 +97,25 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
 
     for (const ep of episodes) {
       ep.bookIds = (notebookMap.get(ep.threadId) || []) as string[];
+    }
+
+    // Load actual thumbnail URLs for referenced books
+    const allBookIds = [...new Set(episodes.flatMap(e => e.bookIds))];
+    if (allBookIds.length > 0) {
+      const bookDocs = await db.collection('books')
+        .find({ id: { $in: allBookIds } })
+        .project({ id: 1, thumbnail: 1, thumbnail_blob: 1 })
+        .toArray();
+      const thumbMap = new Map(bookDocs.map(b => [
+        b.id,
+        (b.thumbnail_blob || b.thumbnail || null) as string | null,
+      ]));
+      for (const ep of episodes) {
+        ep.bookThumbs = ep.bookIds.map(bid => ({
+          id: bid,
+          thumbnail: thumbMap.get(bid) || null,
+        }));
+      }
     }
 
     return episodes.sort((a, b) =>
@@ -162,20 +189,20 @@ export default async function PodcastPage() {
                 className="p-5 bg-white rounded-xl border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors"
               >
                 {/* Book cover thumbnails */}
-                {ep.bookIds.length > 0 && (
+                {ep.bookThumbs.filter(b => b.thumbnail).length > 0 && (
                   <div className="flex gap-1.5 mb-3 overflow-hidden">
-                    {ep.bookIds.slice(0, 5).map(bid => (
+                    {ep.bookThumbs.filter(b => b.thumbnail).slice(0, 5).map(b => (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
-                        key={bid}
-                        src={`https://sourcelibrary.org/api/image?url=https://images.sourcelibrary.org/covers/${bid}.jpg&w=60&q=75`}
+                        key={b.id}
+                        src={`/api/image?url=${encodeURIComponent(b.thumbnail!)}&w=60&q=75`}
                         alt=""
                         className="w-8 h-12 object-cover rounded flex-shrink-0 bg-[#f0ece4]"
                         loading="lazy"
                       />
                     ))}
-                    {ep.bookIds.length > 5 && (
-                      <span className="text-[10px] text-[#8a8480] font-sans self-end mb-1">+{ep.bookIds.length - 5}</span>
+                    {ep.bookThumbs.filter(b => b.thumbnail).length > 5 && (
+                      <span className="text-[10px] text-[#8a8480] font-sans self-end mb-1">+{ep.bookThumbs.filter(b => b.thumbnail).length - 5}</span>
                     )}
                   </div>
                 )}

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -398,7 +398,7 @@ function AskWhileListening({ threadId }: { threadId: string }) {
 
 // ── Podcast Player ────────────────────────────────────────────────────
 
-function PodcastPlayer({ threadId }: { threadId: string }) {
+function PodcastPlayer({ threadId, isOwner }: { threadId: string; isOwner: boolean }) {
   const [podcasts, setPodcasts] = useState<Record<string, PodcastData>>({});
   const [selectedFormat, setSelectedFormat] = useState<PodcastFormat>('deep-dive');
   const [generating, setGenerating] = useState(false);
@@ -565,23 +565,29 @@ function PodcastPlayer({ threadId }: { threadId: string }) {
           <p className="text-[13px] text-[#6b6560] font-body mb-3">
             {FORMAT_OPTIONS.find(f => f.value === selectedFormat)?.desc}
           </p>
-          <button
-            onClick={handleGenerate}
-            disabled={generating}
-            className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {generating ? (
-              <>
-                <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
-                Generating...
-              </>
-            ) : (
-              'Generate'
-            )}
-          </button>
+          {isOwner ? (
+            <button
+              onClick={handleGenerate}
+              disabled={generating}
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#1a1612] text-white rounded-lg text-sm font-sans hover:bg-[#2a2622] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {generating ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  Generating...
+                </>
+              ) : (
+                'Generate'
+              )}
+            </button>
+          ) : (
+            <p className="text-[12px] text-[#8a8480] font-sans">
+              Only the thread creator can generate podcasts.
+            </p>
+          )}
           {error && (
             <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
           )}
@@ -736,7 +742,7 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
         </div>
 
         {/* Podcast section */}
-        <PodcastPlayer threadId={id} />
+        <PodcastPlayer threadId={id} isOwner={!!session?.user?.id && session.user.id === thread.creatorId} />
 
         {/* Source books used in this research */}
         <SourceCards threadId={id} />

--- a/src/components/explore/BookMap.tsx
+++ b/src/components/explore/BookMap.tsx
@@ -221,7 +221,7 @@ export default function BookMap({ locations }: BookMapProps) {
               >
                 <span className="w-2.5 h-2.5 rounded-full" style={{ background: config.color }} />
                 <span style={{ color: 'var(--text-secondary)', fontSize: '13px' }}>
-                  {type === 'publication' ? 'Published' : type === 'author_birth' ? 'Born' : 'Died'}
+                  {config.label}
                 </span>
               </button>
             );

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -671,7 +671,7 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 ## Your approach — conversational first, then deep research
 
 **Step 1: Lead with substance from your own knowledge.**
-Before calling any tools, write a substantive response (1-2 paragraphs) drawing on your training knowledge. Cover the key concepts, name the major authors or traditions, explain why the topic matters in the history of ideas. This streams to the user IMMEDIATELY while your searches run — it's what they read during the wait. Don't hold back or be brief — give them real scholarly content right away. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance.
+Before calling any tools, write a concise opening (2-4 sentences) that names the key authors, texts, or traditions relevant to the question and frames why it matters. This streams to the user IMMEDIATELY while your searches run. Be dense with information, not verbose — every sentence should teach something. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance. Save longer exposition for AFTER you have sources to cite.
 
 **Step 2: For broad topics on the FIRST message, present research directions.**
 If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.


### PR DESCRIPTION
## Summary
- **#1250 Podcast thumbnails**: Load actual `thumbnail_blob`/`thumbnail` from books collection instead of constructing broken `covers/${id}.jpg` URLs
- **#1248 Thread not found on Generate**: Only show the Generate podcast button to the thread creator. Non-creators see "Only the thread creator can generate podcasts" instead of a broken button that returns 404
- **#1252 Map legend**: Use full descriptive labels ("Published here", "Author born here", "Author died here") instead of confusing short forms ("Published", "Born", "Died")
- **#1246 Librarian too verbose**: Changed initial response instruction from "1-2 paragraphs" to "2-4 sentences" -- denser, faster openings that stream to the user while searches run

Not addressed in code (requires external config):
- **#1246 Hermes voice too intense**: Voice personality is configured in ElevenLabs platform (`ELEVENLABS_AGENT_ID`), not in codebase
- **#1253 Notitia Dignitatum**: Book exists at correct slug URL, search results already link correctly. Scholar's issue was discoverability, not a code bug
- **#1252 "0 texts" on timeline**: Cache exists with 10,263 texts and 145 decades. Likely a transient SSR timeout when the user visited. Client-side fallback fetch is already in place

## Test plan
- [ ] Visit `/podcast` -- thumbnails should render using actual book cover images
- [ ] Visit a thread you did NOT create -- Generate button should not appear
- [ ] Visit `/explore/map` -- legend should say "Published here", "Author born here", "Author died here"
- [ ] Ask the Librarian a broad question -- initial response should be 2-4 sentences, not 1-2 paragraphs

Closes #1250, closes #1248, partially addresses #1252, partially addresses #1246.

Generated with [Claude Code](https://claude.com/claude-code)