### PR TITLE
Move API key request form to top of /developers

### DIFF
--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
@@ -310,6 +311,20 @@ source-library search "alchemy" --json | jq .results`}
               </tbody>
             </table>
           </div>
+        </div>
+      </section>
+
+      {/* Dataset API */}
+      <section className="mb-16">
+        <h2 className="text-2xl font-semibold text-primary mb-2">Dataset API</h2>
+        <p className="text-secondary mb-6 max-w-2xl">
+          For bulk access to OCR text, translations, and page-level data, request an API key.
+          Keys are reviewed within 24 hours.
+        </p>
+
+        <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
+          <h3 className="text-lg font-semibold text-primary mb-4">Request an API Key</h3>
+          <ApiKeyRequestForm />
         </div>
       </section>
 

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -21,6 +21,17 @@ export default function DevelopersPage() {
         />
       }
     >
+      {/* Request API Key */}
+      <section className="mb-16">
+        <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
+          <h2 className="text-lg font-semibold text-primary mb-2">Request an API Key</h2>
+          <p className="text-secondary mb-6">
+            For bulk access to OCR text, translations, and page-level data. Keys are reviewed within 24 hours.
+          </p>
+          <ApiKeyRequestForm />
+        </div>
+      </section>
+
       {/* Use case */}
       <section className="mb-16">
         <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
@@ -311,20 +322,6 @@ source-library search "alchemy" --json | jq .results`}
               </tbody>
             </table>
           </div>
-        </div>
-      </section>
-
-      {/* Dataset API */}
-      <section className="mb-16">
-        <h2 className="text-2xl font-semibold text-primary mb-2">Dataset API</h2>
-        <p className="text-secondary mb-6 max-w-2xl">
-          For bulk access to OCR text, translations, and page-level data, request an API key.
-          Keys are reviewed within 24 hours.
-        </p>
-
-        <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
-          <h3 className="text-lg font-semibold text-primary mb-4">Request an API Key</h3>
-          <ApiKeyRequestForm />
         </div>
       </section>
 


### PR DESCRIPTION
Moves the form above the use case section so it's the first thing developers see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)