### PR TITLE
Add root-level /artwork routes

### DIFF
--- a/src/app/artwork/[slug]/loading.tsx
+++ b/src/app/artwork/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function ArtworkLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+
+      {/* Hero image skeleton — dark background like the real artwork page */}
+      <div className="bg-stone-900">
+        <div className="max-w-3xl mx-auto py-4 sm:py-8">
+          <div className="aspect-[3/4] bg-stone-800 rounded animate-pulse flex items-center justify-center">
+            <div className="w-8 h-8 border-2 border-stone-600 border-t-stone-400 rounded-full animate-spin" />
+          </div>
+        </div>
+        {/* Caption bar skeleton */}
+        <div className="border-t border-stone-800">
+          <div className="max-w-4xl mx-auto px-6 md:px-12 py-3">
+            <div className="h-3 w-64 bg-stone-800 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+
+      {/* Info section skeleton */}
+      <div className="max-w-4xl mx-auto px-6 md:px-12 py-8 space-y-4">
+        {/* Title */}
+        <div className="h-8 w-2/3 bg-stone-200 rounded animate-pulse" />
+        {/* Artist */}
+        <div className="h-5 w-1/3 bg-stone-200 rounded animate-pulse" />
+        {/* Date + medium */}
+        <div className="flex gap-4">
+          <div className="h-4 w-20 bg-stone-100 rounded animate-pulse" />
+          <div className="h-4 w-32 bg-stone-100 rounded animate-pulse" />
+        </div>
+        {/* Description */}
+        <div className="mt-6 space-y-3">
+          <div className="h-4 w-full bg-stone-200 rounded animate-pulse" />
+          <div className="h-4 w-5/6 bg-stone-200 rounded animate-pulse" />
+          <div className="h-4 w-3/4 bg-stone-200 rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/artwork/[slug]/page.tsx
+++ b/src/app/artwork/[slug]/page.tsx
@@ -1,0 +1,105 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getReadDb } from '@/lib/mongodb';
+import { Book } from '@/lib/types';
+import SiteHeader from '@/components/layout/SiteHeader';
+import ArtworkInfo from '@/components/artwork/ArtworkInfo';
+
+export const revalidate = false;
+export const dynamicParams = true;
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+async function getArtwork(slug: string) {
+  const db = await getReadDb();
+
+  // Try exact slug match, then with art- prefix
+  const slugsToTry = [slug, `art-${slug}`];
+  const artwork = await db.collection('books').findOne(
+    { slug: { $in: slugsToTry }, resource_type: { $exists: true } },
+  );
+  if (!artwork) return null;
+
+  // Get collections this artwork belongs to
+  const collectionSlugs = (artwork.collections as string[]) || [];
+
+  // Get prev/next works by same artist (chronologically by published date, then title)
+  const [collections, prevWorkRaw, nextWorkRaw] = await Promise.all([
+    collectionSlugs.length > 0
+      ? db.collection('collections')
+          .find({ slug: { $in: collectionSlugs } })
+          .project({ _id: 0, slug: 1, name: 1, subtitle: 1, color: 1 })
+          .toArray()
+      : Promise.resolve([]),
+    // Previous: same artist, earlier in sort order
+    db.collection('books').findOne(
+      {
+        author: artwork.author,
+        resource_type: { $exists: true },
+        $or: [
+          { published: { $lt: artwork.published || '' } },
+          { published: artwork.published || '', title: { $lt: artwork.title } },
+        ],
+      },
+      { projection: { slug: 1, title: 1, display_title: 1 }, sort: { published: -1, title: -1 } }
+    ),
+    // Next: same artist, later in sort order
+    db.collection('books').findOne(
+      {
+        author: artwork.author,
+        resource_type: { $exists: true },
+        $or: [
+          { published: { $gt: artwork.published || '' } },
+          { published: artwork.published || '', title: { $gt: artwork.title } },
+        ],
+      },
+      { projection: { slug: 1, title: 1, display_title: 1 }, sort: { published: 1, title: 1 } }
+    ),
+  ]);
+
+  const prevWork = prevWorkRaw ? { slug: prevWorkRaw.slug, title: prevWorkRaw.display_title || prevWorkRaw.title } : null;
+  const nextWork = nextWorkRaw ? { slug: nextWorkRaw.slug, title: nextWorkRaw.display_title || nextWorkRaw.title } : null;
+
+  return {
+    artwork: JSON.parse(JSON.stringify(artwork)) as Book,
+    collections: collections as { slug: string; name: string; subtitle?: string; color?: string }[],
+    prevWork,
+    nextWork,
+  };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  let data: Awaited<ReturnType<typeof getArtwork>>;
+  try {
+    data = await getArtwork(slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
+  if (!data) return { title: 'Not Found', robots: { index: false, follow: true } };
+  const { artwork } = data;
+  return {
+    title: `${artwork.display_title || artwork.title} — ${artwork.author} — Source Library`,
+    description: (artwork as any).commons_description?.slice(0, 200) || `${artwork.title} by ${artwork.author}`,
+    robots: { index: true, follow: true },
+    openGraph: {
+      title: `${artwork.display_title || artwork.title} by ${artwork.author}`,
+      images: [artwork.thumbnail_blob || artwork.thumbnail || ''],
+    },
+  };
+}
+
+export default async function ArtworkPage({ params }: PageProps) {
+  const { slug } = await params;
+  const data = await getArtwork(slug);
+  if (!data) notFound();
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
+      <SiteHeader variant="dark" />
+      <ArtworkInfo book={data.artwork} collections={data.collections} prevWork={data.prevWork} nextWork={data.nextWork} />
+    </div>
+  );
+}

--- a/src/app/artwork/artist/[slug]/loading.tsx
+++ b/src/app/artwork/artist/[slug]/loading.tsx
@@ -1,0 +1,26 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function ArtworkArtistLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="light" />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8">
+        {/* Artist name */}
+        <div className="h-10 w-64 bg-stone-200 rounded animate-pulse mb-2" />
+        {/* Subtitle */}
+        <div className="h-4 w-40 bg-stone-100 rounded animate-pulse mb-8" />
+
+        {/* Artwork grid skeleton */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="aspect-[3/4] bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-3/4 bg-stone-100 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/artwork/artist/[slug]/page.tsx
+++ b/src/app/artwork/artist/[slug]/page.tsx
@@ -1,0 +1,236 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { getReadDb } from '@/lib/mongodb';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { sanitizeThumbnail } from '@/lib/collections-utils';
+
+export const revalidate = false;
+export const dynamicParams = true;
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+// Names that should not generate artist pages
+const NON_ARTIST_NAMES = ['Various', 'Unknown', 'Anonymous', 'Splendor Solis'];
+
+function isNonArtist(name: string): boolean {
+  return NON_ARTIST_NAMES.some(n => name.toLowerCase().startsWith(n.toLowerCase()));
+}
+
+async function getArtist(slug: string) {
+  const db = await getReadDb();
+
+  // Slug can be "Leonardo-da-Vinci" (dashes) or "Leonardo%20da%20Vinci" (encoded)
+  const artistName = decodeURIComponent(slug).replace(/-/g, ' ');
+
+  // Don't generate pages for non-artist names
+  if (isNonArtist(artistName)) return null;
+
+  const escaped = artistName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const authorRegex = { $regex: `^${escaped}$`, $options: 'i' };
+
+  // Fetch artworks and books by this author in parallel
+  const [artworks, books] = await Promise.all([
+    db.collection('books')
+      .find(
+        { author: authorRegex, resource_type: { $exists: true } },
+        { projection: {
+          slug: 1, title: 1, display_title: 1, author: 1, published: 1,
+          resource_type: 1, medium: 1, thumbnail: 1, thumbnail_blob: 1,
+          commons_width: 1, commons_height: 1, attribution_note: 1,
+        }},
+      )
+      .sort({ published: 1 })
+      .toArray(),
+    db.collection('books')
+      .find(
+        { author: authorRegex, resource_type: { $exists: false }, visible: true },
+        { projection: {
+          slug: 1, title: 1, display_title: 1, author: 1, published: 1,
+          language: 1, thumbnail: 1, thumbnail_blob: 1, pages_translated: 1,
+        }},
+      )
+      .sort({ published: 1 })
+      .toArray(),
+  ]);
+
+  // Also check reversed name format for books (e.g. "Dürer, Albrecht")
+  let allBooks = books;
+  if (books.length === 0 && !artistName.includes(',')) {
+    const parts = artistName.split(' ');
+    if (parts.length >= 2) {
+      const reversed = `${parts[parts.length - 1]}, ${parts.slice(0, -1).join(' ')}`;
+      const reversedEscaped = reversed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      allBooks = await db.collection('books')
+        .find(
+          { author: { $regex: `^${reversedEscaped}$`, $options: 'i' }, resource_type: { $exists: false }, visible: true },
+          { projection: {
+            slug: 1, title: 1, display_title: 1, author: 1, published: 1,
+            language: 1, thumbnail: 1, thumbnail_blob: 1, pages_translated: 1,
+          }},
+        )
+        .sort({ published: 1 })
+        .toArray();
+    }
+  }
+
+  if (artworks.length === 0 && allBooks.length === 0) return null;
+
+  return {
+    name: artistName,
+    artworks: JSON.parse(JSON.stringify(artworks)),
+    books: JSON.parse(JSON.stringify(allBooks)),
+  };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  let data: Awaited<ReturnType<typeof getArtist>>;
+  try {
+    data = await getArtist(slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
+  if (!data) return { title: 'Not Found', robots: { index: false, follow: true } };
+  return {
+    title: `${data.name} — Source Library Visual Art`,
+    description: `${data.artworks.length} works by ${data.name} in Source Library.`,
+    robots: { index: true, follow: true },
+  };
+}
+
+export default async function ArtistPage({ params }: PageProps) {
+  const { slug } = await params;
+  const data = await getArtist(slug);
+  if (!data) notFound();
+
+  const { name, artworks, books } = data;
+
+  // Count by type
+  const typeCounts: Record<string, number> = {};
+  for (const a of artworks) {
+    const t = a.resource_type || 'unknown';
+    typeCounts[t] = (typeCounts[t] || 0) + 1;
+  }
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="relative bg-stone-900 text-white overflow-hidden">
+        {artworks[0]?.thumbnail_blob && sanitizeThumbnail(artworks[0].thumbnail_blob) && (
+          <div className="absolute inset-0 opacity-[0.08]">
+            <Image src={sanitizeThumbnail(artworks[0].thumbnail_blob) as string} alt="" fill className="object-cover" />
+          </div>
+        )}
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6 md:px-12 py-14 sm:py-20">
+          <nav className="flex items-center gap-2 text-xs text-stone-500 mb-8">
+            <Link href="/artwork" className="hover:text-stone-300 transition-colors">Visual Art</Link>
+            <span>/</span>
+            <span className="text-stone-400">{name}</span>
+          </nav>
+
+          <h1 className="font-display text-4xl sm:text-5xl font-bold">{name}</h1>
+          <div className="flex items-center gap-4 mt-3 text-sm text-stone-400">
+            <span>{artworks.length} artworks</span>
+            {books.length > 0 && (
+              <span className="flex items-center gap-1">
+                <span className="w-px h-4 bg-stone-700" />
+                {books.length} {books.length === 1 ? 'book' : 'books'}
+              </span>
+            )}
+            {Object.entries(typeCounts).map(([type, count]) => (
+              <span key={type} className="flex items-center gap-1">
+                <span className="w-px h-4 bg-stone-700" />
+                {count} {type === 'painting' ? 'paintings' : type === 'print' ? 'prints' : type === 'drawing' ? 'drawings' : type === 'object' ? 'sculptures' : type}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="h-px bg-stone-200" />
+
+      {/* Books by this author */}
+      {books.length > 0 && (
+        <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 pt-10 pb-2">
+          <h2 className="text-xl font-display font-bold mb-6" style={{ color: 'var(--text-primary)' }}>
+            Books by {name}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {books.map((b: any) => {
+              const thumb = sanitizeThumbnail(b.thumbnail_blob || b.thumbnail || '');
+              return (
+                <Link
+                  key={b.slug}
+                  href={`/book/${b.slug}`}
+                  className="flex items-start gap-4 p-4 rounded-lg border hover:border-stone-300 transition-colors group"
+                  style={{ background: 'var(--bg-warm)', borderColor: 'var(--border-light)' }}
+                >
+                  {thumb ? (
+                    <div className="relative w-14 h-[72px] flex-shrink-0 rounded-sm overflow-hidden bg-stone-100">
+                      <Image src={thumb} alt="" fill className="object-cover" sizes="56px" />
+                    </div>
+                  ) : (
+                    <div className="w-14 h-[72px] flex-shrink-0 rounded-sm bg-stone-100" />
+                  )}
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-medium leading-tight line-clamp-2 group-hover:text-accent-rust transition-colors" style={{ color: 'var(--text-primary)' }}>
+                      {b.display_title || b.title}
+                    </h3>
+                    <p className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>
+                      {[b.published, b.language].filter(Boolean).join(' · ')}
+                      {b.pages_translated ? ` · ${b.pages_translated} pp translated` : ''}
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Artworks grid */}
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 py-12">
+        {books.length > 0 && (
+          <h2 className="text-xl font-display font-bold mb-6" style={{ color: 'var(--text-primary)' }}>
+            Artworks
+          </h2>
+        )}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-8">
+          {artworks.map((a: any) => {
+            const isPortrait = (a.commons_width || 1) < (a.commons_height || 1);
+            const thumb = sanitizeThumbnail(a.thumbnail || a.thumbnail_blob || '');
+            return (
+              <Link key={a.slug} href={`/artwork/${a.slug}`} className="group block">
+                <div className={`relative overflow-hidden rounded-sm bg-stone-100 ${isPortrait ? 'aspect-[3/4]' : 'aspect-[4/3]'}`}>
+                  {thumb && (
+                    <Image
+                      src={thumb}
+                      alt={a.display_title || a.title}
+                      fill
+                      className="object-cover group-hover:scale-[1.03] transition-transform duration-700 ease-out"
+                      sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                    />
+                  )}
+                </div>
+                <div className="mt-2">
+                  <h3 className="text-sm font-medium leading-tight line-clamp-2 group-hover:text-accent-rust transition-colors" style={{ color: 'var(--text-primary)' }}>
+                    {a.display_title || a.title}
+                  </h3>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                    {[a.attribution_note ? `(${a.attribution_note})` : '', a.published].filter(Boolean).join(' · ')}
+                  </p>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -1,0 +1,168 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { getReadDb } from '@/lib/mongodb';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { sanitizeThumbnail } from '@/lib/collections-utils';
+
+export const metadata: Metadata = {
+  title: 'Visual Art — Source Library',
+  description: 'Over 10,000 works of art cross-referenced with the texts that inspired them — from Egyptian papyri and Tibetan thangka to Renaissance prints and Edo-period woodcuts.',
+};
+
+export const revalidate = false;
+
+interface ArtCollection {
+  slug: string;
+  name: string;
+  subtitle?: string;
+  color?: string;
+  book_count: number;
+  featured_images?: { extracted_url?: string; thumbnail_url?: string; image_url?: string }[];
+}
+
+async function getData() {
+  const db = await getReadDb();
+
+  const collections = await db.collection('collections')
+    .find({ collection_type: 'visual_art', visible: true })
+    .sort({ order: 1 })
+    .project({ _id: 0, slug: 1, name: 1, subtitle: 1, color: 1, book_count: 1, featured_images: 1 })
+    .toArray() as ArtCollection[];
+
+  const totalCount = collections.reduce((sum, c) => sum + (c.book_count || 0), 0);
+
+  return { collections, totalCount };
+}
+
+export default async function ArtworkLandingPage() {
+  const { collections, totalCount } = await getData();
+
+  // Split into featured (first 3 with images) and the rest
+  const featured = collections.filter(c => c.featured_images?.[0]).slice(0, 3);
+  const remaining = collections.filter(c => !featured.includes(c));
+
+  return (
+    <div className="min-h-screen" style={{ background: 'var(--bg-cream)' }}>
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="relative bg-stone-900 text-white overflow-hidden">
+        {/* Subtle background mosaic from first collection images */}
+        <div className="absolute inset-0 opacity-[0.06]">
+          <div className="grid grid-cols-4 h-full">
+            {collections.slice(0, 4).map((col) => {
+              const img = sanitizeThumbnail(col.featured_images?.[0]?.thumbnail_url || col.featured_images?.[0]?.extracted_url || '');
+              return img ? (
+                <div key={col.slug} className="relative">
+                  <Image src={img as string} alt="" fill className="object-cover" sizes="25vw" />
+                </div>
+              ) : <div key={col.slug} />;
+            })}
+          </div>
+        </div>
+
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6 md:px-12 py-20 sm:py-32">
+          <p className="text-xs uppercase tracking-[0.25em] text-accent-gold/70 mb-6 font-medium">Source Library</p>
+          <h1 className="font-display text-4xl sm:text-5xl lg:text-6xl font-bold leading-[1.1] max-w-3xl">
+            Visual Art
+          </h1>
+          <p className="text-lg sm:text-xl text-stone-400 mt-6 max-w-2xl leading-relaxed font-serif">
+            Paintings, prints, sculptures, and manuscripts from antiquity to the nineteenth century — cross-referenced with the texts that inspired them.
+          </p>
+          <div className="flex flex-wrap items-center gap-6 mt-10 text-sm text-stone-500">
+            <span className="font-medium text-stone-400">{totalCount.toLocaleString()} works</span>
+            <span className="w-px h-4 bg-stone-700" />
+            <span>{collections.length} collections</span>
+            <span className="w-px h-4 bg-stone-700" />
+            <span>All public domain</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Featured collections — large cards */}
+      {featured.length > 0 && (
+        <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 pt-16 pb-4">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {featured.map((col, i) => {
+              const img = sanitizeThumbnail(col.featured_images?.[0]?.thumbnail_url || col.featured_images?.[0]?.extracted_url || col.featured_images?.[0]?.image_url || '');
+              return (
+                <Link
+                  key={col.slug}
+                  href={`/collections/${col.slug}`}
+                  className={`group relative overflow-hidden rounded-lg bg-stone-200 ${i === 0 ? 'lg:col-span-2 aspect-[16/9]' : 'aspect-[4/3]'}`}
+                >
+                  {img && (
+                    <Image
+                      src={img as string}
+                      alt=""
+                      fill
+                      className="object-cover group-hover:scale-[1.03] transition-transform duration-700"
+                      sizes={i === 0 ? '(max-width: 1024px) 100vw, 66vw' : '(max-width: 1024px) 100vw, 33vw'}
+                      priority
+                     
+                    />
+                  )}
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+                  <div className="absolute bottom-0 inset-x-0 p-6">
+                    <p className="text-white/50 text-xs uppercase tracking-wider mb-2">{col.book_count} works</p>
+                    <h2 className="text-white font-display font-semibold text-2xl leading-tight group-hover:text-accent-gold transition-colors">
+                      {col.name}
+                    </h2>
+                    {col.subtitle && <p className="text-white/70 text-sm mt-2 font-serif">{col.subtitle}</p>}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* All collections grid */}
+      {remaining.length > 0 && (
+        <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 py-12">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+            {remaining.map((col) => {
+              const img = sanitizeThumbnail(col.featured_images?.[0]?.thumbnail_url || col.featured_images?.[0]?.extracted_url || col.featured_images?.[0]?.image_url || '');
+              return (
+                <Link
+                  key={col.slug}
+                  href={`/collections/${col.slug}`}
+                  className="group relative aspect-[4/3] rounded-lg overflow-hidden bg-stone-200"
+                >
+                  {img && (
+                    <Image
+                      src={img as string}
+                      alt=""
+                      fill
+                      className="object-cover group-hover:scale-[1.03] transition-transform duration-700"
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+                     
+                    />
+                  )}
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+                  <div className="absolute bottom-0 inset-x-0 p-4">
+                    <p className="text-white/50 text-xs mb-1">{col.book_count} works</p>
+                    <h3 className="text-white font-display font-semibold text-base leading-tight group-hover:text-accent-gold transition-colors">
+                      {col.name}
+                    </h3>
+                    {col.subtitle && <p className="text-white/60 text-xs mt-1 line-clamp-1">{col.subtitle}</p>}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Footer attribution */}
+      <div className="border-t" style={{ borderColor: 'var(--border-light)' }}>
+        <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 py-8 text-center">
+          <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            Images from the Metropolitan Museum of Art, Rijksmuseum, Wikimedia Commons, and other public collections. All works are in the public domain.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -945,7 +945,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                 return (
                   <Link
                     key={art.id}
-                    href={`/book/${art.slug || art.id}`}
+                    href={`/artwork/${art.slug || art.id}`}
                     className="group block"
                   >
                     <div className="rounded-lg border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -54,7 +54,7 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
 
   return (
     <Link
-      href={isArtwork && bookUrlPrefix ? `${bookUrlPrefix}/artwork/${slug}` : bookHref}
+      href={isArtwork ? `${bookUrlPrefix || ''}/artwork/${slug}` : bookHref}
       className="group block"
     >
       <div className="h-full rounded-xl border border-border-light hover:border-accent-rust/40 hover:shadow-lg transition-[border-color,box-shadow] overflow-hidden bg-white">

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -358,7 +358,7 @@ export default function CollectionAllBooks({
             return (
               <Link
                 key={book.id}
-                href={`/book/${book.slug || book.id}`}
+                href={`/artwork/${book.slug || book.id}`}
                 className="group relative aspect-[3/4] rounded-lg overflow-hidden bg-stone-100"
               >
                 {thumb ? (


### PR DESCRIPTION
## Summary
- `/artwork/` routes only existed under `[tenant]`, so clicking any artwork on the main site 307-redirected to `/`
- Copied tenant artwork pages to `src/app/artwork/` — they contain no tenant-specific logic
- Reverts the `/book/` link workaround from #1440, restoring proper `/artwork/` links with the specialized art layout
- Routes added: `/artwork` (index), `/artwork/[slug]` (detail), `/artwork/artist/[slug]` (artist page)

## Test plan
- [ ] https://sourcelibrary.org/artwork — should show art collections index
- [ ] Click artwork on https://sourcelibrary.org/collections/erotic-art — should open artwork detail page
- [ ] Prev/next artist navigation should work on artwork detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)