### PR TITLE
Show all books in catalog, not just translated

### DIFF
--- a/src/app/api/catalog/browse/route.ts
+++ b/src/app/api/catalog/browse/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request) {
     const includeLangs = searchParams.get('langs') === '1';
 
     const promises: [Promise<{ books: unknown[]; total: number }>, Promise<{ lang: string; count: number }[]> | null] = [
-      browseBooks({ hasTranslation: true, language, search, sort, offset, limit, exactCount: true }),
+      browseBooks({ language, search, sort, offset, limit, exactCount: true }),
       includeLangs ? getLanguageCounts({}) : null,
     ];
 

--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 
 export default async function CatalogPage() {
   const [browseResult, languages] = await Promise.all([
-    browseBooks({ hasTranslation: true, sort: 'popular', limit: 60 }).catch((err) => {
+    browseBooks({ sort: 'popular', limit: 60 }).catch((err) => {
       console.error('[catalog] browseBooks failed:', err?.message || err);
       return { books: [], total: 0 };
     }),
@@ -33,7 +33,7 @@ export default async function CatalogPage() {
           Catalog
         </h1>
         <p className="text-lg mb-10" style={{ color: 'var(--text-muted)' }}>
-          Every translated book in the library.
+          Every book in the library.
         </p>
 
         <CatalogBrowser


### PR DESCRIPTION
## Summary
- Removed `hasTranslation: true` filter from catalog page and browse API
- Catalog now shows all ~17K books instead of only the ~3,316 with translations
- Updated subtitle from "Every translated book" to "Every book in the library"

## Test plan
- [ ] Visit /catalog and verify total count reflects full library
- [ ] Scroll/paginate to confirm all books load
- [ ] Filter by language still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)