### PR TITLE
Reading room: Thoth rename, loading states, transcripts, timeline touch

### DIFF
--- a/src/app/podcast/TranscriptToggle.tsx
+++ b/src/app/podcast/TranscriptToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+function formatTranscript(script: string): { speaker: string; text: string }[] {
+  return script
+    .split('\n')
+    .filter(line => line.includes(':'))
+    .map(line => {
+      const colonIdx = line.indexOf(':');
+      const speaker = line.slice(0, colonIdx).trim();
+      const text = line.slice(colonIdx + 1).trim()
+        .replace(/\[(laughs|whispers|enthusiasm|thoughtful|determination)\]/gi, '');
+      return { speaker, text };
+    })
+    .filter(entry => entry.text.length > 0);
+}
+
+export default function TranscriptToggle({ script }: { script: string }) {
+  const [open, setOpen] = useState(false);
+  const entries = formatTranscript(script);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="mt-2">
+      <button
+        onClick={() => setOpen(!open)}
+        className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
+      >
+        {open ? 'Hide transcript' : 'Show transcript'}
+      </button>
+      {open && (
+        <div className="mt-3 pt-3 border-t border-[#e0d9cc] space-y-2 max-h-[400px] overflow-y-auto">
+          {entries.map((entry, i) => (
+            <p key={i} className="text-[13px] font-body leading-relaxed text-[#333]">
+              <span className="font-semibold text-[#1a1612]">{entry.speaker}:</span>{' '}
+              {entry.text}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -2,6 +2,7 @@ import { connectToDatabase } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import Link from 'next/link';
+import TranscriptToggle from './TranscriptToggle';
 
 export const revalidate = 3600; // 1h ISR
 
@@ -26,6 +27,7 @@ interface PodcastEpisode {
   generatedAt: string;
   bookIds: string[];
   bookThumbs: BookThumb[];
+  script: string | null;
 }
 
 async function getEpisodes(): Promise<PodcastEpisode[]> {
@@ -63,6 +65,7 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
             generatedAt: p.generatedAt,
             bookIds: [],
             bookThumbs: [],
+            script: p.script || null,
           });
         }
       }
@@ -79,6 +82,7 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
           generatedAt: thread.podcast.generatedAt,
           bookIds: [],
           bookThumbs: [],
+          script: thread.podcast.script || null,
         });
       }
     }
