### PR TITLE
Scholar catalog v2: site branding + full-text search

### DIFF
--- a/src/app/catalog/scholar/page.tsx
+++ b/src/app/catalog/scholar/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
-import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
+import SiteHeader from '@/components/layout/SiteHeader';
 import ScholarCatalog from '@/components/catalog/ScholarCatalog';
+import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
 
 export const revalidate = 86400;
 export const maxDuration = 30;
@@ -24,10 +25,22 @@ export default async function ScholarCatalogPage() {
   ]);
 
   return (
-    <ScholarCatalog
-      initialBooks={browseResult.books}
-      initialTotal={browseResult.total}
-      languages={languages}
-    />
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-7xl mx-auto px-6 md:px-12 py-12 md:py-20">
+        <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+          Catalog
+        </h1>
+        <p className="text-lg mb-10" style={{ color: 'var(--text-muted)' }}>
+          {browseResult.total.toLocaleString()} works. Bibliographic records with permalinks, OCR status, and translation coverage.
+        </p>
+
+        <ScholarCatalog
+          initialBooks={browseResult.books}
+          initialTotal={browseResult.total}
+          languages={languages}
+        />
+      </div>
+    </>
   );
 }

--- a/src/components/catalog/ScholarCatalog.tsx
+++ b/src/components/catalog/ScholarCatalog.tsx
@@ -3,11 +3,12 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import {
-  Search, X, Download, Copy, Check, ChevronLeft, ChevronRight,
-  BookOpen, ArrowUpDown, ArrowUp, ArrowDown,
+  Search, X, Download, Copy, Check,
+  ArrowUpDown, ArrowUp, ArrowDown, FileText,
 } from 'lucide-react';
 import AuthorName from '@/components/AuthorName';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import CatalogPagination from '@/components/collections/CatalogPagination';
 
 const PER_PAGE = 60;
 const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
