### PR TITLE
Redesign BPH embed pages to match Source Library design

### DIFF
--- a/src/app/embed/bph/BPHCatalogue.tsx
+++ b/src/app/embed/bph/BPHCatalogue.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import Image from 'next/image';
+import Link from 'next/link';
+import { Search, Book, LayoutGrid, List, ChevronLeft, ChevronRight } from 'lucide-react';
+import AuthorName from '@/components/AuthorName';
 
-interface Book {
+interface BookItem {
   id: string;
   slug: string;
   title: string;
@@ -22,7 +24,7 @@ interface Book {
 }
 
 interface BooksResponse {
-  books: Book[];
+  books: BookItem[];
   total: number;
   limit: number;
   offset: number;
@@ -66,7 +68,6 @@ export default function BPHCatalogue() {
 
   useEffect(() => { fetchBooks(); }, [fetchBooks]);
 
-  // Notify parent iframe of navigation state
   useEffect(() => {
     if (typeof window === 'undefined' || window.self === window.top) return;
     window.parent.postMessage({ type: 'sl-navigate', path: '/catalogue', query }, '*');
@@ -76,7 +77,6 @@ export default function BPHCatalogue() {
     e.preventDefault();
     setQuery(inputValue);
     setCurrentPage(1);
-    // Update URL without full navigation
     const params = new URLSearchParams();
     if (inputValue) params.set('q', inputValue);
     if (sort !== 'title') params.set('sort', sort);
@@ -84,224 +84,178 @@ export default function BPHCatalogue() {
   };
 
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
-
-  const handleBookClick = (book: Book) => {
-    // Navigate to book detail within embed
-    router.push(`/embed/bph/book/${book.slug}`);
-  };
+  const tp = (b: BookItem) => b.pages_count > 0 ? Math.round((b.pages_translated / b.pages_count) * 100) : 0;
 
   return (
-    <div className="p-4 sm:p-6 max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-serif font-medium text-stone-900">
-            Digital Catalogue
-          </h1>
+    <div className="min-h-screen bg-stone-50">
+      {/* Hero header — matches ContentHeader from main site */}
+      <div className="relative overflow-hidden text-white py-12 md:py-16">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
+          <h1 className="font-serif text-3xl md:text-4xl tracking-tight mb-2">Digital Catalogue</h1>
+          <p className="text-base text-stone-300 max-w-2xl font-body leading-relaxed">
+            Browse the digitized collection of the Bibliotheca Philosophica Hermetica
+          </p>
           {data && !loading && (
-            <p className="text-sm text-stone-500 mt-1">
-              {data.total.toLocaleString()} {query ? 'results' : 'items'}
+            <p className="text-sm text-stone-500 mt-2">
+              {data.total.toLocaleString()} {query ? 'results' : 'texts'}
             </p>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setView('grid')}
-            className={`p-2 rounded ${view === 'grid' ? 'bg-stone-200' : 'hover:bg-stone-100'}`}
-            title="Grid view"
-          >
-            <GridIcon />
-          </button>
-          <button
-            onClick={() => setView('list')}
-            className={`p-2 rounded ${view === 'list' ? 'bg-stone-200' : 'hover:bg-stone-100'}`}
-            title="List view"
-          >
-            <ListIcon />
-          </button>
-        </div>
       </div>
 
-      {/* Search + Sort */}
-      <form onSubmit={handleSearch} className="flex gap-3 mb-6">
-        <div className="flex-1 relative">
-          <input
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            placeholder="Search by title, author, or subject..."
-            className="w-full px-4 py-2.5 border border-stone-300 rounded-lg bg-white
-                       text-stone-900 placeholder:text-stone-400
-                       focus:outline-none focus:ring-2 focus:ring-stone-400 focus:border-transparent"
-          />
-          {inputValue && (
-            <button
-              type="button"
-              onClick={() => { setInputValue(''); setQuery(''); setCurrentPage(1); }}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
-            >
-              ✕
+      <main className="max-w-[var(--container-wide)] mx-auto px-6 py-8">
+        {/* Search + controls — matches main search page style */}
+        <form onSubmit={handleSearch} className="flex flex-col sm:flex-row gap-3 mb-8">
+          <div className="flex-1 relative">
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted" />
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="Search by title, author, or subject..."
+              className="w-full pl-12 pr-10 py-3 border border-medium rounded-xl bg-white
+                         text-primary placeholder:text-muted
+                         focus:outline-none focus:ring-2 focus:ring-accent-rust/40 focus:border-accent-rust/50"
+            />
+            {inputValue && (
+              <button type="button" onClick={() => { setInputValue(''); setQuery(''); setCurrentPage(1); }}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted hover:text-secondary text-lg">&times;</button>
+            )}
+          </div>
+          <select value={sort} onChange={(e) => { setSort(e.target.value); setCurrentPage(1); }}
+            className="px-4 py-3 border border-medium rounded-xl bg-white text-sm text-secondary">
+            <option value="title">A&ndash;Z</option>
+            <option value="date_asc">Oldest first</option>
+            <option value="date_desc">Newest first</option>
+            <option value="recent">Recently added</option>
+          </select>
+          <div className="flex gap-1">
+            <button type="button" onClick={() => setView('grid')}
+              className={`p-3 rounded-xl border ${view === 'grid' ? 'bg-dark text-white border-dark' : 'border-medium text-muted hover:bg-warm'}`}>
+              <LayoutGrid className="w-4 h-4" />
             </button>
-          )}
-        </div>
-        <select
-          value={sort}
-          onChange={(e) => { setSort(e.target.value); setCurrentPage(1); }}
-          className="px-3 py-2.5 border border-stone-300 rounded-lg bg-white text-sm"
-        >
-          <option value="title">A–Z</option>
-          <option value="date_asc">Oldest first</option>
-          <option value="date_desc">Newest first</option>
-          <option value="recent">Recently added</option>
-        </select>
-        <button
-          type="submit"
-          className="px-5 py-2.5 bg-stone-900 text-white rounded-lg hover:bg-stone-800 text-sm font-medium"
-        >
-          Search
-        </button>
-      </form>
+            <button type="button" onClick={() => setView('list')}
+              className={`p-3 rounded-xl border ${view === 'list' ? 'bg-dark text-white border-dark' : 'border-medium text-muted hover:bg-warm'}`}>
+              <List className="w-4 h-4" />
+            </button>
+          </div>
+        </form>
 
-      {/* Results */}
-      {loading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-            <div key={i} className="aspect-[3/4] bg-stone-200 rounded animate-pulse" />
-          ))}
-        </div>
-      ) : view === 'grid' ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-          {data?.books.map((book) => (
-            <button
-              key={book.id}
-              onClick={() => handleBookClick(book)}
-              className="group text-left flex flex-col"
-            >
-              <div className="aspect-[3/4] bg-stone-100 rounded overflow-hidden mb-2 relative">
-                {book.thumbnail ? (
-                  <img
-                    src={book.thumbnail}
-                    alt={book.display_title || book.title}
-                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-stone-400 text-xs p-2 text-center">
+        {/* Loading shimmer — matches BookCard shimmer pattern */}
+        {loading ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+              <div key={i} className="bg-white border border-light rounded-lg overflow-hidden">
+                <div className="aspect-[3/4] bg-gradient-to-r from-stone-200 via-stone-100 to-stone-200 bg-[length:200%_100%] animate-shimmer" />
+                <div className="p-4 space-y-2">
+                  <div className="h-4 bg-stone-200 rounded w-3/4 animate-pulse" />
+                  <div className="h-3 bg-stone-100 rounded w-1/2 animate-pulse" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : view === 'grid' ? (
+          /* Grid — replicates BookCard from src/components/book/BookCard.tsx */
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            {data?.books.map((book) => (
+              <Link key={book.id} href={`/embed/bph/book/${book.slug}`} className="group">
+                <div className="bg-white border border-light rounded-lg overflow-hidden hover:shadow-lg transition-shadow duration-200 h-full flex flex-col">
+                  <div className="aspect-[3/4] relative bg-stone-100 overflow-hidden flex-shrink-0">
+                    {book.thumbnail ? (
+                      <img src={book.thumbnail} alt={book.display_title || book.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" loading="lazy" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center">
+                        <Book className="w-16 h-16 text-stone-300" />
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-4 flex-1 flex flex-col">
+                    <h3 className="font-serif font-semibold text-primary line-clamp-2 group-hover:text-accent-rust transition-colors text-sm">
+                      {book.display_title || book.title}
+                    </h3>
+                    <p className="text-sm text-secondary mt-1 line-clamp-1"><AuthorName author={book.author} /></p>
+                    <div className="flex items-center flex-wrap gap-x-2 gap-y-1 mt-2 text-xs text-muted">
+                      <span className="px-2 py-0.5 bg-stone-100 rounded">{book.language}</span>
+                      {book.published && <span>{book.published}</span>}
+                    </div>
+                    {book.pages_count > 0 && (
+                      <div className="mt-auto pt-3">
+                        <div className="flex items-center justify-between text-xs mb-1">
+                          <span className={tp(book) >= 95 ? 'text-status-success font-medium' : 'text-muted'}>
+                            {tp(book) >= 95 ? '✓ Translated' : `${tp(book)}% Translated`}
+                          </span>
+                        </div>
+                        <div className="h-1.5 bg-stone-100 rounded-full overflow-hidden">
+                          <div className={`h-full transition-all duration-300 ${tp(book) >= 95 ? 'bg-status-success' : tp(book) > 0 ? 'bg-accent-gold/80' : 'bg-stone-200'}`}
+                            style={{ width: `${Math.min(tp(book), 100)}%` }} />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          /* List view */
+          <div className="bg-white border border-light rounded-lg divide-y divide-stone-100">
+            {data?.books.map((book) => (
+              <Link key={book.id} href={`/embed/bph/book/${book.slug}`}
+                className="flex items-center gap-4 p-4 hover:bg-warm transition-colors group">
+                <div className="w-12 h-16 flex-shrink-0 bg-stone-100 rounded overflow-hidden">
+                  {book.thumbnail ? (
+                    <img src={book.thumbnail} alt="" className="w-full h-full object-cover" loading="lazy" />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center"><Book className="w-6 h-6 text-stone-300" /></div>
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-serif font-semibold text-primary truncate group-hover:text-accent-rust transition-colors">
                     {book.display_title || book.title}
-                  </div>
-                )}
-                {book.pages_translated > 0 && (
-                  <div className="absolute top-1.5 right-1.5 bg-emerald-600 text-white text-[10px] px-1.5 py-0.5 rounded-full">
-                    Translated
-                  </div>
-                )}
-              </div>
-              <h3 className="text-xs font-medium leading-tight line-clamp-2 group-hover:text-stone-600">
-                {book.display_title || book.title}
-              </h3>
-              <p className="text-[11px] text-stone-500 mt-0.5 line-clamp-1">
-                {book.author}{book.published ? `, ${book.published}` : ''}
-              </p>
-            </button>
-          ))}
-        </div>
-      ) : (
-        <div className="divide-y divide-stone-200">
-          {data?.books.map((book) => (
-            <button
-              key={book.id}
-              onClick={() => handleBookClick(book)}
-              className="w-full text-left flex items-center gap-4 py-3 hover:bg-stone-50 px-2 rounded"
-            >
-              <div className="w-12 h-16 flex-shrink-0 bg-stone-100 rounded overflow-hidden">
-                {book.thumbnail && (
-                  <img
-                    src={book.thumbnail}
-                    alt=""
-                    className="w-full h-full object-cover"
-                    loading="lazy"
-                  />
-                )}
-              </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="text-sm font-medium truncate">
-                  {book.display_title || book.title}
-                </h3>
-                <p className="text-xs text-stone-500">
-                  {book.author}{book.published ? ` · ${book.published}` : ''} · {book.language}
-                </p>
-              </div>
-              <div className="text-right flex-shrink-0">
-                <p className="text-xs text-stone-400">{book.pages_count} pp.</p>
-                {book.pages_translated > 0 && (
-                  <p className="text-[11px] text-emerald-600">
-                    {Math.round((book.pages_translated / book.pages_count) * 100)}% translated
-                  </p>
-                )}
-              </div>
-            </button>
-          ))}
-        </div>
-      )}
+                  </h3>
+                  <p className="text-sm text-muted"><AuthorName author={book.author} />{book.published ? ` · ${book.published}` : ''} · {book.language}</p>
+                </div>
+                <div className="text-right flex-shrink-0 hidden sm:block">
+                  <p className="text-xs text-faint">{book.pages_count} pp.</p>
+                  {tp(book) >= 95 ? (
+                    <p className="text-xs text-status-success font-medium">✓ Translated</p>
+                  ) : tp(book) > 0 ? (
+                    <p className="text-xs text-accent-gold">{tp(book)}%</p>
+                  ) : null}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-center gap-2 mt-8">
-          <button
-            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
-            disabled={currentPage === 1}
-            className="px-3 py-1.5 text-sm border border-stone-300 rounded disabled:opacity-30 hover:bg-stone-100"
-          >
-            ← Prev
-          </button>
-          <span className="text-sm text-stone-500 px-3">
-            Page {currentPage} of {totalPages}
-          </span>
-          <button
-            onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
-            disabled={currentPage === totalPages}
-            className="px-3 py-1.5 text-sm border border-stone-300 rounded disabled:opacity-30 hover:bg-stone-100"
-          >
-            Next →
-          </button>
-        </div>
-      )}
-
-      {/* Empty state */}
-      {!loading && data?.books.length === 0 && (
-        <div className="text-center py-16">
-          <p className="text-stone-500 text-lg">No results found</p>
-          {query && (
-            <button
-              onClick={() => { setInputValue(''); setQuery(''); setCurrentPage(1); }}
-              className="mt-3 text-sm text-stone-600 underline hover:text-stone-900"
-            >
-              Clear search
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-3 mt-10">
+            <button onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1}
+              className="inline-flex items-center gap-1 px-4 py-2 text-sm border border-medium rounded-lg disabled:opacity-30 hover:bg-warm transition-colors">
+              <ChevronLeft className="w-4 h-4" /> Previous
             </button>
-          )}
-        </div>
-      )}
+            <span className="text-sm text-muted">Page {currentPage} of {totalPages}</span>
+            <button onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages}
+              className="inline-flex items-center gap-1 px-4 py-2 text-sm border border-medium rounded-lg disabled:opacity-30 hover:bg-warm transition-colors">
+              Next <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
+        {!loading && data?.books.length === 0 && (
+          <div className="text-center py-20">
+            <Book className="w-16 h-16 text-stone-300 mx-auto mb-4" />
+            <p className="text-muted text-lg font-serif">No results found</p>
+            {query && (
+              <button onClick={() => { setInputValue(''); setQuery(''); setCurrentPage(1); }}
+                className="mt-3 text-sm text-accent-rust hover:underline">Clear search</button>
+            )}
+          </div>
+        )}
+      </main>
     </div>
-  );
-}
-
-function GridIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-      <rect x="1" y="1" width="6" height="6" rx="1" />
-      <rect x="9" y="1" width="6" height="6" rx="1" />
-      <rect x="1" y="9" width="6" height="6" rx="1" />
-      <rect x="9" y="9" width="6" height="6" rx="1" />
-    </svg>
-  );
-}
-
-function ListIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-      <rect x="1" y="2" width="14" height="2.5" rx="1" />
-      <rect x="1" y="6.75" width="14" height="2.5" rx="1" />
-      <rect x="1" y="11.5" width="14" height="2.5" rx="1" />
-    </svg>
   );
 }

--- a/src/app/embed/bph/book/[slug]/BPHBookDetail.tsx
+++ b/src/app/embed/bph/book/[slug]/BPHBookDetail.tsx
@@ -2,188 +2,141 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Book, ArrowLeft } from 'lucide-react';
+import AuthorName from '@/components/AuthorName';
 
-interface Chapter {
-  title: string;
-  startPage?: number;
-}
-
+interface Chapter { title: string; startPage?: number; }
 interface BookData {
-  id: string;
-  slug: string;
-  title: string;
-  display_title?: string;
-  author: string;
-  language: string;
-  published: string;
-  year: number;
-  pages_count: number;
-  pages_translated: number;
-  pages_ocr: number;
-  thumbnail: string | null;
-  catalogue_number: string | null;
-  description: string | null;
-  summary: string | null;
-  categories: string[];
-  chapters: Chapter[];
-  doi: string | null;
-  is_first_translation: boolean;
+  id: string; slug: string; title: string; display_title?: string;
+  author: string; language: string; published: string; year: number;
+  pages_count: number; pages_translated: number; pages_ocr: number;
+  thumbnail: string | null; catalogue_number: string | null;
+  description: string | null; summary: string | null;
+  categories: string[]; chapters: Chapter[];
+  doi: string | null; is_first_translation: boolean;
 }
 
 export default function BPHBookDetail({ book }: { book: BookData }) {
   const router = useRouter();
 
-  // Notify parent iframe
   useEffect(() => {
     if (typeof window === 'undefined' || window.self === window.top) return;
     window.parent.postMessage({ type: 'sl-navigate', book: book.slug }, '*');
   }, [book.slug]);
 
-  const translationPercent = book.pages_count > 0
-    ? Math.round((book.pages_translated / book.pages_count) * 100)
-    : 0;
+  const tp = book.pages_count > 0 ? Math.round((book.pages_translated / book.pages_count) * 100) : 0;
 
   return (
-    <div className="max-w-4xl mx-auto p-4 sm:p-6">
-      {/* Back button */}
-      <button
-        onClick={() => router.push('/embed/bph')}
-        className="text-sm text-stone-500 hover:text-stone-700 mb-4 flex items-center gap-1"
-      >
-        ← Back to catalogue
-      </button>
-
-      <div className="flex flex-col sm:flex-row gap-6">
-        {/* Cover image */}
-        <div className="sm:w-64 flex-shrink-0">
-          {book.thumbnail ? (
-            <img
-              src={book.thumbnail}
-              alt={book.display_title || book.title}
-              className="w-full rounded shadow-lg"
-            />
-          ) : (
-            <div className="w-full aspect-[3/4] bg-stone-200 rounded flex items-center justify-center text-stone-400">
-              No image
-            </div>
-          )}
-        </div>
-
-        {/* Details */}
-        <div className="flex-1">
-          <h1 className="text-2xl font-serif font-medium leading-tight">
+    <div className="min-h-screen bg-stone-50">
+      <div className="relative overflow-hidden text-white py-12 md:py-16">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <button onClick={() => router.push('/embed/bph')}
+            className="inline-flex items-center gap-2 text-stone-400 hover:text-white mb-6 text-sm transition-colors">
+            <ArrowLeft className="w-4 h-4" /> Back to catalogue
+          </button>
+          <h1 className="font-serif text-3xl md:text-4xl tracking-tight leading-tight">
             {book.display_title || book.title}
           </h1>
           {book.display_title && book.display_title !== book.title && (
-            <p className="text-sm text-stone-500 italic mt-1">{book.title}</p>
+            <p className="text-stone-400 italic mt-2">{book.title}</p>
           )}
-          <p className="text-stone-600 mt-2">{book.author}</p>
-
-          {/* Metadata pills */}
-          <div className="flex flex-wrap gap-2 mt-4">
-            <Pill label={book.language} />
-            {book.published && <Pill label={book.published} />}
-            <Pill label={`${book.pages_count} pages`} />
-            {book.pages_translated > 0 && (
-              <Pill label={`${translationPercent}% translated`} color="emerald" />
-            )}
-            {book.is_first_translation && (
-              <Pill label="First English translation" color="amber" />
-            )}
-            {book.doi && <Pill label="DOI" />}
-          </div>
-
-          {book.catalogue_number && (
-            <p className="text-xs text-stone-400 mt-3">{book.catalogue_number}</p>
-          )}
-
-          {/* Read button */}
-          <a
-            href={`/book/${book.slug}`}
-            target="_self"
-            className="inline-flex items-center gap-2 mt-6 px-6 py-3 bg-stone-900 text-white rounded-lg
-                       hover:bg-stone-800 font-medium text-sm transition-colors"
-          >
-            <BookIcon />
-            Read this book
-          </a>
-
-          {/* Summary */}
-          {book.summary && (
-            <div className="mt-6">
-              <h2 className="text-sm font-semibold text-stone-700 mb-2">About this text</h2>
-              <p className="text-sm text-stone-600 leading-relaxed">{book.summary}</p>
-            </div>
-          )}
-
-          {/* Description */}
-          {book.description && !book.summary && (
-            <div className="mt-6">
-              <h2 className="text-sm font-semibold text-stone-700 mb-2">Description</h2>
-              <p className="text-sm text-stone-600 leading-relaxed">{book.description}</p>
-            </div>
-          )}
-
-          {/* Categories */}
-          {book.categories.length > 0 && (
-            <div className="mt-6">
-              <h2 className="text-sm font-semibold text-stone-700 mb-2">Collection areas</h2>
-              <div className="flex flex-wrap gap-2">
-                {book.categories.map(cat => (
-                  <button
-                    key={cat}
-                    onClick={() => router.push(`/embed/bph?category=${cat}`)}
-                    className="text-xs px-2.5 py-1 bg-stone-100 rounded-full text-stone-600
-                               hover:bg-stone-200 transition-colors capitalize"
-                  >
-                    {cat.replace(/-/g, ' ')}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Chapters */}
-          {book.chapters.length > 0 && (
-            <div className="mt-6">
-              <h2 className="text-sm font-semibold text-stone-700 mb-2">
-                Contents ({book.chapters.length} chapters)
-              </h2>
-              <ul className="text-sm text-stone-600 space-y-1 max-h-48 overflow-y-auto">
-                {book.chapters.map((ch, i) => (
-                  <li key={i} className="truncate">
-                    <span className="text-stone-400 mr-2">{i + 1}.</span>
-                    {ch.title}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          <p className="text-stone-300 mt-2 text-lg"><AuthorName author={book.author} /></p>
         </div>
       </div>
+
+      <main className="max-w-[var(--container-standard)] mx-auto px-6 py-10">
+        <div className="flex flex-col md:flex-row gap-8">
+          <div className="md:w-72 flex-shrink-0">
+            <div className="bg-white border border-light rounded-lg overflow-hidden shadow-md">
+              {book.thumbnail ? (
+                <img src={book.thumbnail} alt={book.display_title || book.title} className="w-full" />
+              ) : (
+                <div className="aspect-[3/4] flex items-center justify-center bg-stone-100">
+                  <Book className="w-20 h-20 text-stone-300" />
+                </div>
+              )}
+            </div>
+            <a href={`/book/${book.slug}`} target="_self"
+              className="mt-4 w-full inline-flex items-center justify-center gap-2 px-6 py-3
+                         bg-accent-rust text-white rounded-lg hover:bg-accent-rust/90
+                         font-medium text-sm transition-colors">
+              <Book className="w-4 h-4" /> Read this book
+            </a>
+          </div>
+
+          <div className="flex-1">
+            <div className="flex items-center flex-wrap gap-2 mb-6">
+              <span className="px-3 py-1 bg-stone-100 rounded text-sm text-secondary">{book.language}</span>
+              {book.published && <span className="px-3 py-1 bg-stone-100 rounded text-sm text-secondary">{book.published}</span>}
+              <span className="px-3 py-1 bg-stone-100 rounded text-sm text-secondary">{book.pages_count} pages</span>
+              {book.is_first_translation && (
+                <span className="px-3 py-1 bg-accent-gold/20 rounded text-sm text-accent-gold font-medium">First English translation</span>
+              )}
+              {book.doi && <span className="px-3 py-1 bg-blue-50 rounded text-sm text-blue-700">DOI</span>}
+            </div>
+
+            {book.pages_count > 0 && (
+              <div className="mb-6 p-4 bg-white border border-light rounded-lg">
+                <div className="flex items-center justify-between text-sm mb-2">
+                  <span className={tp >= 95 ? 'text-status-success font-medium' : 'text-secondary'}>
+                    {tp >= 95 ? '✓ Fully translated' : `${tp}% translated`}
+                  </span>
+                  <span className="text-faint text-xs">{book.pages_translated}/{book.pages_count} pages</span>
+                </div>
+                <div className="h-2 bg-stone-100 rounded-full overflow-hidden">
+                  <div className={`h-full rounded-full ${tp >= 95 ? 'bg-status-success' : tp > 0 ? 'bg-accent-gold/80' : 'bg-stone-200'}`}
+                    style={{ width: `${Math.min(tp, 100)}%` }} />
+                </div>
+              </div>
+            )}
+
+            {book.catalogue_number && <p className="text-xs text-faint mb-4">{book.catalogue_number}</p>}
+
+            {book.summary && (
+              <div className="mb-6">
+                <h2 className="font-display text-lg text-primary mb-2">About this text</h2>
+                <p className="text-secondary leading-relaxed">{book.summary}</p>
+              </div>
+            )}
+            {book.description && !book.summary && (
+              <div className="mb-6">
+                <h2 className="font-display text-lg text-primary mb-2">Description</h2>
+                <p className="text-secondary leading-relaxed">{book.description}</p>
+              </div>
+            )}
+
+            {book.categories.length > 0 && (
+              <div className="mb-6">
+                <h2 className="font-display text-lg text-primary mb-2">Collection areas</h2>
+                <div className="flex flex-wrap gap-2">
+                  {book.categories.map(cat => (
+                    <Link key={cat} href={`/embed/bph?category=${cat}`}
+                      className="px-3 py-1.5 bg-stone-100 rounded-lg text-sm text-secondary
+                                 hover:bg-accent-rust/10 hover:text-accent-rust transition-colors capitalize">
+                      {cat.replace(/-/g, ' ')}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {book.chapters.length > 0 && (
+              <div className="mb-6">
+                <h2 className="font-display text-lg text-primary mb-2">Contents ({book.chapters.length} chapters)</h2>
+                <div className="bg-white border border-light rounded-lg divide-y divide-stone-100 max-h-64 overflow-y-auto">
+                  {book.chapters.map((ch, i) => (
+                    <div key={i} className="px-4 py-2.5 text-sm text-secondary">
+                      <span className="text-faint mr-2 font-mono text-xs">{i + 1}.</span>{ch.title}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
     </div>
-  );
-}
-
-function Pill({ label, color }: { label: string; color?: 'emerald' | 'amber' }) {
-  const colorClasses = color === 'emerald'
-    ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
-    : color === 'amber'
-    ? 'bg-amber-50 text-amber-700 border-amber-200'
-    : 'bg-stone-100 text-stone-600 border-stone-200';
-
-  return (
-    <span className={`text-xs px-2.5 py-1 rounded-full border ${colorClasses}`}>
-      {label}
-    </span>
-  );
-}
-
-function BookIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M2 2.5h4.5a2 2 0 012 2v9a1.5 1.5 0 00-1.5-1.5H2V2.5z" />
-      <path d="M14 2.5H9.5a2 2 0 00-2 2v9a1.5 1.5 0 011.5-1.5H14V2.5z" />
-    </svg>
   );
 }

--- a/src/app/embed/bph/collections/BPHCollections.tsx
+++ b/src/app/embed/bph/collections/BPHCollections.tsx
@@ -2,35 +2,21 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Book, ChevronLeft, ChevronRight } from 'lucide-react';
+import AuthorName from '@/components/AuthorName';
 
 interface Collection {
-  slug: string;
-  name: string;
-  description: string | null;
-  subtitle: string | null;
-  item_count: number;
+  slug: string; name: string; description: string | null;
+  subtitle: string | null; image: any | null; item_count: number;
 }
-
-interface Book {
-  id: string;
-  slug: string;
-  title: string;
-  display_title?: string;
-  author: string;
-  language: string;
-  published: string;
-  year: number;
-  pages_count: number;
-  pages_translated: number;
-  thumbnail: string | null;
-  url: string;
+interface BookItem {
+  id: string; slug: string; title: string; display_title?: string;
+  author: string; language: string; published: string; year: number;
+  pages_count: number; pages_translated: number; thumbnail: string | null; url: string;
 }
-
 interface CollectionDetail extends Collection {
-  books: Book[];
-  total: number;
-  limit: number;
-  offset: number;
+  books: BookItem[]; total: number; limit: number; offset: number;
 }
 
 const PAGE_SIZE = 24;
@@ -49,159 +35,160 @@ export default function BPHCollections() {
     setLoading(true);
     try {
       if (areaSlug) {
-        const params = new URLSearchParams({
-          slug: areaSlug,
-          limit: String(PAGE_SIZE),
-          offset: String((page - 1) * PAGE_SIZE),
-        });
+        const params = new URLSearchParams({ slug: areaSlug, limit: String(PAGE_SIZE), offset: String((page - 1) * PAGE_SIZE) });
         const res = await fetch(`/api/embed/bph/collections?${params}`);
-        const json = await res.json();
-        setDetail(json.collection);
+        setDetail((await res.json()).collection);
       } else {
         const res = await fetch('/api/embed/bph/collections');
-        const json = await res.json();
-        setCollections(json.collections || []);
+        setCollections((await res.json()).collections || []);
       }
-    } catch (err) {
-      console.error('Failed to fetch collections:', err);
-    } finally {
-      setLoading(false);
-    }
+    } catch (err) { console.error('Failed to fetch collections:', err); }
+    finally { setLoading(false); }
   }, [areaSlug, page]);
 
   useEffect(() => { fetchCollections(); }, [fetchCollections]);
 
-  // Notify parent
   useEffect(() => {
     if (typeof window === 'undefined' || window.self === window.top) return;
-    window.parent.postMessage({
-      type: 'sl-navigate',
-      path: areaSlug ? `/collections/${areaSlug}` : '/collections',
-    }, '*');
+    window.parent.postMessage({ type: 'sl-navigate', path: areaSlug ? `/collections/${areaSlug}` : '/collections' }, '*');
   }, [areaSlug]);
+
+  const tp = (b: BookItem) => b.pages_count > 0 ? Math.round((b.pages_translated / b.pages_count) * 100) : 0;
 
   if (loading) {
     return (
-      <div className="p-6 max-w-7xl mx-auto">
-        <div className="h-8 w-48 bg-stone-200 rounded animate-pulse mb-6" />
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {Array.from({ length: 9 }).map((_, i) => (
-            <div key={i} className="h-32 bg-stone-200 rounded animate-pulse" />
-          ))}
+      <div className="min-h-screen bg-stone-50">
+        <div className="relative overflow-hidden text-white py-12 md:py-16">
+          <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+          <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
+            <div className="h-10 w-64 bg-white/10 rounded animate-pulse" />
+          </div>
         </div>
+        <main className="max-w-[var(--container-wide)] mx-auto px-6 py-8">
+          <div className="grid gap-3 sm:gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <div key={i} className="aspect-[4/3] bg-stone-200 rounded-lg animate-pulse" />
+            ))}
+          </div>
+        </main>
       </div>
     );
   }
 
-  // Single collection detail view
+  // Single collection detail
   if (areaSlug && detail) {
     const totalPages = Math.ceil(detail.total / PAGE_SIZE);
     return (
-      <div className="p-4 sm:p-6 max-w-7xl mx-auto">
-        <button
-          onClick={() => router.push('/embed/bph/collections')}
-          className="text-sm text-stone-500 hover:text-stone-700 mb-4 flex items-center gap-1"
-        >
-          ← All collection areas
-        </button>
-
-        <h1 className="text-2xl font-serif font-medium">{detail.name}</h1>
-        {detail.subtitle && (
-          <p className="text-stone-500 mt-1">{detail.subtitle}</p>
-        )}
-        {detail.description && (
-          <p className="text-sm text-stone-600 mt-2 max-w-2xl leading-relaxed">{detail.description}</p>
-        )}
-        <p className="text-sm text-stone-400 mt-2">{detail.total} items</p>
-
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 mt-6">
-          {detail.books.map((book) => (
-            <button
-              key={book.id}
-              onClick={() => router.push(`/embed/bph/book/${book.slug}`)}
-              className="group text-left flex flex-col"
-            >
-              <div className="aspect-[3/4] bg-stone-100 rounded overflow-hidden mb-2">
-                {book.thumbnail ? (
-                  <img
-                    src={book.thumbnail}
-                    alt={book.display_title || book.title}
-                    className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-stone-400 text-xs p-2 text-center">
-                    {book.display_title || book.title}
-                  </div>
-                )}
-              </div>
-              <h3 className="text-xs font-medium leading-tight line-clamp-2 group-hover:text-stone-600">
-                {book.display_title || book.title}
-              </h3>
-              <p className="text-[11px] text-stone-500 mt-0.5 line-clamp-1">
-                {book.author}{book.published ? `, ${book.published}` : ''}
-              </p>
+      <div className="min-h-screen bg-stone-50">
+        <div className="relative overflow-hidden text-white py-12 md:py-16">
+          <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+          <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
+            <button onClick={() => router.push('/embed/bph/collections')}
+              className="inline-flex items-center gap-2 text-stone-400 hover:text-white mb-4 text-sm transition-colors">
+              <ArrowLeft className="w-4 h-4" /> All collection areas
             </button>
-          ))}
-        </div>
-
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-2 mt-8">
-            <button
-              onClick={() => setPage(p => Math.max(1, p - 1))}
-              disabled={page === 1}
-              className="px-3 py-1.5 text-sm border border-stone-300 rounded disabled:opacity-30 hover:bg-stone-100"
-            >
-              ← Prev
-            </button>
-            <span className="text-sm text-stone-500 px-3">
-              Page {page} of {totalPages}
-            </span>
-            <button
-              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-              disabled={page === totalPages}
-              className="px-3 py-1.5 text-sm border border-stone-300 rounded disabled:opacity-30 hover:bg-stone-100"
-            >
-              Next →
-            </button>
+            <h1 className="font-serif text-3xl md:text-4xl tracking-tight">{detail.name}</h1>
+            {detail.subtitle && <p className="text-stone-300 mt-2">{detail.subtitle}</p>}
+            {detail.description && <p className="text-stone-400 mt-2 max-w-2xl leading-relaxed text-sm">{detail.description}</p>}
+            <p className="text-stone-500 mt-2 text-sm">{detail.total} texts</p>
           </div>
-        )}
+        </div>
+        <main className="max-w-[var(--container-wide)] mx-auto px-6 py-8">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            {detail.books.map((book) => (
+              <Link key={book.id} href={`/embed/bph/book/${book.slug}`} className="group">
+                <div className="bg-white border border-light rounded-lg overflow-hidden hover:shadow-lg transition-shadow duration-200 h-full flex flex-col">
+                  <div className="aspect-[3/4] relative bg-stone-100 overflow-hidden flex-shrink-0">
+                    {book.thumbnail ? (
+                      <img src={book.thumbnail} alt={book.display_title || book.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" loading="lazy" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center"><Book className="w-16 h-16 text-stone-300" /></div>
+                    )}
+                  </div>
+                  <div className="p-4 flex-1 flex flex-col">
+                    <h3 className="font-serif font-semibold text-primary line-clamp-2 group-hover:text-accent-rust transition-colors text-sm">
+                      {book.display_title || book.title}
+                    </h3>
+                    <p className="text-sm text-secondary mt-1 line-clamp-1"><AuthorName author={book.author} /></p>
+                    <div className="flex items-center flex-wrap gap-x-2 gap-y-1 mt-2 text-xs text-muted">
+                      <span className="px-2 py-0.5 bg-stone-100 rounded">{book.language}</span>
+                      {book.published && <span>{book.published}</span>}
+                    </div>
+                    {book.pages_count > 0 && (
+                      <div className="mt-auto pt-3">
+                        <div className="h-1.5 bg-stone-100 rounded-full overflow-hidden">
+                          <div className={`h-full ${tp(book) >= 95 ? 'bg-status-success' : tp(book) > 0 ? 'bg-accent-gold/80' : 'bg-stone-200'}`}
+                            style={{ width: `${Math.min(tp(book), 100)}%` }} />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-3 mt-10">
+              <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
+                className="inline-flex items-center gap-1 px-4 py-2 text-sm border border-medium rounded-lg disabled:opacity-30 hover:bg-warm">
+                <ChevronLeft className="w-4 h-4" /> Previous
+              </button>
+              <span className="text-sm text-muted">Page {page} of {totalPages}</span>
+              <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}
+                className="inline-flex items-center gap-1 px-4 py-2 text-sm border border-medium rounded-lg disabled:opacity-30 hover:bg-warm">
+                Next <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+        </main>
       </div>
     );
   }
 
-  // Collection areas grid
+  // Collection areas grid — matches CollectionCard from collections page
   return (
-    <div className="p-4 sm:p-6 max-w-7xl mx-auto">
-      <h1 className="text-2xl font-serif font-medium mb-6">Collection Areas</h1>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {collections.map((col) => (
-          <button
-            key={col.slug}
-            onClick={() => router.push(`/embed/bph/collections?area=${col.slug}`)}
-            className="text-left p-5 border border-stone-200 rounded-lg hover:border-stone-400
-                       hover:shadow-sm transition-all group"
-          >
-            <h2 className="text-lg font-serif font-medium group-hover:text-stone-600">
-              {col.name}
-            </h2>
-            {col.subtitle && (
-              <p className="text-xs text-stone-400 mt-0.5">{col.subtitle}</p>
-            )}
-            {col.description && (
-              <p className="text-sm text-stone-500 mt-2 line-clamp-2">{col.description}</p>
-            )}
-            <p className="text-sm text-stone-400 mt-3">
-              {col.item_count} {col.item_count === 1 ? 'item' : 'items'}
-            </p>
-          </button>
-        ))}
+    <div className="min-h-screen bg-stone-50">
+      <div className="relative overflow-hidden text-white py-12 md:py-16">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
+          <h1 className="font-serif text-3xl md:text-4xl tracking-tight mb-2">Collection Areas</h1>
+          <p className="text-stone-300 max-w-2xl leading-relaxed">Browse the BPH collection by subject area</p>
+        </div>
       </div>
-
-      {collections.length === 0 && (
-        <p className="text-stone-500 text-center py-12">No collection areas found.</p>
-      )}
+      <main className="max-w-[var(--container-wide)] mx-auto px-6 py-8">
+        <div className="grid gap-3 sm:gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          {collections.map((col) => {
+            const heroUrl = col.image?.extracted_url || col.image?.thumbnail_url || col.image?.image_url || null;
+            return (
+              <Link key={col.slug} href={`/embed/bph/collections?area=${col.slug}`}
+                className="group relative block overflow-hidden rounded-lg aspect-[4/3]">
+                {heroUrl ? (
+                  <img src={heroUrl} alt={`Illustration from ${col.name}`}
+                    className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 ease-out group-hover:scale-105" loading="lazy" />
+                ) : (
+                  <div className="absolute inset-0 bg-warm" />
+                )}
+                <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
+                <div className="absolute inset-0 flex flex-col justify-end p-3 sm:p-4">
+                  <p className="text-white/50 text-[11px] mb-1 hidden sm:block">
+                    {col.item_count} {col.item_count === 1 ? 'book' : 'books'}
+                  </p>
+                  <h2 className="font-serif text-sm sm:text-base lg:text-lg text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">
+                    {col.name}
+                  </h2>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+        {collections.length === 0 && (
+          <div className="text-center py-20">
+            <Book className="w-16 h-16 text-stone-300 mx-auto mb-4" />
+            <p className="text-muted font-serif text-lg">No collection areas found</p>
+          </div>
+        )}
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The embed pages looked completely different from the main site. This rewrites all 3 embed page components to use the same design patterns:

- **BookCard pattern** — white cards, `border-light`, hover shadow, 3:4 aspect covers, translation progress bars (gold/green)
- **ContentHeader pattern** — dark gradient hero (`from-[#2a1f17] to-[#1a1612]`), serif titles, stone-300 subtitles
- **CollectionCard pattern** — 4:3 aspect ratio, gradient overlay, gold text on hover, book count
- **Search** — lucide Search icon, rounded-xl inputs, accent-rust focus ring
- **Typography** — `font-serif` for titles, `AuthorName` component, design token classes (`text-primary`, `text-muted`, `text-faint`)
- **Layout** — CSS container vars (`--container-wide`, `--container-standard`), same grid breakpoints

## Test plan

- [ ] Compare `/embed/bph` side-by-side with main site homepage
- [ ] Compare collection cards with `/collections` page
- [ ] Check book detail matches main site book pages
- [ ] Verify translation progress bars use same colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)