### PR TITLE
Improve Read This Book: skip endpapers to land on title page

### DIFF
--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -644,16 +644,18 @@ async function BookInfo({ id }: { id: string }) {
                 <BookDedication bookId={book.id} dedication={(book as any).dedication || null} />
               </div>
 
-              {/* Read This Book — links to title page or first OCR'd page */}
+              {/* Read This Book — links to title page area, skipping endpapers */}
               {(() => {
-                const titlePage = pages.find(p => p.page_type === 'title_page' || p.page_type === 'title-page');
-                const firstOcrPage = pages.find(p => p.ocr);
-                const readPage = titlePage || firstOcrPage || pages[0];
-                if (!readPage) return null;
+                if (pages.length === 0) return null;
+                const bookSlug = book.slug || book.id;
+                // Most printed books have 2-4 blank endpapers before the title page.
+                // Skip to ~page 4 for longer books to land near the title page.
+                const skipTo = totalPages >= 20 ? 4 : totalPages >= 10 ? 2 : 0;
+                const readPage = pages[skipTo] || pages[0];
                 return (
                   <div className="mt-5">
                     <Link
-                      href={`/book/${book.slug || book.id}/page/${readPage.id}`}
+                      href={`/book/${bookSlug}/page/${readPage.id}`}
                       className="inline-flex items-center gap-2.5 px-6 py-3 bg-accent-rust hover:bg-accent-rust/90 text-white font-medium rounded-lg transition-colors text-base"
                     >
                       <BookOpen className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- Fixes the Read This Book button to skip blank endpapers and land near the title page
- `page_type` is never set in the DB (0 pages have it), so the previous logic always fell back to page 1
- New heuristic: skip first ~4 pages for books with 20+ pages (typical printed book structure: 2-4 endpapers before title page)
- For the Kepler Astronomia Nova example: now links to page 5 (title page) instead of page 1 (blank endpaper)

## Test plan
- [ ] Kepler Astronomia Nova should link to page 5 (title page)
- [ ] Short books (<10 pages) should link to page 1
- [ ] Medium books (10-19 pages) should link to page 3

Generated with [Claude Code](https://claude.com/claude-code)