### PR TITLE
Rewrite summary prompts for scholarly tone

### DIFF
--- a/src/app/api/books/[id]/index/route.ts
+++ b/src/app/api/books/[id]/index/route.ts
@@ -666,7 +666,7 @@ ${researchContext}
 ${chapters.map(c => `- Page ${c.pageNumber}: ${c.title}`).join('\n')}
 ` : '';
 
-  const prompt = `You're writing compelling copy to help readers discover "${bookTitle}" by ${bookAuthor}.${languageContext}
+  const prompt = `You are a scholarly cataloger writing a description of "${bookTitle}" by ${bookAuthor}.${languageContext}
 
 ${researchSection}
 ${chapterSection}
@@ -687,28 +687,31 @@ ${batchSummariesText}
 ${quotesText}
 
 ## Your Task
-Synthesize the above into compelling summaries that make readers WANT to explore this text.
+Synthesize the above into clear, informative summaries suitable for an academic library catalog.
 
 **Writing style:**
-- Write like a knowledgeable human, not an AI. Be direct and concrete.
+- Write like a rare books librarian: precise, knowledgeable, and direct.
+- State what the text IS and what it CONTAINS. Do not sell or promote it.
 - NEVER use em-dashes (—). Use commas, colons, semicolons, or separate sentences instead.
-- NEVER use these AI-isms: "delves into", "rich tapestry", "fascinating exploration", "sheds light on", "offers a window into", "comprehensive", "intricate", "nuanced", "multifaceted", "groundbreaking", "seminal".
-- Prefer short, clear sentences over long compound ones.
-- Scholarly but accessible. Say what the text does, not how impressive it is.
+- NEVER open with imperatives or invitations: "Step into", "Discover", "Explore", "Unlock", "Dive into", "Journey into", "Embark on", "Immerse yourself", "Experience", "Venture into", "Uncover".
+- NEVER use these AI-isms: "delves into", "rich tapestry", "fascinating exploration", "sheds light on", "offers a window into", "comprehensive", "intricate", "nuanced", "multifaceted", "groundbreaking", "seminal", "remarkable", "extraordinary".
+- NEVER address the reader directly ("you", "your", "readers").
+- Prefer short, declarative sentences. Lead with the subject matter, not with rhetoric.
+- Name specific ideas, arguments, and methods rather than vaguely praising the work.
 
-1. **BRIEF** (2-3 punchy sentences):
-   - Hook the reader - what's compelling about this text?
-   - What questions does it tackle? What will readers discover?
+1. **BRIEF** (2-3 sentences):
+   - What is this text? What does it argue or contain?
+   - Name specific topics, methods, or claims. Be concrete.
 
 2. **ABSTRACT** (1 paragraph, 4-6 sentences):
-   - What makes this text worth reading?
-   - What bold claims or intriguing ideas does it contain?
-   - What's the author's unique perspective?
+   - Summarize the work's contents, structure, and argument.
+   - Note the author's approach and any notable sources or influences.
+   - Mention the historical or intellectual context where relevant.
 
 3. **DETAILED** (2-4 paragraphs):
-   - Paint a picture of the journey through this text
-   - Highlight the most striking ideas or arguments
-   - Convey the texture and flavor of the writing
+   - Describe the structure and contents of the work.
+   - Highlight specific arguments, examples, or passages.
+   - Note the work's place in its tradition or field.
 
 4. **SECTIONS**: ${hasChapters ? 'Use the detected chapter structure.' : 'Group into 5-8 thematic sections.'} For each:
    - Title and page range

--- a/src/app/api/books/[id]/index/stream/route.ts
+++ b/src/app/api/books/[id]/index/stream/route.ts
@@ -142,7 +142,7 @@ async function synthesizeSummary(
   const batchSummaries = batches.map(b => `Pages ${b.pageRange.start}-${b.pageRange.end}: ${b.summary}`).join('\n');
   const quotesText = allQuotes.map(q => `- "${q.text}" (p.${q.page})`).join('\n');
 
-  const prompt = `Write compelling summaries for "${bookTitle}" by ${bookAuthor}${bookLanguage ? ` (from ${bookLanguage})` : ''}.
+  const prompt = `You are a scholarly cataloger. Write a description of "${bookTitle}" by ${bookAuthor}${bookLanguage ? ` (from ${bookLanguage})` : ''}.
 
 Themes: ${allThemes.join(', ')}
 
@@ -152,14 +152,16 @@ ${batchSummaries}
 Notable quotes:
 ${quotesText}
 
+Style: Write like a rare books librarian. State what the text is and contains. Do not sell or promote it. Never open with "Step into", "Discover", "Explore", "Unlock", or similar invitations. Never address the reader as "you". Be precise and concrete.
+
 Output JSON:
 {
-  "brief": "2-3 punchy sentences that hook readers",
-  "abstract": "1 paragraph (4-6 sentences) - what's compelling about this text?",
-  "detailed": "2-4 paragraphs painting the journey through this text"
+  "brief": "2-3 declarative sentences: what the text is, what it argues or contains",
+  "abstract": "1 paragraph (4-6 sentences) summarizing contents, structure, and context",
+  "detailed": "2-4 paragraphs describing the work's structure, arguments, and significance"
 }
 
-Use the actual quotes provided. Be engaging but accurate.`;
+Use the actual quotes provided. Be accurate.`;
 
   const result = await model.generateContent(prompt);
   const jsonMatch = result.response.text().match(/\{[\s\S]*\}/);


### PR DESCRIPTION
## Summary
- Rewrites the book summary generation prompts (index route + stream route) from marketing-copy tone to scholarly-catalog tone
- Bans imperative openers ("Step into", "Discover", "Explore", "Unlock", etc.) and direct reader address ("you", "your")
- Instructs the model to write like a rare books librarian: precise, declarative, concrete
- **1,362 existing books** start with "Step into..." out of 8,042 with briefs (17%). These need a backfill to regenerate.

### Before
> "Step into the laboratory of the 17th century's most enigmatic inventor to witness the bridge between ancient alchemy and the birth of modern physics."

### After (expected)
> "A 1617 treatise on transmutation by Johann Seger Weidenfeld, arguing that alchemical processes mirror natural generation. The text draws heavily on Paracelsian theory and includes practical laboratory instructions."

## Backfill
A backfill script (`scripts/tmp-backfill-scholarly-briefs.mjs`) is ready but not committed (tmp prefix). It regenerates briefs using existing index data without re-processing pages.

## Test plan
- [ ] Verify new books processed through the pipeline get scholarly-tone briefs
- [ ] Run backfill on ~10 books with `--limit 10` to spot-check quality
- [ ] Full backfill of ~1,400 "Step into" books after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)