### PR TITLE
Exclude photos and museum objects from art galleries

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -63,9 +63,10 @@ export async function GET(
     if (mode === 'manifest') {
       // Art collections: use MongoDB for resolution-based sorting and repro filtering
       if (isArtCollection) {
+        const EXCLUDED_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
         const artFilter: Record<string, unknown> = {
           collections: id,
-          resource_type: { $exists: true },
+          resource_type: { $exists: true, $nin: EXCLUDED_TYPES },
           visible: true,
           $or: [{ year: { $lt: 1700 } }, { year: { $exists: false } }],
         };

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -278,12 +278,13 @@ async function fetchCollectionData(id: string, provider?: string) {
   // Books query: Supabase primary (fast), MongoDB fallback (has collection_scores
   // but Atlas multiplanner timeouts cause 10-15s delays or 500s).
   async function fetchBooksWithFallback() {
-    // Art collections: use MongoDB directly to sort by image resolution
-    // and exclude reproductions (year >= 1700). Supabase lacks resolution data.
+    // Art collections: use MongoDB directly to sort by image resolution.
+    // Exclude photographs, modern reproductions, and museum object photos.
     if (isArtCollection) {
+      const EXCLUDED_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
       const artFilter = {
         collections: id,
-        resource_type: { $exists: true },
+        resource_type: { $exists: true, $nin: EXCLUDED_TYPES },
         $or: [{ year: { $lt: 1700 } }, { year: { $exists: false } }],
       };
       const docs = await withTimeout(


### PR DESCRIPTION
## Summary
- Filters out photograph, object, sculpture, architectural, decorative, ritual-object from art collection grids
- The Cosmos had 147 photos of armillary spheres drowning out Fludd/Kircher cosmological engravings
- Applies to both SSR and manifest API

## Test plan
- [ ] /collections/the-cosmos — no museum photos, Kennedy photo, or broken globe images
- [ ] /collections/ficinos-florence — still shows paintings correctly
- [ ] /collections/rudolf-prague — still shows prints/engravings

🤖 Generated with [Claude Code](https://claude.com/claude-code)