### PR TITLE
Fix BPH gallery link redirecting to search page

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -183,6 +183,12 @@ export function proxy(request: NextRequest) {
       url.pathname = `/embed/${tenant}${pathname}`;
     } else if (pathname === '/catalog') {
       url.pathname = `/embed/${tenant}/catalog`;
+    } else if (pathname.startsWith('/gallery')) {
+      // Gallery doesn't have tenant-specific embeds — redirect to main site
+      const mainUrl = request.nextUrl.clone();
+      mainUrl.host = 'sourcelibrary.org';
+      mainUrl.port = '';
+      return NextResponse.redirect(mainUrl, 302);
     } else {
       // All other paths on tenant subdomain → embed root (filtered search)
       url.pathname = `/embed/${tenant}`;


### PR DESCRIPTION
## Summary
- The "28 images" link on BPH book detail pages (`/gallery?bookId=...`) was being caught by the tenant proxy's catch-all `else` clause and rewritten to the embed root (search page)
- Added explicit `/gallery` route in the tenant proxy that redirects to `sourcelibrary.org/gallery` with query params preserved

## Test plan
- [ ] Visit https://bph.sourcelibrary.org/book/6988a5a1b16bf7c5562e3317
- [ ] Click the "28 images" link
- [ ] Verify it redirects to `sourcelibrary.org/gallery?bookId=...` and shows the book's gallery images

🤖 Generated with [Claude Code](https://claude.com/claude-code)