### PR TITLE
Artwork detail: fall back to Commons for hi-res images

### DIFF
--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -106,7 +106,7 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
         <ArtworkHero
           imageUrl={displayImage}
           thumbUrl={thumbImage}
-          hiResUrl={archivedFullUrl || ''}
+          hiResUrl={archivedFullUrl || commonsFullUrl || ''}
           title={book.title}
           fullResUrl={commonsUrl || commonsFullUrl}
           license={commonsLicense}


### PR DESCRIPTION
## Summary
- When `archived_full_url` is empty, use `commons_full_url` as the hi-res progressive load source
- Example: Venus and Mars (Botticelli) was showing 2000px archived version instead of 7689px Commons original
- One-line change in ArtworkInfo.tsx

## Test plan
- [ ] Visit /artwork/venus-and-mars-... — image should progressively load to full Commons resolution
- [ ] Check that the magnifier works at hi-res

🤖 Generated with [Claude Code](https://claude.com/claude-code)