### PR TITLE
Fix BPH spread dedup: structural detection + wire into orchestrator

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -84,6 +84,84 @@ function getR2Client() {
   });
 }
 
+/**
+ * Detect and remove duplicate pages caused by overlapping BPH spread photography.
+ *
+ * BPH scans photograph overlapping page openings: the RIGHT half of spread N is
+ * the same physical page as the LEFT half of spread N+1. After splitting, this
+ * creates duplicate page records throughout the book.
+ *
+ * Detection is structural (not OCR-based): a LEFT-crop page following a RIGHT-crop
+ * page from a different spread is a duplicate. This is reliable because OCR text
+ * varies between scans of the same page.
+ */
+async function deduplicateOverlappingPages(db, bookId) {
+  const pagesCol = db.collection('pages');
+
+  // Get all pages with crop and spread info, sorted by page_number
+  const pages = await pagesCol
+    .find({ book_id: bookId }, { projection: { _id: 1, id: 1, page_number: 1, crop: 1, photo_original: 1 } })
+    .sort({ page_number: 1 })
+    .toArray();
+
+  if (pages.length === 0) return null;
+
+  // Detect structural duplicates: LEFT page following RIGHT page from different spread
+  const pageIdsToArchive = [];
+  for (let i = 1; i < pages.length; i++) {
+    const prev = pages[i - 1];
+    const curr = pages[i];
+    const prevIsRight = prev.crop && prev.crop.xStart > 0;
+    const currIsLeft = curr.crop && curr.crop.xStart === 0;
+    const differentSpread = prev.photo_original && curr.photo_original && prev.photo_original !== curr.photo_original;
+
+    if (prevIsRight && currIsLeft && differentSpread) {
+      pageIdsToArchive.push(curr.id);
+    }
+  }
+
+  if (pageIdsToArchive.length === 0) return null;
+
+  // Archive duplicate pages (preserve data for recovery)
+  const dupePages = await pagesCol.find({ id: { $in: pageIdsToArchive } }).toArray();
+  if (dupePages.length > 0) {
+    const archiveDocs = dupePages.map(p => {
+      const { _id, ...rest } = p;
+      return { ...rest, original_page_id: p.id, original_mongo_id: _id, archived_at: new Date(), archive_reason: 'duplicate_overlapping_spread', book_id: bookId };
+    });
+    await db.collection('duplicate_pages').insertMany(archiveDocs);
+  }
+
+  // Delete duplicates
+  await pagesCol.deleteMany({ id: { $in: pageIdsToArchive } });
+
+  // Renumber remaining pages sequentially
+  const remainingPages = await pagesCol
+    .find({ book_id: bookId }, { projection: { _id: 1, page_number: 1 } })
+    .sort({ page_number: 1 })
+    .toArray();
+
+  const bulkOps = [];
+  for (let i = 0; i < remainingPages.length; i++) {
+    const expected = i + 1;
+    if (remainingPages[i].page_number !== expected) {
+      bulkOps.push({ updateOne: { filter: { _id: remainingPages[i]._id }, update: { $set: { page_number: expected } } } });
+    }
+  }
+  if (bulkOps.length > 0) await pagesCol.bulkWrite(bulkOps);
+
+  // Update book-level caches
+  const newCount = remainingPages.length;
+  const ocrCount = await pagesCol.countDocuments({ book_id: bookId, 'ocr.data': { $exists: true, $ne: '' } });
+  const transCount = await pagesCol.countDocuments({ book_id: bookId, 'translation.data': { $exists: true, $ne: '' } });
+  await db.collection('books').updateOne(
+    { id: bookId },
+    { $set: { pages_count: newCount, pages_ocr: ocrCount, pages_translated: transCount, updated_at: new Date() } },
+  );
+
+  return { bookId, duplicatesFound: pageIdsToArchive.length, pagesRemoved: pageIdsToArchive.length, pagesRenumbered: bulkOps.length, newPageCount: newCount };
+}
+
 async function uploadToR2(r2, key, buffer, contentType = 'image/jpeg') {
   await r2.send(new PutObjectCommand({
     Bucket: R2_BUCKET, Key: key, Body: buffer, ContentType: contentType,
@@ -3707,6 +3785,18 @@ Rules:
           // split-book.mjs sets split_completed=true and needs_splitting=false on success
           console.log(`    Done: ${label}`);
           splitDone++;
+
+          // Dedup overlapping BPH spread pages (right side of spread N = left side of spread N+1).
+          // Uses OCR fingerprinting (first 400 chars) to detect and archive duplicates.
+          try {
+            const dedupResult = await deduplicateOverlappingPages(db, book.id);
+            if (dedupResult && dedupResult.pagesRemoved > 0) {
+              console.log(`    Dedup: removed ${dedupResult.pagesRemoved} duplicate pages (${dedupResult.newPageCount} remaining)`);
+              log.dedup_removed = (log.dedup_removed || 0) + dedupResult.pagesRemoved;
+            }
+          } catch (dedupErr) {
+            console.log(`    Dedup warning: ${dedupErr.message?.slice(0, 150)}`);
+          }
         } catch (err) {
           const msg = err.stderr || err.message || String(err);
           console.log(`    FAIL: ${label} — ${msg.slice(0, 150)}`);

--- a/src/lib/page-split/dedup-overlapping-pages.ts
+++ b/src/lib/page-split/dedup-overlapping-pages.ts
@@ -1,17 +1,19 @@
 /**
  * Detect and remove duplicate pages caused by overlapping BPH spread photography.
  *
- * BPH digitization photographs overlapping page openings — the RIGHT half of
- * spread N is the same physical page as the LEFT half of spread N+1. After split
- * detection, these produce duplicate page records with identical content.
+ * BPH scans photograph overlapping page openings: the RIGHT half of spread N is
+ * the same physical page as the LEFT half of spread N+1. After splitting, this
+ * creates duplicate page records throughout the book.
  *
- * Detection: fingerprint OCR text (first 400 chars of raw ocr.data), group by
- * fingerprint server-side via MongoDB aggregation, flag groups with 2+ pages.
+ * Detection is structural (not OCR-based): a LEFT-crop page following a RIGHT-crop
+ * page from a different spread is a duplicate. This is reliable because OCR text
+ * varies between scans of the same page, making fingerprint-based dedup unreliable.
  *
- * For each duplicate group, keep the lowest page_number, archive the rest to
- * `duplicate_pages` collection, renumber remaining pages, update book caches.
+ * For each duplicate, the LEFT page (from the later spread) is archived to
+ * `duplicate_pages` collection, remaining pages are renumbered, and book caches
+ * are updated.
  *
- * Integrated into pipeline cron Phase 3 after OCR completion.
+ * Integrated into pipeline orchestrator Phase 3.1 after spread splitting.
  */
 
 import type { Db } from 'mongodb';
@@ -25,8 +27,7 @@ export interface DedupResult {
 }
 
 /**
- * Scan a book for duplicate pages and remove them.
- * Only processes books that have split pages (crop data exists).
+ * Scan a book for duplicate pages from overlapping spread scans and remove them.
  *
  * @returns null if no duplicates found, DedupResult otherwise
  */
@@ -36,55 +37,39 @@ export async function deduplicateOverlappingPages(
 ): Promise<DedupResult | null> {
   const pagesCol = db.collection('pages');
 
-  // Only run on books with split pages — no splits means no overlapping duplicates
-  const hasSplitPages = await pagesCol.countDocuments({
-    book_id: bookId,
-    'crop.xStart': { $exists: true },
-  });
-  if (hasSplitPages === 0) return null;
-
-  // Fingerprint OCR text server-side: take first 400 chars of ocr.data,
-  // group by that substring, return groups with 2+ pages.
-  // XML tags are consistent across duplicate scans so raw comparison works.
-  const pipeline = [
-    {
-      $match: {
-        book_id: bookId,
-        'ocr.data': { $exists: true, $ne: '' },
+  // Get all pages with crop and spread info, sorted by page_number
+  const pages = await pagesCol
+    .find(
+      { book_id: bookId },
+      {
+        projection: {
+          _id: 1,
+          id: 1,
+          page_number: 1,
+          crop: 1,
+          photo_original: 1,
+        },
       },
-    },
-    {
-      $project: {
-        id: 1,
-        page_number: 1,
-        fp_raw: { $substrCP: ['$ocr.data', 0, 400] },
-      },
-    },
-    {
-      $group: {
-        _id: '$fp_raw',
-        count: { $sum: 1 },
-        pages: { $push: { id: '$id', page_number: '$page_number' } },
-      },
-    },
-    { $match: { count: { $gte: 2 } } },
-  ];
-
-  const groups = await pagesCol
-    .aggregate(pipeline, { allowDiskUse: true })
+    )
+    .sort({ page_number: 1 })
     .toArray();
 
-  if (groups.length === 0) return null;
+  if (pages.length === 0) return null;
 
-  // Collect page IDs to archive (keep lowest page_number in each group)
+  // Detect structural duplicates: LEFT page following RIGHT page from different spread
   const pageIdsToArchive: string[] = [];
-  for (const group of groups) {
-    const sorted = group.pages.sort(
-      (a: { page_number: number }, b: { page_number: number }) =>
-        a.page_number - b.page_number,
-    );
-    for (let i = 1; i < sorted.length; i++) {
-      pageIdsToArchive.push(sorted[i].id);
+  for (let i = 1; i < pages.length; i++) {
+    const prev = pages[i - 1];
+    const curr = pages[i];
+    const prevIsRight = prev.crop && prev.crop.xStart > 0;
+    const currIsLeft = curr.crop && curr.crop.xStart === 0;
+    const differentSpread =
+      prev.photo_original &&
+      curr.photo_original &&
+      prev.photo_original !== curr.photo_original;
+
+    if (prevIsRight && currIsLeft && differentSpread) {
+      pageIdsToArchive.push(curr.id as string);
     }
   }
 
@@ -161,7 +146,7 @@ export async function deduplicateOverlappingPages(
 
   return {
     bookId,
-    duplicatesFound: groups.length,
+    duplicatesFound: pageIdsToArchive.length,
     pagesRemoved: pageIdsToArchive.length,
     pagesRenumbered: bulkOps.length,
     newPageCount: newCount,


### PR DESCRIPTION
## Summary
- **Root cause:** The dedup function `deduplicateOverlappingPages()` existed in the archived cron pipeline but was never wired into `pipeline-orchestrator.mjs` during the migration. Additionally, its OCR fingerprint approach (first 400 chars) doesn't work — Gemini produces different OCR from different spread crops of the same physical page.
- **Fix:** Replaced fingerprint-based detection with structural detection: a LEFT-crop page following a RIGHT-crop page from a different spread is always a duplicate (the overlap pattern is deterministic).
- **Wired into Phase 3.1** of the orchestrator, runs immediately after `split-book.mjs` succeeds on each book.

## Impact
- ~2,300 BPH books have overlapping spread duplicates (~50% of their pages are dupes)
- Tested live on Fludd's *Mosaicall Philosophy*: **343 → 174 pages** (169 dupes archived to `duplicate_pages`)
- New books going through the pipeline will be deduped automatically
- Existing books need a backfill script (separate task)

## Test plan
- [x] Dry-run structural detection on Fludd book: 169 duplicates detected (vs 2 with old fingerprint method)
- [x] Live run on Fludd book: 169 archived, 174 remaining, page counts updated
- [ ] Deploy to Hetzner, verify on next pipeline cycle
- [ ] Write backfill script for existing 2,300 BPH books

🤖 Generated with [Claude Code](https://claude.com/claude-code)