### PR TITLE
Fix image extraction filter skipping text pages with inline illustrations

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -4326,7 +4326,7 @@ Rules:
                   book_id: book.id,
                   $or: [
                     { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
-                    { page_type: { $exists: false }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
+                    { page_type: { $nin: IMAGE_CANDIDATE_PAGE_TYPES }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
                   ],
                 }, { projection: { id: 1 } })
                 .toArray();
@@ -4450,7 +4450,7 @@ Rules:
                   book_id: book.id,
                   $or: [
                     { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
-                    { page_type: { $exists: false }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
+                    { page_type: { $nin: IMAGE_CANDIDATE_PAGE_TYPES }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
                   ],
                 }, { projection: { id: 1 } })
                 .toArray();


### PR DESCRIPTION
## Summary
- The image extraction candidate filter had a dead branch: `page_type: { $exists: false }` gated the `<image-desc>` OCR tag check, but OCR v4+ always sets `page_type`, making this branch unreachable
- Changed `$exists: false` to `$nin: IMAGE_CANDIDATE_PAGE_TYPES` so text pages with inline woodcuts/diagrams are now sent for image extraction
- Fixed in both batch and SQS image extraction paths (lines 4329 and 4453)

## Impact
Tested on sample books:
| Book | Old candidates | New candidates |
|------|---------------|----------------|
| Fludd Mosaicall Philosophy | 1 | 45 |
| Mundus symbolicus | 3 | 109 |
| Mosaisches Licht | 2 | 235 |
| Prophetisches Licht | 0 | 200 |
| Magnalia medico-chymica | 0 | 99 |

~5,260 books with 50+ pages passed through the image phase with potentially missed illustrations.

## Test plan
- [x] Verified old vs new filter on 5 books — all show correct gains
- [ ] Deploy to Hetzner, monitor orchestrator logs for increased image candidates
- [ ] Backfill affected books (separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)