### PR TITLE
Restore catalog page deleted in tenant refactor

### DIFF
--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -1,0 +1,47 @@
+import { Metadata } from 'next';
+import SiteHeader from '@/components/layout/SiteHeader';
+import CatalogBrowser from '@/components/catalog/CatalogBrowser';
+import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
+
+export const revalidate = 86400;
+export const maxDuration = 30;
+
+export const metadata: Metadata = {
+  title: 'Catalog - Source Library',
+  description: 'Browse the complete Source Library catalog — thousands of translated primary sources in alchemy, philosophy, theology, and the esoteric traditions.',
+  alternates: { canonical: '/catalog' },
+};
+
+export default async function CatalogPage() {
+  const [browseResult, languages] = await Promise.all([
+    browseBooks({ sort: 'popular', limit: 60 }).catch((err) => {
+      console.error('[catalog] browseBooks failed:', err?.message || err);
+      return { books: [], total: 0 };
+    }),
+    getLanguageCounts({}).catch((err) => {
+      console.error('[catalog] getLanguageCounts failed:', err?.message || err);
+      return [];
+    }),
+  ]);
+  const { books, total } = browseResult;
+
+  return (
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-7xl mx-auto px-6 md:px-12 py-12 md:py-20">
+        <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+          Catalog
+        </h1>
+        <p className="text-lg mb-10" style={{ color: 'var(--text-muted)' }}>
+          Every book in the library.
+        </p>
+
+        <CatalogBrowser
+          initialBooks={books}
+          initialTotal={total}
+          languages={languages}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- `/catalog` page was accidentally deleted in commit 4f15488f (tenant routing refactor by other dev)
- This restores the last working version — shows all books with sort/filter/language options
- Also includes the Browse dropdown nav change from #1432 (Browse + Catalog sub-options)

## Test plan
- [ ] Visit https://sourcelibrary.org/catalog — page loads with books
- [ ] "Browse Catalog" button on homepage works
- [ ] Browse dropdown in header shows Catalog option

🤖 Generated with [Claude Code](https://claude.com/claude-code)