### PR TITLE
Progressive hi-res loading for artwork pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -404,6 +404,9 @@ mark {
 .animate-fade-in {
   animation: fade-in 0.3s ease-out forwards;
 }
+.animate-fade-in-slow {
+  animation: fade-in 0.7s ease-out forwards;
+}
 
 /* Pulse glow animation for loading spinner */
 @keyframes pulse-glow {

--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import ImageWithMagnifier from '@/components/ui/ImageWithMagnifier';
 import { ZoomIn, Maximize, Minimize, ChevronLeft, ChevronRight } from 'lucide-react';
@@ -13,6 +13,7 @@ interface ArtworkNavItem {
 interface ArtworkHeroProps {
   imageUrl: string;
   thumbUrl?: string;
+  hiResUrl?: string;
   title: string;
   fullResUrl: string;
   license: string;
@@ -21,10 +22,23 @@ interface ArtworkHeroProps {
   nextWork?: ArtworkNavItem | null;
 }
 
-export default function ArtworkHero({ imageUrl, thumbUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork }: ArtworkHeroProps) {
+export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork }: ArtworkHeroProps) {
   const [fitHeight, setFitHeight] = useState(false);
   const hasThumb = !!thumbUrl && thumbUrl !== imageUrl;
-  const [hiResLoaded, setHiResLoaded] = useState(!hasThumb);
+  const hasHiRes = !!hiResUrl && hiResUrl !== imageUrl;
+  const [medResLoaded, setMedResLoaded] = useState(!hasThumb);
+  const [hiResLoaded, setHiResLoaded] = useState(false);
+
+  // Start loading hi-res image in background once medium-res is visible
+  useEffect(() => {
+    if (!medResLoaded || !hasHiRes) return;
+    const img = new window.Image();
+    img.onload = () => setHiResLoaded(true);
+    img.src = hiResUrl!;
+  }, [medResLoaded, hasHiRes, hiResUrl]);
+
+  // The best available src for magnifier zoom
+  const magnifierSrc = (hiResLoaded && hiResUrl) ? hiResUrl : imageUrl;
 
   return (
     <div className="bg-stone-900 relative">
@@ -36,8 +50,8 @@ export default function ArtworkHero({ imageUrl, thumbUrl, title, fullResUrl, lic
         >
           {hasThumb ? (
             <>
-              {/* Layer 1: 600px thumb — shows immediately */}
-              <div className={`absolute inset-0 transition-opacity duration-700 ${hiResLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
+              {/* Layer 1: thumb — shows immediately */}
+              <div className={`absolute inset-0 transition-opacity duration-700 ${medResLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
                 <ImageWithMagnifier
                   src={thumbUrl}
                   thumbnail={thumbUrl}
@@ -48,20 +62,66 @@ export default function ArtworkHero({ imageUrl, thumbUrl, title, fullResUrl, lic
                   darkMode
                 />
               </div>
-              {/* Layer 2: full-res — fades in over thumb */}
-              <div className={`absolute inset-0 transition-opacity duration-700 ${hiResLoaded ? 'opacity-100' : 'opacity-0'}`}>
+              {/* Layer 2: medium-res blob — fades in over thumb */}
+              <div className={`absolute inset-0 transition-opacity duration-700 ${medResLoaded ? 'opacity-100' : 'opacity-0'} ${hiResLoaded ? 'pointer-events-none' : ''}`}>
                 <ImageWithMagnifier
                   src={imageUrl}
                   thumbnail={thumbUrl}
-                  highResSrc={imageUrl}
+                  highResSrc={magnifierSrc}
                   alt={title}
                   className="w-full h-full"
                   magnifierSize={240}
                   zoomLevel={3}
                   darkMode
-                  onLoad={() => setHiResLoaded(true)}
+                  onLoad={() => setMedResLoaded(true)}
                 />
               </div>
+              {/* Layer 3: full-res archived — fades in over medium when ready */}
+              {hasHiRes && hiResLoaded && (
+                <div className="absolute inset-0 animate-fade-in-slow">
+                  <ImageWithMagnifier
+                    src={hiResUrl!}
+                    thumbnail={imageUrl}
+                    highResSrc={hiResUrl!}
+                    alt={title}
+                    className="w-full h-full"
+                    magnifierSize={240}
+                    zoomLevel={3}
+                    darkMode
+                  />
+                </div>
+              )}
+            </>
+          ) : hasHiRes ? (
+            <>
+              {/* No thumb but has hi-res: show medium immediately, fade in hi-res */}
+              <div className={`absolute inset-0 ${hiResLoaded ? 'pointer-events-none' : ''}`}>
+                <ImageWithMagnifier
+                  src={imageUrl}
+                  thumbnail={imageUrl}
+                  highResSrc={magnifierSrc}
+                  alt={title}
+                  className="w-full h-full"
+                  magnifierSize={240}
+                  zoomLevel={3}
+                  darkMode
+                  onLoad={() => setMedResLoaded(true)}
+                />
+              </div>
+              {hiResLoaded && (
+                <div className="absolute inset-0 animate-fade-in-slow">
+                  <ImageWithMagnifier
+                    src={hiResUrl!}
+                    thumbnail={imageUrl}
+                    highResSrc={hiResUrl!}
+                    alt={title}
+                    className="w-full h-full"
+                    magnifierSize={240}
+                    zoomLevel={3}
+                    darkMode
+                  />
+                </div>
+              )}
             </>
           ) : (
             <ImageWithMagnifier

--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -106,6 +106,7 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
         <ArtworkHero
           imageUrl={displayImage}
           thumbUrl={thumbImage}
+          hiResUrl={archivedFullUrl || ''}
           title={book.title}
           fullResUrl={commonsUrl || commonsFullUrl}
           license={commonsLicense}


### PR DESCRIPTION
## Summary
- Artwork pages now progressively load three resolution tiers: **thumb** (instant) → **medium blob** (fast) → **full-res archived** (background crossfade)
- After the medium-res image is visible, the full-res archived image (often 4K+) loads silently in the background and fades in over 700ms with no flicker
- The magnifier lens automatically uses the highest loaded resolution for sharper zoom
- Works for 88% of artworks (22,465/25,537) that have `archived_full_url`
- No-op for artworks without archived full-res — falls back to existing two-tier behavior

## Changes
- `ArtworkHero.tsx` — added `hiResUrl` prop, third image layer with `useEffect` background loading, `animate-fade-in-slow` crossfade
- `ArtworkInfo.tsx` — passes `archivedFullUrl` to hero
- `globals.css` — added `animate-fade-in-slow` (700ms) variant

## Test plan
- [ ] Visit https://sourcelibrary.org/artwork/raphael-pinacoteca-nazionale-di-bologna-estasi-di-santa-cecilia-di-raffaello on preview
- [ ] Verify thumb loads instantly, medium fades in, then full-res crossfades seamlessly
- [ ] Check magnifier uses full resolution after hi-res loads
- [ ] Verify artworks without `archived_full_url` still work normally
- [ ] Test on mobile (hi-res still loads but doesn't waste bandwidth on magnifier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)