### PR TITLE
Rewrite Wikimedia URLs to thumb.php to fix broken artwork images

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,6 +49,17 @@ export function getBookThumbnailUrl(
     : (book.thumbnail_blob || book.thumbnail || null);
   if (!raw) return null;
 
+  // Wikimedia Commons: rewrite to thumb.php for CDN-cached resized images.
+  // Loading full-res Wikimedia files (3000-8000px) directly causes 429 rate-limits
+  // and wastes bandwidth. thumb.php serves fast, CDN-cached thumbnails.
+  if (raw.includes('upload.wikimedia.org/wikipedia/commons/')) {
+    const filename = raw.split('/').pop();
+    if (filename) {
+      const w = size === 'thumb' ? 400 : 800;
+      return `https://commons.wikimedia.org/w/thumb.php?f=${filename}&w=${w}`;
+    }
+  }
+
   if (!raw.includes('images.sourcelibrary.org/')) return raw;
 
   // Artwork URLs: many -thumb.jpg variants were never generated, so always


### PR DESCRIPTION
## Summary
- 354/360 artworks in wrathful-deities (and many other art collections) point directly to `upload.wikimedia.org` full-res images
- Loading 60+ multi-megabyte images simultaneously triggers Wikimedia's 429 rate-limit
- Rewrite URLs in `getBookThumbnailUrl` to use `commons.wikimedia.org/w/thumb.php` — CDN-cached, resized thumbnails (800px display, 400px thumb)
- This is a client-side rewrite, no DB changes needed

## Test plan
- [ ] Visit /collections/wrathful-deities — artwork grid should load images without broken thumbnails
- [ ] Check /artwork page — verify Wikimedia-sourced artworks still display
- [ ] Verify R2-archived artworks (images.sourcelibrary.org) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)