### PR TITLE
Search-driven collection curation (#1372)

### DIFF
--- a/.claude/skills/curate-collection/skill.md
+++ b/.claude/skills/curate-collection/skill.md
@@ -187,20 +187,50 @@ const images = await db.collection('gallery_images').find(
 ).sort({ gallery_quality: -1 }).limit(50).toArray();
 ```
 
-### Step 3: Pull Real Quotes
+### Step 3: Search-Driven Discovery (MCP Tools)
 
-For the 5-10 most important books, fetch actual translated passages:
+**This is the key step.** Before writing editorial content, use the Source Library MCP search tools to discover what the collection's books actually contain. This surfaces content that no curator could find by scanning titles alone.
 
-```bash
-curl -s "https://sourcelibrary.org/api/books/BOOK_ID/quote?page=N"
+**3a. Search translations for thematic passages:**
+Run 3-5 `search_translations` queries using the collection's core themes. For example, for "Courts of Wonder":
+- `search_translations("automaton mechanical marvel")`
+- `search_translations("cabinet curiosity collection wonder")`
+- `search_translations("grotto garden artificial")`
+
+Look for: vivid first-person descriptions, surprising connections between books, passages that capture the spirit of the collection. Save the best 8-10 passages with book_id and page_number.
+
+**3b. Search images for visual themes:**
+Run 2-3 `search_images` queries for visual subjects:
+- `search_images(query="automaton mechanical", type="engraving")`
+- `search_images(subject="dragon monster")`
+
+Group results into 3-5 thematic clusters (e.g., "Mechanical Marvels", "Natural Wonders", "Court Spectacles"). Each cluster needs a theme name, short description, and 4-8 images.
+
+**3c. Discover overlooked books:**
+Search results will surface books the metadata scan missed. Note any book that:
+- Has compelling passages but wasn't in the highlighted_books shortlist
+- Connects to the collection's theme in unexpected ways
+- Has striking images that would enhance the visual gallery
+
+**3d. Pull verified quotes:**
+For the best 5-8 passages found above, verify each with `get_quote(book_id, page_number)` to get exact text and citation URL. Also fetch the original language text (use `get_book_text` with `content: "both"` and the same page range).
+
+Structure each verified quote as:
+```json
+{
+  "text": "English translation of the passage",
+  "original_text": "Original language text (Latin, German, etc.)",
+  "original_language": "Latin",
+  "author": "Author Name",
+  "book_id": "the-book-id",
+  "book_title": "Short Book Title",
+  "page_number": 42,
+  "year": 1617,
+  "verified": true
+}
 ```
 
-Try multiple pages to find compelling passages. Good pages to try:
-- Title page (page 1-3)
-- First page of main text (varies, often page 5-15)
-- Pages with illustrations or diagrams
-
-Save quote text + citation URLs for use in the description.
+**IMPORTANT:** Never fabricate quotes. Every quote must come from `get_quote` with a real page number. If search_translations returns a snippet, always verify it with get_quote before including it.
 
 ### Step 4: Write the Expanded Description
 
@@ -354,7 +384,104 @@ const resp = await fetch('https://sourcelibrary.org/api/collections', {
 });
 ```
 
-### Step 10: Verify
+### Step 10: Generate Exhibition Layout (curation_drafts)
+
+After building collection metadata, generate a rich exhibition layout and save it to `curation_drafts`. This drives the ExhibitionLayout component on the collection page.
+
+```javascript
+const exhibition = {
+  collection_slug: 'SLUG',
+  status: 'draft',
+  created_at: new Date(),
+  updated_at: new Date(),
+  curation: {
+    layout: [
+      // Opening hook — one compelling sentence
+      { component: 'hook', text: 'A single sentence that captures the essence of the collection.' },
+
+      // Stats bar
+      { component: 'stats', items: [
+        { label: 'Books', value: '663' },
+        { label: 'Languages', value: '8' },
+        { label: 'Centuries', value: '15th–18th' },
+      ]},
+
+      // Editorial description
+      { component: 'description', paragraphs: ['Paragraph 1...', 'Paragraph 2...'] },
+
+      // Voices from the Collection — search-discovered quotes with original language
+      { component: 'quotes', title: 'Voices from the Collection', quotes: [
+        {
+          text: 'English translation',
+          original_text: 'Original language text',
+          original_language: 'Latin',
+          author: 'Author Name',
+          book_id: 'book-id',
+          book_title: 'Short Title',
+          page_number: 42,
+          year: 1617,
+          verified: true,
+        },
+        // ... 3-5 total quotes
+      ]},
+
+      // Thematic image gallery — clustered by subject
+      { component: 'thematic_gallery', clusters: [
+        {
+          theme: 'Mechanical Marvels',
+          description: 'Automata and hydraulic devices from Kircher, Schott, and Hero of Alexandria.',
+          images: [
+            // gallery_image documents with id, book_id, thumbnail_url, museum_description
+          ],
+        },
+        // ... 3-5 clusters
+      ]},
+
+      // Key sections — thematic groupings of books
+      { component: 'sections', sections: [
+        { title: 'Section Name', subtitle: 'Brief description', books: [{ id: 'book-id', note: 'Why this book matters' }] },
+      ]},
+
+      // Reading paths — named journeys through the collection
+      { component: 'reading_paths', paths: [
+        {
+          audience: "The Engineer's Path",
+          description: 'From ancient pneumatics to Baroque mechanism',
+          steps: [
+            { book_id: 'hero-pneumatica-id', instruction: 'Start here — the engineering manual behind courtly automata' },
+            // ... 4-6 steps
+          ],
+        },
+      ]},
+
+      // Timeline
+      { component: 'timeline', start_year: 1450, end_year: 1700, highlights: [
+        { year: 1550, label: 'Event description', book_id: 'optional-book-id' },
+      ]},
+
+      // Cross-collection links
+      { component: 'cross_collections', links: [
+        { slug: 'alchemy', why: 'Many court cabinets included alchemical instruments' },
+      ]},
+    ],
+  },
+};
+
+// Upsert into curation_drafts
+await db.collection('curation_drafts').updateOne(
+  { collection_slug: 'SLUG' },
+  { $set: exhibition },
+  { upsert: true }
+);
+```
+
+**Key rules for exhibition layout:**
+- Quotes MUST be verified via `get_quote` — never fabricate
+- Thematic gallery images must have real `id` and `thumbnail_url` from `gallery_images` collection
+- Reading path book_ids must exist and be visible
+- All book references are resolved at render time — only include the ID
+
+### Step 11: Verify
 
 After pushing, fetch the collection page and verify:
 ```bash
@@ -373,7 +500,18 @@ print('Books returned:', len(d.get('books', [])))
 "
 ```
 
-Report the live URL: `https://sourcelibrary.org/collection/SLUG`
+Also check the exhibition draft:
+```bash
+curl -s "https://sourcelibrary.org/api/collections/SLUG" | python3 -c "
+import sys, json; d = json.load(sys.stdin)
+e = d.get('exhibition', {})
+layout = e.get('layout', [])
+print('Exhibition blocks:', len(layout))
+for b in layout: print(f'  {b[\"component\"]}')
+"
+```
+
+Report the live URL: `https://sourcelibrary.org/collections/SLUG`
 
 ---
 

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -461,6 +461,11 @@ async function fetchCollectionData(id: string, provider?: string) {
           if (h.book_id) allBookIds.add(h.book_id);
         }
       }
