### PR TITLE
Fix art collection counts: show artwork count, not total items

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -247,9 +247,9 @@ async function fetchCollectionData(id: string, provider?: string) {
     .map((m: { book_id: string }) => m.book_id)
     .filter(Boolean);
 
-  // Use cached book_count — sync-page-counts cron updates this every 6h
-  // to reflect only translated books (pages_translated > 0).
-  const total = collection.book_count || 0;
+  // For book collections, use cached book_count (sync-page-counts cron, 6h).
+  // For art collections, count artworks matching the art filter (excludes photos etc).
+  let total = collection.book_count || 0;
 
   // Track gallery collection slug for linking (captured in the gallery query below)
   let galleryCollectionSlug: string | null = null;
@@ -290,14 +290,22 @@ async function fetchCollectionData(id: string, provider?: string) {
         collections: id,
         resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES },
       };
-      const docs = await withTimeout(
-        db.collection('books')
-          .find(artFilter, { projection, maxTimeMS: 8000 })
-          .sort({ commons_width: -1 })
-          .limit(COMPACT_LIMIT)
-          .toArray(),
-        15000, [],
-      );
+      const [docs, artCount] = await Promise.all([
+        withTimeout(
+          db.collection('books')
+            .find(artFilter, { projection, maxTimeMS: 8000 })
+            .sort({ commons_width: -1 })
+            .limit(COMPACT_LIMIT)
+            .toArray(),
+          15000, [],
+        ),
+        withTimeout(
+          db.collection('books').countDocuments(artFilter, { maxTimeMS: 8000 }),
+          8000, 0,
+        ),
+      ]);
+      // Override cached book_count with actual artwork count
+      total = artCount || docs.length;
       return docs;
     }
 


### PR DESCRIPTION
## Summary
- Art collection pages displayed `book_count` which included all items (books, artworks, photos, excluded types). The header would say "592 works" when only 9 are actually artworks.
- Now the page computes the real artwork count using the same filter as the display query (`resource_type` exists, excluding photos/objects/etc)
- Fixed cached `book_count` in DB for all 26 art collections. Biggest corrections:
  - school-of-athens: 592 → 9
  - erotic-art: 1141 → 632
  - book-of-the-dead: 374 → 196
  - the-cosmos: 527 → 288

## Test plan
- [ ] Check art collection pages show accurate counts
- [ ] Verify non-art collections still show correct book counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)