### PR TITLE
Art collections: sort by resolution, exclude reproductions

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -61,6 +61,37 @@ export async function GET(
 
     // Manifest mode: return all books for client-side filter/sort
     if (mode === 'manifest') {
+      // Art collections: use MongoDB for resolution-based sorting and repro filtering
+      if (isArtCollection) {
+        const artFilter: Record<string, unknown> = {
+          collections: id,
+          resource_type: { $exists: true },
+          visible: true,
+          $or: [{ year: { $lt: 1700 } }, { year: { $exists: false } }],
+        };
+        const docs = await db.collection('books')
+          .find(artFilter, {
+            projection: {
+              _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1,
+              language: 1, pages_count: 1, thumbnail: 1, thumbnail_blob: 1,
+              published: 1, read_count: 1, resource_type: 1, commons_width: 1,
+            },
+            maxTimeMS: 15000,
+          })
+          .sort({ commons_width: -1 })
+          .limit(1000)
+          .toArray();
+        const books = docs.map(b => ({
+          ...b,
+          pages_ocr: 0, pages_translated: 0, pages_blank: 0,
+          is_first_translation: false,
+          created_at: null, last_translation_at: null,
+          medium: null, enrichment: null,
+          relevance: b.commons_width || 0,
+        }));
+        return NextResponse.json({ books, total: books.length });
+      }
+
       const { books: sbBooks, total } = await browseBooks({
         collection: id,
         hasTranslation: !skipTranslationFilter,

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -278,6 +278,25 @@ async function fetchCollectionData(id: string, provider?: string) {
   // Books query: Supabase primary (fast), MongoDB fallback (has collection_scores
   // but Atlas multiplanner timeouts cause 10-15s delays or 500s).
   async function fetchBooksWithFallback() {
+    // Art collections: use MongoDB directly to sort by image resolution
+    // and exclude reproductions (year >= 1700). Supabase lacks resolution data.
+    if (isArtCollection) {
+      const artFilter = {
+        collections: id,
+        resource_type: { $exists: true },
+        $or: [{ year: { $lt: 1700 } }, { year: { $exists: false } }],
+      };
+      const docs = await withTimeout(
+        db.collection('books')
+          .find(artFilter, { projection, maxTimeMS: 8000 })
+          .sort({ commons_width: -1 })
+          .limit(COMPACT_LIMIT)
+          .toArray(),
+        15000, [],
+      );
+      return docs;
+    }
+
     try {
       const { books: sbBooks } = await browseBooks({
         collection: id,


### PR DESCRIPTION
## Summary
- Art collections fetch from MongoDB (not Supabase) to sort by `commons_width` — highest resolution paintings first
- Excludes items with year >= 1700 (19th century reproductions, photos of medallions, etc.)
- Both SSR and manifest API use this path for art collections
- Regular book collections unchanged

## Test plan
- [ ] Visit /collections/ficinos-florence — should show Raphael, Botticelli, Michelangelo masterworks first
- [ ] No 19th-century book reproductions or medallion photos in initial view  
- [ ] Pagination still works
- [ ] Regular collections unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)