### PR TITLE
Add collection cards to unified search results

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -39,6 +39,14 @@ interface GalleryResult {
   bookId: string;
 }
 
+interface CollectionResult {
+  slug: string;
+  name: string;
+  description?: string;
+  book_count: number;
+  featured_image?: string;
+}
+
 /**
  * GET /api/search/unified
  *
@@ -117,8 +125,9 @@ export async function GET(request: NextRequest) {
       similarity: number;
     }
     const emptyArtworks = { results: [] as ArtworkSearchResult[], total: 0 };
+    const emptyCollections = { results: [] as CollectionResult[] };
 
-    const [booksResult, indexResult, galleryResult, visualResult, semanticResultRaw, artworkResult] = await Promise.all([
+    const [booksResult, indexResult, galleryResult, visualResult, semanticResultRaw, artworkResult, collectionsResult] = await Promise.all([
       withTimeout(searchBooks(query, limit, searchFilters, library), emptyBooks, 'books'),
       withTimeout(
         searchIndex(db, query, limit).catch((err) => {
@@ -186,6 +195,11 @@ export async function GET(request: NextRequest) {
           .catch(() => emptyArtworks),
         emptyArtworks, 'artworks', 6000,
       ),
+      // Collection search: match collection names/descriptions (~300 docs, fast)
+      withTimeout(
+        searchCollections(db, queryRegex, query).catch(() => emptyCollections),
+        emptyCollections, 'collections', 2000,
+      ),
     ]);
 
     // Dedup semantic results: remove books already in keyword results
@@ -212,6 +226,7 @@ export async function GET(request: NextRequest) {
       visual: visualResult,
       semantic: semanticResult,
       artworks: artworkResult,
+      collections: collectionsResult,
     }, {
       headers: {
         'Cache-Control': 'no-store',
@@ -542,4 +557,36 @@ async function searchVisual(query: string, limit: number): Promise<{ results: Ga
   } catch {
     return { results: [], total: 0 };
   }
+}
+
+/**
+ * Search collections by name/description.
+ * ~300 docs, fast regex on a small collection.
+ */
+async function searchCollections(db: any, queryRegex: RegExp, query: string): Promise<{ results: CollectionResult[] }> {
+  const cols = await db.collection('collections')
+    .find({
+      visible: { $ne: false },
+      book_count: { $gt: 0 },
+      $or: [
+        { name: queryRegex },
+        { description: queryRegex },
+        { slug: queryRegex },
+      ],
+    })
+    .project({ slug: 1, name: 1, description: 1, book_count: 1, featured_image: 1 })
+    .sort({ book_count: -1 })
+    .limit(3)
+    .maxTimeMS(2000)
+    .toArray();
+
+  return {
+    results: cols.map((c: any) => ({
+      slug: c.slug,
+      name: c.name,
+      description: c.description?.slice(0, 150),
+      book_count: c.book_count,
+      featured_image: c.featured_image,
+    })),
+  };
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -69,6 +69,7 @@ export default function SearchPage() {
   const [indexTotal, setIndexTotal] = useState(0);
   const [imageResults, setImageResults] = useState<GalleryItem[]>([]);
   const [imageTotal, setImageTotal] = useState(0);
+  const [collectionResults, setCollectionResults] = useState<{ slug: string; name: string; description?: string; book_count: number; featured_image?: string }[]>([]);
 
   // Semantic results (parallel search agent)
   const [semanticResults, setSemanticResults] = useState<any[]>([]);
@@ -283,6 +284,7 @@ export default function SearchPage() {
     if (!q || q.length < 2) {
       setBookResults([]); setBookTotal(0);
       setIndexResults([]); setIndexTotal(0);
+      setCollectionResults([]);
       setImageResults([]); setImageTotal(0);
       return;
     }
@@ -378,6 +380,7 @@ export default function SearchPage() {
           setIndexTotal(iTotal);
           setImageResults(images);
           setImageTotal(imTotal);
+          setCollectionResults((data as any).collections?.results || []);
           displayHintLocked.current = true; // lock layout once results render
 
           // Cache the result
@@ -1248,8 +1251,33 @@ export default function SearchPage() {
             </>
           );
 
+          const collectionCards = collectionResults.length > 0 && (
+            <div className="space-y-2">
+              {collectionResults.map(col => (
+                <Link
+                  key={col.slug}
+                  href={`/collections/${col.slug}`}
+                  className="flex items-center gap-3 p-3 bg-white rounded-xl border border-accent-rust/20 hover:border-accent-rust/40 hover:shadow-md transition-all"
+                >
+                  {col.featured_image && (
+                    <Image src={col.featured_image} alt="" width={48} height={48} className="rounded-lg object-cover flex-shrink-0" unoptimized />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-serif font-medium text-primary text-sm">{col.name}</h3>
+                    {col.description && (
+                      <p className="text-xs text-secondary mt-0.5 line-clamp-1">{col.description}</p>
+                    )}
+                    <span className="text-xs text-muted">{col.book_count} books</span>
+                  </div>
+                  <ChevronRight className="w-4 h-4 text-muted flex-shrink-0" />
+                </Link>
+              ))}
+            </div>
+          );
+
           return (
             <div className="space-y-3">
+              {collectionCards}
               {narrationBlock}
               {displayHint === 'images_first' ? (
                 <>


### PR DESCRIPTION
## Summary
Search now surfaces matching collections at the top of unified results. "memento mori" → Dance of Death collection card. "alchemy" → Alchemy collection card.

- New `searchCollections()` lane queries MongoDB collections by name/description (~300 docs, 2s timeout)
- Collection cards show name, description snippet, book count, featured image
- Runs in parallel with all other search lanes

## Test plan
- [ ] "memento mori" → shows Dance of Death / Memento Mori collection
- [ ] "alchemy" → shows Alchemy collection  
- [ ] "kabbalah" → shows Kabbalah collection
- [ ] "Taylor Swift" → no collections (correct)
- [ ] Click collection card → navigates to collection page

🤖 Generated with [Claude Code](https://claude.com/claude-code)