### PR TITLE
Fix: add visual type to UnifiedSearchResponse

### DIFF
--- a/src/lib/api-client/types/search.ts
+++ b/src/lib/api-client/types/search.ts
@@ -119,6 +119,10 @@ export interface UnifiedSearchResponse {
     results: UnifiedGalleryResult[];
     total: number;
   };
+  visual?: {
+    results: UnifiedGalleryResult[];
+    total: number;
+  };
   semantic?: {
     results: SemanticSearchResult[];
     total: number;


### PR DESCRIPTION
The API returns `visual` (CLIP) results but the TypeScript type was missing the field. This could cause the gallery+visual merge code to silently fail in strict builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)