### PR TITLE
Hero images, blog ToC, and search UX fixes

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -16,6 +16,8 @@ export default function AboutPage() {
       header={
         <ContentHeader
           title="Source Library transforms 2500+ years of wisdom texts into a living archive, freely available to all."
+          image="https://images.sourcelibrary.org/archived/6909aba7cf28baa1b4caef69/5.jpg"
+          imageAlt="Historical illustration from the Embassy of the Free Mind collection"
         />
       }
       bg="bg-cream"

--- a/src/app/about/research/page.tsx
+++ b/src/app/about/research/page.tsx
@@ -19,6 +19,8 @@ export default function ResearchPage() {
         <ContentHeader
           title="How Our Translations Work"
           subtitle="Every translation in Source Library is produced by AI and preserved alongside the original text. Here's how the process works, what quality signals we measure, and what the limitations are."
+          image="https://images.sourcelibrary.org/archived/695591547bd6d2cd1d618a62/154.jpg"
+          imageAlt="Historical manuscript page showing original text"
         />
       }
       bg="bg-cream"

--- a/src/app/about/sources/page.tsx
+++ b/src/app/about/sources/page.tsx
@@ -680,6 +680,8 @@ export default function SourcesPage() {
         <ContentHeader
           title="Source Libraries"
           subtitle={`${sources.length} institutions surveyed across ${new Set(sources.map(s => s.country)).size} countries`}
+          image="https://images.sourcelibrary.org/archived/6909d654cf28baa1b4cb0269/4.jpg"
+          imageAlt="Incunabulum page from a partner library"
         />
       }
       bg="bg-cream"

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -368,6 +368,9 @@ async function searchBooks(
 }
 
 async function searchIndex(db: any, query: string, limit: number) {
+  // Skip index search for very short queries — autocomplete + fuzzy on 1-2 chars is too loose
+  if (query.length < 3) return { results: [] as IndexResult[], total: 0, hasMore: false };
+
   const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const queryRegex = new RegExp(escapedQuery, 'i');
 

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,10 @@
+import BlogTableOfContents from '@/components/blog/BlogTableOfContents';
+
+export default function BlogLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <BlogTableOfContents />
+    </>
+  );
+}

--- a/src/app/collections/all/page.tsx
+++ b/src/app/collections/all/page.tsx
@@ -134,6 +134,8 @@ export default async function AllCollectionsPage() {
         <ContentHeader
           title="All Collections"
           subtitle="Every wing and sub-collection in the library."
+          image={wings.find(w => w.image)?.image}
+          imageAlt="Illustration from the collection"
         />
       }
     >

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -95,6 +95,8 @@ export default async function LanguagesPage() {
       <ContentHeader
         title="Languages"
         subtitle={`${totalBooks.toLocaleString()} books across ${languages.length} languages, spanning five millennia of human thought.`}
+        image={major.find(l => l.heroImage)?.heroImage}
+        imageAlt="Multilingual manuscript page"
       />
 
       <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mb-12">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -699,7 +699,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
                 <Loader2 className="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted animate-spin" />
               )}
             </div>
