### PR TITLE
Progressive display loading in ImageWithMagnifier

### DIFF
--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -63,7 +63,18 @@ export default function ImageWithMagnifier({
   };
   const activeSrc = useFallback && fallbackSrc ? fallbackSrc : src;
   const isApiUrl = activeSrc.startsWith('/api/');
-  const displaySrc = thumbnail || (isApiUrl ? activeSrc : getResizedUrl(activeSrc, 400));
+  const initialDisplaySrc = thumbnail || (isApiUrl ? activeSrc : getResizedUrl(activeSrc, 400));
+  // Progressive display: background-load activeSrc, swap in when ready
+  const [hiResDisplayReady, setHiResDisplayReady] = useState(false);
+  const canUpgradeDisplay = !!thumbnail && thumbnail !== activeSrc;
+  useEffect(() => {
+    if (!canUpgradeDisplay) return;
+    setHiResDisplayReady(false);
+    const img = new window.Image();
+    img.onload = () => setHiResDisplayReady(true);
+    img.src = activeSrc;
+  }, [canUpgradeDisplay, activeSrc]);
+  const displaySrc = (hiResDisplayReady && canUpgradeDisplay) ? activeSrc : initialDisplaySrc;
   // Use high-res version for magnifier if available, otherwise use standard src
   const magnifierSrc = highResSrc || activeSrc;
 


### PR DESCRIPTION
## Summary
- When `thumbnail` differs from `src`, background-loads `src` and swaps the visible display image when ready
- Display starts with fast thumb, then silently upgrades to full-res — no fade, instant swap
- Benefits all ImageWithMagnifier users: exhibition featured images, gallery detail pages, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)