### PR TITLE
Fix artwork collection cards linking to /book/ instead of /artwork/

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -80,7 +80,7 @@ export async function GET(
         thumbnail: b.thumbnail, thumbnail_blob: b.thumbnail_blob,
         is_first_translation: b.is_first_translation,
         created_at: null, last_translation_at: null,
-        resource_type: null, medium: null, enrichment: null,
+        resource_type: b.resource_type || null, medium: null, enrichment: null,
         relevance: b.quality_score || 0,
       }));
 

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -296,6 +296,7 @@ async function fetchCollectionData(id: string, provider?: string) {
         published: b.published, read_count: b.read_count,
         is_first_translation: b.is_first_translation,
         categories: b.categories,
+        resource_type: b.resource_type,
       }));
     } catch {
       // MongoDB fallback — if Supabase is down

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -28,6 +28,7 @@ interface CollectionBook {
   ft_disposition?: string;
   published?: string;
   translation_percent?: number;
+  resource_type?: string;
 }
 
 interface CollectionBookCardProps {
@@ -40,14 +41,16 @@ export default function CollectionBookCard({ book, priority = false }: Collectio
   const [imageError, setImageError] = useState(false);
   const [useFallback, setUseFallback] = useState(false);
 
+  const isArtwork = !!book.resource_type;
   const pageCount = book.pages_count || book.pages || 0;
   const primaryUrl = getBookThumbnailUrl(book, 'display');
   const fallbackUrl = getBookThumbnailUrl(book, 'thumb');
   const thumbnailUrl = useFallback && fallbackUrl ? fallbackUrl : primaryUrl;
+  const slug = book.slug || book.id || book.bookId;
 
   return (
     <Link
-      href={`/book/${book.slug || book.id || book.bookId}`}
+      href={isArtwork ? `/artwork/${slug}` : `/book/${slug}`}
       className="group block"
     >
       <div className="h-full rounded-xl border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">
@@ -120,19 +123,30 @@ export default function CollectionBookCard({ book, priority = false }: Collectio
                 {book.year}
               </span>
             )}
-            {pageCount > 0 && (
+            {isArtwork ? (
+              <>{book.resource_type && (
+                <>
+                  <span>•</span>
+                  <span className="capitalize">{book.resource_type.replace(/_/g, ' ')}</span>
+                </>
+              )}</>
+            ) : (
               <>
-                <span>•</span>
-                <span className="flex items-center gap-1">
-                  <FileText className="w-3 h-3" />
-                  {pageCount} pages
-                </span>
-              </>
-            )}
-            {book.language && (
-              <>
-                <span>•</span>
-                <span>{book.language}</span>
+                {pageCount > 0 && (
+                  <>
+                    <span>•</span>
+                    <span className="flex items-center gap-1">
+                      <FileText className="w-3 h-3" />
+                      {pageCount} pages
+                    </span>
+                  </>
+                )}
+                {book.language && (
+                  <>
+                    <span>•</span>
+                    <span>{book.language}</span>
+                  </>
+                )}
               </>
             )}
           </div>

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -33,6 +33,7 @@ interface BookItem {
   relevance?: number;
   created_at?: string;
   last_translation_at?: string;
+  resource_type?: string;
 }
 
 interface CollectionAllBooksProps {
@@ -368,6 +369,7 @@ export default function CollectionAllBooks({
                 translation_percent: book.pages_ocr && book.pages_translated
                   ? Math.round((book.pages_translated / Math.max((book.pages_ocr || 0) - (book.pages_blank || 0), 1)) * 100)
                   : 0,
+                resource_type: book.resource_type,
               }}
               priority={!expanded && i < 4}
             />

--- a/src/components/collections/CollectionListView.tsx
+++ b/src/components/collections/CollectionListView.tsx
@@ -21,6 +21,7 @@ interface BookItem {
   read_count?: number;
   is_first_translation?: boolean;
   ft_disposition?: string;
+  resource_type?: string;
 }
 
 type SortKey = 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'popular' | 'relevance';
@@ -110,7 +111,9 @@ export default function CollectionListView({
         <tbody className="divide-y divide-border-light">
           {books.map((book) => {
             const pct = translationPercent(book);
-            const href = `/book/${book.slug || book.id}`;
+            const href = book.resource_type
+              ? `/artwork/${book.slug || book.id}`
+              : `/book/${book.slug || book.id}`;
             return (
               <tr key={book.id} className="group hover:bg-warm/50 transition-colors">
                 <td className="py-3 pr-4">

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -32,6 +32,7 @@ export interface CatalogBook {
   image_source_provider: string | null;
   categories: string[];
   collections: string[];
+  resource_type: string | null;
 }
 
 /** Extended book detail from Supabase — includes fields for the /book/[id] page shell. */
@@ -42,7 +43,6 @@ export interface CatalogBookDetail extends CatalogBook {
   place_published: string | null;
   doi: string | null;
   work_id: string | null;
-  resource_type: string | null;
   source_url: string | null;
   provider_name: string | null;
   image_attribution: string | null;
@@ -59,7 +59,7 @@ export interface CatalogBookDetail extends CatalogBook {
   updated_at: string | null;
 }
 
-const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections';
+const BOOK_SELECT = 'id, slug, title, display_title, author, year, language, published, pages_count, pages_ocr, pages_translated, pages_blank, photo, thumbnail, thumbnail_blob, read_count, is_first_translation, quality_score, image_source_provider, categories, collections, resource_type';
 
 export type SortOption = 'popular' | 'title' | 'author' | 'year_asc' | 'year_desc' | 'recent' | 'last_translated' | 'quality';
 


### PR DESCRIPTION
## Summary
- Artwork items in visual art collections (e.g. Ficino's Florence) now link to `/artwork/` instead of `/book/`
- Card metadata shows medium type (painting, sculpture, etc.) instead of irrelevant "pages" count
- `resource_type` is now included in the Supabase `BOOK_SELECT` query and passed through the collection manifest API
- Affects grid view (`CollectionBookCard`), list view (`CollectionListView`), and the manifest API

## Test plan
- [ ] Visit https://sourcelibrary.org/artwork, click "Ficino's Florence"
- [ ] Verify artwork cards link to `/artwork/slug` not `/book/slug`
- [ ] Verify cards show medium type instead of "0 pages"
- [ ] Toggle to list view, verify links go to `/artwork/` for artworks
- [ ] Check a regular (non-art) collection still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)