### PR TITLE
Fix RSC cache poisoning on CF Free plan

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -111,48 +111,69 @@ const nextConfig: NextConfig = {
           { key: 'Vary', value: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch' },
         ],
       },
+      // Prevent Cloudflare from caching RSC (React Server Component) responses.
+      // CF Free ignores Vary: RSC, so an RSC payload can poison the cache and
+      // get served to browsers as raw flight data instead of HTML.
+      // This rule sets CDN-Cache-Control: no-store for any request with the RSC header.
+      {
+        source: '/:path*',
+        has: [{ type: 'header', key: 'rsc' }],
+        headers: [{ key: 'CDN-Cache-Control', value: 'no-store' }],
+      },
       // CDN-Cache-Control for Cloudflare edge caching.
       // Cloudflare strips this header before sending to browsers —
       // it only controls Cloudflare's edge cache behavior.
       // Admin/auth/API routes are excluded by Cloudflare Cache Rules (bypass).
+      // The `missing` condition ensures these only apply to non-RSC requests
+      // (RSC requests are handled by the no-store rule above).
       {
         source: '/book/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/collections/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/author/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/browse/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/encyclopedia/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/gallery/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/explore/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/libraries/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/languages/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       {
         source: '/artwork/:path*',
+        missing: [{ type: 'header', key: 'rsc' }],
         headers: [{ key: 'CDN-Cache-Control', value: 'public, max-age=86400, stale-while-revalidate=3600' }],
       },
       // Prevent Cloudflare from caching admin/auth routes

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -292,15 +292,9 @@ export function proxy(request: NextRequest) {
     },
   });
 
-  // Prevent Cloudflare from caching RSC flight data as HTML.
-  // CF Free plan ignores the Vary header (except Accept-Encoding), so RSC
-  // responses (text/x-component) get cached and served to browsers expecting
-  // HTML, showing raw React flight data instead of the page.
-  // CDN-Cache-Control is respected by CF but stripped before reaching the browser.
-  const isRsc = request.headers.get('rsc') === '1';
-  if (isRsc) {
-    response.headers.set('CDN-Cache-Control', 'no-store');
-  }
+  // RSC cache poisoning is handled in next.config.ts headers() via
+  // has/missing conditions on the 'rsc' header. Middleware can't reliably
+  // override CDN-Cache-Control because Next.js ISR sets it after middleware.
 
   return response;
 }


### PR DESCRIPTION
## Summary
- CF Free ignores `Vary: RSC`, causing RSC flight data to poison the cache and get served as HTML to all visitors (shows raw `$react.fragment` text instead of the page)
- Previous middleware fix (`CDN-Cache-Control: no-store` in proxy.ts) didn't work — Next.js ISR overrides middleware-set headers
- Fix: use `next.config.ts` `headers()` with `has`/`missing` conditions on the `rsc` request header. RSC requests get `CDN-Cache-Control: no-store`, non-RSC get the normal 24h edge TTL
- Also purged the currently-broken URL (`/book/check-only-1772468644n-check`)

## Test plan
- [ ] After deploy, purge CF cache for a test book, send RSC request first, verify normal request still returns HTML
- [ ] Verify `CDN-Cache-Control: no-store` appears on RSC responses
- [ ] Verify `CDN-Cache-Control: public, max-age=86400` still appears on normal HTML responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)