### PR TITLE
Fix art collection API year filter + deduplicate constants

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { browseBooks, type SortOption } from '@/lib/books-catalog';
+import { ART_EXCLUDED_RESOURCE_TYPES } from '@/lib/collections-utils';
 
 export const maxDuration = 30;
 
@@ -63,12 +64,10 @@ export async function GET(
     if (mode === 'manifest') {
       // Art collections: use MongoDB for resolution-based sorting and repro filtering
       if (isArtCollection) {
-        const EXCLUDED_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
         const artFilter: Record<string, unknown> = {
           collections: id,
-          resource_type: { $exists: true, $nin: EXCLUDED_TYPES },
+          resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES },
           visible: true,
-          $or: [{ year: { $lt: 1700 } }, { year: { $exists: false } }],
         };
         const docs = await db.collection('books')
           .find(artFilter, {

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -12,7 +12,7 @@ import CollectionAllBooks from '@/components/collections/CollectionAllBooks';
 import ExhibitionLayout from '@/components/collections/ExhibitionLayout';
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { bookUrl } from '@/lib/slugify';
-import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-utils';
+import { bookTitle, sanitizeThumbnail, withTimeout, ART_EXCLUDED_RESOURCE_TYPES } from '@/lib/collections-utils';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import { browseBooks } from '@/lib/books-catalog';
@@ -281,10 +281,9 @@ async function fetchCollectionData(id: string, provider?: string) {
     // Art collections: use MongoDB directly to sort by image resolution.
     // Exclude photographs, modern reproductions, and museum object photos.
     if (isArtCollection) {
-      const EXCLUDED_TYPES = ['photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object'];
       const artFilter = {
         collections: id,
-        resource_type: { $exists: true, $nin: EXCLUDED_TYPES },
+        resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES },
       };
       const docs = await withTimeout(
         db.collection('books')

--- a/src/lib/collections-utils.ts
+++ b/src/lib/collections-utils.ts
@@ -3,6 +3,13 @@
  * Extracted from duplicated code across page components.
  */
 
+// ---------- Art collection filtering ----------
+// Resource types excluded from art collection queries.
+// These are documentary/photographic records, not artworks.
+export const ART_EXCLUDED_RESOURCE_TYPES = [
+  'photograph', 'object', 'sculpture', 'architectural', 'decorative', 'ritual-object',
+];
+
 // ---------- Pinned collection ordering ----------
 
 export const PINNED_COLLECTION_SLUGS = [


### PR DESCRIPTION
## Summary
- Remove year<1700 filter from the **API manifest endpoint** — this was the actual cause of empty Thought-Forms page (the client component fetches from `/api/collections/[id]?mode=manifest`, not the SSR query fixed in #1428)
- Extract duplicated `EXCLUDED_TYPES` array into shared `ART_EXCLUDED_RESOURCE_TYPES` constant in `collections-utils.ts` so the page and API can't drift apart again

## Test plan
- [ ] Visit https://sourcelibrary.org/collections/thought-forms — should show all 50 artworks
- [ ] Check another art collection still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)