### PR TITLE
LLM-enriched image search + adaptive layout

### DIFF
--- a/src/app/api/search/ai-expand/route.ts
+++ b/src/app/api/search/ai-expand/route.ts
@@ -3,8 +3,8 @@ import { getGeminiClient } from '@/lib/gemini-client';
 
 export const preferredRegion = 'fra1';
 
-// Cache full responses (narration + terms + display hint) to avoid repeated AI calls
-const responseCache = new Map<string, { display: string; narration: string; terms: string[]; timestamp: number }>();
+// Cache full responses (narration + terms + display hint + image terms) to avoid repeated AI calls
+const responseCache = new Map<string, { display: string; narration: string; terms: string[]; imageTerms: string[]; timestamp: number }>();
 const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
 /**
@@ -35,6 +35,7 @@ export async function POST(request: NextRequest) {
       `event: display\ndata: ${JSON.stringify(cached.display)}\n`,
       `event: narration\ndata: ${JSON.stringify(cached.narration)}\n`,
       `event: terms\ndata: ${JSON.stringify(cached.terms)}\n`,
+      ...(cached.imageTerms.length > 0 ? [`event: image_terms\ndata: ${JSON.stringify(cached.imageTerms)}\n`] : []),
       `event: done\ndata: {}\n`,
     ].join('\n');
     return new Response(lines, {
@@ -75,19 +76,23 @@ When uncertain, default to "books_first".
 
 PART 2 (NARRATION): After "---DISPLAY---", write 1-2 brief, scholarly sentences (max 40 words) contextualizing this search. Use italics for Latin/foreign terms. Be specific, not generic. Don't say "Source Library" or "our collection." Write as if you're a knowledgeable librarian whispering helpful context. If "not_in_collection", briefly explain what IS available that's related.
 
-PART 3 (TERMS): After "---TERMS---", write ONLY a JSON array of 3-5 alternative search terms.
+PART 3 (TERMS): After "---TERMS---", write ONLY a JSON array of 3-5 alternative search terms for BOOKS (authors, titles, concepts, original-language equivalents).
+
+PART 4 (IMAGE TERMS): After "---IMAGE_TERMS---", write ONLY a JSON array of 2-4 search terms optimized for finding IMAGES in the collection. Think about what illustrations, paintings, engravings, or diagrams would be relevant. Use descriptive visual terms (e.g., "alchemical furnace", "tree of life diagram", "portrait of Paracelsus", "ecstasy vision"). Skip this section if images aren't relevant to the query.
 
 Example response:
 images_first
 ---DISPLAY---
 Raphael's fresco depicts the great philosophers of antiquity — Plato, Aristotle, Pythagoras — in the Vatican's *Stanza della Segnatura*. Many of their works are in the collection.
 ---TERMS---
-["Raphael Vatican", "Plato Aristotle", "Stanza della Segnatura", "School of Athens fresco"]`
+["Plato Aristotle", "Stanza della Segnatura", "Raphael Vatican"]
+---IMAGE_TERMS---
+["School of Athens", "philosophers fresco", "Raphael painting"]`
             }]
           }],
           generationConfig: {
             temperature: 0.5,
-            maxOutputTokens: 300,
+            maxOutputTokens: 400,
           },
         });
 
@@ -158,21 +163,18 @@ Raphael's fresco depicts the great philosophers of antiquity — Plato, Aristotl
             }
           }
 
-          // Phase 3: Parse terms JSON
+          // Phase 3: Parse terms JSON (between ---TERMS--- and ---IMAGE_TERMS---)
           if (hitTermsSep && !sentTerms) {
-            const afterTermsSep = fullText.split('---TERMS---').pop()?.trim() || '';
-            if (afterTermsSep) {
+            const afterTermsSep = fullText.split('---TERMS---')[1] || '';
+            const termsOnly = afterTermsSep.split('---IMAGE_TERMS---')[0].trim();
+            if (termsOnly) {
               try {
-                const jsonStr = afterTermsSep.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
+                const jsonStr = termsOnly.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
                 const parsed = JSON.parse(jsonStr);
                 if (Array.isArray(parsed)) {
                   const terms = parsed.filter((t: unknown) => typeof t === 'string' && t.length >= 2).slice(0, 5);
                   controller.enqueue(encoder.encode(`event: terms\ndata: ${JSON.stringify(terms)}\n\n`));
                   sentTerms = true;
-                  const narrationPart = hitDisplaySep
-                    ? (fullText.split('---DISPLAY---')[1] || '').split('---TERMS---')[0].trim()
-                    : fullText.split('---TERMS---')[0].trim();
-                  responseCache.set(normalized, { display: displayHint, narration: narrationPart, terms, timestamp: Date.now() });
                 }
               } catch {
                 // JSON not complete yet
@@ -186,28 +188,45 @@ Raphael's fresco depicts the great philosophers of antiquity — Plato, Aristotl
           controller.enqueue(encoder.encode(`event: display\ndata: "books_first"\n\n`));
         }
 
-        // Final attempt to parse terms if not yet sent
+        // Final parse from complete text
+        const narrationPart = hitDisplaySep
+          ? (fullText.split('---DISPLAY---')[1] || '').split('---TERMS---')[0].trim()
+          : fullText.split('---TERMS---')[0].trim();
+
+        // Parse terms (between ---TERMS--- and ---IMAGE_TERMS---)
+        let finalTerms: string[] = [];
         if (!sentTerms && fullText.includes('---TERMS---')) {
-          const afterTermsSep = fullText.split('---TERMS---').pop()?.trim() || '';
-          if (afterTermsSep) {
-            try {
-              const jsonStr = afterTermsSep.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
-              const parsed = JSON.parse(jsonStr);
-              if (Array.isArray(parsed)) {
-                const terms = parsed.filter((t: unknown) => typeof t === 'string' && t.length >= 2).slice(0, 5);
-                controller.enqueue(encoder.encode(`event: terms\ndata: ${JSON.stringify(terms)}\n\n`));
-                const narrationPart = hitDisplaySep
-                  ? (fullText.split('---DISPLAY---')[1] || '').split('---TERMS---')[0].trim()
-                  : fullText.split('---TERMS---')[0].trim();
-                responseCache.set(normalized, { display: displayHint, narration: narrationPart, terms, timestamp: Date.now() });
-              }
-            } catch {
-              controller.enqueue(encoder.encode(`event: terms\ndata: []\n\n`));
+          const afterTerms = (fullText.split('---TERMS---')[1] || '').split('---IMAGE_TERMS---')[0].trim();
+          try {
+            const jsonStr = afterTerms.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
+            const parsed = JSON.parse(jsonStr);
+            if (Array.isArray(parsed)) {
+              finalTerms = parsed.filter((t: unknown) => typeof t === 'string' && t.length >= 2).slice(0, 5);
+              controller.enqueue(encoder.encode(`event: terms\ndata: ${JSON.stringify(finalTerms)}\n\n`));
             }
+          } catch {
+            controller.enqueue(encoder.encode(`event: terms\ndata: []\n\n`));
           }
         } else if (!sentTerms) {
           controller.enqueue(encoder.encode(`event: terms\ndata: []\n\n`));
         }
+
+        // Parse image_terms (after ---IMAGE_TERMS---)
+        let imageTerms: string[] = [];
+        if (fullText.includes('---IMAGE_TERMS---')) {
+          const afterImageSep = fullText.split('---IMAGE_TERMS---').pop()?.trim() || '';
+          try {
+            const jsonStr = afterImageSep.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
+            const parsed = JSON.parse(jsonStr);
+            if (Array.isArray(parsed)) {
+              imageTerms = parsed.filter((t: unknown) => typeof t === 'string' && t.length >= 2).slice(0, 4);
+              controller.enqueue(encoder.encode(`event: image_terms\ndata: ${JSON.stringify(imageTerms)}\n\n`));
+            }
+          } catch { /* no image terms */ }
+        }
+
+        // Cache
+        responseCache.set(normalized, { display: displayHint, narration: narrationPart, terms: finalTerms, imageTerms, timestamp: Date.now() });
 
         controller.enqueue(encoder.encode(`event: done\ndata: {}\n\n`));
         controller.close();

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -244,6 +244,35 @@ export default function SearchPage() {
           setDisplayHint(hint);
         }
       },
