### PR TITLE
Remove year<1700 filter from art collection queries

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -285,7 +285,6 @@ async function fetchCollectionData(id: string, provider?: string) {
       const artFilter = {
         collections: id,
         resource_type: { $exists: true, $nin: EXCLUDED_TYPES },
-        $or: [{ year: { $lt: 1700 } }, { year: { $exists: false } }],
       };
       const docs = await withTimeout(
         db.collection('books')


### PR DESCRIPTION
## Summary
- The art collection page query had a `year < 1700` filter intended to exclude modern photos, but the `resource_type` exclusion list (`photograph`, `object`, etc.) already handles that
- This filter was hiding all 50 artworks in Thought-Forms (1905) and would affect any post-1700 art collection
- Also fixed via DB: 3 thought-forms books had Wikimedia upload dates (2005/2006) → corrected to 1905

## Test plan
- [ ] Visit https://sourcelibrary.org/collections/thought-forms — should show books now
- [ ] Verify other art collections still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)