### PR TITLE
Fix reader toolbar jitter and book search Enter key

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -109,6 +109,12 @@ function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => query.trim() && setShowResults(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && query.trim()) {
+              e.preventDefault();
+              window.location.href = `${tenantPrefix || ''}/book/${bookId}/search?q=${encodeURIComponent(query.trim())}`;
+            }
+          }}
           placeholder="Search this book..."
           aria-label="Search within this book"
           className="bg-transparent outline-none text-xs w-full"
@@ -1043,7 +1049,7 @@ export default function TranslationEditor({
 
 
               {/* Mode Toggle - admin and inner circle */}
-              <AuthCheck role="inner_circle">
+              <AuthCheck role="inner_circle" fallback={<div className="w-[68px] sm:w-[140px]" />}>
                 <div className="flex items-center rounded-lg p-0.5 sm:p-1" style={{ background: 'var(--bg-warm)' }}>
                   <button
                     onClick={() => setMode('read')}


### PR DESCRIPTION
## Summary
- Reserve space for Read/Edit toggle during auth loading to prevent layout jitter
- Pressing Enter in the inline book search bar now navigates to the full search results page (was a no-op on mobile)

## Test plan
- [ ] Open a book page as logged-in user — verify no layout shift when Read/Edit toggle appears
- [ ] Open a book page, use the inline search bar at bottom, press Enter — should navigate to `/book/{id}/search?q=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)