### PR TITLE
Fix broken artwork links: /artwork/ doesn't exist on main site

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -945,7 +945,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                 return (
                   <Link
                     key={art.id}
-                    href={`/artwork/${art.slug || art.id}`}
+                    href={`/book/${art.slug || art.id}`}
                     className="group block"
                   >
                     <div className="rounded-lg border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -54,7 +54,7 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
 
   return (
     <Link
-      href={isArtwork ? `/artwork/${slug}` : bookHref}
+      href={isArtwork && bookUrlPrefix ? `${bookUrlPrefix}/artwork/${slug}` : bookHref}
       className="group block"
     >
       <div className="h-full rounded-xl border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -358,7 +358,7 @@ export default function CollectionAllBooks({
             return (
               <Link
                 key={book.id}
-                href={`/artwork/${book.slug || book.id}`}
+                href={`/book/${book.slug || book.id}`}
                 className="group relative aspect-[3/4] rounded-lg overflow-hidden bg-stone-100"
               >
                 {thumb ? (


### PR DESCRIPTION
## Summary
- Clicking any artwork on art collection pages (e.g. /collections/erotic-art) redirected to the homepage
- `/artwork/{slug}` only exists under `[tenant]` routes, not at the root level
- Changed artwork links to use `/book/{slug}` on the main site
- Tenant sites still use `/{tenant}/artwork/{slug}` (which has the specialized art layout)

## Test plan
- [ ] Click artworks on https://sourcelibrary.org/collections/erotic-art — should open book page
- [ ] Click artworks on https://sourcelibrary.org/collections/thought-forms — should open book page

🤖 Generated with [Claude Code](https://claude.com/claude-code)