+      async (imgTerms) => {
+        // Fire supplementary gallery searches with LLM-suggested image terms
+        if (!imgTerms || imgTerms.length === 0) return;
+        const existingIds = new Set(imageResults.map(i => `${i.pageId}-${i.detectionIndex}`));
+        const newImages: GalleryItem[] = [];
+        for (const term of imgTerms.slice(0, 3)) {
+          try {
+            const data = await searchApi.unified(term, { limit: 1, galleryLimit: 4 });
+            const galleryResults = [...(data.gallery?.results || []), ...((data as any).visual?.results || [])];
+            for (const g of galleryResults) {
+              const parts = (g.id || '').split('-');
+              const detectionIndex = parseInt(parts.pop() || '0');
+              const pageId = parts.join('-');
+              const key = `${pageId}-${detectionIndex}`;
+              if (existingIds.has(key)) continue;
+              existingIds.add(key);
+              newImages.push({
+                pageId, bookId: g.bookId || '', pageNumber: 0, detectionIndex,
+                imageUrl: g.imageUrl || '', thumbnailUrl: g.imageUrl || '',
+                bookTitle: g.bookTitle || '', author: '', description: g.description || '', type: g.type,
+              } as GalleryItem);
+            }
+          } catch { /* skip failed term */ }
+        }
+        if (newImages.length > 0) {
+          setImageResults(prev => [...prev, ...newImages]);
+          setImageTotal(prev => prev + newImages.length);
+        }
+      },
     );
     aiAbortRef.current = abort;
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/lib/api-client/search.ts
+++ b/src/lib/api-client/search.ts
@@ -78,6 +78,7 @@ export const search = {
     onTerms: (terms: string[]) => void,
     onDone: () => void,
     onDisplay?: (hint: string) => void,
+    onImageTerms?: (terms: string[]) => void,
   ): (() => void) => {
     const controller = new AbortController();
 
@@ -117,6 +118,8 @@ export const search = {
                   onNarration(JSON.parse(data));
                 } else if (eventType === 'terms') {
                   onTerms(JSON.parse(data));
+                } else if (eventType === 'image_terms') {
+                  onImageTerms?.(JSON.parse(data));
                 } else if (eventType === 'done') {
                   onDone();
                 }


### PR DESCRIPTION
## Summary
Two related improvements to search UX:

### 1. LLM-driven adaptive layout (from #1281)
The AI stream emits a display hint (`images_first`, `books_first`, `not_in_collection`) so the UI adapts to query intent.

### 2. LLM-enriched image search (new)
The AI stream now generates **image-specific search terms** that fire supplementary gallery queries to find visually relevant results the original text query missed.

Example: searching "mystical ecstasy" → LLM suggests image terms like "ecstasy vision", "divine rapture", "mystical illumination" → gallery finds relevant illustrations that weren't matched by the literal query.

## Changes
- `ai-expand/route.ts`: 4-part prompt (display + narration + terms + image_terms), new `image_terms` SSE event
- `search.ts` client: `onDisplay` + `onImageTerms` callbacks  
- `search/page.tsx`: Adaptive layout + supplementary gallery searches from image_terms

## Test plan
- [ ] "mystical ecstasy" → enriched images appear (visions, rapture, illumination)
- [ ] "school of athens" → images_first layout, larger grid
- [ ] "alchemy" → books_first (default), image strip at bottom
- [ ] "goya christ" → not_in_collection, narration leads
- [ ] "tree of life" → images of sephirotic diagrams found via image_terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)