### PR TITLE
Reorganize collection taxonomy: 18 wings + curated pathways

### DIFF
--- a/scripts/migration/reorganize-collection-taxonomy.mjs
+++ b/scripts/migration/reorganize-collection-taxonomy.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Reorganize collection taxonomy: nest orphan collections under parents,
+ * merge duplicates, hide shells/catch-alls, fix orphaned children.
+ *
+ * DRY RUN by default. Pass --execute to apply changes.
+ *
+ * Usage:
+ *   node scripts/migration/reorganize-collection-taxonomy.mjs          # dry run
+ *   node scripts/migration/reorganize-collection-taxonomy.mjs --execute # apply
+ */
+
+import { MongoClient } from 'mongodb';
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env.production.local' });
+
+const DRY_RUN = !process.argv.includes('--execute');
+
+// ─── Parent assignments ────────────────────────────────────────────
+// slug → parent (string or array for multi-parent)
+const NEST_UNDER = {
+  // Author/figure collections
+  'fechner': 'psychology',
+  'leonardo-da-vinci': 'art-illustrated',
+  'rumi': 'mysticism',
+  'jungs-library': 'psychology',
+
+  // Non-curated thematic → parent
+  'dreams-unconscious': 'psychology',
+  'gnostic-texts': 'sacred-texts',
+  'kloss-collection': 'secret-societies',
+  'medieval-heresies': 'theology',
+  'the-moon': 'astrology',
+  'slavic-tradition': 'mysticism',
+  'sumerian-mesopotamian': 'sacred-texts',
+
+  // Hidden niche
+  'chinese-technology': 'natural-philosophy',
+  'indic-alchemy': 'alchemy',
+  'indic-magic': 'magic',
+  'islamic-sciences': 'natural-philosophy',
+  'mycology': 'medicine',
+
+  // Large hidden thematic
+  'ficinos-florence': 'renaissance-philosophy',
+  'dance-of-death': 'art-illustrated',
+  'haarlem-mannerists': 'art-illustrated',
+  'portraits-tradition': 'art-illustrated',
+  'the-cosmos': 'natural-philosophy',
+  'the-infernal': 'demonology',
+  'classical-mysteries': 'classical-philosophy',
+  'school-of-athens': 'classical-philosophy',
+  'erotic-art': 'art-illustrated',
+  'esoteric-engravers': 'art-illustrated',
+  'visions-ecstasies': 'mysticism',
+  'wrathful-deities': ['demonology', 'sacred-texts'],
+  'yokai-oni': 'demonology',
+  'thought-forms': 'mysticism',
+  'before-ficino': 'classical-philosophy',
+  'rudolf-prague': 'renaissance-philosophy',
+  'angels-celestials': 'mysticism',
+
+  // Curated exhibitions → parent
+  'agrippas-world': 'magic',
+  'ancient-egyptian': 'sacred-texts',
+  'ancient-engineering': 'natural-philosophy',
+  'ancient-papyri': 'sacred-texts',
+  'ayurveda': 'medicine',
+  'courts-of-wonder': 'renaissance-philosophy',
+  'esoteric-capitalism': 'secret-societies',
+  'famous-women': 'history-political-thought',
+  'global-demonology': 'demonology',
+  'great-manuscripts': 'art-illustrated',
+  'herculaneum-papyri': 'classical-philosophy',
+  'illuminated-manuscripts': 'art-illustrated',
+  'islamic-philosophy-meets-christian-mysticism': 'mysticism',
+  'letters-from-the-desert': 'theology',
+  'making-things-visible': 'natural-philosophy',
+  'maps-of-the-invisible': 'hermetica',
+  'mining-metals-and-fire': 'alchemy',
+  'nova-reperta': 'natural-philosophy',
+  'renaissance-literary-imagination': 'literature',
+  'robert-hooke-polymath': 'natural-philosophy',
+  'sacred-books-of-the-east': 'sacred-texts',
+  'sacred-objects': 'sacred-texts',
+  'alchemical-emblem': 'alchemy',
+  'apocrypha': 'sacred-texts',
+  'art-of-memory': 'renaissance-philosophy',
+  'beguine-mystics': 'mysticism',
+  'behmenist-underground': 'mysticism',
+  'bestiary-tradition': 'medicine',
+  'byzantine-bridge': 'theology',
+  'canon-of-avicenna': 'medicine',
+  'contemplative-traditions': 'mysticism',
+  'dutch-golden-age-of-science': 'natural-philosophy',
+  'encyclopedists': 'natural-philosophy',
+  'grimoire-tradition': 'magic',
+  'hesychast-tradition': 'mysticism',
+  'indian-mathematical-tradition': 'natural-philosophy',
+  'invention-of-method': 'natural-philosophy',
+  'kepler-fludd-debate': ['natural-philosophy', 'hermetica'],
+  'printing-press-revolution': 'history-political-thought',
+  'rhineland-mystics': 'mysticism',
+  'rosicrucian-moment': 'secret-societies',
+  'sympathy-of-all-things': 'hermetica',
+  'weapon-salve-controversy': 'medicine',
+  'witches-sabbath': 'demonology',
+  'theatres-of-machines': 'natural-philosophy',
+  'theosophical-society': 'secret-societies',
+  'women-of-the-secret-tradition': ['mysticism', 'history-political-thought'],
+
+  // Music merge: music-harmony → nested under music-sound, then music-sound under natural-philosophy
+  'music-harmony': 'music-sound',
+  'music-sound': 'natural-philosophy',
+
+  // Syriac merge: syriac-church → nested under syriac-tradition, then syriac-tradition under theology
+  'syriac-church': 'syriac-tradition',
+  'syriac-tradition': 'theology',
+
+  // SHWEP & Miscellany — keep top-level but will be hidden below
+};
+
+// ─── Collections to hide ───────────────────────────────────────────
+const HIDE = [
+  'miscellany',
+  'shwep',
+  'world-traditions',  // nameless regional shell
+  'east-asia',         // nameless regional shell
+  'south-asia',        // nameless regional shell
+];
+
+// ─── Regional container names (fix missing name field) ─────────────
+const SET_NAMES = {
+  'world-traditions': 'World Traditions',
+  'east-asia': 'East Asia',
+  'south-asia': 'South Asia',
+  'middle-east-africa': 'Middle East & Africa',
+  'americas': 'Americas',
+  'mesoamerican': 'Mesoamerican',
+  'oceania': 'Oceania',
+};
+
+// ─── Fix orphaned children (comma-separated parent → array) ────────
+const FIX_ORPHAN_PARENTS = {
+  'chinese-astrology': ['chinese-classics', 'astrology'],
+  'chinese-divination-cosmology': ['chinese-classics', 'astrology'],
+  'jyotisha-vedic-astrology': ['indic-traditions', 'astrology'],
+};
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const coll = db.collection('collections');
+
+  console.log(DRY_RUN ? '🔍 DRY RUN — no changes will be made\n' : '⚡ EXECUTING — changes will be applied\n');
+
+  let updated = 0;
+  let errors = 0;
+
+  // 1. Set parent fields
+  for (const [slug, parent] of Object.entries(NEST_UNDER)) {
+    const doc = await coll.findOne({ slug });
+    if (!doc) {
+      console.log(`  ⚠️  ${slug} — not found, skipping`);
+      errors++;
+      continue;
+    }
+    // Skip if already has the correct parent
+    const currentParent = doc.parent;
+    const targetParent = parent;
+    if (JSON.stringify(currentParent) === JSON.stringify(targetParent)) {
+      console.log(`  ✓  ${slug} — already nested under ${JSON.stringify(parent)}`);
+      continue;
+    }
+    console.log(`  → ${slug} — set parent: ${JSON.stringify(parent)}${currentParent ? ` (was: ${JSON.stringify(currentParent)})` : ''}`);
+    if (!DRY_RUN) {
+      await coll.updateOne({ slug }, { $set: { parent: targetParent } });
+    }
+    updated++;
+  }
+
+  // 2. Hide shells/catch-alls
+  console.log('\n--- Hiding shells & catch-alls ---');
+  for (const slug of HIDE) {
+    const doc = await coll.findOne({ slug });
+    if (!doc) {
+      console.log(`  ⚠️  ${slug} — not found`);
+      continue;
+    }
+    if (doc.visible === false) {
+      console.log(`  ✓  ${slug} — already hidden`);
+      continue;
+    }
+    console.log(`  → ${slug} — hiding`);
+    if (!DRY_RUN) {
+      await coll.updateOne({ slug }, { $set: { visible: false } });
+    }
+    updated++;
+  }
+
+  // 3. Fix missing names
+  console.log('\n--- Fixing missing names ---');
+  for (const [slug, name] of Object.entries(SET_NAMES)) {
+    const doc = await coll.findOne({ slug });
+    if (!doc) {
+      console.log(`  ⚠️  ${slug} — not found`);
+      continue;
+    }
+    if (doc.name) {
+      console.log(`  ✓  ${slug} — already has name "${doc.name}"`);
+      continue;
+    }
+    console.log(`  → ${slug} — setting name: "${name}"`);
+    if (!DRY_RUN) {
+      await coll.updateOne({ slug }, { $set: { name } });
+    }
+    updated++;
+  }
+
+  // 4. Fix orphaned children (comma-separated parents)
+  console.log('\n--- Fixing orphaned children ---');
+  for (const [slug, parents] of Object.entries(FIX_ORPHAN_PARENTS)) {
+    const doc = await coll.findOne({ slug });
+    if (!doc) {
+      console.log(`  ⚠️  ${slug} — not found`);
+      continue;
+    }
+    console.log(`  → ${slug} — fix parent: ${JSON.stringify(doc.parent)} → ${JSON.stringify(parents)}`);
+    if (!DRY_RUN) {
+      await coll.updateOne({ slug }, { $set: { parent: parents } });
+    }
+    updated++;
+  }
+
+  console.log(`\n✅ ${DRY_RUN ? 'Would update' : 'Updated'} ${updated} collections (${errors} not found)`);
+
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/collections/page.tsx
+++ b/src/app/collections/page.tsx
@@ -65,14 +65,47 @@ async function fetchCollections(): Promise<CollectionDoc[]> {
   return sortCollections(all);
 }
 
