### PR TITLE
Fix artwork links in search results (404 → /artwork/slug)

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -228,11 +228,25 @@ export async function GET(request: NextRequest) {
     };
     filteredSemantic.total = filteredSemantic.results.length;
 
+    const artworksAboveFloor = artworkResult.results.filter(r => r.similarity >= ARTWORK_SIM_FLOOR);
+    // Enrich artworks with slugs from MongoDB (needed for /artwork/[slug] links)
+    if (artworksAboveFloor.length > 0) {
+      try {
+        const artworkIds = artworksAboveFloor.map(a => a.book_id);
+        const artworkDocs = await db.collection('books').find(
+          { id: { $in: artworkIds } },
+          { projection: { id: 1, slug: 1 } }
+        ).maxTimeMS(2000).toArray();
+        const slugMap = new Map(artworkDocs.map(d => [d.id, d.slug]));
+        for (const a of artworksAboveFloor) {
+          (a as any).slug = slugMap.get(a.book_id) || null;
+        }
+      } catch { /* non-fatal */ }
+    }
     const filteredArtworks = {
-      results: artworkResult.results.filter(r => r.similarity >= ARTWORK_SIM_FLOOR),
-      total: 0,
+      results: artworksAboveFloor,
+      total: artworksAboveFloor.length,
     };
-    filteredArtworks.total = filteredArtworks.results.length;
 
     // Log search query (fire-and-forget)
     db.collection('analytics_events').insertOne({

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -378,7 +378,8 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
               description: a.display_title || a.title || '',
               type: a.genre || 'artwork',
               isArtwork: true,
-            } as GalleryItem & { isArtwork?: boolean });
+              artworkSlug: a.slug || null,
+            } as GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null });
           }
           const imTotal = (data.gallery?.total || 0) + (data.visual?.total || 0) + artworkResults.length;
 
@@ -1704,16 +1705,21 @@ function IndexResultCard({ result, query }: { result: IndexSearchResult; query: 
   );
 }
 
-function ImageResultCard({ item, query, large }: { item: GalleryItem; query: string; large?: boolean }) {
+function ImageResultCard({ item, query, large }: { item: GalleryItem & { isArtwork?: boolean; artworkSlug?: string | null }; query: string; large?: boolean }) {
   const [imageError, setImageError] = useState(false);
 
   // Use pre-generated thumbnail/extracted URL first (publicly accessible),
   // fall back to original imageUrl (crop-image API requires auth and breaks for visitors)
   const displayUrl = item.thumbnailUrl || item.extractedUrl || item.imageUrl;
 
+  // Artworks link to /artwork/[slug], gallery images to /gallery/image/[id]
+  const href = item.isArtwork
+    ? `/artwork/${item.artworkSlug || item.pageId}`
+    : `/gallery/image/${item.pageId}-${item.detectionIndex}`;
+
   return (
     <Link
-      href={`/gallery/image/${item.pageId}-${item.detectionIndex}`}
+      href={href}
       className="group block bg-white rounded-lg border border-border-light overflow-hidden hover:border-accent-gold/30 hover:shadow-md transition-all"
     >
       <div className={`relative bg-warm ${large ? 'aspect-[3/4]' : 'aspect-square'}`}>


### PR DESCRIPTION
## Summary
- Artwork search results linked to `/gallery/image/{bookId}-0` which always 404'd
- Artworks are books with `content_type: artwork`, not gallery images
- API now enriches artwork results with slugs from MongoDB
- ImageResultCard routes artworks to `/artwork/{slug}` 
- Also includes onError fallbacks from previous PR

## Test plan
- [ ] Search "sex" or "love" — artwork results should link to `/artwork/slug` pages
- [ ] Clicking an artwork card opens the artwork viewer, not a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)