### PR TITLE
Fix broken artwork thumbnails on collection pages

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -51,6 +51,13 @@ export function getBookThumbnailUrl(
 
   if (!raw.includes('images.sourcelibrary.org/')) return raw;
 
+  // Artwork URLs: many -thumb.jpg variants were never generated, so always
+  // normalize to -full.jpg (the only version guaranteed to exist).
+  if (raw.includes('/artwork/')) {
+    if (raw.endsWith('-thumb.jpg')) return raw.replace(/-thumb\.jpg$/, '-full.jpg');
+    return raw;
+  }
+
   // Rewrite legacy /thumbnails/{bookId}/{num}.jpg → /pages/{bookId}/{0num}.jpg
   // The /thumbnails/ path has only small images, but /pages/ has all three variants.
   const thumbMatch = raw.match(/\/thumbnails\/([^/]+)\/(\d+)\.jpg$/);


### PR DESCRIPTION
## Summary
- Artwork images in R2 only have `-full.jpg` variants, not `-thumb.jpg` — but `thumbnail_blob` points to the nonexistent `-thumb.jpg`
- `getBookThumbnailUrl()` already handles `/pages/` URL rewriting but passed `/artwork/` URLs through unchanged
- Added an `/artwork/` handler that rewrites `-thumb.jpg` → `-full.jpg`
- Fixes broken images on https://sourcelibrary.org/collections/wrathful-deities and ~10K other artworks site-wide

## Test plan
- [ ] Visit /collections/wrathful-deities — all artwork thumbnails should load
- [ ] Visit /artwork — spot check that artwork images still display correctly
- [ ] Check other art collections (e.g. /collections/renaissance-art)

🤖 Generated with [Claude Code](https://claude.com/claude-code)