### PR TITLE
Add page revision tracking to all pipeline write paths

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -26,7 +26,7 @@ import { nanoid } from 'nanoid';
 import { SQSClient, SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { GoogleGenAI } from '@google/genai';
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs';
@@ -46,6 +46,37 @@ const SQS_IMAGE_EXTRACTION_QUEUE_URL = process.env.SQS_PAGE_IMAGE_EXTRACTION_QUE
 
 // Gemini Batch API config (for direct OCR submission, bypassing Vercel)
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+/**
+ * Save current page content as a revision before overwriting.
+ * Lightweight inline version of src/lib/page-revisions.ts createRevision().
+ */
+async function saveRevisionBeforeOverwrite(db, pageId, field) {
+  try {
+    const page = await db.collection('pages').findOne(
+      { id: pageId },
+      { projection: { book_id: 1, ocr: 1, translation: 1 } }
+    );
+    if (!page) return;
+    const fieldData = page[field];
+    if (!fieldData?.data) return; // No existing content — first write
+    await db.collection('page_revisions').insertOne({
+      id: randomBytes(6).toString('hex'),
+      page_id: pageId,
+      book_id: page.book_id,
+      field,
+      data: fieldData.data,
+      source: fieldData.source || 'ai',
+      model: fieldData.model,
+      language: fieldData.language,
+      prompt_version: fieldData.prompt_version,
+      original_date: fieldData.updated_at,
+      created_at: new Date(),
+    });
+  } catch (e) {
+    // Non-fatal — don't block pipeline on revision failure
+  }
+}
+
 const OCR_MODEL_FLASH = 'gemini-3-flash-preview';
 const OCR_MODEL_LITE = 'gemini-3.1-flash-lite-preview';
 function getOcrModelForBook(book) {
@@ -607,7 +638,8 @@ async function translatePage(db, page, sourceLanguage, previousTranslation) {
   // Extract metadata from translation output
   const meta = extractTranslationMetadata(text);
 
-  // Save translation to page
+  // Save revision before overwriting, then write translation
+  await saveRevisionBeforeOverwrite(db, page.id, 'translation');
   await db.collection('pages').updateOne(
     { id: page.id },
     {
@@ -2797,6 +2829,7 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
               const usage = data.usageMetadata || {};
 
               if (text) {
+                await saveRevisionBeforeOverwrite(db, pageId, 'ocr');
                 await db.collection('pages').updateOne(
                   { id: pageId },
                   { $set: {

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -23,7 +23,7 @@
 
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { nanoid } from 'nanoid';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
 import { syncPageUpdate, syncPageBatch } from './lib/supabase-page-writer.mjs';
@@ -345,8 +345,43 @@ function effectiveBatchSize(pages, maxBatchSize) {
   return Math.max(1, size);
 }
 
+/**
+ * Save current page content as a revision before overwriting.
+ * Lightweight inline version of src/lib/page-revisions.ts createRevision().
+ */
+async function saveRevisionBeforeOverwrite(db, pageId, field, jobId) {
+  try {
+    const page = await db.collection('pages').findOne(
+      { id: pageId },
+      { projection: { book_id: 1, ocr: 1, translation: 1 } }
+    );
+    if (!page) return;
+    const fieldData = page[field];
+    if (!fieldData?.data) return; // No existing content — first write
+    await db.collection('page_revisions').insertOne({
+      id: randomBytes(6).toString('hex'),
+      page_id: pageId,
+      book_id: page.book_id,
+      field,
+      data: fieldData.data,
+      source: fieldData.source || 'ai',
+      model: fieldData.model,
+      language: fieldData.language,
+      prompt_version: fieldData.prompt_version,
+      edited_by: fieldData.edited_by,
+      job_id: jobId,
+      original_date: fieldData.updated_at,
+      created_at: new Date(),
+    });
+  } catch (e) {
+    // Non-fatal — don't block translation on revision failure
+    console.error(`  [revision] Failed for ${pageId}/${field}: ${e.message?.slice(0, 50)}`);
+  }
+}
+
 // ── Write a single page translation to DB ──
 async function writePageTranslation(db, page, text, book) {
+  await saveRevisionBeforeOverwrite(db, page.id, 'translation');
   const setPayload = {
     translation: {
       data: text,
@@ -371,6 +406,10 @@ async function bulkWritePageTranslations(db, entries, book) {
   if (entries.length === 1) {
     return writePageTranslation(db, entries[0].page, entries[0].text, book);
   }
+  // Save revisions before overwriting (parallel, non-blocking)
+  await Promise.all(entries.map(({ page }) =>
+    saveRevisionBeforeOverwrite(db, page.id, 'translation')
+  ));
   const now = new Date();
   const model = getModelForBook(book);
   const ops = entries.map(({ page, text }) => ({

--- a/src/workers/write-processor-logic.ts
+++ b/src/workers/write-processor-logic.ts
@@ -20,6 +20,7 @@ import { logGeminiCall } from '@/lib/gemini-logger';
 import { retryDbWrite } from '@/lib/retry-utils';
 import { checkJobCompletion } from '@/lib/job-completion';
 import { syncPageUpdate } from '@/lib/supabase-page-writer';
+import { createRevision } from '@/lib/page-revisions';
 import type { PageJobType } from '@/lib/types/job';
 import type {
   WriteResultMessage,
@@ -69,6 +70,8 @@ async function processOcrResult(db: Awaited<ReturnType<typeof getDb>>, message: 
       }
     ), `record OCR failure for page ${pageId}`, 3, LOG_PREFIX);
   } else if (message.data) {
+    // Save revision before overwriting OCR (no-op on first write)
+    try { await createRevision(pageId, 'ocr', jobId); } catch {}
     // Save OCR result to page
     const { text, language, model, promptVersion, promptId, promptHash, pageType, columns, scriptType, detectedImages } = message.data;
     const ocrSetPayload = {


### PR DESCRIPTION
## Summary

- Adds `createRevision()` / `saveRevisionBeforeOverwrite()` calls to three pipeline write paths that were missing revision tracking:
  - **translate-worker.mjs** — single and bulk page translation writes
  - **pipeline-orchestrator.mjs** — preview OCR and inline translation writes
  - **write-processor-logic.ts** — Lambda OCR result writes

All other write paths (batch-collector, API routes, manual editor) already had revision tracking.

## Why

Page revisions are critical for scholarly auditability — they preserve the prior content before any overwrite. The translate-worker processes the most pages (~40 concurrent) and had zero revision tracking.

## Risk

Low. The revision function is non-fatal (try/catch, fire-and-forget). On first writes (no existing data), it's a no-op. Adds one extra DB read per page write, but the revision pattern is proven in batch-collector which handles similar volume.

## Test plan

- [ ] Verify translate-worker.mjs syntax (`node -c` passes)
- [ ] Verify pipeline-orchestrator.mjs syntax (`node -c` passes)
- [ ] Verify write-processor-logic.ts compiles (same import pattern as existing)
- [ ] Deploy to Hetzner and verify page_revisions collection gets entries from translate-worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)