@@ -234,8 +238,9 @@ export default async function PodcastPage() {
                     href={`/reading-room/thread/${ep.threadId}`}
                     className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
                   >
-                    View sources & transcript
+                    View research &amp; sources
                   </Link>
+                  {ep.script && <TranscriptToggle script={ep.script} />}
                 </div>
               </article>
             ))}

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -566,6 +566,7 @@ function PodcastPlayer({ threadId, isOwner }: { threadId: string; isOwner: boole
             {FORMAT_OPTIONS.find(f => f.value === selectedFormat)?.desc}
           </p>
           {isOwner ? (
+            <>
             <button
               onClick={handleGenerate}
               disabled={generating}
@@ -586,13 +587,14 @@ function PodcastPlayer({ threadId, isOwner }: { threadId: string; isOwner: boole
             {generating && (
               <p className="text-[11px] text-[#8a8480] font-sans mt-2">This usually takes 30–60 seconds</p>
             )}
+            {error && (
+              <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
+            )}
+          </>
           ) : (
             <p className="text-[12px] text-[#8a8480] font-sans">
               Only the thread creator can generate podcasts.
             </p>
-          )}
-          {error && (
-            <p className="text-xs text-red-600 font-sans mt-2">{error}</p>
           )}
         </div>
       )}

--- a/src/app/reading-room/thread/[id]/page.tsx
+++ b/src/app/reading-room/thread/[id]/page.tsx
@@ -373,7 +373,7 @@ function AskWhileListening({ threadId }: { threadId: string }) {
       <audio ref={audioRef} className="hidden" />
       {loading && (
         <p className="mt-2 text-[12px] text-[#8a8480] font-sans animate-pulse">
-          Elena and Marcus are thinking...
+          Elena and Marcus are thinking... <span className="opacity-60">(~15 seconds)</span>
         </p>
       )}
       {exchanges.map((ex, i) => (
@@ -577,12 +577,15 @@ function PodcastPlayer({ threadId, isOwner }: { threadId: string; isOwner: boole
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                   </svg>
-                  Generating...
+                  Elena &amp; Marcus are writing...
                 </>
               ) : (
                 'Generate'
               )}
             </button>
+            {generating && (
+              <p className="text-[11px] text-[#8a8480] font-sans mt-2">This usually takes 30–60 seconds</p>
+            )}
           ) : (
             <p className="text-[12px] text-[#8a8480] font-sans">
               Only the thread creator can generate podcasts.

--- a/src/app/reading-room/voice/VoiceAgentClient.tsx
+++ b/src/app/reading-room/voice/VoiceAgentClient.tsx
@@ -254,7 +254,7 @@ function VoiceAgentInner() {
 
         <div className="relative max-w-[1200px] mx-auto px-6 md:px-12 pt-14 sm:pt-20 pb-16 flex flex-col items-center text-center">
           <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-display mb-3 drop-shadow-lg" style={{ fontWeight: 500 }}>
-            Hermes
+            Thoth
           </h1>
           <p className="text-white/60 text-base sm:text-lg font-body leading-relaxed max-w-[520px] mb-8">
             Voice research across 10,000 rare books &mdash; alchemy, Daoist texts, Sanskrit philosophy, Sufi mysticism, Kabbalah, and more.
@@ -284,7 +284,7 @@ function VoiceAgentInner() {
               >
                 <div className={`flex flex-col items-center ${holding ? 'text-[#0e0c0a]' : pttMode && !agentSpeaking ? 'text-white/70' : 'text-[#0e0c0a]'}`}>
                   {holding ? (<><MicIcon /><span className="text-xs mt-1 font-sans font-medium">Speaking</span></>)
-                    : agentSpeaking ? (<><SpeakerIcon /><span className="text-xs mt-1 font-sans opacity-70">Hermes</span></>)
+                    : agentSpeaking ? (<><SpeakerIcon /><span className="text-xs mt-1 font-sans opacity-70">Thoth</span></>)
                       : pttMode ? (<><MicIcon /><span className="text-xs mt-1 font-sans opacity-70">Hold to talk</span></>)
                         : (<><MicIcon /><span className="text-xs mt-1 font-sans opacity-70">Listening</span></>)}
                 </div>
@@ -323,12 +323,12 @@ function VoiceAgentInner() {
                   <div className="text-center py-10">
                     <img src="/brand/png/icon-only--black-on-transparent--96h.png" alt="" className="w-10 h-10 mx-auto mb-3 opacity-30" />
                     <p className="text-[#8a8480] text-sm font-body max-w-[360px] mx-auto leading-relaxed">
-                      Hermes searches the collection as you speak &mdash; alchemy, philosophy, sacred texts, manuscripts from every tradition.
+                      Thoth searches the collection as you speak &mdash; alchemy, philosophy, sacred texts, manuscripts from every tradition.
                     </p>
                   </div>
                 )}
                 {transcript.length === 0 && appStatus === 'connected' && (
-                  <div className="text-center py-10 animate-pulse"><p className="text-[#b0a89c] text-sm font-body">Hermes is here...</p></div>
+                  <div className="text-center py-10 animate-pulse"><p className="text-[#b0a89c] text-sm font-body">Thoth is here...</p></div>
                 )}
                 {transcript.map((entry, i) => (
                   <div key={i} className={`flex gap-3 ${entry.role === 'user' ? 'justify-end' : ''}`}>
@@ -361,7 +361,7 @@ function VoiceAgentInner() {
               <p className="text-[11px] text-[#8a8480] tracking-[0.15em] uppercase font-sans">Sources found</p>
               {sources.length === 0 ? (
                 <div className="bg-white rounded-lg border border-[#e8e4dc] p-5 text-center shadow-sm">
-                  <p className="text-[#b0a89c] text-sm font-body leading-relaxed">Sources will appear here as Hermes searches the collection.</p>
+                  <p className="text-[#b0a89c] text-sm font-body leading-relaxed">Sources will appear here as Thoth searches the collection.</p>
                 </div>
               ) : (
                 <div className="space-y-2 max-h-[60vh] overflow-y-auto">
@@ -374,7 +374,7 @@ function VoiceAgentInner() {
                       </Link>
                       {appStatus === 'connected' && (
                         <button onClick={() => pushContext(`The user is now looking at "${s.title}" by ${s.author}${s.pageNumber ? `, page ${s.pageNumber}` : ''}. ${s.snippet ? `Passage: "${s.snippet.slice(0, 150)}"` : ''}`)}
-                          className="mt-2 text-[10px] text-[#c9a86c] hover:text-[#a88a4c] font-sans tracking-wide uppercase">Tell Hermes</button>
+                          className="mt-2 text-[10px] text-[#c9a86c] hover:text-[#a88a4c] font-sans tracking-wide uppercase">Tell Thoth</button>
                       )}
                     </div>
                   ))}

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -647,10 +647,12 @@ function DecadeBar({
     <div
       ref={barRef}
       className="flex-1 relative cursor-pointer group"
-      style={{ minWidth: 8, height: '100%' }}
+      style={{ minWidth: 10, height: '100%' }}
       onClick={onClick}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={() => setTooltipPos(null)}
+      onTouchStart={handleMouseEnter}
+      onTouchEnd={() => setTimeout(() => setTooltipPos(null), 2000)}
     >
       {/* Tooltip — fixed position to escape overflow:hidden */}
       {tooltipPos && (

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -670,8 +670,8 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 
 ## Your approach — conversational first, then deep research
 
-**Step 1: Lead with substance from your own knowledge.**
-Before calling any tools, write a concise opening (2-4 sentences) that names the key authors, texts, or traditions relevant to the question and frames why it matters. This streams to the user IMMEDIATELY while your searches run. Be dense with information, not verbose — every sentence should teach something. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with the substance. Save longer exposition for AFTER you have sources to cite.
+**Step 1: Lead with substance — briefly.**
+Before calling any tools, write 1-3 sentences (max 50 words) that name the key tradition, author, or concept. This streams immediately while searches run. Keep it SHORT — the user wants results, not a lecture. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with substance. Save exposition for AFTER you have sources.
 
 **Step 2: For broad topics on the FIRST message, present research directions.**
 If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.


### PR DESCRIPTION
## Summary
- **#1246** — Rename Hermes → Thoth in voice agent UI + shorten Librarian to max 50 words
- **#1247** — "Elena & Marcus are writing..." with 30-60s estimate; interactive ask shows ~15s
- **#1249** — `TranscriptToggle` component on /podcast with speaker-attributed lines
- **#1255** — Timeline histogram bars: touch tooltip support + wider min-width for mobile

## Test plan
- [ ] `/reading-room/voice` — title should say "Thoth", all references updated
- [ ] Start Librarian thread — opening should be 1-3 sentences max
- [ ] Click Generate on podcast format — shows "Elena & Marcus are writing..." + time
- [ ] `/podcast` — "Show transcript" toggle on each episode
- [ ] `/timeline` on mobile — tap bars for tooltip (auto-dismisses after 2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)