### PR TITLE
Remove misleading resource_type badges from art galleries

### DIFF
--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -387,11 +387,6 @@ export default function CollectionAllBooks({
                     {book.author}{year > 0 ? `, ${year}` : ''}
                   </p>
                 </div>
-                {book.resource_type && book.resource_type !== 'painting' && (
-                  <span className="absolute top-2 left-2 text-[10px] bg-black/60 text-white px-1.5 py-0.5 rounded capitalize">
-                    {book.resource_type.replace(/_/g, ' ')}
-                  </span>
-                )}
               </Link>
             );
           })}


### PR DESCRIPTION
## Summary
- Removes the resource_type badge (e.g. "print") from art collection gallery cards
- Commons metadata frequently mislabels paintings as prints — the badge was misleading

🤖 Generated with [Claude Code](https://claude.com/claude-code)