### PR TITLE
Fix progressive loading brightness flicker

### DIFF
--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -50,8 +50,8 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
         >
           {hasThumb ? (
             <>
-              {/* Layer 1: thumb — shows immediately */}
-              <div className={`absolute inset-0 transition-opacity duration-700 ${medResLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
+              {/* Layer 1: thumb — always visible underneath, covered by higher layers */}
+              <div className={`absolute inset-0 ${medResLoaded ? 'pointer-events-none' : ''}`}>
                 <ImageWithMagnifier
                   src={thumbUrl}
                   thumbnail={thumbUrl}
@@ -62,7 +62,7 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
                   darkMode
                 />
               </div>
-              {/* Layer 2: medium-res blob — fades in over thumb */}
+              {/* Layer 2: medium-res blob — fades in over thumb (thumb stays opaque beneath) */}
               <div className={`absolute inset-0 transition-opacity duration-700 ${medResLoaded ? 'opacity-100' : 'opacity-0'} ${hiResLoaded ? 'pointer-events-none' : ''}`}>
                 <ImageWithMagnifier
                   src={imageUrl}
@@ -76,7 +76,7 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
                   onLoad={() => setMedResLoaded(true)}
                 />
               </div>
-              {/* Layer 3: full-res archived — fades in over medium when ready */}
+              {/* Layer 3: full-res archived — fades in over medium (medium stays opaque beneath) */}
               {hasHiRes && hiResLoaded && (
                 <div className="absolute inset-0 animate-fade-in-slow">
                   <ImageWithMagnifier


### PR DESCRIPTION
## Summary
- Fixes brightness flickering during artwork image crossfade transitions
- Lower-res layers now stay at full opacity — higher-res layers fade in **on top** rather than replacing
- Previously both layers were transitioning opacity simultaneously, revealing the dark `bg-stone-900` background at the midpoint

## Changes
- `ArtworkHero.tsx` — Layer 1 (thumb) stays fully opaque instead of fading to 0; only pointer-events change

🤖 Generated with [Claude Code](https://claude.com/claude-code)