### PR TITLE
Fix BPH page reader returning 404

### DIFF
--- a/src/app/embed/bph/book/[slug]/page/[pageId]/page.tsx
+++ b/src/app/embed/bph/book/[slug]/page/[pageId]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from 'next/navigation';
+import { getReadDb } from '@/lib/mongodb';
+import PageEditorPage from '@/app/book/[id]/page/[pageId]/page';
+
+export const revalidate = 86400;
+export const preferredRegion = 'fra1';
+export const dynamicParams = true;
+export async function generateStaticParams() { return []; }
+
+/**
+ * BPH embed page reader — verifies the book exists, then renders the real page component.
+ */
+export default async function EmbedPageRoute({ params }: { params: Promise<{ slug: string; pageId: string }> }) {
+  const { slug, pageId } = await params;
+
+  const db = await getReadDb();
+  const exists = await db.collection('books').findOne(
+    { $or: [{ slug }, { id: slug }], visible: true, pages_count: { $gt: 0 } },
+    { projection: { _id: 1 } }
+  );
+  if (!exists) notFound();
+
+  return <PageEditorPage params={Promise.resolve({ id: slug, pageId })} />;
+}


### PR DESCRIPTION
## Summary
- `bph.sourcelibrary.org/book/X/page/Y` was returning 404
- The proxy rewrites tenant subdomain paths to `/embed/bph/...` but no page reader route existed at `/embed/bph/book/[slug]/page/[pageId]`
- Added the missing route, following the same pattern as the existing book detail embed (`embed/bph/book/[slug]/page.tsx`)

## Test plan
- [ ] Visit https://bph.sourcelibrary.org/book/6988a5a1b16bf7c5562e3317/page/6988aa52e7fccb676e2e8915
- [ ] Verify page loads with OCR/translation content

🤖 Generated with [Claude Code](https://claude.com/claude-code)