### PR TITLE
Add semantic search fallback to Images tab

### DIFF
--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -199,10 +199,15 @@ export async function GET(request: NextRequest) {
     // Shuffle is handled client-side — server-side $sample/$skip both timeout on Atlas
     // with broad filters (minQuality=0.5, maxPerBook=999). The shuffle param is ignored.
 
-    // Fire CLIP visual search in parallel with text search
+    // Fire CLIP visual search and semantic embedding search in parallel with text search.
+    // Semantic search understands meaning ("vulva" → "uterus", "yoni", "reproductive anatomy")
+    // while text search only matches exact terms in metadata.
     const clipPromise = searchQuery
       ? clipTextSearch(searchQuery, Math.max(limit * 2, 60))
       : Promise.resolve(new Map<string, number>());
+    const semanticPromise = searchQuery
+      ? semanticGallerySearch(searchParams, searchQuery).catch(() => ({ items: [] as any[] }))
+      : Promise.resolve({ items: [] as any[] });
 
     let textItems: any[] = [];
 
@@ -280,8 +285,33 @@ export async function GET(request: NextRequest) {
         .toArray();
     }
 
-    const clipScores = await clipPromise;
+    const [clipScores, semanticResult] = await Promise.all([clipPromise, semanticPromise]);
     let items = textItems;
+
+    // Merge semantic results — these find conceptually related images
+    // (e.g. "vulva" matches images described as "uterus", "yoni", "reproductive anatomy")
+    if (semanticResult.items && semanticResult.items.length > 0) {
+      const textIds = new Set(items.map(doc => `${doc.page_id}-${doc.detection_index}`));
+      const semanticDocs = semanticResult.items
+        .filter((doc: any) => !textIds.has(`${doc.pageId}-${doc.detectionIndex}`))
+        .map((doc: any) => ({
+          ...doc,
+          // Remap camelCase back to snake_case for consistency with text results
+          page_id: doc.pageId,
+          book_id: doc.bookId,
+          page_number: doc.pageNumber,
+          detection_index: doc.detectionIndex,
+          image_url: doc.imageUrl,
+          book_title: doc.bookTitle,
+          book_author: doc.author,
+          book_year: doc.year,
+          extracted_url: doc.extractedUrl,
+          thumbnail_url: doc.thumbnailUrl,
+          gallery_quality: doc.galleryQuality,
+          museum_description: doc.museumDescription,
+        }));
+      items = [...items, ...semanticDocs];
+    }
 
     // Merge CLIP visual results with text results
     if (clipScores.size > 0) {

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -196,41 +196,91 @@ export async function GET(request: NextRequest) {
       filter.book_year = yearFilter;
     }
 
-    if (searchQuery) {
-      // Use $text index (covers description, book_title, book_author)
-      // instead of 7-branch regex scan across 73k docs
-      filter.$text = { $search: searchQuery };
-    }
-
     // Shuffle is handled client-side — server-side $sample/$skip both timeout on Atlas
     // with broad filters (minQuality=0.5, maxPerBook=999). The shuffle param is ignored.
 
-    // When text searching, sort by relevance first, then quality
-    const sortOrder: Record<string, any> = searchQuery
-      ? { score: { $meta: 'textScore' }, gallery_quality: -1 }
-      : { gallery_quality: -1, book_year: 1, book_id: 1, page_number: 1 };
-    const projection: Record<string, any> = searchQuery
-      ? { _id: 0, score: { $meta: 'textScore' } }
-      : { _id: 0 };
-
-    // Fire CLIP visual search in parallel with MongoDB text search
+    // Fire CLIP visual search in parallel with text search
     const clipPromise = searchQuery
       ? clipTextSearch(searchQuery, Math.max(limit * 2, 60))
       : Promise.resolve(new Map<string, number>());
 
-    // countDocuments with compound filters takes 20s+ on Atlas (no covering index).
-    // Strategy: run find first, then only count if we need pagination info.
-    // For first page with full results, total = offset + items.length (or +1 if full page).
-    const [textItems, clipScores] = await Promise.all([
-      db.collection('gallery_images')
-        .find(filter, { projection })
+    let textItems: any[] = [];
+
+    if (searchQuery) {
+      // Primary: Atlas Search (gallery_search index) — searches description,
+      // museum_description, subjects, figures. Same index used by unified search.
+      try {
+        textItems = await db.collection('gallery_images').aggregate([
+          {
+            $search: {
+              index: 'gallery_search',
+              compound: {
+                should: [
+                  { autocomplete: { query: searchQuery, path: 'description', score: { boost: { value: 3 } }, fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+                  { text: { query: searchQuery, path: 'museum_description', score: { boost: { value: 2 } }, fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+                  { text: { query: searchQuery, path: 'metadata.subjects', fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+                  { text: { query: searchQuery, path: 'metadata.figures', fuzzy: { maxEdits: 1, prefixLength: 2 } } },
+                ],
+                minimumShouldMatch: 1,
+                filter: [
+                  { range: { path: 'gallery_quality', gte: minQuality } },
+                ],
+              },
+            },
+          },
+          { $match: {
+            book_visible: true,
+            extracted_url: { $ne: null },
+            image_url: { $ne: null },
+            ...(!bookId && maxPerBook < 100 ? { book_rank: { $lte: maxPerBook } } : {}),
+            ...(bookId ? { book_id: bookId } : {}),
+            ...(collectionBookIds && libraryBookIds
+              ? { book_id: { $in: collectionBookIds.filter(id => libraryBookIds!.includes(id)) } }
+              : collectionBookIds ? { book_id: { $in: collectionBookIds } }
+              : libraryBookIds ? { book_id: { $in: libraryBookIds } }
+              : {}),
+            ...(imageType ? { type: imageType } : {}),
+            ...(subjectFilter ? { 'metadata.subjects': subjectFilter } : {}),
+            ...(figureFilter ? { 'metadata.figures': figureFilter } : {}),
+            ...(symbolFilter ? { 'metadata.symbols': symbolFilter } : {}),
+            ...(yearStart !== null || yearEnd !== null ? {
+              book_year: {
+                ...(yearStart !== null ? { $gte: yearStart } : {}),
+                ...(yearEnd !== null ? { $lte: yearEnd } : {}),
+              },
+            } : {}),
+          }},
+          { $project: { _id: 0 } },
+          { $skip: offset },
+          { $limit: limit + 1 },
+        ], { maxTimeMS: 8000 }).toArray();
+      } catch {
+        // Atlas Search index not ready — fall back to $text
+      }
+
+      // Fallback: $text index (covers description, book_title, book_author)
+      if (textItems.length === 0) {
+        filter.$text = { $search: searchQuery };
+        const sortOrder: Record<string, any> = { score: { $meta: 'textScore' }, gallery_quality: -1 };
+        const projection = { _id: 0, score: { $meta: 'textScore' as const } };
+        textItems = await db.collection('gallery_images')
+          .find(filter, { projection })
+          .sort(sortOrder)
+          .skip(offset)
+          .limit(limit + 1)
+          .toArray();
+      }
+    } else {
+      const sortOrder: Record<string, any> = { gallery_quality: -1, book_year: 1, book_id: 1, page_number: 1 };
+      textItems = await db.collection('gallery_images')
+        .find(filter, { projection: { _id: 0 } })
         .sort(sortOrder)
         .skip(offset)
-        .limit(limit + 1) // fetch one extra to know if there are more
-        .toArray(),
-      clipPromise,
-    ]);
+        .limit(limit + 1)
+        .toArray();
+    }
 
+    const clipScores = await clipPromise;
     let items = textItems;
 
     // Merge CLIP visual results with text results
@@ -270,8 +320,14 @@ export async function GET(request: NextRequest) {
     } else if (!hasMore) {
       total = offset + items.length; // last page
     } else if (searchQuery || collectionBookIds || libraryBookIds || imageType || subjectFilter || figureFilter || symbolFilter || iconclassFilter || yearStart !== null || yearEnd !== null) {
-      // Filtered query — estimated count is wildly wrong, do a real count (capped at 10s)
-      total = await db.collection('gallery_images').countDocuments(filter, { maxTimeMS: 10000 }).catch(() => offset + items.length + 1);
+      // Filtered query — for Atlas Search queries, countDocuments can't replicate the
+      // search pipeline, so estimate from result count. For $text queries, use countDocuments.
+      if (searchQuery && !filter.$text) {
+        // Atlas Search was used — estimate total from what we have
+        total = offset + items.length + (hasMore ? 1 : 0);
+      } else {
+        total = await db.collection('gallery_images').countDocuments(filter, { maxTimeMS: 10000 }).catch(() => offset + items.length + 1);
+      }
     } else {
       // Unfiltered browsing — estimated count is fine
       total = await db.collection('gallery_images').estimatedDocumentCount();

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -75,6 +75,11 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
   const [semanticResults, setSemanticResults] = useState<any[]>([]);
   const [semanticLoading, setSemanticLoading] = useState(false);
 
+  // Track when the base search has set image results, so AI imgTerms callback
+  // doesn't add images that get immediately overwritten by the base search completing.
+  const baseImagesSet = useRef(false);
+  const pendingAiImages = useRef<GalleryItem[]>([]);
+
   // Accordion open state for unified view sections
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['books', 'semantic']));
   const toggleSection = (section: string) => {
@@ -209,6 +214,10 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
       setAiTerms([]);
     }
 
+    // Reset the base-images gate so imgTerms buffers until performSearch sets results
+    baseImagesSet.current = false;
+    pendingAiImages.current = [];
+
     if (!q || q.length < 3) return;
     setAiStreaming(true);
 
@@ -275,8 +284,14 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           }
         }
         if (newImages.length > 0) {
-          setImageResults(prev => [...prev, ...newImages]);
-          setImageTotal(prev => prev + newImages.length);
+          if (baseImagesSet.current) {
+            // Base search already set results — safe to append
+            setImageResults(prev => [...prev, ...newImages]);
+            setImageTotal(prev => prev + newImages.length);
+          } else {
+            // Base search hasn't completed yet — buffer these so they don't get wiped
+            pendingAiImages.current = [...pendingAiImages.current, ...newImages];
+          }
         }
       },
     );
@@ -387,8 +402,19 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           setBookTotal(bTotal);
           setIndexResults(index);
           setIndexTotal(iTotal);
-          setImageResults(images);
-          setImageTotal(imTotal);
+          // Merge any AI-supplemented images that arrived before the base search completed
+          const pending = pendingAiImages.current;
+          if (pending.length > 0) {
+            const baseIds = new Set(images.map((i: GalleryItem) => `${i.pageId}-${i.detectionIndex}`));
+            const unique = pending.filter(p => !baseIds.has(`${p.pageId}-${p.detectionIndex}`));
+            setImageResults([...images, ...unique]);
+            setImageTotal(imTotal + unique.length);
+            pendingAiImages.current = [];
+          } else {
+            setImageResults(images);
+            setImageTotal(imTotal);
+          }
+          baseImagesSet.current = true;
           setCollectionResults((data as any).collections?.results || []);
           displayHintLocked.current = true; // lock layout once results render
 
@@ -446,8 +472,20 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
         setIndexTotal(data.total || 0);
       } else if (mode === 'images') {
         const data = await galleryApi.list({ query: q, limit: resultsPerPage, offset: pageOffset });
-        setImageResults(data.items || []);
-        setImageTotal(data.total || 0);
+        const items = data.items || [];
+        // Merge any AI-supplemented images that arrived before gallery API responded
+        const pending = pendingAiImages.current;
+        if (pending.length > 0) {
+          const baseIds = new Set(items.map((i: GalleryItem) => `${i.pageId}-${i.detectionIndex}`));
+          const unique = pending.filter(p => !baseIds.has(`${p.pageId}-${p.detectionIndex}`));
+          setImageResults([...items, ...unique]);
+          setImageTotal((data.total || 0) + unique.length);
+          pendingAiImages.current = [];
+        } else {
+          setImageResults(items);
+          setImageTotal(data.total || 0);
+        }
+        baseImagesSet.current = true;
       }
     } catch (error) {
       console.error('Search error:', error);


### PR DESCRIPTION
## Summary
- Image search only matched exact keywords in metadata — "vulva" found nothing because images were described as "uterus", "yoni", "reproductive anatomy"
- Now runs semantic embedding search (Supabase pgvector) in parallel with text search
- Semantic search understands meaning: "vulva" → finds uterus diagrams, yoni symbols, anatomical illustrations
- Results from all three lanes (Atlas Search text, CLIP visual, semantic embeddings) are merged and deduplicated

## Test plan
- [ ] Search "vulva" on Images tab — should find anatomical/reproductive images
- [ ] Search "death" on Images tab — should find skeleton, memento mori, etc.
- [ ] Search "dragon" — text results should still appear first (exact match)
- [ ] Browse without query — unchanged
- [ ] Performance: page load should not be noticeably slower (semantic runs in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)