### PR TITLE
Security hardening: 5 fixes (#1354-#1360)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -83,6 +83,24 @@ const nextConfig: NextConfig = {
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
           {
+            key: 'Content-Security-Policy',
+            value: [
+              // Next.js requires 'unsafe-inline' for styles and 'unsafe-eval' for dev; in prod we need 'unsafe-inline' for React inline styles
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://translate.google.com https://translate.googleapis.com",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://translate.googleapis.com",
+              "font-src 'self' https://fonts.gstatic.com",
+              // Images: self + all configured remote image sources + data URIs for base64 thumbnails
+              "img-src 'self' data: blob: https://images.sourcelibrary.org https://*.r2.dev https://*.public.blob.vercel-storage.com https://*.amazonaws.com https://iiif.archive.org https://archive.org https://gallica.bnf.fr https://api.digitale-sammlungen.de https://www.e-rara.ch https://digi.vatlib.it https://*.bodleian.ox.ac.uk https://cudl.lib.cam.ac.uk https://diglib.hab.de https://iiif.wellcomecollection.org https://upload.wikimedia.org https://*.loc.gov https://babel.hathitrust.org https://bl.digirati.io https://images.lib.cam.ac.uk https://www.e-codices.unifr.ch https://cdm21059.contentdm.oclc.org https://iiif.universiteitleiden.nl https://image.digitalcollections.manchester.ac.uk https://digi.ub.uni-heidelberg.de https://iiif.qdl.qa https://permalinkbnd.bnportugal.gov.pt https://cdli.earth https://images.uba.uva.nl https://imagenes.patrimonionacional.es https://images.eap.bl.uk",
+              "connect-src 'self' https://*.supabase.co https://generativelanguage.googleapis.com https://translate.googleapis.com wss://*.supabase.co",
+              "media-src 'self' blob:",
+              "frame-src 'self' https://translate.google.com",
+              "object-src 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+            ].join('; '),
+          },
+          {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },

--- a/src/app/api/books/[id]/clear-ocr/route.ts
+++ b/src/app/api/books/[id]/clear-ocr/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { withAuth } from '@/lib/auth-helpers';
+import { withAdminAuth } from '@/lib/auth-helpers';
 
 /**
  * Clear OCR/translation data from pages of a book.
@@ -13,7 +13,7 @@ import { withAuth } from '@/lib/auth-helpers';
  *   reason?: string  // For audit logging
  * }
  */
-export const POST = withAuth(async (request, session, context) => {
+export const POST = withAdminAuth(async (request, session, context) => {
   try {
     const { id: bookId } = await context.params;
     const body = await request.json();

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
+import { supabase, sanitizeFilterValue } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,7 +19,8 @@ export async function GET(req: NextRequest) {
 
   // Text search
   if (q.length >= 2) {
-    query = query.or(`title.ilike.%${q}%,author.ilike.%${q}%,shelf_mark.ilike.%${q}%`);
+    const safe = sanitizeFilterValue(q);
+    query = query.or(`title.ilike.%${safe}%,author.ilike.%${safe}%,shelf_mark.ilike.%${safe}%`);
   }
 
   // Keyword filter

--- a/src/app/api/census/search/route.ts
+++ b/src/app/api/census/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase';
+import { supabase, sanitizeFilterValue } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
 
@@ -69,7 +69,7 @@ async function fallbackSearch(query: string, limit: number) {
   const { data: enriched } = await supabase
     .from('ustc_enrichments')
     .select('id, std_title, english_title, original_author, detected_language, work_type')
-    .or(`std_title.ilike.%${query}%,english_title.ilike.%${query}%,original_author.ilike.%${query}%`)
+    .or(`std_title.ilike.%${sanitizeFilterValue(query)}%,english_title.ilike.%${sanitizeFilterValue(query)}%,original_author.ilike.%${sanitizeFilterValue(query)}%`)
     .limit(limit);
 
   if (!enriched || enriched.length === 0) {
@@ -88,7 +88,7 @@ async function fallbackSearch(query: string, limit: number) {
   const { data: catalogs } = await supabase
     .from('translation_catalogs')
     .select('author_surname, english_title, translator, pub_year, source, completeness')
-    .or(`author_surname.ilike.%${query}%,english_title.ilike.%${query}%`)
+    .or(`author_surname.ilike.%${sanitizeFilterValue(query)}%,english_title.ilike.%${sanitizeFilterValue(query)}%`)
     .limit(50);
 
   const catalogBySurname = new Map<string, any[]>();

--- a/src/app/api/dataset/v1/request-key/route.ts
+++ b/src/app/api/dataset/v1/request-key/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 
 /**
  * POST /api/dataset/v1/request-key — Public endpoint to request an API key
@@ -9,6 +10,11 @@ import { getDb } from '@/lib/mongodb';
  * Creates a pending request that an admin can approve.
  */
 export async function POST(request: NextRequest) {
+  const rl = checkRateLimit({ name: 'request-key', limit: 3, windowSeconds: 3600 }, getClientIp(request));
+  if (!rl.allowed) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } });
+  }
+
   const body = await request.json();
   const { name, email, organization, use_case, tier } = body;
 

--- a/src/app/api/highlights/route.ts
+++ b/src/app/api/highlights/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
+import { withAuth } from '@/lib/auth-helpers';
 
 export interface Highlight {
   id: string;
@@ -50,10 +51,11 @@ export async function GET(request: NextRequest) {
 }
 
 // POST /api/highlights - Create a new highlight
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request: NextRequest, session) => {
   try {
     const body = await request.json();
-    const { book_id, page_id, page_number, book_title, book_author, text, context, note, color, user_name } = body;
+    const { book_id, page_id, page_number, book_title, book_author, text, context, note, color } = body;
+    const user_name = session?.user?.name || session?.user?.email || undefined;
 
     if (!book_id || !page_id || !text) {
       return NextResponse.json(
@@ -122,4 +124,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -3,6 +3,7 @@ import { getNextApiKey } from '@/lib/gemini-client';
 import { getDb } from '@/lib/mongodb';
 import { supabase } from '@/lib/supabase';
 import { semanticArtworkSearch, type SemanticArtworkResult } from '@/lib/semantic-search';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 
 export const maxDuration = 30;
 export const dynamic = 'force-dynamic';
@@ -88,6 +89,11 @@ interface IdentifyResult {
 }
 
 export async function POST(request: NextRequest) {
+  const rl = checkRateLimit({ name: 'identify', limit: 10, windowSeconds: 3600 }, getClientIp(request));
+  if (!rl.allowed) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } });
+  }
+
   try {
     const formData = await request.formData();
     const file = formData.get('image') as File | null;

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { z } from 'zod';
 import { logAuditEvent } from '@/lib/audit-logger';
-import { withAuth } from '@/lib/auth-helpers';
+import { withAuth, withAdminAuth } from '@/lib/auth-helpers';
 import { createRevision } from '@/lib/page-revisions';
 import { contentHash } from '@/lib/steganographia';
 
@@ -177,7 +177,7 @@ export const PATCH = withAuth(async (request, session, context) => {
   }
 });
 
-export const DELETE = withAuth(async (request, session, context) => {
+export const DELETE = withAdminAuth(async (request, session, context) => {
   try {
     const { id } = await context.params;
     const db = await getDb();

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -5,6 +5,7 @@ import type { BookSearchFilters } from '@/lib/atlas-search';
 import type { SearchResult } from '@/lib/api-client/types/search';
 import { searchBooksCatalog } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticArtworkSearch } from '@/lib/semantic-search';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
 
 // CLIP server on Hetzner for visual text→image search
 const CLIP_URL = process.env.CLIP_URL || 'http://46.224.122.120:3456/clip';
@@ -55,6 +56,11 @@ interface CollectionResult {
  * Designed for typeahead — no page content search (that's the slow part).
  */
 export async function GET(request: NextRequest) {
+  const rl = checkRateLimit({ name: 'search', limit: 60, windowSeconds: 60 }, getClientIp(request));
+  if (!rl.allowed) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') || '';

--- a/src/app/fulldata/layout.tsx
+++ b/src/app/fulldata/layout.tsx
@@ -1,0 +1,10 @@
+import { requireAdmin } from '@/lib/auth-helpers';
+
+export default async function FullDataLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAdmin();
+  return <>{children}</>;
+}

--- a/src/app/scan/layout.tsx
+++ b/src/app/scan/layout.tsx
@@ -1,0 +1,10 @@
+import { requireAdmin } from '@/lib/auth-helpers';
+
+export default async function ScanLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAdmin();
+  return <>{children}</>;
+}

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -8,7 +8,7 @@
  * via the Hetzner supabase-sync cron.
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabase, sanitizeFilterValue } from '@/lib/supabase';
 
 export interface CatalogBook {
   id: string;
@@ -126,9 +126,9 @@ export async function browseBooks(opts: {
   if (opts.firstTranslation) query = query.eq('is_first_translation', true);
   if (opts.yearMin != null) query = query.gte('year', opts.yearMin);
   if (opts.yearMax != null) query = query.lte('year', opts.yearMax);
-  if (opts.titlePrefix) query = query.or(`display_title.ilike.${opts.titlePrefix}%,title.ilike.${opts.titlePrefix}%`);
-  if (opts.authorPrefix) query = query.ilike('author', `${opts.authorPrefix}%`);
-  if (opts.search) query = query.or(`title.ilike.%${opts.search}%,display_title.ilike.%${opts.search}%,author.ilike.%${opts.search}%`);
+  if (opts.titlePrefix) { const s = sanitizeFilterValue(opts.titlePrefix); query = query.or(`display_title.ilike.${s}%,title.ilike.${s}%`); }
+  if (opts.authorPrefix) query = query.ilike('author', `${sanitizeFilterValue(opts.authorPrefix)}%`);
+  if (opts.search) { const s = sanitizeFilterValue(opts.search); query = query.or(`title.ilike.%${s}%,display_title.ilike.%${s}%,author.ilike.%${s}%`); }
 
   query = applySort(query, opts.sort || 'popular');
   query = query.range(offset, offset + limit - 1);
@@ -322,9 +322,10 @@ export async function searchBooksCatalog(
   const limit = opts?.limit || 20;
 
   // Build OR filter — same logic as searchBookIds
+  const safe = sanitizeFilterValue(text);
   const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
-  const words = text.trim().split(/\s+/).filter(w => w.length >= 2);
-  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`;
+  const words = safe.trim().split(/\s+/).filter(w => w.length >= 2);
+  const phraseFilters = `title.ilike.%${safe}%,display_title.ilike.%${safe}%,author.ilike.%${safe}%`;
 
   let orFilter = phraseFilters;
   if (words.length >= 2) {
@@ -332,7 +333,7 @@ export async function searchBooksCatalog(
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');
     orFilter += `,and(${titleAnds}),and(${displayAnds})`;
   } else {
-    orFilter += `,language.ilike.%${text}%`;
+    orFilter += `,language.ilike.%${safe}%`;
   }
 
   let query = supabase
@@ -373,12 +374,13 @@ export async function searchBookIds(
 
   // Build OR filter: exact phrase match + word-level AND matches
   // "mathematical magick" should match "Mathematicall Magick" by matching each word
+  const safe = sanitizeFilterValue(text);
   const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
-  const words = text.trim().split(/\s+/).filter(w => w.length >= 2);
+  const words = safe.trim().split(/\s+/).filter(w => w.length >= 2);
   const contentWords = words.filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
   // Only ilike on indexed/short fields — summary_text and description cause
   // full-table scans and Supabase statement timeouts (no trigram indexes)
-  const phraseFilters = `title.ilike.%${text}%,display_title.ilike.%${text}%,author.ilike.%${text}%`;
+  const phraseFilters = `title.ilike.%${safe}%,display_title.ilike.%${safe}%,author.ilike.%${safe}%`;
 
   let orFilter = phraseFilters;
   if (words.length >= 2) {
@@ -392,7 +394,7 @@ export async function searchBookIds(
   } else {
     // Single word: also match against language (e.g. "Sanskrit", "Arabic")
     // This is fast since it's a single ilike on an indexed field
-    orFilter += `,language.ilike.%${text}%`;
+    orFilter += `,language.ilike.%${safe}%`;
   }
 
   let query = supabase

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,75 @@
+/**
+ * Simple in-memory rate limiter for Vercel serverless.
+ *
+ * Each serverless instance maintains its own counter map, so limits are
+ * per-instance rather than global. This is sufficient to catch abuse
+ * (bots hitting one instance repeatedly) without external infrastructure.
+ *
+ * Counters are pruned on access to prevent memory leaks.
+ */
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const limiters = new Map<string, Map<string, RateLimitEntry>>();
+
+interface RateLimitConfig {
+  /** Unique name for this limiter (e.g., "identify", "search") */
+  name: string;
+  /** Max requests per window */
+  limit: number;
+  /** Window size in seconds */
+  windowSeconds: number;
+}
+
+/**
+ * Check if a request is within rate limits.
+ * Returns { allowed: true } or { allowed: false, retryAfter: seconds }.
+ */
+export function checkRateLimit(
+  config: RateLimitConfig,
+  ip: string,
+): { allowed: true } | { allowed: false; retryAfter: number } {
+  if (!limiters.has(config.name)) {
+    limiters.set(config.name, new Map());
+  }
+  const store = limiters.get(config.name)!;
+
+  const now = Date.now();
+  const entry = store.get(ip);
+
+  // Prune stale entries periodically (every 100th call)
+  if (store.size > 1000 && Math.random() < 0.01) {
+    for (const [key, val] of store) {
+      if (val.resetAt < now) store.delete(key);
+    }
+  }
+
+  if (!entry || entry.resetAt < now) {
+    store.set(ip, { count: 1, resetAt: now + config.windowSeconds * 1000 });
+    return { allowed: true };
+  }
+
+  entry.count++;
+  if (entry.count > config.limit) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    return { allowed: false, retryAfter };
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Extract client IP from request headers.
+ * Vercel sets x-forwarded-for; Cloudflare sets cf-connecting-ip.
+ */
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown'
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -40,6 +40,19 @@ export const supabaseAdmin: SupabaseClient | null = SUPABASE_SERVICE_ROLE_KEY
   : null;
 
 /**
+ * Sanitize user input for interpolation into PostgREST filter strings (.or(), .ilike(), etc.).
+ * Strips characters that have special meaning in PostgREST filter syntax:
+ *   , — separates filter conditions
+ *   ( ) — logical grouping
+ *   . followed by operator keywords could be interpreted as new filters
+ *
+ * Without this, a search for `%,id.gt.0` could inject additional filter conditions.
+ */
+export function sanitizeFilterValue(value: string): string {
+  return value.replace(/[,()]/g, '');
+}
+
+/**
  * Helper: query USTC editions by Supabase auto-increment ID.
  * Note: `id` is the Supabase row ID, NOT the USTC serial number (`sn`).
  */
@@ -56,10 +69,11 @@ export async function getUstcEditionById(id: number) {
  * Helper: search USTC enrichments by English title (uses trigram index).
  */
 export async function searchUstcEnrichments(query: string, limit = 20) {
+  const safe = sanitizeFilterValue(query);
   const { data } = await supabase
     .from('ustc_enrichments')
     .select('id, english_title, std_title, original_author, detected_language')
-    .ilike('english_title', `%${query}%`)
+    .ilike('english_title', `%${safe}%`)
     .limit(limit);
   return data || [];
 }


### PR DESCRIPTION
## Summary

Fixes 5 security issues from the 2026-04-24 audit (epic #1367):

- **#1355 PostgREST injection**: Added `sanitizeFilterValue()` to strip `,()` from user input before interpolation into `.or()` filter strings. Applied to 7 injection points across `books-catalog.ts`, `bph/route.ts`, `census/search/route.ts`, and `supabase.ts`.

- **#1354 Unauthenticated writes**: Wrapped `POST /api/highlights` with `withAuth()` (was completely open). Upgraded `DELETE /api/pages/[id]` and `POST /api/books/[id]/clear-ocr` from `withAuth` to `withAdminAuth`.

- **#1360 Debug pages exposed**: Added `requireAdmin()` layouts to `/fulldata` and `/scan/*` pages.

- **#1357 Missing CSP**: Added `Content-Security-Policy` header with allowlisted sources for scripts, styles, fonts, images, and connect targets.

- **#1356 Rate limiting**: Added in-memory rate limiter (`src/lib/rate-limit.ts`) to `/api/identify` (10/hr), `/api/search/unified` (60/min), `/api/dataset/v1/request-key` (3/hr).

## Test plan

- [ ] Search still works (PostgREST sanitizer doesn't break normal queries)
- [ ] `/fulldata` and `/scan/auto` redirect to login when not admin
- [ ] CSP doesn't block fonts, images, or Supabase connections
- [ ] Rate limiter returns 429 after threshold (test with rapid curl)

Closes #1354, closes #1355, closes #1356, closes #1357, closes #1360

🤖 Generated with [Claude Code](https://claude.com/claude-code)