### PR TITLE
Artwork pages: link back to source books

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -395,10 +395,28 @@ async function BookInfo({ id }: { id: string }) {
 
   // Visual art gets a dedicated layout — no OCR, no pages grid, no translation stats
   if (isVisualArt) {
+    // Find related books by this artist (when source_book isn't already set)
+    let relatedBooksByAuthor: Array<{ id: string; slug: string; title: string; thumbnail?: string; thumbnail_blob?: string }> = [];
+    const hasSourceBook = !!(book as any).source_book;
+    const authorName = book.author?.trim();
+    const isKnownAuthor = authorName && !/^unknown/i.test(authorName) && !/^unidentified/i.test(authorName) && !/^anonymous/i.test(authorName);
+    if (!hasSourceBook && isKnownAuthor) {
+      relatedBooksByAuthor = await db.collection('books')
+        .find(
+          { author: authorName, content_type: { $ne: 'artwork' }, pages_count: { $gt: 0 } },
+          { projection: { id: 1, slug: 1, title: 1, thumbnail: 1, thumbnail_blob: 1 }, maxTimeMS: 3000 },
+        )
+        .limit(6)
+        .toArray()
+        .then(docs => JSON.parse(JSON.stringify(docs)))
+        .catch(() => []);
+    }
+
     return (
       <ArtworkInfo
         book={book}
         collections={bookCollections}
+        relatedBooks={relatedBooksByAuthor}
       />
     );
   }

--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -51,14 +51,23 @@ interface ArtworkNavItem {
   title: string;
 }
 
+interface RelatedBookPreview {
+  id: string;
+  slug: string;
+  title: string;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+}
+
 interface ArtworkInfoProps {
   book: Book;
   collections: Array<{ slug: string; name: string; subtitle?: string; color?: string }>;
   prevWork?: ArtworkNavItem | null;
   nextWork?: ArtworkNavItem | null;
+  relatedBooks?: RelatedBookPreview[];
 }
 
-export default function ArtworkInfo({ book, collections, prevWork, nextWork }: ArtworkInfoProps) {
+export default function ArtworkInfo({ book, collections, prevWork, nextWork, relatedBooks = [] }: ArtworkInfoProps) {
   const displayImage = (book as any).thumbnail_blob || book.thumbnail || '';
   const thumbImage = book.thumbnail || '';
   const commonsUrl = (book as any).commons_url || '';
@@ -321,6 +330,39 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork }: A
               </p>
             </div>
           </Link>
+        )}
+
+        {/* Related books by this artist */}
+        {!sourceBook && relatedBooks.length > 0 && (
+          <div className="card p-6 sm:p-8">
+            <h2 className="text-lg font-display font-semibold mb-4 flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+              <BookOpen className="w-5 h-5" style={{ color: 'var(--accent-rust)' }} />
+              Books by {book.author}
+            </h2>
+            <div className="space-y-2">
+              {relatedBooks.map(rb => (
+                <Link
+                  key={rb.id}
+                  href={`/book/${rb.slug || rb.id}`}
+                  className="flex items-center gap-3 p-2 -mx-2 rounded-lg hover:bg-stone-50 transition-colors group"
+                >
+                  {(rb.thumbnail_blob || rb.thumbnail) && (
+                    <div className="w-10 h-14 rounded overflow-hidden bg-stone-100 flex-shrink-0">
+                      <img src={rb.thumbnail_blob || rb.thumbnail} alt="" className="w-full h-full object-cover" />
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium group-hover:text-accent-rust transition-colors truncate" style={{ color: 'var(--text-primary)' }}>
+                      {rb.title}
+                    </p>
+                    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                      Read with translation →
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
         )}
 
         {/* Collections */}


### PR DESCRIPTION
## Summary
- When an artwork has a `source_book` field, shows a "From this manuscript" card linking to the parent book
- When no explicit `source_book` but the artist has books in the library, shows a "Books by [author]" section with thumbnails
- Data fix: linked the Vesalius uterus illustration to its source book (De Humani Corporis Fabrica 1543)

Addresses feedback: "Things like this should link to page of book" (from `/book/vesalius-de-humani-1543-illustration-of-a-uterus`)

## Test plan
- [ ] Visit https://sourcelibrary.org/book/vesalius-de-humani-1543-illustration-of-a-uterus — should show "From this manuscript" card linking to the 1543 edition
- [ ] Visit an artwork by an author who also has books (e.g. a Da Vinci artwork) — should show "Books by Leonardo da Vinci" section
- [ ] Visit an artwork by "Unknown artist" — should NOT show the related books section

🤖 Generated with [Claude Code](https://claude.com/claude-code)