### PR TITLE
Fix 5 user feedback items: search, gallery, header

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -263,14 +263,17 @@ export async function GET(request: NextRequest) {
     const hasMore = items.length > limit;
     if (hasMore) items.splice(limit); // trim to limit
 
-    // Avoid countDocuments entirely — derive total from what we know
+    // Derive total — avoid countDocuments for unfiltered browsing, but use it for searches
     let total: number;
     if (!hasMore && offset === 0) {
       total = items.length; // we have everything
     } else if (!hasMore) {
       total = offset + items.length; // last page
+    } else if (searchQuery || collectionBookIds || libraryBookIds || imageType || subjectFilter || figureFilter || symbolFilter || iconclassFilter || yearStart !== null || yearEnd !== null) {
+      // Filtered query — estimated count is wildly wrong, do a real count (capped at 10s)
+      total = await db.collection('gallery_images').countDocuments(filter, { maxTimeMS: 10000 }).catch(() => offset + items.length + 1);
     } else {
-      // There are more results — use estimated count as approximation
+      // Unfiltered browsing — estimated count is fine
       total = await db.collection('gallery_images').estimatedDocumentCount();
     }
 

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -178,7 +178,7 @@ export async function GET(request: NextRequest) {
       ),
       // Artwork semantic search: dedicated artwork_embeddings table (3072 dims)
       withTimeout(
-        semanticArtworkSearch(query, 8)
+        semanticArtworkSearch(query, 4)
           .then(artworks => ({
             results: artworks.map(a => ({
               book_id: a.book_id,

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -71,6 +71,8 @@ async function fetchInitialGalleryData(): Promise<GalleryResponse> {
       gallery_quality: { $gte: minQuality },
       book_rank: { $lte: maxPerBook },
       book_visible: true,
+      extracted_url: { $ne: null },
+      image_url: { $ne: null },
     };
 
     // Read pre-computed filters from system_config (subjects/year aggs take 20-40s on Atlas)

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -353,11 +353,15 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
               type: g.type,
             } as GalleryItem);
           }
-          // Merge artwork semantic results as image cards (they have thumbnails)
+          // Merge artwork semantic results as image cards (cap at 3 to avoid flooding)
+          const maxArtworks = 3;
+          let artworkCount = 0;
           for (const a of artworkResults) {
+            if (artworkCount >= maxArtworks) break;
             const artId = `artwork-${a.book_id}`;
             if (seenImageIds.has(artId)) continue;
             seenImageIds.add(artId);
+            artworkCount++;
             images.push({
               pageId: a.book_id,
               bookId: a.book_id,
@@ -661,8 +665,8 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
                   className="w-full sm:w-auto pl-9 pr-3 py-3 border border-border-medium rounded-xl text-sm text-secondary bg-white focus:outline-none focus:ring-2 focus:ring-accent-rust/30 appearance-none cursor-pointer"
                 >
                   <option value="relevance">Relevance</option>
-                  <option value="date_desc">Newest first</option>
-                  <option value="date_asc">Oldest first</option>
+                  <option value="date_desc">Year (newest)</option>
+                  <option value="date_asc">Year (oldest)</option>
                   <option value="title">Title A-Z</option>
                 </select>
               </div>

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Logo from './Logo';
 import UserMenu from './UserMenu';
+import { Search } from 'lucide-react';
 
 const NAV_LINKS = [
   { label: 'Collections', href: '/collections' },
@@ -105,6 +106,19 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
               );
             })}
           </nav>
+
+          {/* Desktop search icon */}
+          <Link
+            href="/search"
+            className={`hidden lg:flex items-center justify-center w-8 h-8 rounded-lg transition-colors ${
+              pathname === '/search'
+                ? (isWhiteText ? 'text-white bg-white/10' : 'text-primary bg-warm')
+                : (isWhiteText ? 'text-white/60 hover:text-white hover:bg-white/10' : 'text-secondary hover:text-primary hover:bg-warm/50')
+            }`}
+            aria-label="Search"
+          >
+            <Search className="w-4 h-4" />
+          </Link>
 
           {/* Mobile hamburger */}
           <div className="relative lg:hidden" ref={menuRef}>


### PR DESCRIPTION
## Summary
- **Search icon in desktop header** — was mobile-only, now shows on desktop nav too (requested by Mike)
- **Gallery broken images on load** — SSR fetch was missing `extracted_url`/`image_url` null filters, serving 45K+ images with no URLs
- **Gallery search pagination** — API was returning `estimatedDocumentCount` (~72K) as total for filtered text searches, making pagination show thousands of empty pages. Now uses `countDocuments` for filtered queries
- **Artwork dedup in search** — capped from 8 to 3 artworks in unified results to avoid flooding image section with similar paintings
- **Sort label clarity** — renamed "Newest/Oldest first" to "Year (newest/oldest)" so users notice year sorting exists

## Test plan
- [ ] Verify search icon appears in desktop header, links to `/search`
- [ ] Search "Adam and Eve" → Images tab → verify pagination works beyond page 1
- [ ] Search "Adam and Eve" → verify max ~3 artwork cards in unified image section
- [ ] Visit `/gallery` → verify all initial images load (no broken thumbnails)
- [ ] Check sort dropdown labels show "Year (oldest)" / "Year (newest)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)