### PR TITLE
Nav: Explore goes directly to map

### DIFF
--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -11,7 +11,7 @@ const NAV_LINKS = [
   { label: 'Collections', href: '/collections' },
   { label: 'Gallery', href: '/gallery' },
   { label: 'Browse', href: '/browse' },
-  { label: 'Explore', href: '/explore' },
+  { label: 'Explore', href: '/explore/map', activePrefix: '/explore' },
   { label: 'Librarian', href: '/librarian' },
   { label: 'Podcast', href: '/podcast' },
 ];
@@ -92,7 +92,8 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
           {/* Desktop nav links */}
           <nav className="hidden lg:flex items-center gap-5">
             {NAV_LINKS.map((link) => {
-              const isActive = pathname === link.href || pathname?.startsWith(link.href + '/');
+              const prefix = ('activePrefix' in link ? link.activePrefix : link.href) as string;
+              const isActive = pathname === prefix || pathname?.startsWith(prefix + '/');
               return (
                 <Link
                   key={link.href}
@@ -144,7 +145,8 @@ export default function SiteHeader({ variant = 'light', breadcrumbs, sticky, cla
             {menuOpen && (
               <div className="absolute right-0 top-full mt-2 w-52 bg-white rounded-lg shadow-lg border border-border-light py-2 z-50">
                 {NAV_LINKS.map((link) => {
-                  const isActive = pathname === link.href || pathname?.startsWith(link.href + '/');
+                  const prefix = ('activePrefix' in link ? link.activePrefix : link.href) as string;
+                  const isActive = pathname === prefix || pathname?.startsWith(prefix + '/');
                   return (
                     <Link
                       key={link.href}


### PR DESCRIPTION
## Summary
- Clicking "Explore" in the header now links to `/explore/map` instead of the `/explore` landing page
- Timeline, constellation, and other explore views are reachable via the tab bar toggle on the map page
- Active-link highlighting still works across all `/explore/*` routes

## Test plan
- [ ] Click Explore in header — should land on map
- [ ] Navigate to timeline/constellation via tab bar on map
- [ ] Verify Explore stays highlighted in nav on all explore sub-pages
- [ ] Check mobile menu behavior

Generated with [Claude Code](https://claude.com/claude-code)