-            {!isBrowseMode && (
+            {!isBrowseMode && viewMode !== 'unified' && (
               <div className="relative flex-shrink-0">
                 <ArrowUpDown className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" />
                 <select

--- a/src/components/blog/BlogTableOfContents.tsx
+++ b/src/components/blog/BlogTableOfContents.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+
+interface TocEntry {
+  id: string;
+  text: string;
+}
+
+/**
+ * Floating table of contents for long blog posts.
+ * Scans for h2 elements inside the nearest <article>, assigns IDs, and
+ * renders a sticky sidebar nav on desktop (hidden on mobile — uses a
+ * collapsible button instead).
+ *
+ * Drop into any blog page: <BlogTableOfContents />
+ * Only renders if ≥ 3 headings are found.
+ */
+export default function BlogTableOfContents() {
+  const [entries, setEntries] = useState<TocEntry[]>([]);
+  const [activeId, setActiveId] = useState('');
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const article = document.querySelector('article');
+    if (!article) return;
+
+    const headings = Array.from(article.querySelectorAll('h2'));
+    if (headings.length < 3) return;
+
+    // Assign IDs and build entries
+    const tocEntries: TocEntry[] = headings.map((h) => {
+      if (!h.id) {
+        h.id = (h.textContent || '')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '');
+      }
+      return { id: h.id, text: h.textContent || '' };
+    });
+    setEntries(tocEntries);
+
+    // Track active heading via IntersectionObserver
+    observerRef.current = new IntersectionObserver(
+      (ioEntries) => {
+        for (const entry of ioEntries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: '-80px 0px -70% 0px', threshold: 0 }
+    );
+
+    for (const h of headings) {
+      observerRef.current.observe(h);
+    }
+
+    return () => observerRef.current?.disconnect();
+  }, []);
+
+  if (entries.length === 0) return null;
+
+  const handleClick = (id: string) => {
+    setMobileOpen(false);
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  return (
+    <>
+      {/* Desktop: sticky sidebar */}
+      <nav className="hidden xl:block fixed top-32 w-52 max-h-[calc(100vh-10rem)] overflow-y-auto" style={{ right: 'max(1.5rem, calc((100vw - 1024px) / 2 - 15rem))' }}>
+        <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-3">Contents</p>
+        <ul className="space-y-1.5 border-l border-border-light pl-3">
+          {entries.map((e) => (
+            <li key={e.id}>
+              <button
+                onClick={() => handleClick(e.id)}
+                className={`text-left text-[13px] leading-snug transition-colors hover:text-accent-rust block w-full ${
+                  activeId === e.id
+                    ? 'text-accent-rust font-medium'
+                    : 'text-muted'
+                }`}
+              >
+                {e.text}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Mobile: floating button + dropdown */}
+      <div className="xl:hidden fixed bottom-6 right-6 z-50">
+        {mobileOpen && (
+          <div className="absolute bottom-14 right-0 w-72 max-h-80 overflow-y-auto bg-white rounded-xl shadow-xl border border-border-light p-4">
+            <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-2">Contents</p>
+            <ul className="space-y-2">
+              {entries.map((e) => (
+                <li key={e.id}>
+                  <button
+                    onClick={() => handleClick(e.id)}
+                    className={`text-left text-sm leading-snug transition-colors hover:text-accent-rust block w-full ${
+                      activeId === e.id
+                        ? 'text-accent-rust font-medium'
+                        : 'text-secondary'
+                    }`}
+                  >
+                    {e.text}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <button
+          onClick={() => setMobileOpen(!mobileOpen)}
+          className="w-12 h-12 rounded-full bg-stone-900 text-white shadow-lg flex items-center justify-center hover:bg-stone-800 transition-colors"
+          aria-label="Table of contents"
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h12" />
+          </svg>
+        </button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- **Hero background images** on 5 browse pages: `/collections/all`, `/languages`, `/about`, `/about/sources`, `/about/research` — uses the existing `ContentHeader` image prop with curated images from the collection (#1371)
- **Blog table of contents** — floating sticky sidebar on desktop, FAB button on mobile. Auto-detects posts with 3+ h2 headings. Added via blog layout so all posts get it automatically (#1254)
- **Search UX** — hide non-functional sort dropdown in unified mode; skip fuzzy index search for queries under 3 characters (fixes "al" → Leonardo da Vinci) (#1349)

## Test plan
- [ ] Check hero images render on `/collections/all`, `/languages`, `/about`, `/about/sources`, `/about/research`
- [ ] Visit `/blog/hidden-engineers` — verify ToC appears on desktop sidebar and as FAB on mobile
- [ ] Visit `/blog/mcp-server` (short post, 4 headings) — verify ToC shows
- [ ] Visit a blog post with <3 headings — verify no ToC
- [ ] Search for "al" — verify no index results (was returning Leonardo da Vinci)
- [ ] Search in unified mode — verify sort dropdown is hidden
- [ ] Search in books/index mode — verify sort dropdown still shows

Closes #1371. Partial fix for #1349, #1254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)