### PR TITLE
Fix gallery images not loading when source photos missing

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -157,11 +157,12 @@ export async function GET(request: NextRequest) {
       }, { maxTimeMS: 10000 }) as string[];
     }
 
-    // Build query filter — exclude images without extracted thumbnails
+    // Build query filter — exclude images without extracted thumbnails or missing source photos
     const filter: Record<string, unknown> = {
       gallery_quality: { $gte: minQuality },
       book_visible: true,
       extracted_url: { $ne: null },
+      image_url: { $ne: null },
     };
 
     // Book diversity: limit to top N images per book (unless filtering by single book or showing all)


### PR DESCRIPTION
## Summary
- Add `image_url: { $ne: null }` filter to gallery API query
- Prevents broken image cards when all source photo fields are null
- Especially visible in "Show all illustrations" (archive mode) which lowers quality threshold

## Context
User report from Qasim Anwar (2026-04-20): "On the Cosmos Library, none of the images are working, when you click on show all illustrations"

## Test plan
- [ ] Visit /gallery and confirm images load
- [ ] Click "Show all illustrations" and confirm no broken cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)