### PR TITLE
Thoth rename, loading states, transcripts, People timeline tab

### DIFF
--- a/src/components/explore/ExploreTabBar.tsx
+++ b/src/components/explore/ExploreTabBar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 
 const TABS = [
   { href: '/timeline', label: 'Timeline' },
+  { href: '/explore/timeline', label: 'People' },
   { href: '/explore/map', label: 'Map' },
 ] as const;
 

--- a/src/components/explore/Timeline.tsx
+++ b/src/components/explore/Timeline.tsx
@@ -505,14 +505,14 @@ export default function Timeline({ entities, stats }: TimelineProps) {
       >
         {/* Back nav */}
         <Link
-          href="/explore"
+          href="/timeline"
           className="flex items-center gap-1 text-xs hover:opacity-70 transition-opacity mr-1"
           style={{ color: 'var(--text-muted)' }}
         >
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
-          Explore
+          Timeline
         </Link>
 
         <span className="w-px h-5" style={{ background: 'var(--border-light)' }} />
@@ -584,7 +584,7 @@ export default function Timeline({ entities, stats }: TimelineProps) {
           {viewStart}–{viewEnd}
         </span>
 
-        <div className="ml-auto flex gap-1">
+        <div className="ml-auto flex gap-1 flex-wrap">
           <button
             onClick={() => {
               const span = viewEnd - viewStart;
@@ -592,7 +592,7 @@ export default function Timeline({ entities, stats }: TimelineProps) {
               setViewStart((s) => s - shift);
               setViewEnd((s) => s - shift);
             }}
-            className="px-1.5 py-0.5 rounded text-xs font-mono"
+            className="px-2 py-1 rounded text-xs font-mono"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
             title="Pan left"
           >
@@ -605,14 +605,14 @@ export default function Timeline({ entities, stats }: TimelineProps) {
               setViewStart((s) => s + shift);
               setViewEnd((s) => s + shift);
             }}
-            className="px-1.5 py-0.5 rounded text-xs font-mono"
+            className="px-2 py-1 rounded text-xs font-mono"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
             title="Pan right"
           >
             &rarr;
           </button>
 
-          <span className="w-px h-5 mx-0.5" style={{ background: 'var(--border-light)' }} />
+          <span className="w-px h-5 mx-0.5 hidden sm:block" style={{ background: 'var(--border-light)' }} />
 
           <button
             onClick={() => {
@@ -621,7 +621,7 @@ export default function Timeline({ entities, stats }: TimelineProps) {
               setViewStart(Math.round(mid - span / 2));
               setViewEnd(Math.round(mid + span / 2));
             }}
-            className="px-1.5 py-0.5 rounded text-xs font-mono"
+            className="px-2 py-1 rounded text-xs font-mono"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
             title="Zoom in"
           >
@@ -634,25 +634,25 @@ export default function Timeline({ entities, stats }: TimelineProps) {
               setViewStart(Math.round(mid - span / 2));
               setViewEnd(Math.round(mid + span / 2));
             }}
-            className="px-1.5 py-0.5 rounded text-xs font-mono"
+            className="px-2 py-1 rounded text-xs font-mono"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
             title="Zoom out"
           >
             &minus;
           </button>
 
-          <span className="w-px h-5 mx-0.5" style={{ background: 'var(--border-light)' }} />
+          <span className="w-px h-5 mx-0.5 hidden sm:block" style={{ background: 'var(--border-light)' }} />
 
           <button
             onClick={() => { setViewStart(-500); setViewEnd(200); }}
-            className="px-2 py-0.5 rounded text-xs"
+            className="hidden sm:inline-block px-2 py-1 rounded text-xs"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
           >
             Antiquity
           </button>
           <button
             onClick={() => { setViewStart(1350); setViewEnd(1750); }}
-            className="px-2 py-0.5 rounded text-xs"
+            className="hidden sm:inline-block px-2 py-1 rounded text-xs"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
           >
             Renaissance
@@ -663,7 +663,7 @@ export default function Timeline({ entities, stats }: TimelineProps) {
               setViewStart(lo - 50);
               setViewEnd(hi + 50);
             }}
-            className="px-2 py-0.5 rounded text-xs"
+            className="px-2 py-1 rounded text-xs"
             style={{ border: '1px solid var(--border-light)', color: 'var(--text-muted)' }}
           >
             All


### PR DESCRIPTION
## Summary
- **#1246** — Rename Hermes → Thoth in voice agent UI + shorten Librarian to max 50 words
- **#1247** — "Elena & Marcus are writing..." with 30-60s estimate; ~15s on interactive ask
- **#1249** — `TranscriptToggle` on /podcast: inline speaker-attributed transcript
- **#1255** — Entity timeline: add "People" tab to explore bar, mobile UX improvements (hidden presets, larger buttons, back link)

## Test plan
- [ ] `/reading-room/voice` — title says "Thoth"
- [ ] Generate podcast — shows "Elena & Marcus are writing..." + time estimate
- [ ] `/podcast` — "Show transcript" toggle on each episode
- [ ] `/timeline` — tab bar now shows Timeline | People | Map
- [ ] `/explore/timeline` on mobile — controls don't overflow, buttons are tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)