### PR TITLE
Add modernized text toggle to book reader

### DIFF
--- a/scripts/tmp-insert-translation-v12.mjs
+++ b/scripts/tmp-insert-translation-v12.mjs
@@ -1,0 +1,123 @@
+/**
+ * Insert translation prompt v12 into the prompts collection.
+ *
+ * v12 is identical to v11 but adds "Readability requirements" after the "Writing style" section.
+ * Does NOT set is_default — this is opt-in only.
+ *
+ * Run: set -a; source .env.production.local; set +a; node scripts/tmp-insert-translation-v12.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set');
+  process.exit(1);
+}
+
+const client = new MongoClient(uri);
+
+async function main() {
+  await client.connect();
+  const db = client.db('bookstore');
+  const prompts = db.collection('prompts');
+
+  // Find current v11 translation prompt
+  const v11 = await prompts.findOne({
+    type: 'translation',
+    name: 'Standard Translation',
+    version: 11,
+  });
+
+  if (!v11) {
+    console.error('Could not find Standard Translation v11. Searching for latest...');
+    const latest = await prompts.findOne(
+      { type: 'translation', name: 'Standard Translation' },
+      { sort: { version: -1 } }
+    );
+    if (latest) {
+      console.log(`Found latest version: v${latest.version}`);
+      console.log('Adjust this script to use the correct base version.');
+    } else {
+      console.error('No Standard Translation prompt found at all.');
+    }
+    process.exit(1);
+  }
+
+  // Check if v12 already exists
+  const existing = await prompts.findOne({
+    type: 'translation',
+    name: 'Standard Translation',
+    version: 12,
+  });
+
+  if (existing) {
+    console.log('Standard Translation v12 already exists. Skipping.');
+    process.exit(0);
+  }
+
+  const readabilityAddition = `
+
+**Readability requirements (new in v12):**
+- Write in clear, natural modern English. Avoid Latinate syntax inherited from the source language.
+- Use short sentences (15-25 words). Split long Latin periods into multiple sentences.
+- Use active voice: "The king ordered" not "It was ordered by the king."
+- Add paragraph breaks every 3-5 sentences, even if the source has none.
+- Avoid: "wherefore," "lest," "aforementioned," "it is not to be doubted that," "a certain," and similar archaic constructions.
+- The text should sound natural when read aloud.
+- Preserve all content, details, names, and meaning — only change how it's expressed, not what it says.`;
+
+  // The v11 content field holds the prompt text.
+  // Insert the readability section after the "Writing style" section.
+  const v11Content = v11.content || v11.text || '';
+
+  // Find the "Writing style" section — insert after it
+  // Look for the next section header after "Writing style" or end of content
+  const writingStyleIdx = v11Content.indexOf('**Writing style');
+  let insertionPoint;
+
+  if (writingStyleIdx !== -1) {
+    // Find the next major section header (a line starting with **)
+    const afterWritingStyle = v11Content.indexOf('\n**', writingStyleIdx + 20);
+    if (afterWritingStyle !== -1) {
+      insertionPoint = afterWritingStyle;
+    } else {
+      // No subsequent section — append at end
+      insertionPoint = v11Content.length;
+    }
+  } else {
+    // Fallback: append at end
+    console.warn('Could not find "Writing style" section — appending at end of prompt.');
+    insertionPoint = v11Content.length;
+  }
+
+  const v12Content = v11Content.slice(0, insertionPoint) + readabilityAddition + v11Content.slice(insertionPoint);
+
+  const v12Doc = {
+    name: 'Standard Translation',
+    type: 'translation',
+    version: 12,
+    content: v12Content,
+    text: v12Content,
+    variables: v11.variables || ['language'],
+    description: 'v12: Adds readability requirements (short sentences, active voice, paragraph breaks, no archaic constructions). Based on v11.',
+    is_default: false,
+    created_at: new Date(),
+    created_by: 'claude-code',
+  };
+
+  const result = await prompts.insertOne(v12Doc);
+  console.log(`Inserted Standard Translation v12: ${result.insertedId}`);
+  console.log('is_default: false (not active by default)');
+
+  // Print a preview of the added section
+  console.log('\n--- Added readability section ---');
+  console.log(readabilityAddition.trim());
+}
+
+main()
+  .catch(err => {
+    console.error('Error:', err);
+    process.exit(1);
+  })
+  .finally(() => client.close());

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -425,6 +425,14 @@ export default function TranslationEditor({
   const [summaryText, setSummaryText] = useState(page.summary?.data || '');
   const { fontSize, lineHeight, increaseFontSize, decreaseFontSize, resetFontSize, isMinSize, isMaxSize, isDefaultSize } = useReaderPreferences();
 
+  // Modernized text toggle
+  const [modernizedMode, setModernizedMode] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem('sl_reader_mode') === 'modern';
+  });
+  const [modernizedText, setModernizedText] = useState<string | null>(page.modernized?.data || null);
+  const [modernizing, setModernizing] = useState(false);
+
   // Translation request (guest users)
   const [translationRequested, setTranslationRequested] = useState(false);
 
@@ -745,12 +753,45 @@ export default function TranslationEditor({
     setOcrText(page.ocr?.data || '');
     setTranslationText(page.translation?.data || '');
     setSummaryText(page.summary?.data || '');
+    setModernizedText(page.modernized?.data || null);
+    setModernizing(false);
     // Reset scroll on all content panels and the outer panel container (mobile stacked layout)
     document.querySelectorAll('[data-reader-panel]').forEach(el => {
       el.scrollTop = 0;
     });
     document.querySelector('[data-reader-panels-container]')?.scrollTo(0, 0);
   }, [page]);
+
+  // Toggle modernized mode and persist to localStorage
+  const toggleModernizedMode = () => {
+    const next = !modernizedMode;
+    setModernizedMode(next);
+    localStorage.setItem('sl_reader_mode', next ? 'modern' : 'scholarly');
+  };
+
+  // Generate modernized text for the current page
+  const handleModernize = async () => {
+    setModernizing(true);
+    try {
+      const res = await fetch(`/api/pages/${page.id}/modernize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Failed to modernize' }));
+        toast.error(err.error || 'Failed to modernize');
+        return;
+      }
+      const data = await res.json();
+      setModernizedText(data.modernized);
+      toast.success('Modernized text generated');
+    } catch {
+      toast.error('Failed to modernize');
+    } finally {
+      setModernizing(false);
+    }
+  };
 
   const handleProcess = async (action: 'ocr' | 'translation' | 'summary' | 'all') => {
     setProcessing(action);
@@ -1386,6 +1427,34 @@ export default function TranslationEditor({
                           model={page.translation?.model}
                         />
                       )}
+                      {/* Scholarly / Modern toggle pill */}
+                      {translationText && (
+                        <button
+                          onClick={toggleModernizedMode}
+                          className="flex items-center rounded-full text-[10px] font-medium overflow-hidden border"
+                          style={{ borderColor: 'var(--border-light)' }}
+                          title={modernizedMode ? 'Switch to scholarly translation' : 'Switch to modern prose'}
+                        >
+                          <span
+                            className="px-2 py-0.5 transition-colors"
+                            style={{
+                              background: !modernizedMode ? 'var(--accent-sage)' : 'transparent',
+                              color: !modernizedMode ? '#fff' : 'var(--text-muted)',
+                            }}
+                          >
+                            Scholarly
+                          </span>
+                          <span
+                            className="px-2 py-0.5 transition-colors"
+                            style={{
+                              background: modernizedMode ? 'var(--accent-sage)' : 'transparent',
+                              color: modernizedMode ? '#fff' : 'var(--text-muted)',
+                            }}
+                          >
+                            Modern
+                          </span>
+                        </button>
+                      )}
                     </div>
                     {translationText && (
                       <div className="flex items-center gap-2">
@@ -1413,7 +1482,7 @@ export default function TranslationEditor({
                           Info
                         </button>
                         <button
-                          onClick={() => copyToClipboard(translationText)}
+                          onClick={() => copyToClipboard(modernizedMode && modernizedText ? modernizedText : translationText)}
                           className="flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors hover:bg-stone-100"
                           style={{ color: 'var(--text-muted)' }}
                         >
@@ -1424,7 +1493,50 @@ export default function TranslationEditor({
                     )}
                   </div>
                   <div className="flex-1 overflow-auto p-4 min-h-0" data-reader-panel>
-                    {translationText ? (
+                    {translationText && modernizedMode && modernizedText ? (
+                      /* Modernized text view */
+                      <div className="prose prose-sm max-w-none" style={{ color: 'var(--text-primary)', fontSize: 'var(--reader-font-size, 15px)', lineHeight: 'var(--reader-line-height, 1.8)' }}>
+                        {modernizedText.split('\n\n').map((para, i) => {
+                          // Render italic section headers (lines starting with *)
+                          const trimmed = para.trim();
+                          if (/^\*[^*]+\*$/.test(trimmed)) {
+                            return <p key={i} className="italic mt-6 mb-2" style={{ color: 'var(--text-muted)' }}>{trimmed.slice(1, -1)}</p>;
+                          }
+                          return <p key={i} className="mb-3">{trimmed}</p>;
+                        })}
+                      </div>
+                    ) : translationText && modernizedMode && !modernizedText ? (
+                      /* Modernize button — text exists but no modernized version yet */
+                      <div className="h-full flex flex-col items-center justify-center text-center px-4 gap-3">
+                        <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+                          No modern version of this page yet.
+                        </p>
+                        <button
+                          onClick={handleModernize}
+                          disabled={modernizing}
+                          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+                          style={{
+                            background: modernizing ? 'var(--bg-subtle)' : 'var(--accent-sage)',
+                            color: modernizing ? 'var(--text-muted)' : '#fff',
+                          }}
+                        >
+                          {modernizing ? (
+                            <>
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                              Modernizing...
+                            </>
+                          ) : (
+                            <>
+                              <BookOpen className="w-4 h-4" />
+                              Generate Modern Version
+                            </>
+                          )}
+                        </button>
+                        <p className="text-xs max-w-xs" style={{ color: 'var(--text-faint)' }}>
+                          AI will rewrite the scholarly translation into clear, readable modern prose while preserving all content.
+                        </p>
+                      </div>
+                    ) : translationText ? (
                       <>
                         <HighlightSelection
                           bookId={book.id}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -293,31 +293,35 @@ export async function generateSummary(
 }
 
 // Default prompt for modernizing translations
-const MODERNIZATION_PROMPT = `You are rewriting a scholarly translation into clear, accessible modern English.
+const MODERNIZATION_PROMPT = `You are an editor turning a scholarly translation of a pre-modern text into clear, compelling modern prose — the kind you'd find in a well-edited trade paperback or hear in a quality podcast.
 
-**Goal:** Make the text easy to read while preserving the author's meaning and ideas. This is NOT a summary - keep all the content but reorganize and clarify it.
+**Your reader:** An intelligent person with no specialist knowledge. They should be able to read this aloud naturally.
 
-**Your task:**
-1. **Break up long sentences** - Renaissance prose often has very long periods. Split into digestible sentences.
-2. **Use modern vocabulary** - Replace archaic terms with modern equivalents (but keep key technical terms with brief inline explanations)
-3. **Add paragraph breaks** - Create logical paragraph structure even if the original is a wall of text
-4. **Clarify references** - When the text says "as we discussed" or "the aforementioned", briefly restate what's being referred to
-5. **Preserve meaning** - Never change the author's ideas, just how they're expressed
-6. **Maintain flow** - If the previous page ended mid-thought, continue naturally
+**Core rules:**
+1. **Short, direct sentences.** Split Latinate periods into 1-2 clause sentences. No sentence longer than 25 words unless quoting.
+2. **Modern vocabulary.** "Wherefore" → so/therefore. "Lest" → in case. "It is not easy to describe how" → "You can't imagine how." "Most honest men" → "genuinely honest people."
+3. **Active voice.** "A banquet was prepared by the king" → "The king prepared a banquet."
+4. **Paragraph breaks every 3-5 sentences.** The original has none. Create logical groupings.
+5. **Section headers** — Add a brief italic line before major topic shifts: *Leo describes the food and customs of the mountain people* or *A night encounter with bandits on the Atlas*. Use markdown italic, not headings.
+6. **Cut formulaic Latin filler:** Remove "wherefore," "the aforementioned," "as we have already said," "it is incredible to relate," "which I believe happened for this reason," and similar throat-clearing. Just say what happened.
+7. **Preserve every fact, name, date, and detail.** Never summarize or skip content. Change HOW things are said, not WHAT is said.
+8. **Preserve the author's voice** — humor, irony, asides, opinions, first-person moments. These are the best parts. Make them shine, don't flatten them.
+9. **Read-aloud test:** Every sentence should sound natural if spoken aloud. Avoid nested subordinate clauses, double negatives, and inverted word order.
 
-**What to keep:**
-- All substantive content (don't summarize or skip anything)
-- Key terms and names (with brief context if needed)
-- The author's arguments and reasoning
-- Any quoted passages (can paraphrase but note it)
+**What to remove:**
+- Redundant transitions: "Wherefore," "Moreover," "Furthermore," "Now," "Indeed"
+- Formulaic qualifiers: "a certain," "of that kind," "as has already been said"
+- Latinate padding: "it is not to be doubted that," "one could hardly believe," "it is incredible to say how"
+- Passive constructions where active is clearer
 
-**What to modernize:**
-- Sentence structure (shorter, clearer)
-- Vocabulary (modern equivalents)
-- Paragraph organization (logical groupings)
-- Pronouns and references (make explicit when unclear)
+**What to keep/enhance:**
+- Specific details (numbers, distances, prices, names)
+- Direct speech and dialogue
+- Personal observations ("I remember," "I saw," "I was there when")
+- Humor and irony
+- Cultural details and customs
 
-**Format:** Clean prose with paragraph breaks. No markdown headers, bullet points, or annotations. Just flowing, readable text.
+**Format:** Clean prose with paragraph breaks and occasional italic section headers. No markdown headings (#), no bullet points, no annotations. Just flowing, readable modern text that preserves every detail of the original.
 
 **IMPORTANT:** If the translation has <note>...</note>, <term>...</term>, or other XML/bracket tags, incorporate that information naturally into the text rather than preserving the markup. Remove all tags from output.`;
 


### PR DESCRIPTION
## Summary
- **Improved modernization prompt** in `src/lib/ai.ts` — stronger rules for section headers, active voice, read-aloud test, formulaic filler removal, and author voice preservation
- **Scholarly/Modern toggle** in the translation panel header — pill toggle persisted to localStorage, shows modernized text when available or a "Generate Modern Version" button when not
- **Translation prompt v12** inserted into MongoDB `prompts` collection (is_default: false) — adds readability requirements (short sentences, active voice, paragraph breaks, no archaic constructions)

## Test plan
- [ ] Open any translated book page, verify the Scholarly/Modern toggle appears in the translation panel header
- [ ] Click "Modern" — if no modernized text exists, see the "Generate Modern Version" button
- [ ] Click "Generate Modern Version" — verify it calls the API and displays the result
- [ ] Toggle back to "Scholarly" — verify the original translation is shown
- [ ] Refresh the page — verify the toggle state persists via localStorage
- [ ] Navigate between pages — verify modernized text loads from cache when available
- [ ] Verify the Copy button copies the correct text based on active mode

Generated with Claude Code