### PR TITLE
Add full BPH catalog + held_by field for bph.sourcelibrary.org

### DIFF
--- a/scripts/migration/backfill-held-by.mjs
+++ b/scripts/migration/backfill-held-by.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Backfill `held_by` array on all books.
+ *
+ * Phase 1: Set held_by = [image_source.provider] for all books with a provider
+ * Phase 2: Add 'bph' to held_by for books that match BPH catalog (via dublin_core.dc_identifier UBN)
+ * Phase 3: Add 'bph' to held_by for cmc_kloss books (Kloss is a BPH sub-collection)
+ * Phase 4: Create index on { held_by: 1, visible: 1, pages_count: 1 }
+ *
+ * Usage:
+ *   node scripts/migration/backfill-held-by.mjs --dry-run    # Preview (default)
+ *   node scripts/migration/backfill-held-by.mjs --apply       # Write to DB
+ */
+
+import { MongoClient } from 'mongodb';
+import fs from 'fs';
+
+// Load env
+function loadEnv() {
+  for (const f of ['.env.production.local', '.env.local']) {
+    try {
+      const content = fs.readFileSync(f, 'utf8');
+      for (const line of content.split('\n')) {
+        const m = line.match(/^([^=#]+)=(.*)$/);
+        if (m) {
+          let v = m[2].trim();
+          if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+          if (!process.env[m[1].trim()]) process.env[m[1].trim()] = v;
+        }
+      }
+    } catch { /* skip */ }
+  }
+}
+
+loadEnv();
+
+const DRY_RUN = !process.argv.includes('--apply');
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const books = db.collection('books');
+
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'APPLY'}\n`);
+
+  // Phase 1: Set held_by = [provider] for all books that have a provider but no held_by
+  const withProvider = await books.countDocuments({
+    'image_source.provider': { $exists: true, $ne: null },
+    held_by: { $exists: false },
+  });
+  console.log(`Phase 1: ${withProvider} books with provider but no held_by`);
+
+  if (!DRY_RUN && withProvider > 0) {
+    const result = await books.updateMany(
+      {
+        'image_source.provider': { $exists: true, $ne: null },
+        held_by: { $exists: false },
+      },
+      [{ $set: { held_by: ['$image_source.provider'] } }]
+    );
+    console.log(`  Updated: ${result.modifiedCount}`);
+  }
+
+  // Phase 2: Add 'bph' to held_by for cmc_kloss books (Kloss is BPH sub-collection)
+  const klossBooks = await books.countDocuments({
+    'image_source.provider': 'cmc_kloss',
+    held_by: { $not: { $elemMatch: { $eq: 'bph' } } },
+  });
+  console.log(`Phase 2: ${klossBooks} Kloss books missing 'bph' in held_by`);
+
+  if (!DRY_RUN && klossBooks > 0) {
+    const result = await books.updateMany(
+      {
+        'image_source.provider': 'cmc_kloss',
+        held_by: { $not: { $elemMatch: { $eq: 'bph' } } },
+      },
+      { $addToSet: { held_by: 'bph' } }
+    );
+    console.log(`  Updated: ${result.modifiedCount}`);
+  }
+
+  // Phase 3: Match books against BPH catalog via dublin_core.dc_identifier (UBN)
+  // Books imported from other providers (MDZ, IA, etc.) that BPH also holds
+  // Fetch all BPH UBNs from Supabase to cross-reference
+  console.log('Phase 3: Fetching BPH catalog UBNs from Supabase...');
+  const SUPABASE_URL = process.env.SUPABASE_URL || 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+  const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlraHhhZWNiYnhhYXFsdWp1emRlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjUwNjExMDEsImV4cCI6MjA4MDYzNzEwMX0.O2chfnHGQWLOaVSFQ-F6UJMlya9EzPbsUh848SEOPj4';
+
+  // Fetch all UBNs from bph_works (paginated, Supabase limit is 1000)
+  const bphUbns = new Set();
+  let offset = 0;
+  const PAGE = 1000;
+  while (true) {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/bph_works?select=ubn&offset=${offset}&limit=${PAGE}`, {
+      headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+    });
+    const data = await res.json();
+    if (!data.length) break;
+    for (const row of data) if (row.ubn) bphUbns.add(row.ubn);
+    offset += PAGE;
+    if (data.length < PAGE) break;
+  }
+  console.log(`  Loaded ${bphUbns.size} BPH catalog UBNs`);
+
+  // Find non-BPH books whose dc_identifier matches a BPH UBN
+  const booksWithUbn = await books.find(
+    {
+      'dublin_core.dc_identifier': { $exists: true, $ne: null },
+      'image_source.provider': { $ne: 'bph' },
+    },
+    { projection: { _id: 1, id: 1, title: 1, 'dublin_core.dc_identifier': 1, 'image_source.provider': 1, held_by: 1 } }
+  ).toArray();
+
+  const bphMatches = booksWithUbn.filter(b => {
+    const ubn = b.dublin_core?.dc_identifier;
+    return ubn && bphUbns.has(String(ubn));
+  });
+  // Exclude books already tagged
+  const toTag = bphMatches.filter(b => !b.held_by || !b.held_by.includes('bph'));
+  console.log(`  ${booksWithUbn.length} non-BPH books with dc_identifier, ${bphMatches.length} match BPH catalog, ${toTag.length} need tagging`);
+
+  if (!DRY_RUN && toTag.length > 0) {
+    let matched = 0;
+    for (const book of toTag) {
+      await books.updateOne(
+        { _id: book._id },
+        { $addToSet: { held_by: 'bph' } }
+      );
+      matched++;
+    }
+    console.log(`  Added 'bph' to held_by for ${matched} books`);
+  }
+
+  // Phase 4: Create compound index
+  console.log('\nPhase 4: Index { held_by: 1, visible: 1, pages_count: 1 }');
+  if (!DRY_RUN) {
+    try {
+      await books.createIndex(
+        { held_by: 1, visible: 1, pages_count: 1 },
+        { name: 'held_by_visible_pages', background: true }
+      );
+      console.log('  Index created');
+    } catch (e) {
+      console.log(`  Index error: ${e.message}`);
+    }
+  }
+
+  // Summary
+  const totalHeldBy = await books.countDocuments({ held_by: { $exists: true } });
+  const bphHeldBy = await books.countDocuments({ held_by: 'bph' });
+  console.log(`\nSummary:`);
+  console.log(`  Books with held_by: ${totalHeldBy}`);
+  console.log(`  Books held by BPH: ${bphHeldBy}`);
+
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/embed/bph/books/[slug]/route.ts
+++ b/src/app/api/embed/bph/books/[slug]/route.ts
@@ -28,7 +28,7 @@ export async function GET(
     // Try slug first, then ID
     const book = await db.collection('books').findOne({
       $or: [{ slug }, { id: slug }],
-      'image_source.provider': 'bph',
+      held_by: 'bph',
       visible: true,
     }, {
       projection: {

--- a/src/app/api/embed/bph/books/route.ts
+++ b/src/app/api/embed/bph/books/route.ts
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
 
     // Base BPH filter
     const filter: Record<string, unknown> = {
-      'image_source.provider': 'bph',
+      held_by: 'bph',
       visible: true,
       pages_count: { $gt: 0 },
     };

--- a/src/app/api/embed/bph/collections/route.ts
+++ b/src/app/api/embed/bph/collections/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
       }
 
       const bookFilter = {
-        'image_source.provider': 'bph',
+        held_by: 'bph',
         visible: true,
         pages_count: { $gt: 0 },
         categories: slug,
@@ -116,7 +116,7 @@ export async function GET(request: NextRequest) {
     const collectionsWithCounts: Array<{ slug: string; name: string; description?: string; subtitle?: string; featured_images?: unknown[]; bph_count: number }> = [];
     for (const col of collections) {
       const count = await bphBooks.countDocuments({
-        'image_source.provider': 'bph',
+        held_by: 'bph',
         visible: true,
         pages_count: { $gt: 0 },
         categories: col.slug,

--- a/src/app/api/embed/bph/featured/route.ts
+++ b/src/app/api/embed/bph/featured/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
 
     const db = await getReadDb();
     const filter: Record<string, unknown> = {
-      'image_source.provider': 'bph',
+      held_by: 'bph',
       visible: true,
       pages_count: { $gt: 0 },
       pages_translated: { $gt: 0 },

--- a/src/app/api/embed/bph/languages/route.ts
+++ b/src/app/api/embed/bph/languages/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
     const result = await db.collection('books').aggregate([
       {
         $match: {
-          'image_source.provider': 'bph',
+          held_by: 'bph',
           visible: true,
           pages_count: { $gt: 0 },
           language: { $exists: true, $nin: [null, ''] },

--- a/src/app/api/embed/bph/stats/route.ts
+++ b/src/app/api/embed/bph/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { supabase } from '@/lib/supabase';
 
 export const revalidate = 3600; // Cache for 1 hour
 
@@ -17,7 +18,8 @@ export async function OPTIONS() {
  * GET /api/embed/bph/stats
  *
  * Returns aggregate stats for BPH collection:
- * - total: total number of BPH books
+ * - catalog_total: total works in BPH catalog (Supabase bph_works)
+ * - digitized: digitized books on Source Library
  * - translated: books with at least one translated page
  * - languages: number of distinct original languages
  * - pages_total: total pages across all BPH books
@@ -29,12 +31,12 @@ export async function GET() {
     const books = db.collection('books');
 
     const bphFilter = {
-      'image_source.provider': 'bph',
+      held_by: 'bph',
       visible: true,
       pages_count: { $gt: 0 },
     };
 
-    const [totalResult, translatedResult, languagesResult, pagesResult] = await Promise.all([
+    const [totalResult, translatedResult, languagesResult, pagesResult, catalogResult] = await Promise.all([
       books.countDocuments(bphFilter),
       books.countDocuments({ ...bphFilter, pages_translated: { $gt: 0 } }),
       books.distinct('language', bphFilter),
@@ -48,11 +50,15 @@ export async function GET() {
           },
         },
       ]).toArray(),
+      supabase.from('bph_works').select('*', { count: 'exact', head: true }),
     ]);
 
     const pageStats = pagesResult[0] || { pages_total: 0, pages_translated: 0 };
 
     return NextResponse.json({
+      catalog_total: catalogResult.count || 0,
+      digitized: totalResult,
+      // Keep 'total' for backwards compat with existing consumers
       total: totalResult,
       translated: translatedResult,
       languages: languagesResult.filter(Boolean).length,

--- a/src/app/api/embed/bph/suggest/route.ts
+++ b/src/app/api/embed/bph/suggest/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
     const books = await db.collection('books')
       .find({
         id: { $in: matchedIds },
-        'image_source.provider': 'bph',
+        held_by: 'bph',
         visible: true,
         pages_count: { $gt: 0 },
       })

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -105,7 +105,7 @@ export async function GET(request: NextRequest) {
       if (hasDoi === 'true') filters.doi = { $exists: true, $ne: null };
       if (hasTranslation === 'true') filters.pages_translated = { $gt: 0 };
       if (firstTranslation === 'true') filters.is_first_translation = true;
-      if (library) filters['image_source.provider'] = library;
+      if (library) filters.$or = [{ held_by: library }, { 'image_source.provider': library }];
       return filters;
     }
 

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -217,8 +217,14 @@ async function fetchCollectionData(id: string, provider?: string) {
           { resource_type: { $exists: true } },
         ],
       };
-  // Tenant provider filter — restrict to a specific library's books
-  if (provider) filter['image_source.provider'] = provider;
+  // Tenant provider filter — restrict to a specific library's books.
+  // Use $and to avoid overwriting an existing $or on the filter.
+  if (provider) {
+    filter.$and = [
+      ...(filter.$and as unknown[] || []),
+      { $or: [{ held_by: provider }, { 'image_source.provider': provider }] },
+    ];
+  }
 
   const projection = {
     _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1,

--- a/src/app/embed/bph/book/[slug]/page.tsx
+++ b/src/app/embed/bph/book/[slug]/page.tsx
@@ -9,19 +9,19 @@ export const dynamicParams = true;
 export async function generateStaticParams() { return []; }
 
 /**
- * BPH embed book page — verifies the book belongs to BPH, then renders
- * the real BookDetailPage. Non-BPH books 404 in the embed.
+ * BPH embed book page — verifies the book exists on Source Library, then renders
+ * the real BookDetailPage. Allows any visible book (not just BPH-sourced) since
+ * BPH holds copies of books we may have imported from other providers (MDZ, IA, etc).
  */
 export default async function EmbedBookPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
 
-  // Verify this is a BPH book before rendering
   const db = await getReadDb();
-  const isBph = await db.collection('books').findOne(
-    { $or: [{ slug }, { id: slug }], 'image_source.provider': 'bph' },
+  const exists = await db.collection('books').findOne(
+    { $or: [{ slug }, { id: slug }], visible: true, pages_count: { $gt: 0 } },
     { projection: { _id: 1 } }
   );
-  if (!isBph) notFound();
+  if (!exists) notFound();
 
   return <BookDetailPage params={Promise.resolve({ id: slug })} />;
 }

--- a/src/app/embed/bph/catalog/page.tsx
+++ b/src/app/embed/bph/catalog/page.tsx
@@ -1,0 +1,54 @@
+import { Suspense } from 'react';
+import { getReadDb } from '@/lib/mongodb';
+import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
+
+export const revalidate = 86400;
+export const preferredRegion = 'fra1';
+
+export const metadata = {
+  title: 'Full Catalog — Bibliotheca Philosophica Hermetica',
+  robots: { index: false, follow: false },
+};
+
+/** Build a UBN → { id, slug } map for BPH books on Source Library */
+async function fetchBphDigitizedMap(): Promise<Record<string, { id: string; slug: string }>> {
+  try {
+    const db = await getReadDb();
+    const bphBooks = await db.collection('books').find(
+      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true } },
+      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 15_000 }
+    ).toArray();
+
+    const map: Record<string, { id: string; slug: string }> = {};
+    for (const b of bphBooks) {
+      const ubn = b.dublin_core?.dc_identifier;
+      if (ubn) {
+        map[ubn] = { id: b.id, slug: b.slug || b.id };
+      }
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+export default async function EmbedCatalogPage() {
+  const digitizedUbns = await fetchBphDigitizedMap();
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+      <div className="mb-6">
+        <h1 className="text-2xl sm:text-3xl font-display text-primary mb-1">
+          Full Catalog
+        </h1>
+        <p className="text-sm text-secondary">
+          Browse all 27,000+ works in the Bibliotheca Philosophica Hermetica collection.
+          Works available to read online are marked with a <span className="text-accent-rust">book icon</span>.
+        </p>
+      </div>
+      <Suspense fallback={<div className="text-muted py-12 text-center">Loading catalog...</div>}>
+        <BphCatalogBrowser basePath="/catalog" digitizedUbns={digitizedUbns} />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/embed/bph/collections/page.tsx
+++ b/src/app/embed/bph/collections/page.tsx
@@ -46,7 +46,7 @@ async function fetchBPHCollections(): Promise<CollectionDoc[]> {
 
   for (const col of collections) {
     const count = await books.countDocuments({
-      'image_source.provider': 'bph',
+      held_by: 'bph',
       visible: true,
       pages_count: { $gt: 0 },
       categories: col.slug,

--- a/src/app/embed/bph/page.tsx
+++ b/src/app/embed/bph/page.tsx
@@ -1,4 +1,6 @@
 import { Suspense } from 'react';
+import Link from 'next/link';
+import { Library } from 'lucide-react';
 import SearchPage from '@/app/search/page';
 
 export const dynamic = 'force-dynamic';
@@ -14,8 +16,19 @@ export const metadata = {
  */
 export default function EmbedCataloguePage() {
   return (
-    <Suspense>
-      <SearchPage defaultLibrary="bph" />
-    </Suspense>
+    <>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-4 pb-2">
+        <Link
+          href="/catalog"
+          className="inline-flex items-center gap-2 text-sm text-secondary hover:text-accent-rust transition-colors border border-border-light rounded-md px-3 py-1.5 hover:bg-warm"
+        >
+          <Library className="w-4 h-4" />
+          Browse Full Catalog (27,000+ works)
+        </Link>
+      </div>
+      <Suspense>
+        <SearchPage defaultLibrary="bph" />
+      </Suspense>
+    </>
   );
 }

--- a/src/lib/types/book.ts
+++ b/src/lib/types/book.ts
@@ -61,6 +61,8 @@ export interface Book {
 
   // Workflow status
   status?: BookStatus;
+  /** Libraries/institutions that hold a copy of this work (e.g. ['bph', 'mdz']) */
+  held_by?: string[];
   summary?: string | BookSummary;
   job?: {  // Active processing job (set during processing, cleared on completion)
     type: 'realtime' | 'batch';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -181,6 +181,8 @@ export function proxy(request: NextRequest) {
       url.pathname = `/embed/${tenant}${pathname}`;
     } else if (pathname.startsWith('/collections')) {
       url.pathname = `/embed/${tenant}${pathname}`;
+    } else if (pathname === '/catalog') {
+      url.pathname = `/embed/${tenant}/catalog`;
     } else {
       // All other paths on tenant subdomain → embed root (filtered search)
       url.pathname = `/embed/${tenant}`;


### PR DESCRIPTION
## Summary
- **Fixes BPH 404s**: EFM staff reported Boehme books 404ing on bph.sourcelibrary.org because they were imported from MDZ, not BPH. Removed the provider gate on the embed book page.
- **Full catalog browser**: Added `/catalog` page to BPH embed showing all 27,879 BPH works (reuses existing `BphCatalogBrowser` + `/api/catalog/bph`)
- **`held_by` field**: New array field on books tracking which institutions hold a copy. All 41K+ books backfilled. BPH embed APIs now filter on `held_by: 'bph'` instead of `image_source.provider: 'bph'`, surfacing 3,116 books (including 799 Kloss).
- **Stats**: BPH stats endpoint now includes `catalog_total` from Supabase `bph_works`

## Test plan
- [ ] Visit `bph.sourcelibrary.org/book/theosophische-send-briefe-boehme-2` — should load (was 404)
- [ ] Visit `bph.sourcelibrary.org/catalog` — should show searchable catalog
- [ ] Search "Boehme" on `bph.sourcelibrary.org` — should find results
- [ ] Check `/api/embed/bph/stats` includes `catalog_total`
- [ ] Verify main site search still works with library filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)