### PR TITLE
Use thumbnail images in art gallery grid for performance

### DIFF
--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -352,7 +352,7 @@ export default function CollectionAllBooks({
         /* Art gallery grid — image-forward layout */
         <div className={`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 ${loading ? 'opacity-50 pointer-events-none' : ''}`}>
           {displayBooks.map((book) => {
-            const thumb = getBookThumbnailUrl(book) || book.photo;
+            const thumb = getBookThumbnailUrl(book, 'thumb') || book.photo;
             const title = bookTitle(book);
             const year = book.year || parseInt(book.published || '', 10) || 0;
             return (


### PR DESCRIPTION
## Summary
- Art gallery grid was loading full-resolution originals (up to 23MB each) for 300px cards
- Switch to 600px thumbnails — pre-downscaled, sharper rendering, much faster loads
- One-line change in CollectionAllBooks gallery grid

## Test plan
- [ ] /collections/haarlem-mannerists — images should load faster and look sharper
- [ ] Check network tab — no multi-MB image loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)