-async function fetchCuratedCollections(): Promise<CollectionDoc[]> {
+// Hand-picked subcollections that serve as compelling entry points.
+// These are the "hooks" — evocative names that pull readers in.
+const CURATED_PATHWAYS = [
+  'courts-of-wonder',
+  'maps-of-the-invisible',
+  'rosicrucian-moment',
+  'grimoire-tradition',
+  'women-of-the-secret-tradition',
+  'alchemical-emblem',
+  'dance-of-death',
+  'ficinos-florence',
+  'bestiary-tradition',
+  'ancient-egyptian',
+  'art-of-memory',
+  'behmenist-underground',
+  'visions-ecstasies',
+  'yokai-oni',
+  'sumerian-mesopotamian',
+  'forbidden-books',
+  'music-of-the-spheres',
+  'rudolf-prague',
+  'jungs-library',
+  'kloss-collection',
+  'newtons-other-science',
+  'contemplative-traditions',
+  'sympathy-of-all-things',
+  'kepler-fludd-debate',
+];
+
+async function fetchCuratedPathways(): Promise<CollectionDoc[]> {
   const db = await getReadDb();
   const docs = await db.collection('collections')
-    .find({ type: 'curated', published: true })
-    .sort({ book_count: -1, name: 1 })
+    .find({ slug: { $in: CURATED_PATHWAYS } })
     .toArray();
 
-  return docs.map(({ _id, ...rest }) => rest) as unknown as CollectionDoc[];
+  // Maintain the hand-picked order
+  const bySlug = new Map(docs.map(d => [d.slug, d]));
+  return CURATED_PATHWAYS
+    .map(slug => bySlug.get(slug))
+    .filter((d): d is NonNullable<typeof d> => d != null)
+    .map(({ _id, ...rest }) => rest) as unknown as CollectionDoc[];
 }
 
 async function fetchTimelineDecades(): Promise<{ decades: DecadeBucket[]; total: number }> {
@@ -203,9 +236,9 @@ function CuratedCard({ col, priority = false }: { col: CollectionDoc; priority?:
 }
 
 export default async function CollectionsPage() {
-  const [categories, curated, timeline] = await Promise.all([
+  const [categories, pathways, timeline] = await Promise.all([
     fetchCollections(),
-    fetchCuratedCollections(),
+    fetchCuratedPathways(),
     fetchTimelineDecades(),
   ]);
 
@@ -219,27 +252,22 @@ export default async function CollectionsPage() {
       }
     >
 
-      {/* Category collections */}
+      {/* Core wings of the library */}
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
         {categories.map((col, i) => (
           <CollectionCard key={col.slug} col={col} priority={i < 8} />
         ))}
       </div>
 
-      {/* Curated exhibitions */}
-      {curated.length > 0 && (
+      {/* Curated pathways — the hooks */}
+      {pathways.length > 0 && (
         <div className="mt-12">
-          <div className="flex items-baseline justify-between mb-4">
-            <h2 className="font-display text-2xl text-primary">Curated Exhibitions</h2>
-            <Link
-              href="/curated"
-              className="text-sm text-accent-rust hover:text-accent-rust/80 transition-colors"
-            >
-              View all &rarr;
-            </Link>
+          <div className="mb-4">
+            <h2 className="font-display text-2xl text-primary">Curated Pathways</h2>
+            <p className="text-stone-500 mt-1 text-sm">Thematic journeys through the collection</p>
           </div>
           <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-            {curated.map((col, i) => (
+            {pathways.map((col, i) => (
               <CuratedCard key={col.slug} col={col} priority={i < 3} />
             ))}
           </div>

--- a/src/lib/collections-utils.ts
+++ b/src/lib/collections-utils.ts
@@ -6,16 +6,29 @@
 // ---------- Pinned collection ordering ----------
 
 export const PINNED_COLLECTION_SLUGS = [
-  // Row 1
-  'natural-philosophy',
-  'classical-philosophy',
-  'renaissance-philosophy',
+  // Row 1 — the ancient roots
   'sacred-texts',
-  // Row 2
+  'classical-philosophy',
   'hermetica',
-  'alchemy',
   'mysticism',
+  // Row 2 — the esoteric arts
+  'alchemy',
+  'magic',
   'kabbalah',
+  'astrology',
+  // Row 3 — knowledge & world
+  'natural-philosophy',
+  'renaissance-philosophy',
+  'medicine',
+  'secret-societies',
+  // Row 4 — culture & thought
+  'theology',
+  'literature',
+  'art-illustrated',
+  'demonology',
+  // Row 5 — remaining
+  'psychology',
+  'history-political-thought',
 ];
 
 /** Pin specific collections first, shuffle the rest. */


### PR DESCRIPTION
## Summary
- Nest ~80 orphan collections under proper parent categories, reducing visible top-level from 90+ to 18 major wings
- Add hand-picked "Curated Pathways" section to `/collections` page with evocative subcollections as entry points (Courts of Wonder, Maps of the Invisible, The Grimoire Tradition, etc.)
- Merge duplicates: `music-harmony` → `music-sound`, `syriac-church` → `syriac-tradition`
- Hide catch-alls (Miscellany, SHWEP) and nameless regional shells
- Fix 3 orphaned children with malformed parent strings
- Pin all 18 wings in conceptual order (ancient roots → esoteric arts → knowledge → culture)

## Migration
The DB migration has already been applied. The script is included at `scripts/migration/reorganize-collection-taxonomy.mjs` for reference (supports `--execute` flag, dry run by default).

## Test plan
- [ ] Verify `/collections` shows exactly 18 core wing cards
- [ ] Verify "Curated Pathways" section renders below with ~24 subcollection cards
- [ ] Click into a wing (e.g., Mysticism) and verify subcollections appear
- [ ] Verify previously top-level collections (e.g., Fechner, Leonardo) now appear nested
- [ ] Check that hidden collections (Miscellany, SHWEP) no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)