### PR TITLE
Hide illustrations section on art collection pages

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -835,8 +835,8 @@ export default async function CollectionDetailPage({ params, provider }: Props &
         </div>
       )}
 
-      {/* Gallery — labeled illustrations (hidden when exhibition provides its own gallery_grid) */}
-      {diverseGalleryImages.length > 0 && !exhibition?.layout && (
+      {/* Gallery — labeled illustrations (hidden for art collections and exhibitions) */}
+      {diverseGalleryImages.length > 0 && !isArtCollection && !exhibition?.layout && (
         <div className="bg-warm border-b border-border-light">
           <div className="max-w-7xl mx-auto px-6 py-8">
             <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
## Summary
- Hides the "Illustrations" extracted-image grid on visual_art collection pages
- These are redundant when the collection content IS artwork

## Test plan
- [ ] /collections/ficinos-florence — no "Illustrations" section above the gallery
- [ ] Regular book collections still show illustrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)