### PR TITLE
Fix missing SemanticArtworkResult type import

### DIFF
--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getNextApiKey } from '@/lib/gemini-client';
 import { getDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
-import { semanticArtworkSearch } from '@/lib/semantic-search';
+import { semanticArtworkSearch, type SemanticArtworkResult } from '@/lib/semantic-search';
 
 export const maxDuration = 30;
 export const dynamic = 'force-dynamic';


### PR DESCRIPTION
## Summary
- Added missing `SemanticArtworkResult` type import in `/api/identify` route
- This was breaking all production builds since the semantic artwork search was added

## Test plan
- [ ] Vercel build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)