+      if (block.component === 'quotes') {
+        for (const q of block.quotes || []) {
+          if (q.book_id) allBookIds.add(q.book_id);
+        }
+      }
     }
     if (allBookIds.size > 0) {
       const exBooks = await withTimeout(

--- a/src/components/collections/ExhibitionLayout.tsx
+++ b/src/components/collections/ExhibitionLayout.tsx
@@ -287,49 +287,73 @@ function KeyFiguresBlock({ figures, books }: {
 
 // ─── Component: Quotes ──────────────────────────────────────────
 
-function QuotesBlock({ quotes, books }: {
+function QuotesBlock({ quotes, books, title }: {
   quotes: {
     text: string;
+    original_text?: string;
+    original_language?: string;
     author?: string;
     book_title?: string;
     book_id?: string;
     page_number?: number;
+    year?: number;
     verified?: boolean;
   }[];
   books: BookRef[];
+  title?: string;
 }) {
   return (
-    <div className="space-y-6">
-      {quotes.filter(q => q.verified !== false).map((q, i) => {
-        const book = q.book_id ? findBook(books, q.book_id) : undefined;
-        return (
-          <blockquote
-            key={i}
-            className="relative pl-6 border-l-2 border-accent-gold/40 py-2"
-          >
-            <Quote className="absolute -left-3 -top-1 w-5 h-5 text-accent-gold/30 bg-cream" />
-            <p className="text-lg sm:text-xl font-display text-primary/80 leading-relaxed italic">
-              &ldquo;{q.text}&rdquo;
-            </p>
-            <footer className="mt-2 text-sm text-muted">
-              — <AuthorName author={q.author} />
-              {book ? (
-                <Link
-                  href={q.page_number
-                    ? `${bookUrl({ id: book.id, slug: book.slug })}?page=${q.page_number}`
-                    : bookUrl({ id: book.id, slug: book.slug })}
-                  className="text-accent-rust hover:underline ml-1"
-                >
-                  {q.book_title || bookTitle(book)}
-                  {q.page_number ? `, p. ${q.page_number}` : ''}
-                </Link>
-              ) : (
-                q.book_title ? `, ${q.book_title}` : ''
+    <div>
+      {title && (
+        <h3 className="text-xl sm:text-2xl font-display text-primary mb-6 flex items-center gap-2">
+          <Quote className="w-5 h-5 text-accent-gold/40" />
+          {title}
+        </h3>
+      )}
+      <div className="space-y-8">
+        {quotes.filter(q => q.verified !== false).map((q, i) => {
+          const book = q.book_id ? findBook(books, q.book_id) : undefined;
+          const bookHref = book
+            ? (q.page_number
+                ? `${bookUrl({ id: book.id, slug: book.slug })}?page=${q.page_number}`
+                : bookUrl({ id: book.id, slug: book.slug }))
+            : undefined;
+          return (
+            <blockquote
+              key={i}
+              className="relative pl-6 border-l-2 border-accent-gold/40 py-2"
+            >
+              <Quote className="absolute -left-3 -top-1 w-5 h-5 text-accent-gold/30 bg-cream" />
+              <p className="text-lg sm:text-xl font-display text-primary/80 leading-relaxed italic">
+                &ldquo;{q.text}&rdquo;
+              </p>
+              {q.original_text && (
+                <p className="mt-2 text-sm text-secondary/60 italic leading-relaxed">
+                  <span className="text-[10px] uppercase tracking-wider text-muted/50 not-italic mr-1.5">
+                    {q.original_language || 'original'}
+                  </span>
+                  &ldquo;{q.original_text}&rdquo;
+                </p>
               )}
-            </footer>
-          </blockquote>
-        );
-      })}
+              <footer className="mt-3 text-sm text-muted">
+                — <AuthorName author={q.author} />
+                {q.year && <span className="text-muted/60"> ({q.year})</span>}
+                {bookHref ? (
+                  <Link
+                    href={bookHref}
+                    className="text-accent-rust hover:underline ml-1"
+                  >
+                    {q.book_title || (book ? bookTitle(book) : '')}
+                    {q.page_number ? `, p. ${q.page_number}` : ''}
+                  </Link>
+                ) : (
+                  q.book_title ? `, ${q.book_title}` : ''
+                )}
+              </footer>
+            </blockquote>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -507,6 +531,60 @@ function CrossCollectionsBlock({ links }: {
   );
 }
 
+// ─── Component: Thematic Gallery ────────────────────────────────
+
+function ThematicGalleryBlock({ clusters, books }: {
+  clusters: {
+    theme: string;
+    description?: string;
+    images: GalleryImage[];
+  }[];
+  books: BookRef[];
+}) {
+  if (clusters.length === 0) return null;
+  return (
+    <div className="space-y-8">
+      {clusters.map((cluster, ci) => (
+        <div key={ci}>
+          <h3 className="text-lg sm:text-xl font-display text-primary mb-1">
+            {cluster.theme}
+          </h3>
+          {cluster.description && (
+            <p className="text-sm text-muted mb-3">{linkBookNames(cluster.description, books)}</p>
+          )}
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {cluster.images.map((img) => {
+              const src = imageUrl(img);
+              if (!src) return null;
+              return (
+                <Link
+                  key={img.id}
+                  href={imagePageHref(img)}
+                  className="group relative aspect-square rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 transition-all hover:shadow-md"
+                  title={img.museum_description}
+                >
+                  <Image
+                    src={src}
+                    alt={img.museum_description || img.book_title || 'Illustration'}
+                    fill
+                    className="object-cover group-hover:scale-105 transition-transform duration-300"
+                    sizes="(min-width: 1024px) 200px, (min-width: 640px) 160px, 50vw"
+                  />
+                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent p-2 pt-6 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <p className="text-[11px] text-white/90 line-clamp-2 leading-tight">
+                      {img.museum_description || img.book_title}
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // ─── Component: Gallery Grid ────────────────────────────────────
 
 function GalleryGridBlock({ embeddedImages, fallbackImages, indices, title }: {
@@ -581,7 +659,7 @@ export default function ExhibitionLayout({ layout, books, images, collectionSlug
             return <KeyFiguresBlock key={i} figures={block.figures} books={books} />;
 
           case 'quotes':
-            return <QuotesBlock key={i} quotes={block.quotes} books={books} />;
+            return <QuotesBlock key={i} quotes={block.quotes} books={books} title={block.title} />;
 
           case 'timeline':
             return <TimelineBlock key={i} start_year={block.start_year} end_year={block.end_year} highlights={block.highlights} books={books} />;
@@ -598,6 +676,9 @@ export default function ExhibitionLayout({ layout, books, images, collectionSlug
 
           case 'gallery_grid':
             return <GalleryGridBlock key={i} embeddedImages={block.images} fallbackImages={images} indices={block.image_indices} title={block.title || 'Illustrations from the Collection'} />;
+
+          case 'thematic_gallery':
+            return <ThematicGalleryBlock key={i} clusters={block.clusters || []} books={books} />;
 
           case 'cross_collections':
             return <CrossCollectionsBlock key={i} links={block.links} />;


### PR DESCRIPTION
## Summary
- Enhanced `QuotesBlock` with original language text, year, and "Voices from the Collection" title — primary sources speak in their own words alongside translations
- New `ThematicGalleryBlock` component for image galleries clustered by theme (e.g., "Machines of Wonder", "Cosmic Creatures") instead of flat grids
- Updated `curate-collection` skill with MCP search-driven discovery workflow (Step 3: search translations + images before writing editorial content)
- Populated Courts of Wonder exhibition with search-discovered quotes from Palissy, Hero of Alexandria, and de Caus

## Test plan
- [ ] Visit https://sourcelibrary.org/collections/courts-of-wonder on preview deploy
- [ ] Verify "Voices from the Collection" quotes render with original French/Italian text
- [ ] Verify thematic gallery clusters render with themed headers and descriptions
- [ ] Verify reading paths link to correct books
- [ ] Check that existing exhibition layouts on other collections still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)