@@ -30,8 +31,18 @@ interface BookItem {
   is_first_translation?: boolean;
   ft_disposition?: string;
   image_source_provider?: string | null;
-  categories?: string[];
-  collections?: string[];
+}
+
+interface ContentMatch {
+  book_id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  language: string;
+  page_number?: number;
+  snippet?: string;
+  snippet_type?: string;
 }
 
 interface ScholarCatalogProps {
@@ -45,13 +56,11 @@ function SortIcon({ column, currentSort }: { column: string; currentSort: string
     title: ['title'],
     author: ['author'],
     year: ['year_asc', 'year_desc'],
-    language: ['language'],
-    pages: ['pages'],
   };
   const isActive = mapping[column]?.includes(currentSort);
-  if (!isActive) return <ArrowUpDown className="w-3 h-3 opacity-30" />;
-  if (currentSort === 'year_desc') return <ArrowDown className="w-3 h-3" />;
-  return <ArrowUp className="w-3 h-3" />;
+  if (!isActive) return <ArrowUpDown className="w-3 h-3 text-muted/50" />;
+  if (currentSort === 'year_desc') return <ArrowDown className="w-3 h-3 text-accent-rust" />;
+  return <ArrowUp className="w-3 h-3 text-accent-rust" />;
 }
 
 function translationPercent(book: BookItem): number {
@@ -74,8 +83,7 @@ function CopyPermalink({ slug, id }: { slug?: string | null; id: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="inline-flex items-center gap-1 text-xs opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
-      style={{ color: 'var(--text-muted)' }}
+      className="inline-flex items-center gap-1 text-xs text-muted opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
       title={`Copy permalink: ${url}`}
     >
       {copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
@@ -93,10 +101,17 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
   const [query, setQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [titlePrefix, setTitlePrefix] = useState('');
+
+  // Full-text search state
+  const [contentMatches, setContentMatches] = useState<ContentMatch[]>([]);
+  const [contentTotal, setContentTotal] = useState(0);
+  const [contentLoading, setContentLoading] = useState(false);
+
   const searchRef = useRef<HTMLInputElement>(null);
   const initializedRef = useRef(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const contentAbortRef = useRef<AbortController | null>(null);
 
   const totalPages = Math.ceil(total / PER_PAGE);
 
@@ -124,7 +139,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
     setLoading(true);
     try {
       const qs = new URLSearchParams();
-      qs.set('sort', params.sort);
+      if (params.sort !== 'popular') qs.set('sort', params.sort);
       if (params.language) qs.set('language', params.language);
       if (params.query) qs.set('q', params.query);
       if (params.page > 1) qs.set('page', String(params.page));
@@ -137,6 +152,33 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
       if ((err as Error).name === 'AbortError') return;
     } finally {
       if (!controller.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  // Full-text content search (parallel to catalog search)
+  const fetchContentMatches = useCallback(async (q: string, lang: string) => {
+    if (contentAbortRef.current) contentAbortRef.current.abort();
+    if (!q || q.length < 3) {
+      setContentMatches([]);
+      setContentTotal(0);
+      return;
+    }
+    const controller = new AbortController();
+    contentAbortRef.current = controller;
+    setContentLoading(true);
+    try {
+      const qs = new URLSearchParams({ q, limit: '10', search_content: '1' });
+      if (lang) qs.set('language', lang);
+      const res = await fetch(`/api/search?${qs.toString()}`, { signal: controller.signal });
+      if (!res.ok) throw new Error('search failed');
+      const data = await res.json();
+      const pageResults = (data.results || []).filter((r: any) => r.type === 'page');
+      setContentMatches(pageResults);
+      setContentTotal(data.total || 0);
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+    } finally {
+      if (!controller.signal.aborted) setContentLoading(false);
     }
   }, []);
 
@@ -156,8 +198,9 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
     const isDefault = urlSort === 'title' && !urlLang && !urlQ && urlPage === 1;
     if (!isDefault) {
       fetchBooks({ sort: urlSort, language: urlLang, query: urlQ, page: urlPage });
+      if (urlQ && urlQ.length >= 3) fetchContentMatches(urlQ, urlLang);
     }
-  }, [fetchBooks]);
+  }, [fetchBooks, fetchContentMatches]);
 
   const updateUrl = useCallback((s: string, lang: string, page: number, q: string) => {
     const params = new URLSearchParams();
@@ -177,13 +220,9 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
   }, [language, query, updateUrl, fetchBooks]);
 
   const handleColumnSort = (column: string) => {
-    if (column === 'year') {
-      handleSort(sort === 'year_asc' ? 'year_desc' : 'year_asc');
-    } else if (column === 'title') {
-      handleSort('title');
-    } else if (column === 'author') {
-      handleSort('author');
-    }
+    if (column === 'year') handleSort(sort === 'year_asc' ? 'year_desc' : 'year_asc');
+    else if (column === 'title') handleSort('title');
+    else if (column === 'author') handleSort('author');
   };
 
   const handleLanguage = useCallback((newLang: string) => {
@@ -192,7 +231,8 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
     setTitlePrefix('');
     updateUrl(sort, newLang, 1, query);
     fetchBooks({ sort, language: newLang, query, page: 1 });
-  }, [sort, query, updateUrl, fetchBooks]);
+    if (query.length >= 3) fetchContentMatches(query, newLang);
+  }, [sort, query, updateUrl, fetchBooks, fetchContentMatches]);
 
   const handleSearch = useCallback((value: string) => {
     setQuery(value);
@@ -202,15 +242,18 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
     debounceRef.current = setTimeout(() => {
       updateUrl(sort, language, 1, value);
       fetchBooks({ sort, language, query: value, page: 1 });
+      fetchContentMatches(value, language);
     }, 300);
-  }, [sort, language, updateUrl, fetchBooks]);
+  }, [sort, language, updateUrl, fetchBooks, fetchContentMatches]);
 
   const handleLetterFilter = useCallback((letter: string) => {
     const newPrefix = titlePrefix === letter ? '' : letter;
     setTitlePrefix(newPrefix);
     setCurrentPage(1);
-    const q = newPrefix ? `${newPrefix}` : '';
+    const q = newPrefix || '';
     setQuery(q);
+    setContentMatches([]);
+    setContentTotal(0);
     updateUrl(sort, language, 1, q);
     fetchBooks({ sort, language, query: q, page: 1 });
   }, [titlePrefix, sort, language, updateUrl, fetchBooks]);
@@ -222,88 +265,64 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [sort, language, query, updateUrl, fetchBooks]);
 
+  const clearSearch = useCallback(() => {
+    setQuery('');
+    setTitlePrefix('');
+    setCurrentPage(1);
+    setContentMatches([]);
+    setContentTotal(0);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    updateUrl(sort, language, 1, '');
+    fetchBooks({ sort, language, query: '', page: 1 });
+    searchRef.current?.focus();
+  }, [sort, language, updateUrl, fetchBooks]);
+
   const csvUrl = `/api/catalog/csv${language ? `?language=${encodeURIComponent(language)}` : ''}`;
 
   return (
-    <div className="min-h-screen" style={{ background: '#fff' }}>
-      {/* Minimal header */}
-      <header className="border-b" style={{ borderColor: '#e5e5e5' }}>
-        <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
-              <BookOpen className="w-5 h-5" style={{ color: '#8B4513' }} />
-              <span className="text-lg font-semibold tracking-tight" style={{ color: '#1a1a1a' }}>
-                Source Library
-              </span>
-            </Link>
-            <span style={{ color: '#ccc' }}>/</span>
-            <span className="text-sm" style={{ color: '#666' }}>Scholar Catalog</span>
-          </div>
-          <nav className="hidden sm:flex items-center gap-6 text-sm" style={{ color: '#666' }}>
-            <Link href="/catalog" className="hover:underline">Standard view</Link>
-            <Link href="/browse" className="hover:underline">Browse indexes</Link>
-            <Link href="/search" className="hover:underline">Full-text search</Link>
-          </nav>
-        </div>
-      </header>
-
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        {/* Title area */}
-        <div className="mb-6">
-          <h1 className="text-2xl font-semibold tracking-tight mb-1" style={{ color: '#1a1a1a' }}>
-            Catalog
-          </h1>
-          <p className="text-sm" style={{ color: '#888' }}>
-            {total.toLocaleString()} works.{' '}
-            Bibliographic records with permalinks, OCR status, and translation coverage.
+    <div>
+      {/* Controls */}
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
+        <div className="flex items-center gap-3">
+          <p className="text-sm text-muted">
+            {query || language
+              ? `${total.toLocaleString()} of ${initialTotal.toLocaleString()} books`
+              : `${total.toLocaleString()} books`}
           </p>
+          <a
+            href={csvUrl}
+            className="inline-flex items-center gap-1.5 text-xs text-muted hover:text-accent-rust transition-colors"
+            title="Download catalog as CSV"
+          >
+            <Download className="w-3.5 h-3.5" />
+            CSV
+          </a>
+          <Link href="/catalog" className="text-xs text-muted hover:text-accent-rust transition-colors">
+            Grid view
+          </Link>
         </div>
 
-        {/* Controls row */}
-        <div className="flex flex-wrap items-center gap-3 mb-4 pb-4 border-b" style={{ borderColor: '#e5e5e5' }}>
-          {/* Search */}
-          <div className="relative flex-1 min-w-[200px] max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: '#999' }} />
-            <input
-              ref={searchRef}
-              type="text"
-              value={query}
-              onChange={e => handleSearch(e.target.value)}
-              placeholder="Search by title or author...  (press /)"
-              className="w-full text-sm border rounded-md pl-9 pr-8 py-2 focus:outline-none focus:ring-1"
-              style={{
-                borderColor: '#ddd',
-                color: '#1a1a1a',
-                background: '#fafafa',
-              }}
-              onFocus={e => (e.target.style.borderColor = '#8B4513')}
-              onBlur={e => (e.target.style.borderColor = '#ddd')}
-            />
-            {query && (
-              <button
-                onClick={() => {
-                  setQuery('');
-                  setTitlePrefix('');
-                  setCurrentPage(1);
-                  if (debounceRef.current) clearTimeout(debounceRef.current);
-                  updateUrl(sort, language, 1, '');
-                  fetchBooks({ sort, language, query: '', page: 1 });
-                  searchRef.current?.focus();
-                }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer"
-                style={{ color: '#999' }}
-              >
-                <X className="w-4 h-4" />
-              </button>
-            )}
-          </div>
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Sort */}
+          <select
+            value={sort}
+            onChange={e => handleSort(e.target.value)}
+            className="text-sm border border-border-light rounded-lg px-3 py-1.5 bg-white text-secondary focus:outline-none focus:border-accent-rust cursor-pointer"
+          >
+            <option value="title">Title A-Z</option>
+            <option value="author">Author A-Z</option>
+            <option value="year_asc">Year (oldest)</option>
+            <option value="year_desc">Year (newest)</option>
+            <option value="popular">Most read</option>
+            <option value="recent">Recently added</option>
+            <option value="last_translated">Recently translated</option>
+          </select>
 
-          {/* Language */}
+          {/* Language filter */}
           <select
             value={language}
             onChange={e => handleLanguage(e.target.value)}
-            className="text-sm border rounded-md px-3 py-2 cursor-pointer focus:outline-none focus:ring-1"
-            style={{ borderColor: '#ddd', color: '#333', background: '#fafafa' }}
+            className="text-sm border border-border-light rounded-lg px-3 py-1.5 bg-white text-secondary focus:outline-none focus:border-accent-rust cursor-pointer"
           >
             <option value="">All languages</option>
             {languages.map(l => (
@@ -311,246 +330,197 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
             ))}
           </select>
 
-          {/* Sort */}
-          <select
-            value={sort}
-            onChange={e => handleSort(e.target.value)}
-            className="text-sm border rounded-md px-3 py-2 cursor-pointer focus:outline-none focus:ring-1"
-            style={{ borderColor: '#ddd', color: '#333', background: '#fafafa' }}
-          >
-            <option value="title">Title A-Z</option>
-            <option value="author">Author A-Z</option>
-            <option value="year_asc">Year (oldest first)</option>
-            <option value="year_desc">Year (newest first)</option>
-            <option value="popular">Most read</option>
-            <option value="recent">Recently added</option>
-            <option value="last_translated">Recently translated</option>
-          </select>
-
-          {/* Export */}
-          <div className="flex items-center gap-2 ml-auto">
-            <a
-              href={csvUrl}
-              className="inline-flex items-center gap-1.5 text-xs px-3 py-2 border rounded-md hover:bg-gray-50 transition-colors"
-              style={{ borderColor: '#ddd', color: '#666' }}
-              title="Download as CSV"
-            >
-              <Download className="w-3.5 h-3.5" />
-              CSV
-            </a>
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted" />
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              onChange={e => handleSearch(e.target.value)}
+              placeholder="Search titles, authors, and content...  (/)"
+              className="text-sm border border-border-light rounded-lg pl-8 pr-8 py-1.5 bg-white text-primary placeholder:text-muted/60 focus:outline-none focus:border-accent-rust w-56 sm:w-72"
+            />
+            {query && (
+              <button
+                onClick={clearSearch}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-primary cursor-pointer"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
           </div>
         </div>
+      </div>
 
-        {/* Alphabetical quick-jump */}
-        <div className="flex flex-wrap gap-1 mb-5">
+      {/* Alphabetical quick-jump */}
+      <div className="flex flex-wrap gap-1 mb-6">
+        <button
+          onClick={() => handleLetterFilter('')}
+          className={`px-2.5 py-1 text-xs rounded-lg cursor-pointer transition-colors ${
+            !titlePrefix ? 'bg-accent-rust/10 text-accent-rust font-medium' : 'text-muted hover:text-primary'
+          }`}
+        >
+          All
+        </button>
+        {LETTERS.map(letter => (
           <button
-            onClick={() => handleLetterFilter('')}
-            className={`px-2 py-1 text-xs rounded cursor-pointer transition-colors ${
-              !titlePrefix ? 'font-semibold' : ''
+            key={letter}
+            onClick={() => handleLetterFilter(letter)}
+            className={`w-7 h-7 text-xs rounded-lg cursor-pointer transition-colors ${
+              titlePrefix === letter ? 'bg-accent-rust/10 text-accent-rust font-medium' : 'text-muted hover:text-primary'
             }`}
-            style={{
-              color: !titlePrefix ? '#fff' : '#666',
-              background: !titlePrefix ? '#8B4513' : 'transparent',
-            }}
           >
-            All
+            {letter}
           </button>
-          {LETTERS.map(letter => (
-            <button
-              key={letter}
-              onClick={() => handleLetterFilter(letter)}
-              className={`w-7 h-7 text-xs rounded cursor-pointer transition-colors ${
-                titlePrefix === letter ? 'font-semibold' : ''
-              }`}
-              style={{
-                color: titlePrefix === letter ? '#fff' : '#666',
-                background: titlePrefix === letter ? '#8B4513' : 'transparent',
-              }}
-            >
-              {letter}
-            </button>
-          ))}
-        </div>
+        ))}
+      </div>
 
-        {/* Results table */}
-        <div className={`${loading ? 'opacity-50' : ''} transition-opacity`}>
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr className="text-xs uppercase tracking-wider border-b" style={{ color: '#888', borderColor: '#e5e5e5' }}>
-                <th className="pb-2 pr-3 font-medium w-[40%]">
-                  <button onClick={() => handleColumnSort('title')} className="flex items-center gap-1 cursor-pointer hover:opacity-70">
-                    Title <SortIcon column="title" currentSort={sort} />
-                  </button>
-                </th>
-                <th className="pb-2 pr-3 font-medium hidden sm:table-cell w-[20%]">
-                  <button onClick={() => handleColumnSort('author')} className="flex items-center gap-1 cursor-pointer hover:opacity-70">
-                    Author <SortIcon column="author" currentSort={sort} />
-                  </button>
-                </th>
-                <th className="pb-2 pr-3 font-medium w-16">
-                  <button onClick={() => handleColumnSort('year')} className="flex items-center gap-1 cursor-pointer hover:opacity-70">
-                    Year <SortIcon column="year" currentSort={sort} />
-                  </button>
-                </th>
-                <th className="pb-2 pr-3 font-medium hidden md:table-cell w-24">Language</th>
-                <th className="pb-2 pr-3 font-medium hidden lg:table-cell w-16 text-right">Pages</th>
-                <th className="pb-2 font-medium hidden lg:table-cell w-20 text-right">Translated</th>
-                <th className="pb-2 font-medium hidden xl:table-cell w-28">Source</th>
-              </tr>
-            </thead>
-            <tbody>
-              {books.length === 0 && !loading ? (
-                <tr>
-                  <td colSpan={7} className="py-16 text-center text-sm" style={{ color: '#999' }}>
-                    No results found.
-                  </td>
+      {/* Content matches (when searching 3+ chars) */}
+      {contentMatches.length > 0 && (
+        <div className="mb-8 p-4 rounded-lg border border-border-light bg-warm/30">
+          <h3 className="text-xs uppercase tracking-wide text-muted font-medium mb-3 flex items-center gap-1.5">
+            <FileText className="w-3.5 h-3.5" />
+            Content matches ({contentTotal.toLocaleString()} results)
+          </h3>
+          <div className="space-y-2">
+            {contentMatches.map((match, i) => {
+              const href = match.page_number
+                ? `/book/${match.slug || match.book_id}/page/${match.page_number}`
+                : `/book/${match.slug || match.book_id}`;
+              return (
+                <div key={`${match.book_id}-${match.page_number}-${i}`} className="text-sm">
+                  <Link href={href} className="hover:text-accent-rust transition-colors">
+                    <span className="font-medium text-primary" style={{ fontFamily: 'var(--font-serif)' }}>
+                      {match.display_title || match.title}
+                    </span>
+                    {match.page_number && <span className="text-muted ml-1">p. {match.page_number}</span>}
+                    {match.author && <span className="text-secondary ml-2">— {match.author}</span>}
+                  </Link>
+                  {match.snippet && (
+                    <p className="text-xs text-muted mt-0.5 line-clamp-2 pl-4 border-l-2 border-border-light">
+                      ...{match.snippet}...
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {contentTotal > 10 && (
+            <Link
+              href={`/search?q=${encodeURIComponent(query)}${language ? `&language=${language}` : ''}`}
+              className="inline-block mt-3 text-xs text-accent-rust hover:underline"
+            >
+              See all {contentTotal.toLocaleString()} content matches →
+            </Link>
+          )}
+        </div>
+      )}
+      {contentLoading && query.length >= 3 && (
+        <div className="mb-8 p-4 rounded-lg border border-border-light bg-warm/30">
+          <p className="text-xs text-muted">Searching page content...</p>
+        </div>
+      )}
+
+      {/* Book table */}
+      <div className={loading ? 'opacity-60 pointer-events-none transition-opacity' : 'transition-opacity'}>
+        {books.length === 0 && !loading ? (
+          <div className="py-20 text-center text-muted">No books match your filters.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left">
+              <thead>
+                <tr className="border-b border-border-medium text-xs text-muted uppercase tracking-wide">
+                  <th className="pb-3 pr-4 font-medium w-[40%]">
+                    <button onClick={() => handleColumnSort('title')} className="flex items-center gap-1.5 hover:text-primary transition-colors cursor-pointer">
+                      Title <SortIcon column="title" currentSort={sort} />
+                    </button>
+                  </th>
+                  <th className="pb-3 pr-4 font-medium hidden sm:table-cell w-[20%]">
+                    <button onClick={() => handleColumnSort('author')} className="flex items-center gap-1.5 hover:text-primary transition-colors cursor-pointer">
+                      Author <SortIcon column="author" currentSort={sort} />
+                    </button>
+                  </th>
+                  <th className="pb-3 pr-4 font-medium w-16">
+                    <button onClick={() => handleColumnSort('year')} className="flex items-center gap-1.5 hover:text-primary transition-colors cursor-pointer">
+                      Year <SortIcon column="year" currentSort={sort} />
+                    </button>
+                  </th>
+                  <th className="pb-3 pr-4 font-medium hidden md:table-cell w-24">Language</th>
+                  <th className="pb-3 pr-4 font-medium hidden lg:table-cell w-16 text-right">Pages</th>
+                  <th className="pb-3 font-medium hidden lg:table-cell w-20 text-right">Translated</th>
+                  <th className="pb-3 font-medium hidden xl:table-cell w-28">Source</th>
                 </tr>
-              ) : (
-                books.map((book) => {
+              </thead>
+              <tbody className="divide-y divide-border-light">
+                {books.map((book) => {
                   const pct = translationPercent(book);
                   const href = `/book/${book.slug || book.id}`;
-                  const fullUrl = `https://sourcelibrary.org${href}`;
                   return (
-                    <tr
-                      key={book.id}
-                      className="group border-b hover:bg-gray-50/50 transition-colors"
-                      style={{ borderColor: '#f0f0f0' }}
-                    >
-                      <td className="py-2.5 pr-3">
+                    <tr key={book.id} className="group hover:bg-warm/50 transition-colors">
+                      <td className="py-3 pr-4">
                         <div className="flex items-center gap-2">
-                          <Link
-                            href={href}
-                            className="text-sm hover:underline decoration-1 underline-offset-2 line-clamp-1"
-                            style={{ color: '#1a1a1a' }}
-                          >
-                            {book.display_title || book.title}
+                          <Link href={href} className="block">
+                            <span className="text-sm font-medium text-primary group-hover:text-accent-rust transition-colors line-clamp-1" style={{ fontFamily: 'var(--font-serif)' }}>
+                              {book.display_title || book.title}
+                            </span>
                           </Link>
                           {book.is_first_translation && (
-                            <span
-                              className="shrink-0 text-[10px] px-1.5 py-0.5 rounded font-medium"
-                              style={{ background: '#f5e6d3', color: '#8B6914' }}
-                            >
+                            <span className="shrink-0 inline-block bg-accent-gold/15 text-accent-gold-dark text-[10px] px-1.5 py-0.5 rounded-full font-medium">
                               {firstTranslationBadge(book.ft_disposition, book.language ?? undefined)}
                             </span>
                           )}
                           <CopyPermalink slug={book.slug} id={book.id} />
                         </div>
-                        {/* Author on mobile */}
-                        <span className="block sm:hidden text-xs mt-0.5" style={{ color: '#888' }}>
+                        <span className="block sm:hidden text-xs text-muted mt-0.5 line-clamp-1">
                           <AuthorName author={book.author} fallback="" />
                           {book.year ? `, ${book.year}` : ''}
                         </span>
                       </td>
-                      <td className="py-2.5 pr-3 hidden sm:table-cell">
-                        <span className="text-sm line-clamp-1" style={{ color: '#555' }}>
-                          <AuthorName author={book.author} fallback="--" />
-                        </span>
+                      <td className="py-3 pr-4 hidden sm:table-cell">
+                        <Link href={href} className="text-sm text-secondary line-clamp-1 block">
+                          <AuthorName author={book.author} fallback="—" />
+                        </Link>
                       </td>
-                      <td className="py-2.5 pr-3 text-sm tabular-nums" style={{ color: '#666' }}>
-                        {book.year || '--'}
+                      <td className="py-3 pr-4 text-sm text-muted tabular-nums">
+                        <Link href={href} className="block">{book.year || '—'}</Link>
                       </td>
-                      <td className="py-2.5 pr-3 hidden md:table-cell">
-                        <span className="text-xs px-2 py-0.5 rounded" style={{ background: '#f5f5f5', color: '#666' }}>
-                          {book.language || '--'}
-                        </span>
+                      <td className="py-3 pr-4 hidden md:table-cell">
+                        <Link href={href} className="block">
+                          <span className="text-xs text-muted bg-warm px-2 py-0.5 rounded">{book.language || '—'}</span>
+                        </Link>
                       </td>
-                      <td className="py-2.5 pr-3 hidden lg:table-cell text-right text-sm tabular-nums" style={{ color: '#666' }}>
-                        {book.pages_count || '--'}
+                      <td className="py-3 pr-4 hidden lg:table-cell text-right">
+                        <Link href={href} className="block text-sm text-muted tabular-nums">{book.pages_count || '—'}</Link>
                       </td>
-                      <td className="py-2.5 hidden lg:table-cell text-right">
-                        {pct > 0 ? (
-                          <span className="text-sm tabular-nums" style={{ color: pct === 100 ? '#16a34a' : '#888' }}>
-                            {pct}%
-                          </span>
-                        ) : (
-                          <span className="text-sm" style={{ color: '#ccc' }}>--</span>
-                        )}
+                      <td className="py-3 hidden lg:table-cell text-right">
+                        <Link href={href} className="block text-sm tabular-nums">
+                          {pct > 0 ? (
+                            <span className={pct === 100 ? 'text-green-700' : 'text-muted'}>{pct}%</span>
+                          ) : (
+                            <span className="text-muted/40">—</span>
+                          )}
+                        </Link>
                       </td>
-                      <td className="py-2.5 hidden xl:table-cell">
+                      <td className="py-3 hidden xl:table-cell">
                         {book.image_source_provider ? (
-                          <span className="text-[11px] truncate block max-w-[100px]" style={{ color: '#999' }} title={book.image_source_provider}>
+                          <span className="text-[11px] text-muted/60 truncate block max-w-[100px]" title={book.image_source_provider}>
                             {book.image_source_provider}
                           </span>
                         ) : (
-                          <span className="text-sm" style={{ color: '#ccc' }}>--</span>
+                          <span className="text-muted/40">—</span>
                         )}
                       </td>
                     </tr>
                   );
-                })
-              )}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between mt-6 pt-4 border-t" style={{ borderColor: '#e5e5e5' }}>
-            <p className="text-xs" style={{ color: '#888' }}>
-              Page {currentPage} of {totalPages} ({total.toLocaleString()} works)
-            </p>
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => handlePage(currentPage - 1)}
-                disabled={currentPage <= 1}
-                className="p-1.5 rounded hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
-              >
-                <ChevronLeft className="w-4 h-4" />
-              </button>
-              {/* Page numbers */}
-              {Array.from({ length: Math.min(7, totalPages) }, (_, i) => {
-                let pageNum: number;
-                if (totalPages <= 7) {
-                  pageNum = i + 1;
-                } else if (currentPage <= 4) {
-                  pageNum = i + 1;
-                } else if (currentPage >= totalPages - 3) {
-                  pageNum = totalPages - 6 + i;
-                } else {
-                  pageNum = currentPage - 3 + i;
-                }
-                return (
-                  <button
-                    key={pageNum}
-                    onClick={() => handlePage(pageNum)}
-                    className={`w-8 h-8 text-xs rounded cursor-pointer transition-colors ${
-                      pageNum === currentPage ? 'font-semibold' : 'hover:bg-gray-100'
-                    }`}
-                    style={{
-                      color: pageNum === currentPage ? '#fff' : '#666',
-                      background: pageNum === currentPage ? '#8B4513' : 'transparent',
-                    }}
-                  >
-                    {pageNum}
-                  </button>
-                );
-              })}
-              <button
-                onClick={() => handlePage(currentPage + 1)}
-                disabled={currentPage >= totalPages}
-                className="p-1.5 rounded hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
-              >
-                <ChevronRight className="w-4 h-4" />
-              </button>
-            </div>
+                })}
+              </tbody>
+            </table>
           </div>
         )}
-
-        {/* Footer */}
-        <footer className="mt-12 pt-6 border-t text-xs" style={{ borderColor: '#e5e5e5', color: '#aaa' }}>
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              Source Library — {total.toLocaleString()} digitized primary sources with OCR and English translation.
-            </div>
-            <div className="flex items-center gap-4">
-              <a href="/api/catalog/csv" className="hover:underline">Full CSV export</a>
-              <Link href="/catalog" className="hover:underline">Standard catalog</Link>
-              <Link href="/browse" className="hover:underline">Browse indexes</Link>
-              <Link href="/search" className="hover:underline">Search</Link>
-            </div>
-          </div>
-        </footer>
       </div>
+
+      <CatalogPagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePage} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Restyle scholar catalog to match site design (SiteHeader, CSS vars, cream bg, serif titles)
- Add full-text content search: searches page OCR/translations in parallel with catalog browse
- Shows content matches with snippets above the book table
- Reuses CatalogPagination, same table patterns as CollectionListView

## Test plan
- [ ] `/catalog/scholar` matches site branding
- [ ] Search 3+ chars triggers content matches panel
- [ ] A-Z quick-jump works
- [ ] "Grid view" links back to `/catalog`

Generated with [Claude Code](https://claude.com/claude-code)