### PR TITLE
Restore 6 public routes deleted in tenant refactor

### DIFF
--- a/src/app/catalog/page.tsx
+++ b/src/app/catalog/page.tsx
@@ -1,0 +1,47 @@
+import { Metadata } from 'next';
+import SiteHeader from '@/components/layout/SiteHeader';
+import CatalogBrowser from '@/components/catalog/CatalogBrowser';
+import { browseBooks, getLanguageCounts } from '@/lib/books-catalog';
+
+export const revalidate = 86400;
+export const maxDuration = 30;
+
+export const metadata: Metadata = {
+  title: 'Catalog - Source Library',
+  description: 'Browse the complete Source Library catalog — thousands of translated primary sources in alchemy, philosophy, theology, and the esoteric traditions.',
+  alternates: { canonical: '/catalog' },
+};
+
+export default async function CatalogPage() {
+  const [browseResult, languages] = await Promise.all([
+    browseBooks({ sort: 'popular', limit: 60 }).catch((err) => {
+      console.error('[catalog] browseBooks failed:', err?.message || err);
+      return { books: [], total: 0 };
+    }),
+    getLanguageCounts({}).catch((err) => {
+      console.error('[catalog] getLanguageCounts failed:', err?.message || err);
+      return [];
+    }),
+  ]);
+  const { books, total } = browseResult;
+
+  return (
+    <>
+      <SiteHeader variant="light" />
+      <div className="max-w-7xl mx-auto px-6 md:px-12 py-12 md:py-20">
+        <h1 className="text-3xl md:text-4xl font-display mb-2" style={{ color: 'var(--text-primary)' }}>
+          Catalog
+        </h1>
+        <p className="text-lg mb-10" style={{ color: 'var(--text-muted)' }}>
+          Every book in the library.
+        </p>
+
+        <CatalogBrowser
+          initialBooks={books}
+          initialTotal={total}
+          languages={languages}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/app/categories/[id]/opengraph-image.tsx
+++ b/src/app/categories/[id]/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import { generateBrandedOGImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og-image';
+import { LIBRARY_CATEGORIES } from '@/app/api/categories/route';
+
+export const alt = 'Category - Source Library';
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default async function Image({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const category = LIBRARY_CATEGORIES.find(c => c.id === id);
+
+  if (!category) {
+    return generateBrandedOGImage({ title: 'Category', subtitle: 'Source Library' });
+  }
+
+  return generateBrandedOGImage({
+    title: category.name,
+    subtitle: category.description,
+  });
+}

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -1,0 +1,206 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BookOpen, Book as BookIcon } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { getReadDb } from '@/lib/mongodb';
+import { LIBRARY_CATEGORIES } from '@/app/api/categories/route';
+import { notFound } from 'next/navigation';
+import CategorySchema from '@/components/seo/CategorySchema';
+import { bookUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+interface Book {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author: string;
+  language: string;
+  published: string;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+  pages_count?: number;
+  pages_translated?: number;
+  translation_percent?: number;
+  summary?: { data: string } | string;
+}
+
+// ISR: rebuild at most every hour
+export const revalidate = false;
+export const dynamicParams = true;
+export async function generateStaticParams() {
+  return []; // All paths generated on demand via ISR
+}
+
+interface CategoryPageProps {
+  params: Promise<{ id: string }>;
+}
+
+function getCategory(id: string) {
+  return LIBRARY_CATEGORIES.find(c => c.id === id);
+}
+
+async function getCategoryBooks(id: string): Promise<Book[]> {
+  try {
+    const db = await getReadDb();
+    // Use cached pages_translated on books — no $lookup against 9.5M pages collection
+    const books = await db.collection('books').find(
+      { categories: id, visible: true, pages_translated: { $gt: 0 } },
+      { maxTimeMS: 30000 }
+    )
+    .project({ _id: 0, pages_array: 0 })
+    .sort({ pages_translated: -1, title: 1 })
+    .toArray();
+    return books as unknown as Book[];
+  } catch (err) {
+    console.error(`Category books fetch failed for ${id}:`, err);
+    return [];
+  }
+}
+
+export async function generateMetadata({ params }: CategoryPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const category = getCategory(id);
+  if (!category) return { title: 'Category Not Found' };
+
+  return {
+    title: `${category.name} — Source Library`,
+    description: `Browse ${category.description.toLowerCase()} in Source Library's collection of rare historical texts, digitized and translated with AI.`,
+    alternates: { canonical: `/categories/${id}` },
+    openGraph: {
+      title: `${category.name} — Source Library`,
+      description: category.description,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${category.name} — Source Library`,
+      description: category.description,
+    },
+  };
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  const { id } = await params;
+  const category = getCategory(id);
+  if (!category) notFound();
+
+  const books = await getCategoryBooks(id);
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <CategorySchema
+        id={id}
+        name={category.name}
+        description={category.description}
+        bookCount={books.length}
+        books={books.slice(0, 20).map(b => ({
+          id: b.id,
+          slug: b.slug,
+          title: b.display_title || b.title,
+          author: b.author,
+        }))}
+      />
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">
+        <div className="max-w-5xl mx-auto px-4 py-12">
+          <div className="flex items-center gap-4">
+            <span className="text-4xl">{category.icon}</span>
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-serif font-bold">
+                {category.name}
+              </h1>
+              {category.description && (
+                <p className="text-stone-300 mt-2">{category.description}</p>
+              )}
+            </div>
+          </div>
+          <p className="text-accent-gold mt-4 font-medium">
+            {books.length} book{books.length !== 1 ? 's' : ''} in this category
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <main className="max-w-5xl mx-auto px-4 py-8">
+        {books.length === 0 ? (
+          <div className="text-center py-16">
+            <BookOpen className="w-16 h-16 text-stone-300 mx-auto mb-4" />
+            <h2 className="text-xl font-semibold text-stone-700 mb-2">
+              No books in this category yet
+            </h2>
+            <p className="text-stone-500">
+              Books will appear here as they are categorized.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {books.map(book => {
+              const summaryText = typeof book.summary === 'string'
+                ? book.summary
+                : book.summary?.data;
+
+              return (
+                <Link
+                  key={book.id}
+                  href={bookUrl(book)}
+                  className="group bg-white rounded-xl border border-stone-200 overflow-hidden hover:border-accent-gold/20 hover:shadow-lg transition-all"
+                >
+                  {/* Thumbnail */}
+                  <div className="aspect-[3/2] bg-stone-100 relative overflow-hidden">
+                    {getBookThumbnailUrl(book) ? (
+                      <Image
+                        src={getBookThumbnailUrl(book)!}
+                        alt={book.title}
+                        fill
+                        className="object-cover group-hover:scale-105 transition-transform duration-300"
+                        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <BookIcon className="w-12 h-12 text-stone-300" />
+                      </div>
+                    )}
+                    {/* Translation badge */}
+                    {book.translation_percent !== undefined && (
+                      <div className={`absolute top-2 right-2 px-2 py-1 rounded-full text-xs font-medium ${
+                        (book.translation_percent ?? 0) >= 95
+                          ? 'bg-status-success text-white'
+                          : (book.translation_percent ?? 0) > 0
+                            ? 'bg-accent-gold/80 text-white'
+                            : 'bg-stone-500 text-white'
+                      }`}>
+                        {(book.translation_percent ?? 0) >= 95
+                          ? 'Translated'
+                          : `${book.translation_percent}%`}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Info */}
+                  <div className="p-4">
+                    <h3 className="font-serif font-semibold text-stone-900 group-hover:text-accent-rust transition-colors line-clamp-2">
+                      {book.display_title || book.title}
+                    </h3>
+                    <p className="text-sm text-stone-600 mt-1">{book.author}</p>
+                    <div className="flex items-center gap-2 mt-2 text-xs text-stone-500">
+                      <span className="px-2 py-0.5 bg-stone-100 rounded">{book.language}</span>
+                      {book.published && <span>{book.published}</span>}
+                    </div>
+                    {summaryText && (
+                      <p className="text-sm text-stone-600 mt-3 line-clamp-2">
+                        {summaryText}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/categories/layout.tsx
+++ b/src/app/categories/layout.tsx
@@ -1,0 +1,30 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Categories - Source Library',
+  description: 'Browse books by category: alchemy, astrology, Hermetica, Kabbalah, natural philosophy, and more. Explore the Western esoteric tradition.',
+  alternates: {
+    canonical: '/categories',
+  },
+  openGraph: {
+    title: 'Categories - Source Library',
+    description: 'Browse books by category: alchemy, astrology, Hermetica, Kabbalah, natural philosophy, and more.',
+    type: 'website',
+    siteName: 'Source Library',
+    locale: 'en_US',
+    url: '/categories',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Categories - Source Library',
+    description: 'Browse books by category: alchemy, astrology, Hermetica, Kabbalah, natural philosophy, and more.',
+  },
+};
+
+export default function CategoriesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,0 +1,146 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { BookOpen, ChevronRight } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { getReadDb } from '@/lib/mongodb';
+import { LIBRARY_CATEGORIES, CategoryWithCount } from '@/app/api/categories/route';
+
+// ISR: rebuild every 6 hours. Categories change rarely.
+export const revalidate = 21600;
+export const maxDuration = 60;
+
+export const metadata: Metadata = {
+  title: 'Browse by Category — Source Library',
+  description: 'Explore rare esoteric, alchemical, and philosophical texts organized by tradition: alchemy, Hermeticism, Kabbalah, Neoplatonism, Rosicrucianism, astrology, and more.',
+  alternates: { canonical: '/categories' },
+  openGraph: {
+    title: 'Browse by Category — Source Library',
+    description: 'Explore rare esoteric texts organized by tradition and subject.',
+  },
+};
+
+async function getCategoriesWithCounts(): Promise<CategoryWithCount[]> {
+  let countMap = new Map<string, number>();
+
+  try {
+    const db = await getReadDb();
+    const categoryCounts = await db.collection('books').aggregate([
+      { $match: { visible: true, categories: { $exists: true } } },
+      { $unwind: '$categories' },
+      { $group: { _id: '$categories', count: { $sum: 1 } } },
+    ], { maxTimeMS: 30000, hint: 'categories_1' }).toArray();
+
+    for (const item of categoryCounts) {
+      countMap.set(item._id as string, item.count as number);
+    }
+  } catch {
+    // DB unavailable (e.g. build time) — render with zero counts
+  }
+
+  const categories: CategoryWithCount[] = LIBRARY_CATEGORIES.map(cat => ({
+    ...cat,
+    book_count: countMap.get(cat.id) || 0,
+  }));
+
+  categories.sort((a, b) => {
+    if (b.book_count !== a.book_count) return b.book_count - a.book_count;
+    return a.name.localeCompare(b.name);
+  });
+
+  return categories;
+}
+
+export default async function CategoriesPage() {
+  const categories = await getCategoriesWithCounts();
+
+  const activeCategories = categories.filter(c => c.book_count > 0);
+  const emptyCategories = categories.filter(c => c.book_count === 0);
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">
+        <div className="max-w-5xl mx-auto px-4 py-12 text-center">
+          <h1 className="text-3xl sm:text-4xl font-serif font-bold">
+            Browse by Category
+          </h1>
+          <p className="text-stone-300 mt-3 max-w-2xl mx-auto">
+            Explore our collection of esoteric, alchemical, and early modern philosophical texts
+            organized by tradition and subject.
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <main className="max-w-5xl mx-auto px-4 py-8">
+        {/* Categories with books */}
+        {activeCategories.length > 0 && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {activeCategories.map(category => (
+              <Link
+                key={category.id}
+                href={`/categories/${category.id}`}
+                className="group bg-white rounded-xl border border-stone-200 p-5 hover:border-accent-gold/20 hover:shadow-md transition-all"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="text-2xl">{category.icon}</span>
+                    <div>
+                      <h2 className="font-semibold text-stone-900 group-hover:text-accent-rust transition-colors">
+                        {category.name}
+                      </h2>
+                      <p className="text-sm text-accent-rust font-medium">
+                        {category.book_count} book{category.book_count !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-stone-400 group-hover:text-accent-rust transition-colors" />
+                </div>
+                {category.description && (
+                  <p className="text-sm text-stone-600 mt-3 line-clamp-2">
+                    {category.description}
+                  </p>
+                )}
+              </Link>
+            ))}
+          </div>
+        )}
+
+        {/* Empty categories */}
+        {emptyCategories.length > 0 && (
+          <div className="mt-12">
+            <h3 className="text-sm font-semibold text-stone-500 uppercase tracking-wider mb-4">
+              Coming Soon
+            </h3>
+            <div className="flex flex-wrap gap-3">
+              {emptyCategories.map(category => (
+                <div
+                  key={category.id}
+                  className="flex items-center gap-2 px-4 py-2 bg-stone-100 text-stone-500 rounded-lg"
+                >
+                  <span>{category.icon}</span>
+                  <span className="text-sm">{category.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* No categories */}
+        {categories.length === 0 && (
+          <div className="text-center py-16">
+            <BookOpen className="w-16 h-16 text-stone-300 mx-auto mb-4" />
+            <h2 className="text-xl font-semibold text-stone-700 mb-2">
+              No categories yet
+            </h2>
+            <p className="text-stone-500">
+              Books will be organized into categories as they are processed.
+            </p>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,0 +1,482 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { BookLoader } from '@/components/ui/BookLoader';
+import { likes } from '@/lib/api-client';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+const VISITOR_ID_KEY = 'sl_visitor_id';
+
+function getVisitorId(): string {
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem(VISITOR_ID_KEY) || '';
+}
+
+interface FeaturedImage {
+  url: string;
+  description?: string;
+  type?: string;
+}
+
+interface PopularBook {
+  id: string;
+  slug?: string;
+  title: string;
+  author?: string;
+  year?: number;
+  published?: string;
+  language?: string;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+  featured_images?: FeaturedImage[];
+  likeCount: number;
+}
+
+interface PopularPage {
+  id: string;
+  pageNumber: number;
+  bookId: string;
+  bookTitle: string;
+  bookAuthor?: string;
+  bookYear?: number;
+  thumbnail?: string;
+  excerpt: string;
+  likeCount: number;
+}
+
+interface PopularImage {
+  galleryImageId: string;
+  pageId: string;
+  detectionIndex: number;
+  likeCount: number;
+  description: string;
+  type: string;
+  museumDescription?: string;
+  croppedUrl: string;
+  bookId: string;
+  bookTitle: string;
+  bookAuthor?: string;
+  bookYear?: number;
+}
+
+type Tab = 'books' | 'pages' | 'images';
+type Mode = 'popular' | 'mine';
+
+export default function FavoritesPage() {
+  const [tab, setTab] = useState<Tab>('books');
+  const [mode, setMode] = useState<Mode>('mine');
+
+  // Popular data
+  const [popularBooks, setPopularBooks] = useState<PopularBook[]>([]);
+  const [popularPages, setPopularPages] = useState<PopularPage[]>([]);
+  const [popularImages, setPopularImages] = useState<PopularImage[]>([]);
+  const [loadingPopularBooks, setLoadingPopularBooks] = useState(false);
+  const [loadingPopularPages, setLoadingPopularPages] = useState(false);
+  const [loadingPopularImages, setLoadingPopularImages] = useState(false);
+  const [popularLoaded, setPopularLoaded] = useState(false);
+
+  // My likes data
+  const [myBooks, setMyBooks] = useState<PopularBook[]>([]);
+  const [myPages, setMyPages] = useState<PopularPage[]>([]);
+  const [myImages, setMyImages] = useState<PopularImage[]>([]);
+  const [loadingMyBooks, setLoadingMyBooks] = useState(true);
+  const [loadingMyPages, setLoadingMyPages] = useState(true);
+  const [loadingMyImages, setLoadingMyImages] = useState(true);
+
+  // Load my likes on mount
+  useEffect(() => {
+    const visitorId = getVisitorId();
+    if (!visitorId) {
+      setLoadingMyBooks(false);
+      setLoadingMyPages(false);
+      setLoadingMyImages(false);
+      return;
+    }
+
+    likes.getMine<PopularBook>({ type: 'book', visitorId })
+      .then(data => setMyBooks(data.items))
+      .catch(console.error)
+      .finally(() => setLoadingMyBooks(false));
+
+    likes.getMine<PopularPage>({ type: 'page', visitorId })
+      .then(data => setMyPages(data.items))
+      .catch(console.error)
+      .finally(() => setLoadingMyPages(false));
+
+    likes.getMine<PopularImage>({ type: 'image', visitorId })
+      .then(data => setMyImages(data.items))
+      .catch(console.error)
+      .finally(() => setLoadingMyImages(false));
+  }, []);
+
+  // Lazy-load popular data only when switching to that mode
+  const loadPopular = useCallback(() => {
+    if (popularLoaded) return;
+    setPopularLoaded(true);
+    setLoadingPopularBooks(true);
+    setLoadingPopularPages(true);
+    setLoadingPopularImages(true);
+
+    likes.getPopular<PopularBook>({ type: 'book', limit: 50 })
+      .then(data => setPopularBooks(data.items))
+      .catch(console.error)
+      .finally(() => setLoadingPopularBooks(false));
+
+    likes.getPopular<PopularPage>({ type: 'page', limit: 50 })
+      .then(data => setPopularPages(data.items))
+      .catch(console.error)
+      .finally(() => setLoadingPopularPages(false));
+
+    likes.getPopular<PopularImage>({ type: 'image', limit: 50 })
+      .then(data => setPopularImages(data.items))
+      .catch(console.error)
+      .finally(() => setLoadingPopularImages(false));
+  }, [popularLoaded]);
+
+  const handleModeSwitch = (newMode: Mode) => {
+    setMode(newMode);
+    if (newMode === 'popular') loadPopular();
+  };
+
+  const books = mode === 'mine' ? myBooks : popularBooks;
+  const pages = mode === 'mine' ? myPages : popularPages;
+  const images = mode === 'mine' ? myImages : popularImages;
+
+  const loadingBooks = mode === 'mine' ? loadingMyBooks : loadingPopularBooks;
+  const loadingPages = mode === 'mine' ? loadingMyPages : loadingPopularPages;
+  const loadingImages = mode === 'mine' ? loadingMyImages : loadingPopularImages;
+
+  const loading = tab === 'books' ? loadingBooks : tab === 'pages' ? loadingPages : loadingImages;
+  const items = tab === 'books' ? books : tab === 'pages' ? pages : images;
+  const isEmpty = items.length === 0;
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Dark hero */}
+      <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-16">
+        <div className="max-w-5xl mx-auto px-6">
+          <h1 className="text-4xl md:text-5xl mb-4">Favorites</h1>
+          <p className="text-xl text-stone-300 max-w-2xl">
+            {mode === 'mine'
+              ? 'Books, pages, and illustrations you\'ve liked.'
+              : 'The most loved books, pages, and illustrations \u2014 as chosen by readers.'}
+          </p>
+
+          {/* Mode toggle */}
+          <div className="mt-6 inline-flex bg-white/10 rounded-lg p-1">
+            <button
+              onClick={() => handleModeSwitch('mine')}
+              className={`px-4 py-2 text-sm font-medium rounded-md transition-colors flex items-center gap-2 ${
+                mode === 'mine'
+                  ? 'bg-white text-stone-900'
+                  : 'text-white/70 hover:text-white'
+              }`}
+            >
+              <User className="w-4 h-4" />
+              My Likes
+            </button>
+            <button
+              onClick={() => handleModeSwitch('popular')}
+              className={`px-4 py-2 text-sm font-medium rounded-md transition-colors flex items-center gap-2 ${
+                mode === 'popular'
+                  ? 'bg-white text-stone-900'
+                  : 'text-white/70 hover:text-white'
+              }`}
+            >
+              <TrendingUp className="w-4 h-4" />
+              Most Popular
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="bg-white border-b border-stone-200 sticky top-0 z-10">
+        <div className="max-w-5xl mx-auto px-6">
+          <div className="flex gap-1">
+            {([
+              { key: 'books' as Tab, icon: BookOpen, label: 'Books', count: books.length, isLoading: loadingBooks },
+              { key: 'pages' as Tab, icon: FileText, label: 'Pages', count: pages.length, isLoading: loadingPages },
+              { key: 'images' as Tab, icon: ImageIcon, label: 'Gallery', count: images.length, isLoading: loadingImages },
+            ]).map(({ key, icon: Icon, label, count, isLoading }) => (
+              <button
+                key={key}
+                onClick={() => setTab(key)}
+                className={`px-5 py-3.5 text-sm font-medium border-b-2 transition-colors ${
+                  tab === key
+                    ? 'border-stone-900 text-stone-900'
+                    : 'border-transparent text-stone-400 hover:text-stone-600'
+                }`}
+              >
+                <span className="flex items-center gap-2">
+                  <Icon className="w-4 h-4" />
+                  {label}
+                  {!isLoading && count > 0 && (
+                    <span className="text-[10px] bg-stone-100 text-stone-500 px-1.5 py-0.5 rounded-full">{count}</span>
+                  )}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <main className="max-w-5xl mx-auto px-6 py-10">
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <BookLoader size="sm" />
+          </div>
+        ) : isEmpty ? (
+          <div className="text-center py-20">
+            <Heart className="w-12 h-12 text-stone-300 mx-auto mb-4" />
+            <h2 className="text-lg font-medium text-stone-600 mb-2">
+              {mode === 'mine' ? 'No likes yet' : 'No favorites yet'}
+            </h2>
+            <p className="text-stone-400 mb-6 text-sm">
+              {mode === 'mine'
+                ? tab === 'books'
+                  ? 'Like books to see them here.'
+                  : tab === 'pages'
+                    ? 'Like pages while reading to see them here.'
+                    : 'Like images in the gallery to see them here.'
+                : 'No items have been liked yet.'}
+            </p>
+            <Link
+              href={tab === 'images' ? '/gallery' : '/'}
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-stone-800 text-white text-sm rounded-lg hover:bg-stone-700 transition-colors"
+            >
+              {tab === 'images' ? 'Browse Gallery' : 'Browse Library'}
+            </Link>
+          </div>
+
+        ) : tab === 'books' ? (
+          /* Books — collection-style cards with extracted illustrations */
+          <div className="grid gap-5 grid-cols-1 sm:grid-cols-2">
+            {books.map((book, i) => {
+              const imgs = book.featured_images || [];
+              const heroUrl = imgs[0]?.url || getBookThumbnailUrl(book);
+
+              return (
+                <Link
+                  key={book.id}
+                  href={`/book/${book.slug || book.id}`}
+                  className="group relative block overflow-hidden rounded-lg"
+                >
+                  {/* Image mosaic: 1 hero + up to 2 side images */}
+                  <div className="relative aspect-[4/3]">
+                    {imgs.length >= 3 ? (
+                      /* 3-image layout: large left, two stacked right */
+                      <div className="absolute inset-0 flex gap-0.5">
+                        <div className="relative flex-[2]">
+                          <Image
+                            src={imgs[0].url}
+                            alt={imgs[0].description || book.title}
+                            fill
+                            className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+                            sizes="(max-width: 640px) 66vw, 33vw"
+                            priority={i < 4}
+                            unoptimized
+                          />
+                        </div>
+                        <div className="flex-1 flex flex-col gap-0.5">
+                          <div className="relative flex-1">
+                            <Image
+                              src={imgs[1].url}
+                              alt={imgs[1].description || ''}
+                              fill
+                              className="object-cover"
+                              sizes="(max-width: 640px) 33vw, 17vw"
+                              unoptimized
+                            />
+                          </div>
+                          <div className="relative flex-1">
+                            <Image
+                              src={imgs[2].url}
+                              alt={imgs[2].description || ''}
+                              fill
+                              className="object-cover"
+                              sizes="(max-width: 640px) 33vw, 17vw"
+                              unoptimized
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    ) : imgs.length === 2 ? (
+                      /* 2-image layout: side by side */
+                      <div className="absolute inset-0 flex gap-0.5">
+                        <div className="relative flex-1">
+                          <Image
+                            src={imgs[0].url}
+                            alt={imgs[0].description || book.title}
+                            fill
+                            className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+                            sizes="(max-width: 640px) 50vw, 25vw"
+                            priority={i < 4}
+                            unoptimized
+                          />
+                        </div>
+                        <div className="relative flex-1">
+                          <Image
+                            src={imgs[1].url}
+                            alt={imgs[1].description || ''}
+                            fill
+                            className="object-cover"
+                            sizes="(max-width: 640px) 50vw, 25vw"
+                            unoptimized
+                          />
+                        </div>
+                      </div>
+                    ) : heroUrl ? (
+                      /* Single image fallback */
+                      <Image
+                        src={heroUrl}
+                        alt={book.title}
+                        fill
+                        className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+                        sizes="(max-width: 640px) 100vw, 50vw"
+                        priority={i < 4}
+                        unoptimized={!!imgs[0]}
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-gradient-to-br from-stone-700 to-stone-800" />
+                    )}
+                  </div>
+
+                  {/* Gradient overlay */}
+                  <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent pointer-events-none" />
+
+                  {/* Content */}
+                  <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-6">
+                    <div className="flex items-center gap-2 mb-2">
+                      {mode === 'popular' && (
+                        <span className="px-2.5 py-0.5 text-xs text-white/80 bg-white/15 backdrop-blur-sm rounded-full">
+                          #{i + 1}
+                        </span>
+                      )}
+                      <span className="px-2.5 py-0.5 text-xs text-red-300 bg-white/10 backdrop-blur-sm rounded-full inline-flex items-center gap-1">
+                        <Heart className="w-3 h-3" fill="currentColor" />
+                        {book.likeCount}
+                      </span>
+                      {book.language && (
+                        <span className="text-xs text-white/40">
+                          {book.language}
+                        </span>
+                      )}
+                    </div>
+                    <h2 className="font-serif text-xl sm:text-2xl text-white font-semibold leading-tight">
+                      {book.title}
+                    </h2>
+                    <p className="mt-1 text-sm text-white/60 line-clamp-1">
+                      {[book.author, book.published].filter(Boolean).join(' \u00b7 ')}
+                    </p>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+        ) : tab === 'pages' ? (
+          /* Pages — cream cards with excerpts */
+          <div className="space-y-3">
+            {pages.map((page, i) => (
+              <Link
+                key={page.id}
+                href={`/book/${page.bookId}/page-number/${page.pageNumber}`}
+                className="group block rounded-lg overflow-hidden bg-warm border border-border-light hover:border-border-medium transition-colors"
+              >
+                <div className="flex items-start gap-4 p-5">
+                  {mode === 'popular' && (
+                    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-stone-200 flex items-center justify-center text-sm font-bold text-muted">
+                      {i + 1}
+                    </div>
+                  )}
+                  {page.thumbnail && (
+                    <div className="flex-shrink-0 w-14 h-[72px] relative rounded overflow-hidden bg-stone-200">
+                      <Image
+                        src={page.thumbnail}
+                        alt={`Page ${page.pageNumber}`}
+                        fill
+                        className="object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+                        sizes="56px"
+                      />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <span className="text-sm font-serif font-medium text-primary group-hover:text-accent-rust transition-colors">
+                          {page.bookTitle}
+                        </span>
+                        {page.bookAuthor && (
+                          <span className="text-sm text-muted ml-2">{page.bookAuthor}</span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        <span className="text-xs text-faint">p. {page.pageNumber}</span>
+                        <span className="inline-flex items-center gap-1 text-xs text-status-error">
+                          <Heart className="w-3 h-3" fill="currentColor" />
+                          {page.likeCount}
+                        </span>
+                      </div>
+                    </div>
+                    {page.excerpt && (
+                      <p className="text-sm text-muted mt-2 line-clamp-2 font-body leading-relaxed">
+                        {page.excerpt}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+
+        ) : (
+          /* Gallery images — dark grid with overlays */
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+            {images.map((img, i) => (
+              <Link
+                key={img.galleryImageId}
+                href={`/gallery/image/${img.galleryImageId}`}
+                className="group relative block overflow-hidden rounded-lg aspect-square"
+              >
+                <Image
+                  src={img.croppedUrl}
+                  alt={img.description || 'Gallery image'}
+                  fill
+                  className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+                  sizes="(max-width: 640px) 50vw, 33vw"
+                  priority={i < 6}
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent opacity-80 group-hover:opacity-100 transition-opacity" />
+                <div className="absolute inset-0 flex flex-col justify-end p-4">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <span className="px-2 py-0.5 text-[10px] text-white/70 bg-white/15 backdrop-blur-sm rounded-full capitalize">
+                      {img.type}
+                    </span>
+                    <span className="px-2 py-0.5 text-[10px] text-red-300 bg-white/10 backdrop-blur-sm rounded-full inline-flex items-center gap-1">
+                      <Heart className="w-2.5 h-2.5" fill="currentColor" />
+                      {img.likeCount}
+                    </span>
+                  </div>
+                  <p className="text-xs text-white/90 line-clamp-2 leading-snug">
+                    {img.description}
+                  </p>
+                  <p className="text-[10px] text-white/40 mt-1 line-clamp-1 font-serif">
+                    {img.bookTitle}
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/languages/[code]/loading.tsx
+++ b/src/app/languages/[code]/loading.tsx
@@ -1,0 +1,44 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function LanguageDetailLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="bg-dark overflow-hidden">
+        <div className="bg-gradient-to-b from-black/70 via-black/40 to-transparent">
+          <div className="max-w-7xl mx-auto px-6 pt-8 pb-12 sm:pb-16">
+            <div className="h-4 w-24 bg-white/10 rounded animate-pulse mb-6" />
+            <div className="h-14 sm:h-16 w-48 bg-white/15 rounded-lg animate-pulse mb-3" />
+            <div className="h-5 w-32 bg-white/10 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+
+      {/* Gallery strip */}
+      <div className="bg-warm border-b border-border-light">
+        <div className="max-w-7xl mx-auto px-6 py-6">
+          <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="aspect-square bg-stone-200 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Book grid */}
+      <div className="max-w-7xl mx-auto px-6 py-10">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="aspect-[3/4] bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-3/4 bg-stone-200 rounded animate-pulse" />
+              <div className="h-3 w-1/2 bg-stone-100 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -1,0 +1,343 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BookOpen, Images } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { getReadDb } from '@/lib/mongodb';
+import { browseBooks, countBooks } from '@/lib/books-catalog';
+import { notFound } from 'next/navigation';
+import CollectionBookCard from '@/components/CollectionBookCard';
+import CollectionFilters from '@/components/collections/CollectionFilters';
+import { bookTitle } from '@/lib/collections-utils';
+
+const PER_PAGE = 60;
+
+interface Props {
+  params: Promise<{ code: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+// Decode slug back to language name — handles multi-word and hyphenated languages.
+// Tries exact match first (space-joined), then hyphen-joined, then case-insensitive DB lookup.
+function decodeLanguageSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+async function resolveLanguageName(slug: string): Promise<string | null> {
+  const { supabase } = await import('@/lib/supabase');
+
+  // Generate candidate names from the slug
+  const parts = slug.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1));
+  const candidates = [
+    parts.join(' '),     // "Latin German"
+    parts.join('-'),     // "Latin-German"
+    slug,                // "egy" (raw slug, for short codes)
+  ];
+
+  // Try exact matches first (fast)
+  for (const name of candidates) {
+    const { count } = await supabase
+      .from('books_catalog')
+      .select('id', { count: 'exact', head: true })
+      .eq('visible', true)
+      .gt('pages_count', 0)
+      .eq('language', name);
+    if (count && count > 0) return name;
+  }
+
+  // Fallback: case-insensitive search
+  const { data } = await supabase
+    .from('books_catalog')
+    .select('language')
+    .eq('visible', true)
+    .gt('pages_count', 0)
+    .ilike('language', candidates[0].replace(/ /g, '%'))
+    .limit(1);
+  if (data && data.length > 0) return data[0].language as string;
+
+  return null;
+}
+
+// ---------- Metadata ----------
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { code } = await params;
+  const langName = await resolveLanguageName(code) || decodeLanguageSlug(code);
+
+  let count: number;
+  try {
+    count = await countBooks({ language: langName });
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
+
+  if (count === 0) return { title: 'Language Not Found - Source Library', robots: { index: false, follow: true } };
+
+  const description = `Browse ${count} ${langName} texts in Source Library — digitized and translated from original manuscripts and early printed books.`;
+
+  return {
+    title: `${langName} Texts | Source Library`,
+    description,
+    alternates: { canonical: `/languages/${code}` },
+    openGraph: {
+      title: `${langName} Texts | Source Library`,
+      description,
+      type: 'website',
+    },
+  };
+}
+
+// ---------- Data types ----------
+
+interface BookItem {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author?: string;
+  year?: number;
+  language?: string;
+  pages_count?: number;
+  pages_ocr?: number;
+  pages_translated?: number;
+  photo?: string;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+  published?: string;
+  read_count?: number;
+  is_first_translation?: boolean;
+}
+
+// ---------- Data fetching ----------
+
+async function fetchLanguageData(langName: string, sort: string, offset: number, q?: string) {
+  // Books + counts from Supabase (instant), gallery from MongoDB
+  const [booksResult, firstTranslationCount, sampleResult] = await Promise.all([
+    browseBooks({
+      language: langName,
+      search: q && q.length >= 2 ? q : undefined,
+      sort: (sort as 'popular' | 'title' | 'year_asc' | 'year_desc' | 'recent') || 'popular',
+      offset,
+      limit: PER_PAGE,
+    }),
+    countBooks({ language: langName, firstTranslation: true }),
+    browseBooks({ language: langName, sort: 'popular', limit: 50 }),
+  ]);
+
+  const books = booksResult.books;
+  const total = booksResult.total;
+  const sampleBookIds = sampleResult.books.map(b => b.id);
+
+  // Gallery images from MongoDB (fast, well-indexed)
+  let galleryImages: unknown[] = [];
+  if (sampleBookIds.length > 0) {
+    try {
+      const db = await getReadDb();
+      galleryImages = await db.collection('gallery_images').aggregate([
+        { $match: {
+          book_id: { $in: sampleBookIds },
+          gallery_quality: { $gte: 0.7 },
+          book_visible: true,
+          type: { $nin: ['decorative', 'symbol', 'musical_score', 'exlibris', 'bookplate'] },
+        }},
+        { $sort: { gallery_quality: -1 } },
+        { $group: { _id: '$book_id', images: { $push: '$$ROOT' } } },
+        { $project: { images: { $slice: ['$images', 2] } } },
+        { $unwind: '$images' },
+        { $replaceRoot: { newRoot: '$images' } },
+        { $sort: { gallery_quality: -1 } },
+        { $limit: 12 },
+      ]).toArray();
+    } catch {
+      // Gallery is optional
+    }
+  }
+
+  return {
+    books: books as unknown as BookItem[],
+    total,
+    firstTranslationCount,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    galleryImages: galleryImages as any[],
+  };
+}
+
+// ---------- Page ----------
+
+export default async function LanguageDetailPage({ params, searchParams }: Props) {
+  const { code } = await params;
+  const langName = await resolveLanguageName(code) || decodeLanguageSlug(code);
+
+  const sp = await searchParams;
+  const sort = (typeof sp.sort === 'string' ? sp.sort : '') || 'popular';
+  const q = typeof sp.q === 'string' ? sp.q : '';
+  const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0') || 0;
+
+  const { books, total, firstTranslationCount, galleryImages } = await fetchLanguageData(
+    langName, sort, offset, q || undefined
+  );
+
+  if (total === 0 && !q) notFound();
+
+  const totalPages = Math.ceil(total / PER_PAGE);
+  const currentPage = Math.floor(offset / PER_PAGE) + 1;
+  const basePath = `/languages/${code}`;
+
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+      {/* Hero Section */}
+      <div className="relative bg-dark overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-transparent" />
+        <div className="relative max-w-7xl mx-auto px-6 pt-8 pb-12 sm:pb-16">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl text-white font-semibold leading-tight mb-3 font-display">
+            {langName}
+          </h1>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
+            <span>{total.toLocaleString()} books</span>
+            {firstTranslationCount > 0 && (
+              <>
+                <span className="w-px h-4 bg-white/20" />
+                <span className="text-accent-gold-light">{firstTranslationCount} first English translations</span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Gallery Grid */}
+      {galleryImages.length > 0 && (
+        <div className="bg-warm border-b border-border-light">
+          <div className="max-w-7xl mx-auto px-6 py-6">
+            <h2 className="text-xl sm:text-2xl text-primary mb-4 font-display">Illustrations</h2>
+            <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+              {galleryImages.map((img: { pageId?: string; page_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
+                const thumb = img.thumbnailUrl || img.thumbnail_url || img.extractedUrl || img.extracted_url || img.imageUrl || img.image_url;
+                const pageId = img.pageId || img.page_id;
+                const detIdx = img.detectionIndex ?? img.detection_index;
+                const galleryId = `${pageId}-${detIdx}`;
+                return (
+                  <Link
+                    key={galleryId}
+                    href={`/gallery/image/${galleryId}`}
+                    className="group relative aspect-square rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 transition-all hover:shadow-md"
+                    title={img.museumDescription || img.museum_description || img.description || img.bookTitle || img.book_title}
+                  >
+                    {thumb ? (
+                      <Image
+                        src={thumb}
+                        alt={img.description || img.bookTitle || img.book_title || 'Illustration'}
+                        fill
+                        className="object-cover group-hover:scale-105 transition-transform duration-300"
+                        sizes="(min-width: 1024px) 160px, (min-width: 640px) 140px, 120px"
+                      />
+                    ) : (
+                      <div className="w-full h-full bg-cream flex items-center justify-center">
+                        <Images className="w-6 h-6 text-muted" />
+                      </div>
+                    )}
+                    {img.type && (
+                      <span className="absolute bottom-1.5 left-1.5 text-[10px] bg-dark/70 text-white px-1.5 py-0.5 rounded capitalize leading-none">
+                        {img.type}
+                      </span>
+                    )}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="max-w-7xl mx-auto px-6 py-10">
+        {/* Books Header */}
+        <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
+          <div>
+            <h2 className="text-2xl sm:text-3xl text-primary font-display">All Books</h2>
+            <p className="text-sm text-muted mt-1">
+              {total.toLocaleString()} {langName} texts
+            </p>
+          </div>
+
+          <CollectionFilters
+            collectionId={code}
+            languages={[]}
+            basePath={basePath}
+            showSearch
+          />
+        </div>
+
+        {/* Books Grid */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {books.map((book, i) => (
+            <CollectionBookCard
+              key={book.id}
+              book={{
+                bookId: book.id,
+                id: book.id,
+                slug: book.slug,
+                title: bookTitle(book),
+                author: book.author || '',
+                year: book.year || 0,
+                pages_count: book.pages_count,
+                pages_ocr: book.pages_ocr,
+                pages_translated: book.pages_translated,
+                thumbnail: book.thumbnail_blob || book.thumbnail || book.photo,
+                thumbnail_blob: book.thumbnail_blob,
+                language: book.language,
+                published: book.published,
+                is_first_translation: book.is_first_translation,
+                translation_percent: book.pages_ocr && book.pages_translated
+                  ? Math.round((book.pages_translated / book.pages_ocr) * 100)
+                  : 0,
+              }}
+              priority={i < 10}
+            />
+          ))}
+        </div>
+
+        {/* Empty state */}
+        {books.length === 0 && (
+          <div className="text-center py-16">
+            <BookOpen className="w-12 h-12 text-muted mx-auto mb-4" />
+            <p className="text-lg text-secondary">No books found matching your search.</p>
+            <Link href={basePath} className="text-sm text-accent-rust hover:underline mt-2 inline-block">
+              Clear search
+            </Link>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-4 mt-10 text-sm">
+            {offset > 0 ? (
+              <Link
+                href={`${basePath}?sort=${sort}${q ? `&q=${encodeURIComponent(q)}` : ''}&offset=${Math.max(0, offset - PER_PAGE)}`}
+                className="px-4 py-2 rounded-lg border border-border-light hover:bg-warm transition-colors"
+              >
+                Previous
+              </Link>
+            ) : (
+              <span className="px-4 py-2 rounded-lg border border-border-light opacity-30">Previous</span>
+            )}
+            <span className="text-muted">Page {currentPage} of {totalPages}</span>
+            {currentPage < totalPages ? (
+              <Link
+                href={`${basePath}?sort=${sort}${q ? `&q=${encodeURIComponent(q)}` : ''}&offset=${offset + PER_PAGE}`}
+                className="px-4 py-2 rounded-lg border border-border-light hover:bg-warm transition-colors"
+              >
+                Next
+              </Link>
+            ) : (
+              <span className="px-4 py-2 rounded-lg border border-border-light opacity-30">Next</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/languages/loading.tsx
+++ b/src/app/languages/loading.tsx
@@ -1,0 +1,37 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function LanguagesLoading() {
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-16 md:py-20">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-48 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12">
+        {/* Major languages grid */}
+        <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="aspect-[4/3] bg-stone-200 rounded-xl animate-pulse" />
+          ))}
+        </div>
+
+        {/* Other languages chips */}
+        <div className="mt-10">
+          <div className="h-6 w-36 bg-stone-200 rounded animate-pulse mb-4" />
+          <div className="flex flex-wrap gap-2">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <div key={i} className="h-7 w-20 bg-stone-200 rounded-full animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -1,0 +1,158 @@
+import { supabase } from '@/lib/supabase';
+import Link from 'next/link';
+import Image from 'next/image';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import type { Metadata } from 'next';
+
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: 'Languages | Source Library',
+  description: 'Browse Source Library by language — Latin, German, French, Greek, Hebrew, Arabic, and 30+ more languages spanning 5,000 years of human thought.',
+  alternates: { canonical: '/languages' },
+  openGraph: {
+    title: 'Languages | Source Library',
+    description: 'Browse Source Library by language — Latin, German, French, Greek, Hebrew, Arabic, and 30+ more languages spanning 5,000 years of human thought.',
+    type: 'website',
+  },
+};
+
+interface LanguageStats {
+  name: string;
+  slug: string;
+  bookCount: number;
+  yearRange?: string;
+  heroImage?: string;
+}
+
+function languageSlug(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+async function fetchLanguageStats(): Promise<{ languages: LanguageStats[]; totalBooks: number }> {
+  // Query books_catalog in Supabase — instant vs 10s+ MongoDB aggregation
+  const { data, error } = await supabase
+    .from('books_catalog')
+    .select('language, published, thumbnail, thumbnail_blob')
+    .eq('visible', true)
+    .gt('pages_count', 0)
+    .not('language', 'is', null)
+    .neq('language', '');
+
+  if (error) throw new Error(`Language stats query failed: ${error.message}`);
+
+  // Group by language
+  const langMap = new Map<string, { count: number; minYear?: string; maxYear?: string; heroImage?: string }>();
+  for (const row of (data || [])) {
+    const lang = row.language as string;
+    const existing = langMap.get(lang) || { count: 0 };
+    existing.count++;
+    const pub = row.published as string | null;
+    if (pub) {
+      if (!existing.minYear || pub < existing.minYear) existing.minYear = pub;
+      if (!existing.maxYear || pub > existing.maxYear) existing.maxYear = pub;
+    }
+    if (!existing.heroImage) {
+      const thumb = (row.thumbnail_blob || row.thumbnail) as string | null;
+      if (thumb) existing.heroImage = thumb;
+    }
+    langMap.set(lang, existing);
+  }
+
+  let totalBooks = 0;
+  const languages: LanguageStats[] = [];
+  for (const [name, stats] of langMap.entries()) {
+    if (stats.count < 2) continue;
+    totalBooks += stats.count;
+    const yearRange = stats.minYear && stats.maxYear && stats.minYear !== stats.maxYear
+      ? `${stats.minYear} - ${stats.maxYear}`
+      : stats.minYear || stats.maxYear || undefined;
+    languages.push({
+      name,
+      slug: languageSlug(name),
+      bookCount: stats.count,
+      yearRange,
+      heroImage: stats.heroImage,
+    });
+  }
+
+  languages.sort((a, b) => b.bookCount - a.bookCount);
+  return { languages, totalBooks };
+}
+
+export default async function LanguagesPage() {
+  const { languages, totalBooks } = await fetchLanguageStats().catch((err) => {
+    console.error('Languages fetch failed:', err);
+    return { languages: [] as LanguageStats[], totalBooks: 0 };
+  });
+
+  // Split into major (10+ books) and minor
+  const major = languages.filter(l => l.bookCount >= 10);
+  const minor = languages.filter(l => l.bookCount < 10);
+
+  return (
+    <ContentPageLayout>
+      <ContentHeader
+        title="Languages"
+        subtitle={`${totalBooks.toLocaleString()} books across ${languages.length} languages, spanning five millennia of human thought.`}
+        image={major.find(l => l.heroImage)?.heroImage}
+        imageAlt="Multilingual manuscript page"
+      />
+
+      <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 mb-12">
+        {major.map((lang) => (
+          <Link
+            key={lang.slug}
+            href={`/languages/${lang.slug}`}
+            className="group relative block overflow-hidden rounded-lg aspect-[4/3]"
+          >
+            {lang.heroImage ? (
+              <Image
+                src={lang.heroImage}
+                alt={`Illustration from ${lang.name} text`}
+                fill
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+                unoptimized
+              />
+            ) : (
+              <div className="absolute inset-0 bg-warm" />
+            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
+            <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-6">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="px-2.5 py-0.5 text-xs text-white/80 bg-white/15 backdrop-blur-sm rounded-full">
+                  {lang.bookCount.toLocaleString()} books
+                </span>
+                {lang.yearRange && (
+                  <span className="text-xs text-white/50">{lang.yearRange}</span>
+                )}
+              </div>
+              <h2 className="font-serif text-xl sm:text-2xl text-white font-semibold leading-tight">
+                {lang.name}
+              </h2>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {minor.length > 0 && (
+        <>
+          <h2 className="text-2xl font-display text-primary mb-4">Other Languages</h2>
+          <div className="flex flex-wrap gap-2">
+            {minor.map((lang) => (
+              <Link
+                key={lang.slug}
+                href={`/languages/${lang.slug}`}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-white border border-border-light rounded-full text-secondary hover:border-accent-rust/30 transition-colors"
+              >
+                {lang.name}
+                <span className="text-xs text-muted">({lang.bookCount})</span>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+    </ContentPageLayout>
+  );
+}

--- a/src/app/reading-history/page.tsx
+++ b/src/app/reading-history/page.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { BookOpen, Clock, Eye, ArrowRight, Trash2, ChevronDown, ChevronUp } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { readingHistory, type ReadingHistoryEntry } from '@/lib/api-client';
+import { BookLoader } from '@/components/ui/BookLoader';
+import { bookUrl } from '@/lib/slugify';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const seconds = Math.floor((now - then) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export default function ReadingHistoryPage() {
+  const [entries, setEntries] = useState<ReadingHistoryEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const load = useCallback(async (newOffset = 0) => {
+    setLoading(true);
+    try {
+      const res = await readingHistory.list({ limit, offset: newOffset });
+      setEntries(res.entries);
+      setTotal(res.total);
+      setOffset(newOffset);
+    } catch (err) {
+      console.error('Failed to load reading history:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleClearAll = async () => {
+    if (!confirm('Clear all reading history?')) return;
+    await readingHistory.clear();
+    load();
+  };
+
+  const handleClearBook = async (bookId: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    await readingHistory.clear(bookId);
+    setEntries(prev => prev.filter(entry => entry.book_id !== bookId));
+    setTotal(prev => prev - 1);
+  };
+
+  // Group entries by date
+  const groupedEntries = entries.reduce<Record<string, ReadingHistoryEntry[]>>((groups, entry) => {
+    const date = formatDate(entry.updated_at);
+    if (!groups[date]) groups[date] = [];
+    groups[date].push(entry);
+    return groups;
+  }, {});
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Dark hero */}
+      <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white py-16">
+        <div className="max-w-5xl mx-auto px-6">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className="text-4xl md:text-5xl mb-4">Reading History</h1>
+              <p className="text-xl text-stone-300 max-w-2xl">
+                Every page you read is saved here, so you can pick up where you left off
+                or revisit passages that caught your eye.
+              </p>
+              {total > 0 && (
+                <p className="text-stone-500 text-sm mt-4">
+                  {total} reading {total === 1 ? 'session' : 'sessions'}
+                </p>
+              )}
+            </div>
+            {total > 0 && (
+              <button
+                onClick={handleClearAll}
+                className="flex-shrink-0 text-sm text-stone-500 hover:text-stone-300 transition-colors mt-2"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <main className="max-w-5xl mx-auto px-6 py-10">
+        {loading && (
+          <div className="flex items-center justify-center py-20">
+            <BookLoader size="sm" />
+          </div>
+        )}
+
+        {!loading && entries.length === 0 && (
+          <div className="text-center py-20">
+            <BookOpen className="w-12 h-12 text-stone-300 mx-auto mb-4" />
+            <h2 className="text-lg font-medium text-stone-600 mb-2">No reading history yet</h2>
+            <p className="text-stone-400 mb-6 text-sm">
+              Pages you read will appear here so you can pick up where you left off.
+            </p>
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-stone-800 text-white text-sm rounded-lg hover:bg-stone-700 transition-colors"
+            >
+              Browse Library
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+        )}
+
+        {!loading && entries.length > 0 && (
+          <>
+            <div className="space-y-8">
+              {Object.entries(groupedEntries).map(([date, dateEntries]) => (
+                <div key={date}>
+                  <h2 className="text-xs font-medium text-stone-400 uppercase tracking-wider mb-3">
+                    {date}
+                  </h2>
+                  <div className="space-y-3">
+                    {dateEntries.map((entry, i) => (
+                      <ReadingHistoryCard
+                        key={`${entry.book_id}-${entry.started_at}-${i}`}
+                        entry={entry}
+                        onRemove={handleClearBook}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Pagination */}
+            {total > limit && (
+              <div className="flex items-center justify-center gap-3 mt-10">
+                <button
+                  onClick={() => load(Math.max(0, offset - limit))}
+                  disabled={offset === 0}
+                  className="px-4 py-2 text-sm text-stone-600 bg-white border border-stone-200 rounded-lg shadow-sm hover:shadow-md disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-stone-500">
+                  {offset + 1}&ndash;{Math.min(offset + limit, total)} of {total}
+                </span>
+                <button
+                  onClick={() => load(offset + limit)}
+                  disabled={offset + limit >= total}
+                  className="px-4 py-2 text-sm text-stone-600 bg-white border border-stone-200 rounded-lg shadow-sm hover:shadow-md disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function ReadingHistoryCard({
+  entry,
+  onRemove,
+}: {
+  entry: ReadingHistoryEntry;
+  onRemove: (bookId: string, e: React.MouseEvent) => void;
+}) {
+  const [imageError, setImageError] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const book = entry.book;
+  const displayTitle = book.display_title || book.title;
+  const url = bookUrl({ slug: book.slug, id: book.id });
+  const pageUrl = `${url}/page/${entry.last_page_id}`;
+
+  const progress = book.pages_count
+    ? Math.round((entry.last_page_number / book.pages_count) * 100)
+    : 0;
+
+  const pagesRead = entry.pages_read || [];
+  const sortedPages = [...pagesRead].sort((a, b) => a.page_number - b.page_number);
+  const hasPageDetail = sortedPages.length > 0;
+
+  return (
+    <div className="group rounded-lg overflow-hidden bg-warm border border-border-light hover:border-border-medium transition-colors">
+      <Link
+        href={pageUrl}
+        className="flex gap-4 p-5"
+      >
+        {/* Cover */}
+        <div className="relative w-14 h-[72px] flex-shrink-0 bg-stone-100 rounded overflow-hidden">
+          {getBookThumbnailUrl(book, 'thumb') && !imageError ? (
+            <Image
+              src={getBookThumbnailUrl(book, 'thumb')!}
+              alt={displayTitle}
+              fill
+              className="object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+              sizes="56px"
+              onError={() => setImageError(true)}
+              unoptimized
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center text-stone-300">
+              <BookOpen className="w-5 h-5" />
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="font-serif font-medium text-primary group-hover:text-accent-rust transition-colors line-clamp-1">
+                {displayTitle}
+              </h3>
+              <div className="flex items-center gap-2 text-sm text-muted mt-0.5">
+                {book.author && <span>{book.author}</span>}
+                {book.year && <span className="text-faint">({book.year})</span>}
+              </div>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <span className="text-xs text-faint flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {timeAgo(entry.updated_at)}
+              </span>
+              <button
+                onClick={(e) => onRemove(entry.book_id, e)}
+                className="p-1.5 text-stone-300 hover:text-red-400 rounded transition-colors opacity-0 group-hover:opacity-100"
+                title="Remove from history"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </div>
+
+          {/* Progress row */}
+          <div className="mt-3 flex items-center gap-3">
+            {book.pages_count && (
+              <div className="flex-1 max-w-xs">
+                <div className="w-full h-1.5 bg-stone-100 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-accent-gold/80 rounded-full transition-all"
+                    style={{ width: `${Math.min(100, progress)}%` }}
+                  />
+                </div>
+              </div>
+            )}
+            <div className="flex items-center gap-3 text-xs text-faint">
+              <span className="flex items-center gap-1">
+                <Eye className="w-3 h-3" />
+                {entry.pages_viewed} {entry.pages_viewed === 1 ? 'page' : 'pages'}
+              </span>
+              {book.pages_count && (
+                <span>p. {entry.last_page_number} of {book.pages_count}</span>
+              )}
+              <span className="text-accent-rust flex items-center gap-1 font-medium">
+                Continue
+                <ArrowRight className="w-3 h-3" />
+              </span>
+            </div>
+          </div>
+        </div>
+      </Link>
+
+      {/* Expandable pages-read detail */}
+      {hasPageDetail && (
+        <div className="border-t border-border-light">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="w-full px-5 py-2 flex items-center gap-2 text-xs text-faint hover:text-muted transition-colors"
+          >
+            {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+            {sortedPages.length} {sortedPages.length === 1 ? 'page' : 'pages'} visited
+          </button>
+          {expanded && (
+            <div className="px-5 pb-3 flex flex-wrap gap-1.5">
+              {sortedPages.map((p) => (
+                <Link
+                  key={p.page_id}
+                  href={`${url}/page/${p.page_id}`}
+                  className="px-2 py-0.5 text-xs bg-stone-100 text-stone-600 hover:bg-accent-gold/20 hover:text-accent-rust rounded transition-colors"
+                >
+                  p. {p.page_number}
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -1,0 +1,812 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { ChevronDown, X, BookOpen, Image as ImageIcon } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { BookLoader } from '@/components/ui/BookLoader';
+import CollectionBookCard from '@/components/CollectionBookCard';
+import { formatAuthor } from '@/lib/utils';
+import type { TimelineOverview, TimelineBook, TimelineArtItem, DecadeBucket } from '@/lib/api-client/types/timeline';
+
+/* ── Historical eras ── */
+interface Era {
+  name: string;
+  label: string;
+  from: number;
+  to: number;
+  color: string;
+  description: string;
+}
+
+const ERAS: Era[] = [
+  {
+    name: 'antiquity',
+    label: 'Antiquity',
+    from: -3000,
+    to: 500,
+    color: 'var(--accent-sage)',
+    description: 'The classical foundations — Hermes Trismegistus, Plato, the Neoplatonists, and the Corpus Hermeticum.',
+  },
+  {
+    name: 'medieval',
+    label: 'Medieval',
+    from: 500,
+    to: 1400,
+    color: 'var(--accent-gold)',
+    description: 'Transmission and transformation — Arab scholars preserve Greek wisdom, the Kabbalah emerges, alchemy enters the Latin West.',
+  },
+  {
+    name: 'renaissance',
+    label: 'Renaissance',
+    from: 1400,
+    to: 1550,
+    color: 'var(--accent-rust)',
+    description: 'The great recovery — Ficino translates the Hermetica, Pico writes the Oration, the prisca theologia becomes philosophy.',
+  },
+  {
+    name: 'reformation',
+    label: 'Reformation',
+    from: 1550,
+    to: 1650,
+    color: 'var(--accent-violet)',
+    description: 'Rosicrucian manifestos, Paracelsian medicine, Dee and Fludd — esoteric thought flourishes amid religious upheaval.',
+  },
+  {
+    name: 'enlightenment',
+    label: 'Enlightenment',
+    from: 1650,
+    to: 1800,
+    color: '#6b8a9e',
+    description: 'Freemasonry, Swedenborg, and the occult underground — hidden knowledge adapts to the age of reason.',
+  },
+  {
+    name: 'modern',
+    label: 'Modern',
+    from: 1800,
+    to: 2100,
+    color: '#8a8480',
+    description: 'Revival and scholarship — the Golden Dawn, Theosophy, and the academic study of Western esotericism.',
+  },
+];
+
+function getEraForDecade(decade: number): Era | undefined {
+  return ERAS.find(e => decade >= e.from && decade < e.to);
+}
+
+/* ── Language colors ── */
+const LANG_COLORS: Record<string, string> = {
+  Latin: 'var(--accent-rust)',
+  German: 'var(--accent-sage)',
+  French: 'var(--accent-violet)',
+  English: 'var(--accent-gold)',
+  Italian: '#7c8c6e',
+  Hebrew: '#b0856a',
+  Arabic: '#8a7b6b',
+  Greek: '#6b8a9e',
+};
+const DEFAULT_COLOR = '#a8a29e';
+
+function getLangColor(lang: string): string {
+  return LANG_COLORS[lang] || DEFAULT_COLOR;
+}
+
+const PER_PAGE = 30;
+
+interface Props {
+  initialData: TimelineOverview;
+}
+
+export default function TimelineClient({ initialData }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const language = searchParams.get('language') || '';
+  const selectedDecade = searchParams.get('decade') ? parseInt(searchParams.get('decade')!) : null;
+  const selectedEraName = searchParams.get('era') || '';
+  const offset = parseInt(searchParams.get('offset') || '0');
+
+  const [books, setBooks] = useState<TimelineBook[]>([]);
+  const [artItems, setArtItems] = useState<TimelineArtItem[]>([]);
+  const [booksTotal, setBooksTotal] = useState(0);
+  const [loadingBooks, setLoadingBooks] = useState(false);
+  const [viewMode, setViewMode] = useState<'books' | 'art'>('books');
+
+  const detailRef = useRef<HTMLDivElement>(null);
+
+  const updateParams = useCallback((updates: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [k, v] of Object.entries(updates)) {
+      if (v) params.set(k, v);
+      else params.delete(k);
+    }
+    router.push(`/timeline?${params.toString()}`, { scroll: false });
+  }, [searchParams, router]);
+
+  // Filter decades by language and/or era
+  const filteredDecades = useMemo(() => {
+    let decades = initialData.decades;
+
+    if (language) {
+      decades = decades
+        .map(d => {
+          const match = d.languages.find(l => l.lang === language);
+          if (!match) return null;
+          return { decade: d.decade, count: match.count, languages: [match] } as DecadeBucket;
+        })
+        .filter((d): d is DecadeBucket => d !== null);
+    }
+
+    if (selectedEraName) {
+      const era = ERAS.find(e => e.name === selectedEraName);
+      if (era) {
+        decades = decades.filter(d => d.decade >= era.from && d.decade < era.to);
+      }
+    }
+
+    return decades;
+  }, [initialData.decades, language, selectedEraName]);
+
+  const filteredSummary = useMemo(() => {
+    const total = filteredDecades.reduce((sum, d) => sum + d.count, 0);
+    const allYears = filteredDecades.map(d => d.decade);
+    return {
+      total,
+      yearRange: {
+        min: allYears.length ? allYears[0] : 0,
+        max: allYears.length ? allYears[allYears.length - 1] + 9 : 0,
+      },
+    };
+  }, [filteredDecades]);
+
+  // Fetch books or art when decade selected
+  useEffect(() => {
+    if (selectedDecade === null) {
+      setBooks([]);
+      setArtItems([]);
+      setBooksTotal(0);
+      return;
+    }
+    let cancelled = false;
+    setLoadingBooks(true);
+    const qs = new URLSearchParams({
+      decade: String(selectedDecade),
+      limit: String(PER_PAGE),
+      offset: String(offset),
+    });
+    if (language) qs.set('language', language);
+    if (viewMode === 'art') qs.set('mode', 'art');
+
+    fetch(`/api/books/timeline?${qs}`)
+      .then(r => r.json())
+      .then(d => {
+        if (!cancelled) {
+          if (viewMode === 'art') {
+            setArtItems(d.art || []);
+            setBooks([]);
+          } else {
+            setBooks(d.books || []);
+            setArtItems([]);
+          }
+          setBooksTotal(d.total || 0);
+        }
+      })
+      .finally(() => { if (!cancelled) setLoadingBooks(false); });
+
+    return () => { cancelled = true; };
+  }, [selectedDecade, offset, language, viewMode]);
+
+  // Scroll to detail panel when books load
+  useEffect(() => {
+    if (selectedDecade !== null && detailRef.current && !loadingBooks && books.length > 0) {
+      detailRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [selectedDecade, loadingBooks, books.length]);
+
+  // Breakline scaling: cap at a threshold so outlier decades don't crush everything
+  // Bars above the cap get a jagged break and a count label
+  const barCap = useMemo(() => {
+    if (filteredDecades.length === 0) return 1;
+    const counts = filteredDecades.map(d => d.count).sort((a, b) => a - b);
+    const p90 = counts[Math.floor(counts.length * 0.9)] || 1;
+    // Cap at 1.5x the P90 — anything above gets a breakline
+    return Math.max(p90 * 1.5, 10);
+  }, [filteredDecades]);
+
+  // Group decades by era for bracket labels
+  const eraGroups = useMemo(() => {
+    if (!filteredDecades.length) return [];
+    const result: { era: Era; startIndex: number; span: number }[] = [];
+    let currentEra = getEraForDecade(filteredDecades[0].decade);
+    let startIndex = 0;
+    let span = 0;
+
+    for (let i = 0; i < filteredDecades.length; i++) {
+      const era = getEraForDecade(filteredDecades[i].decade);
+      if (era?.name !== currentEra?.name) {
+        if (currentEra) result.push({ era: currentEra, startIndex, span });
+        currentEra = era;
+        startIndex = i;
+        span = 0;
+      }
+      span++;
+    }
+    if (currentEra) result.push({ era: currentEra, startIndex, span });
+    return result;
+  }, [filteredDecades]);
+
+  // Top languages for the legend
+  const legendLanguages = useMemo(() => {
+    return initialData.summary.topLanguages.slice(0, 6);
+  }, [initialData.summary.topLanguages]);
+
+  const selectedEra = selectedDecade !== null ? getEraForDecade(selectedDecade) : null;
+
+  return (
+    <div className="space-y-10">
+      {/* Era navigation pills */}
+      <div className="flex flex-wrap gap-2 justify-center">
+        {ERAS.filter(era => {
+          // Only show eras that have data
+          return initialData.decades.some(d => d.decade >= era.from && d.decade < era.to);
+        }).map(era => {
+          const isActive = selectedEraName === era.name;
+          const eraCount = initialData.decades
+            .filter(d => d.decade >= era.from && d.decade < era.to)
+            .reduce((sum, d) => sum + d.count, 0);
+
+          return (
+            <button
+              key={era.name}
+              onClick={() => updateParams({
+                era: isActive ? null : era.name,
+                decade: null,
+                offset: null,
+              })}
+              className={`group relative px-4 py-2 rounded-full text-sm transition-all ${
+                isActive
+                  ? 'text-white shadow-md'
+                  : 'text-stone-600 hover:text-stone-900 bg-stone-100/60 hover:bg-stone-100'
+              }`}
+              style={isActive ? { backgroundColor: era.color } : undefined}
+            >
+              <span className="font-serif tracking-wide">{era.label}</span>
+              <span className={`ml-1.5 text-xs ${isActive ? 'text-white/70' : 'text-stone-400'}`}>
+                {eraCount}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Era description card */}
+      {selectedEraName && (() => {
+        const era = ERAS.find(e => e.name === selectedEraName);
+        if (!era) return null;
+        return (
+          <div
+            className="rounded-xl px-6 py-5 border"
+            style={{
+              borderColor: `color-mix(in srgb, ${era.color} 25%, transparent)`,
+              backgroundColor: `color-mix(in srgb, ${era.color} 4%, white)`,
+            }}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="font-serif text-xl text-stone-900 mb-1">
+                  {era.label}
+                  <span className="ml-2 text-sm font-sans text-stone-400 font-normal">
+                    {era.from < 0 ? `${Math.abs(era.from)} BC` : era.from}&ndash;{era.to}
+                  </span>
+                </h3>
+                <p className="text-stone-600 text-sm leading-relaxed font-body max-w-2xl">
+                  {era.description}
+                </p>
+              </div>
+              <button
+                onClick={() => updateParams({ era: null, decade: null, offset: null })}
+                className="text-stone-400 hover:text-stone-600 p-1 shrink-0"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* Filter bar + legend */}
+      <div className="flex flex-wrap items-center gap-3">
+        <FilterDropdown
+          label="Language"
+          value={language}
+          options={initialData.filters.languages}
+          onChange={v => updateParams({ language: v || null, decade: null, offset: null })}
+        />
+        {language && (
+          <button
+            onClick={() => updateParams({ language: null, decade: null, offset: null })}
+            className="flex items-center gap-1 px-3 py-2 text-sm text-stone-600 hover:text-stone-900 border border-stone-200 rounded-lg hover:bg-stone-50 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+            Reset
+          </button>
+        )}
+        <span className="text-sm text-stone-500 ml-auto font-body">
+          {filteredSummary.total.toLocaleString()} texts
+        </span>
+      </div>
+
+      {/* Language legend */}
+      {!language && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-stone-500">
+          {legendLanguages.map(l => (
+            <button
+              key={l.lang}
+              className="flex items-center gap-1.5 hover:text-stone-700 transition-colors"
+              onClick={() => updateParams({ language: l.lang, decade: null, offset: null })}
+            >
+              <span
+                className="w-2.5 h-2.5 rounded-sm inline-block"
+                style={{ backgroundColor: getLangColor(l.lang) }}
+              />
+              {l.lang}
+            </button>
+          ))}
+          {initialData.summary.topLanguages.length > 6 && (
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-sm inline-block" style={{ backgroundColor: DEFAULT_COLOR }} />
+              Other
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* ── Histogram ── */}
+      <div className="relative">
+        {/* Chart area with warm background */}
+        <div className="rounded-xl bg-[#faf8f4] border border-stone-200/60 p-4 pb-2 overflow-x-auto">
+          <div
+            className="flex items-end gap-px relative"
+            style={{ minWidth: Math.max(filteredDecades.length * 14, 600), height: 320 }}
+          >
+            {/* Horizontal guide lines */}
+            {[0.25, 0.5, 0.75, 1].map(frac => (
+              <div
+                key={frac}
+                className="absolute left-0 right-0 border-t border-stone-200/40"
+                style={{ bottom: `${frac * 100}%` }}
+              />
+            ))}
+
+            {filteredDecades.map(d => (
+              <DecadeBar
+                key={d.decade}
+                bucket={d}
+                barCap={barCap}
+                isSelected={d.decade === selectedDecade}
+                era={getEraForDecade(d.decade)}
+                onClick={() => {
+                  if (d.decade === selectedDecade) {
+                    updateParams({ decade: null, offset: null });
+                  } else {
+                    updateParams({ decade: String(d.decade), offset: null });
+                  }
+                }}
+              />
+            ))}
+          </div>
+
+          {/* Decade tick labels along x-axis */}
+          <div className="flex mt-1.5" style={{ minWidth: Math.max(filteredDecades.length * 14, 600) }}>
+            {filteredDecades.map((d, i) => {
+              // Compute label interval based on pixel density
+              // Each bar is ~14px min, so show labels spaced >=60px apart
+              const barWidth = Math.max(14, 600 / filteredDecades.length);
+              const labelEvery = Math.max(1, Math.ceil(60 / barWidth)); // bars between labels
+              const centuryStep = labelEvery <= 3 ? 50 : labelEvery <= 6 ? 100 : 200;
+              const absDecade = Math.abs(d.decade);
+              const showLabel = absDecade % centuryStep === 0;
+              return (
+                <div key={d.decade} className="flex-1 text-center" style={{ minWidth: 8 }}>
+                  {showLabel && (
+                    <span className="text-[9px] text-stone-400 font-mono whitespace-nowrap">
+                      {d.decade < 0 ? `${Math.abs(d.decade)} BC` : d.decade}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Era labels along x-axis */}
+          <div className="flex mt-1 border-t border-[var(--accent-gold)]/20 pt-2" style={{ minWidth: Math.max(filteredDecades.length * 14, 600) }}>
+            {eraGroups.map(({ era, span }) => (
+              <button
+                key={era.name}
+                className="text-center group cursor-pointer"
+                style={{ flex: `${span} 1 0%` }}
+                onClick={() => updateParams({
+                  era: selectedEraName === era.name ? null : era.name,
+                  decade: null,
+                  offset: null,
+                })}
+              >
+                <div
+                  className="h-0.5 mx-2 mb-1.5 rounded-full opacity-40 group-hover:opacity-70 transition-opacity"
+                  style={{ backgroundColor: era.color }}
+                />
+                <span
+                  className="text-[11px] font-serif tracking-wide transition-colors"
+                  style={{ color: selectedEraName === era.name ? era.color : 'var(--text-muted)' }}
+                >
+                  {era.label}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Detail panel ── */}
+      {selectedDecade !== null && (
+        <div ref={detailRef} className="pt-2">
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center gap-4">
+              <h2 className="text-2xl font-serif text-stone-900">
+                {formatDecadeLabel(selectedDecade)}
+                {selectedEra && (
+                  <span
+                    className="ml-3 text-sm font-sans font-normal"
+                    style={{ color: selectedEra.color }}
+                  >
+                    {selectedEra.label}
+                  </span>
+                )}
+                <span className="ml-3 text-base font-sans font-normal text-stone-500">
+                  {booksTotal.toLocaleString()} {viewMode === 'art' ? (booksTotal === 1 ? 'artist' : 'artists') : (booksTotal === 1 ? 'text' : 'texts')}
+                </span>
+              </h2>
+
+              {/* Books / Art toggle */}
+              <div className="flex rounded-lg border border-stone-200 overflow-hidden text-sm">
+                <button
+                  onClick={() => { setViewMode('books'); updateParams({ offset: null }); }}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${
+                    viewMode === 'books'
+                      ? 'bg-stone-800 text-white'
+                      : 'bg-white text-stone-500 hover:text-stone-700 hover:bg-stone-50'
+                  }`}
+                >
+                  <BookOpen className="w-3.5 h-3.5" />
+                  Books
+                </button>
+                <button
+                  onClick={() => { setViewMode('art'); updateParams({ offset: null }); }}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${
+                    viewMode === 'art'
+                      ? 'bg-stone-800 text-white'
+                      : 'bg-white text-stone-500 hover:text-stone-700 hover:bg-stone-50'
+                  }`}
+                >
+                  <ImageIcon className="w-3.5 h-3.5" />
+                  Art
+                </button>
+              </div>
+            </div>
+
+            <button
+              onClick={() => updateParams({ decade: null, offset: null })}
+              className="text-stone-400 hover:text-stone-600 p-1"
+              aria-label="Close"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          {loadingBooks ? (
+            <div className="flex justify-center py-16">
+              <BookLoader size="sm" />
+            </div>
+          ) : viewMode === 'art' ? (
+            artItems.length === 0 ? (
+              <p className="text-center py-12 text-stone-500 font-body">No illustrations found for this decade.</p>
+            ) : (
+              <>
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                  {artItems.map((item, i) => (
+                    <TimelineArtCard key={item.id} item={item} priority={i < 5} />
+                  ))}
+                </div>
+
+                {booksTotal > PER_PAGE && (
+                  <div className="flex items-center justify-center gap-4 mt-8">
+                    <button
+                      onClick={() => updateParams({ offset: String(Math.max(0, offset - PER_PAGE)) })}
+                      disabled={offset === 0}
+                      className="px-4 py-2 text-sm border border-stone-200 rounded-lg disabled:opacity-40 hover:bg-stone-50 transition-colors"
+                    >
+                      Previous
+                    </button>
+                    <span className="text-sm text-stone-500 font-body">
+                      {offset + 1}&ndash;{Math.min(offset + PER_PAGE, booksTotal)} of {booksTotal}
+                    </span>
+                    <button
+                      onClick={() => updateParams({ offset: String(offset + PER_PAGE) })}
+                      disabled={offset + PER_PAGE >= booksTotal}
+                      className="px-4 py-2 text-sm border border-stone-200 rounded-lg disabled:opacity-40 hover:bg-stone-50 transition-colors"
+                    >
+                      Next
+                    </button>
+                  </div>
+                )}
+              </>
+            )
+          ) : books.length === 0 ? (
+            <p className="text-center py-12 text-stone-500 font-body">No texts found for this decade.</p>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                {books.map((book, i) => (
+                  <CollectionBookCard
+                    key={book.id}
+                    book={{
+                      bookId: book.id,
+                      id: book.id,
+                      slug: book.slug,
+                      title: book.display_title || book.title,
+                      author: book.author || '',
+                      year: book.year,
+                      pages_count: book.pages_count,
+                      pages_translated: book.pages_translated,
+                      thumbnail: book.thumbnail,
+                      thumbnail_blob: book.thumbnail_blob,
+                      language: book.language,
+                    }}
+                    priority={i < 5}
+                  />
+                ))}
+              </div>
+
+              {/* Pagination */}
+              {booksTotal > PER_PAGE && (
+                <div className="flex items-center justify-center gap-4 mt-8">
+                  <button
+                    onClick={() => updateParams({ offset: String(Math.max(0, offset - PER_PAGE)) })}
+                    disabled={offset === 0}
+                    className="px-4 py-2 text-sm border border-stone-200 rounded-lg disabled:opacity-40 hover:bg-stone-50 transition-colors"
+                  >
+                    Previous
+                  </button>
+                  <span className="text-sm text-stone-500 font-body">
+                    {offset + 1}&ndash;{Math.min(offset + PER_PAGE, booksTotal)} of {booksTotal}
+                  </span>
+                  <button
+                    onClick={() => updateParams({ offset: String(offset + PER_PAGE) })}
+                    disabled={offset + PER_PAGE >= booksTotal}
+                    className="px-4 py-2 text-sm border border-stone-200 rounded-lg disabled:opacity-40 hover:bg-stone-50 transition-colors"
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Sub-components ── */
+
+function DecadeBar({
+  bucket,
+  barCap,
+  isSelected,
+  era,
+  onClick,
+}: {
+  bucket: DecadeBucket;
+  barCap: number;
+  isSelected: boolean;
+  era?: Era;
+  onClick: () => void;
+}) {
+  const barRef = useRef<HTMLDivElement>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
+  const isClipped = bucket.count > barCap;
+  // Clipped bars fill to 100%, normal bars scale linearly against the cap
+  const heightPct = isClipped ? 100 : Math.max(1.5, (bucket.count / barCap) * 100);
+  const top3 = bucket.languages.slice(0, 3);
+  const rest = bucket.count - top3.reduce((s, l) => s + l.count, 0);
+
+  const handleMouseEnter = useCallback(() => {
+    if (!barRef.current) return;
+    const rect = barRef.current.getBoundingClientRect();
+    setTooltipPos({ x: rect.left + rect.width / 2, y: rect.top });
+  }, []);
+
+  return (
+    <div
+      ref={barRef}
+      className="flex-1 relative cursor-pointer group"
+      style={{ minWidth: 8, height: '100%' }}
+      onClick={onClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={() => setTooltipPos(null)}
+    >
+      {/* Tooltip — fixed position to escape overflow:hidden */}
+      {tooltipPos && (
+        <div
+          className="fixed z-50 pointer-events-none"
+          style={{ left: tooltipPos.x, top: tooltipPos.y, transform: 'translate(-50%, -100%)' }}
+        >
+          <div className="bg-[#1a1612] text-white text-xs rounded-lg px-3 py-2.5 whitespace-nowrap shadow-lg mb-2">
+            <div className="font-serif text-sm mb-1">
+              {formatDecadeLabel(bucket.decade)}
+              <span className="text-stone-400 font-sans text-[10px] ml-1.5">
+                ({bucket.decade}&ndash;{bucket.decade + 9})
+              </span>
+            </div>
+            {era && (
+              <div className="text-stone-400 text-[10px] mb-1.5">{era.label}</div>
+            )}
+            <div className="text-stone-300 mb-1.5">{bucket.count} {bucket.count === 1 ? 'text' : 'texts'}</div>
+            {bucket.languages.slice(0, 4).map(l => (
+              <div key={l.lang} className="flex items-center gap-1.5">
+                <span className="w-2 h-2 rounded-sm" style={{ backgroundColor: getLangColor(l.lang) }} />
+                <span>{l.lang}: {l.count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Bar — positioned at the bottom */}
+      <div className="absolute bottom-0 left-0 right-0 flex flex-col justify-end" style={{ height: '100%' }}>
+        {/* Breakline zigzag for clipped bars */}
+        {isClipped && (
+          <svg
+            className="absolute left-0 right-0"
+            style={{ top: `${100 - heightPct}%`, transform: 'translateY(-3px)' }}
+            height="8"
+            preserveAspectRatio="none"
+            viewBox="0 0 20 8"
+          >
+            <path
+              d="M0,4 L2,1 L4,7 L6,1 L8,7 L10,1 L12,7 L14,1 L16,7 L18,1 L20,4"
+              fill="none"
+              stroke="#faf8f4"
+              strokeWidth="2.5"
+            />
+            <path
+              d="M0,4 L2,1 L4,7 L6,1 L8,7 L10,1 L12,7 L14,1 L16,7 L18,1 L20,4"
+              fill="none"
+              stroke="var(--border-light)"
+              strokeWidth="1"
+            />
+          </svg>
+        )}
+
+        <div
+          className={`rounded-t-sm overflow-hidden transition-all duration-200 ${
+            isSelected
+              ? 'ring-2 ring-[var(--accent-rust)] ring-offset-1 ring-offset-[#faf8f4]'
+              : 'opacity-75 group-hover:opacity-100'
+          }`}
+          style={{ height: `${heightPct}%` }}
+        >
+          <div className="w-full h-full flex flex-col-reverse">
+            {rest > 0 && (
+              <div
+                style={{
+                  height: `${(rest / bucket.count) * 100}%`,
+                  backgroundColor: DEFAULT_COLOR,
+                }}
+              />
+            )}
+            {[...top3].reverse().map(l => (
+              <div
+                key={l.lang}
+                style={{
+                  height: `${(l.count / bucket.count) * 100}%`,
+                  backgroundColor: getLangColor(l.lang),
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FilterDropdown({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        className="appearance-none bg-white border border-stone-200 rounded-lg pl-3 pr-8 py-2 text-sm text-stone-700 hover:border-stone-300 focus:outline-none focus:ring-2 focus:ring-[var(--accent-rust)]/30 focus:border-[var(--accent-rust)] cursor-pointer"
+      >
+        <option value="">All {label}s</option>
+        {options.map(o => (
+          <option key={o} value={o}>{o}</option>
+        ))}
+      </select>
+      <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" />
+    </div>
+  );
+}
+
+function TimelineArtCard({ item, priority = false }: { item: TimelineArtItem; priority?: boolean }) {
+  const [imageError, setImageError] = useState(false);
+  const displayUrl = item.thumbnailUrl || item.extractedUrl || item.imageUrl;
+  const galleryImageId = `${item.pageId}-${item.detectionIndex}`;
+  const authorDisplay = item.author && item.author !== 'Unknown' && item.author !== 'Various'
+    ? formatAuthor(item.author).name
+    : null;
+
+  return (
+    <div className="group rounded-lg overflow-hidden bg-white border border-stone-200/60 hover:shadow-md transition-all hover:-translate-y-0.5">
+      <Link href={`/gallery/image/${galleryImageId}`} className="block relative aspect-square bg-stone-100">
+        {!imageError ? (
+          <Image
+            src={displayUrl}
+            alt={item.description}
+            fill
+            quality={85}
+            className="object-cover group-hover:scale-105 transition-transform duration-300"
+            sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 20vw"
+            onError={() => setImageError(true)}
+            unoptimized={!item.thumbnailUrl && !item.extractedUrl}
+            priority={priority}
+            loading={priority ? 'eager' : 'lazy'}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-stone-300">
+            <ImageIcon className="w-8 h-8" />
+          </div>
+        )}
+
+        {item.type && (
+          <span className="absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[10px] bg-black/60 text-white capitalize">
+            {item.type}
+          </span>
+        )}
+      </Link>
+
+      <div className="p-2.5">
+        {authorDisplay && (
+          <p className="text-sm font-serif text-stone-900 truncate">{authorDisplay}</p>
+        )}
+        <p className="text-xs text-stone-500 truncate mt-0.5">
+          {item.bookTitle}{item.year ? `, ${item.year}` : ''}
+        </p>
+        {item.description && (
+          <p className="text-xs text-stone-400 line-clamp-2 mt-1 leading-relaxed">
+            {item.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Helpers ── */
+
+function formatDecadeLabel(decade: number): string {
+  if (decade < 0) return `${Math.abs(decade)}s BC`;
+  return `${decade}s`;
+}

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,0 +1,135 @@
+import { Suspense } from 'react';
+import { getReadDb } from '@/lib/mongodb';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import ExploreTabBar from '@/components/explore/ExploreTabBar';
+import TimelineClient from './TimelineClient';
+import type { Metadata } from 'next';
+import type { TimelineOverview, DecadeBucket } from '@/lib/api-client/types/timeline';
+
+export const revalidate = 3600; // ISR: rebuild every hour
+
+export const metadata: Metadata = {
+  title: 'Timeline | Source Library',
+  description: 'Browse thousands of historical texts chronologically, from antiquity through the early modern period. See what was published when and explore by decade.',
+  alternates: { canonical: '/timeline' },
+};
+
+async function fetchTimelineData(): Promise<TimelineOverview> {
+  const empty: TimelineOverview = {
+    decades: [],
+    summary: { total: 0, yearRange: { min: 0, max: 0 }, topLanguages: [] },
+    filters: { languages: [], collections: [] },
+  };
+
+  try {
+    const db = await getReadDb();
+
+    // Try pre-computed cache first (seeded by scripts/seed-timeline-filters.mjs)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cached = await db.collection('system_config').findOne({ _id: 'timeline_overview' } as any);
+    if (cached && cached.data?.decades?.length > 0) {
+      // Refresh the total count live — cached snapshots go stale
+      const liveTotal = await db.collection('books').countDocuments({
+        year: { $exists: true, $ne: null },
+        visible: true,
+        pages_count: { $gt: 0 },
+      }, { maxTimeMS: 5000 }).catch(() => 0);
+      const data = cached.data as TimelineOverview;
+      if (liveTotal > 0) data.summary.total = liveTotal;
+      return data;
+    }
+
+    // Fallback: live aggregation with generous timeout
+    const baseMatch = {
+      year: { $exists: true, $ne: null },
+      visible: true,
+    };
+
+    const pipeline = [
+      { $match: baseMatch },
+      { $project: { year: 1, language: { $ifNull: ['$language', 'Unknown'] } } },
+      {
+        $group: {
+          _id: {
+            decade: { $multiply: [{ $floor: { $divide: ['$year', 10] } }, 10] },
+            language: '$language',
+          },
+          count: { $sum: 1 },
+        },
+      },
+      { $sort: { '_id.decade': 1 as const, count: -1 as const } },
+      {
+        $group: {
+          _id: '$_id.decade',
+          count: { $sum: '$count' },
+          languages: { $push: { lang: '$_id.language', count: '$count' } },
+        },
+      },
+      { $sort: { _id: 1 as const } },
+    ];
+
+    const [rawDecades, languages] = await Promise.all([
+      db.collection('books').aggregate(pipeline, { maxTimeMS: 45000 }).toArray(),
+      db.collection('books').distinct('language', baseMatch),
+    ]);
+
+    const decades: DecadeBucket[] = rawDecades.map(d => ({
+      decade: d._id,
+      count: d.count,
+      languages: d.languages,
+    }));
+
+    const total = decades.reduce((sum, d) => sum + d.count, 0);
+    const allYears = decades.map(d => d.decade);
+    const yearRange = {
+      min: allYears.length ? allYears[0] : 0,
+      max: allYears.length ? allYears[allYears.length - 1] + 9 : 0,
+    };
+
+    const globalLangCounts: Record<string, number> = {};
+    for (const d of decades) {
+      for (const l of d.languages) {
+        globalLangCounts[l.lang] = (globalLangCounts[l.lang] || 0) + l.count;
+      }
+    }
+    const topLanguages = Object.entries(globalLangCounts)
+      .map(([lang, count]) => ({ lang, count }))
+      .sort((a, b) => b.count - a.count);
+
+    return {
+      decades,
+      summary: { total, yearRange, topLanguages },
+      filters: {
+        languages: (languages.filter(Boolean) as string[]).sort(),
+        collections: [],
+      },
+    };
+  } catch (err) {
+    console.error('Timeline data fetch failed:', err);
+    return empty;
+  }
+}
+
+export default async function TimelinePage() {
+  const data = await fetchTimelineData();
+
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Timeline"
+          subtitle="10,000+ texts from antiquity to the Enlightenment — browse the tradition by era"
+        >
+          <div className="mt-5">
+            <ExploreTabBar />
+          </div>
+        </ContentHeader>
+      }
+      maxWidth="wide"
+    >
+      <Suspense>
+        <TimelineClient initialData={data} />
+      </Suspense>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/topics/[slug]/loading.tsx
+++ b/src/app/topics/[slug]/loading.tsx
@@ -1,0 +1,47 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function TopicDetailLoading() {
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-12">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-5xl mx-auto px-6">
+          <div className="h-4 w-20 bg-white/10 rounded animate-pulse mb-6" />
+          <div className="h-10 sm:h-12 w-2/3 bg-white/15 rounded-lg animate-pulse mb-3" />
+          <div className="h-5 w-32 bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      {/* Content with sidebar */}
+      <div className="max-w-5xl mx-auto px-6 py-10">
+        <div className="flex flex-col lg:flex-row gap-8">
+          {/* Main content */}
+          <div className="flex-1">
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex gap-3 p-3 rounded-lg">
+                  <div className="w-12 h-16 bg-stone-200 rounded animate-pulse flex-shrink-0" />
+                  <div className="flex-1 space-y-1.5">
+                    <div className="h-4 w-3/4 bg-stone-200 rounded animate-pulse" />
+                    <div className="h-3 w-1/2 bg-stone-100 rounded animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Sidebar */}
+          <div className="lg:w-64 space-y-3">
+            <div className="h-5 w-20 bg-stone-200 rounded animate-pulse mb-2" />
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-4 w-full bg-stone-100 rounded animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/[slug]/opengraph-image.tsx
+++ b/src/app/topics/[slug]/opengraph-image.tsx
@@ -1,0 +1,36 @@
+import { generateBrandedOGImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og-image';
+import { FACETS } from '@/lib/taxonomy/faceted-vocabulary';
+
+export const alt = 'Topic - Source Library';
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+function parseFacetSlug(slug: string): { facetId: string; valueId: string } | null {
+  const parts = slug.split('--');
+  if (parts.length !== 2) return null;
+  return { facetId: parts[0], valueId: parts[1] };
+}
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  const facetParsed = parseFacetSlug(slug);
+  if (facetParsed) {
+    const facet = FACETS.find((f) => f.id === facetParsed.facetId);
+    const value = facet?.values.find((v) => v.id === facetParsed.valueId);
+
+    if (facet && value) {
+      return generateBrandedOGImage({
+        title: value.label,
+        subtitle: value.differentia || `${facet.label} in Source Library`,
+      });
+    }
+  }
+
+  // Fallback for old cluster slugs
+  const topicName = slug.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  return generateBrandedOGImage({
+    title: topicName,
+    subtitle: 'Topic in Source Library',
+  });
+}

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -1,0 +1,484 @@
+import { getReadDb } from '@/lib/mongodb';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Metadata } from 'next';
+import { BookOpen } from 'lucide-react';
+import SiteHeader from '@/components/layout/SiteHeader';
+import { notFound } from 'next/navigation';
+import { bookUrl } from '@/lib/slugify';
+import { FACETS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+export const revalidate = false;
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+interface BookItem {
+  id: string;
+  slug?: string;
+  title: string;
+  display_title?: string;
+  author?: string;
+  language?: string;
+  pages_count?: number;
+  pages_translated?: number;
+  pages_ocr?: number;
+  pages_blank?: number;
+  read_count?: number;
+  thumbnail?: string;
+  thumbnail_blob?: string;
+  faceted_tags?: Record<string, string[]>;
+  taxonomy?: { cluster?: string; subcluster?: string };
+}
+
+// ─── Parse slug ──────────────────────────────────────────────────
+
+function parseFacetSlug(slug: string): { facetId: string; valueId: string } | null {
+  const parts = slug.split('--');
+  if (parts.length !== 2) return null;
+  const [facetId, valueId] = parts;
+  const facet = FACETS.find((f) => f.id === facetId);
+  if (!facet) return null;
+  const value = facet.values.find((v) => v.id === valueId);
+  if (!value) return null;
+  return { facetId, valueId };
+}
+
+function topicSlug(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// ─── Metadata ────────────────────────────────────────────────────
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+
+  // Try facet slug first
+  const facetParsed = parseFacetSlug(slug);
+  if (facetParsed) {
+    const facet = FACETS.find((f) => f.id === facetParsed.facetId)!;
+    const value = facet.values.find((v) => v.id === facetParsed.valueId)!;
+    return {
+      title: `${value.label} — ${facet.label} | Source Library`,
+      description: `Browse Source Library books tagged "${value.label}" in the ${facet.label} facet. ${value.differentia}`,
+      alternates: { canonical: `/topics/${slug}` },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${value.label} — ${facet.label} | Source Library`,
+        description: `Browse Source Library books tagged "${value.label}" in the ${facet.label} facet.`,
+      },
+    };
+  }
+
+  // Fall back to old cluster slug
+  let match;
+  try {
+    const db = await getReadDb();
+    const allClusters = await db.collection('books').aggregate([
+      { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
+      { $group: { _id: '$taxonomy.cluster' } },
+    ]).toArray();
+    match = allClusters.find((c) => topicSlug(c._id) === slug);
+  } catch {
+    return { title: 'Source Library', robots: { index: false, follow: false } };
+  }
+  if (!match) return { title: 'Topic Not Found - Source Library', robots: { index: false, follow: true } };
+
+  return {
+    title: `${match._id} | Source Library`,
+    description: `Browse books in the ${match._id} topic on Source Library.`,
+    alternates: { canonical: `/topics/${slug}` },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${match._id} | Source Library`,
+      description: `Browse books in the ${match._id} topic on Source Library.`,
+    },
+  };
+}
+
+// ─── Data fetching ───────────────────────────────────────────────
+
+async function fetchFacetData(facetId: string, valueId: string) {
+  const db = await getReadDb();
+  const facet = FACETS.find((f) => f.id === facetId)!;
+  const value = facet.values.find((v) => v.id === valueId)!;
+
+  const dbField = facetDbField(facet);
+  const query = {
+    visible: true,
+    [`faceted_tags.${dbField}`]: valueId,
+  };
+
+  const books = await db
+    .collection('books')
+    .find(query, {
+      projection: {
+        _id: 0,
+        id: 1, slug: 1, title: 1, display_title: 1, author: 1, language: 1,
+        pages_count: 1, pages_translated: 1, pages_ocr: 1, pages_blank: 1, read_count: 1,
+        thumbnail: 1, thumbnail_blob: 1, faceted_tags: 1,
+      },
+    })
+    .sort({ read_count: -1, pages_translated: -1, title: 1 })
+    .toArray();
+
+  // Group by the most interesting cross-facet
+  // E.g., if browsing a tradition, group by domain; if browsing a domain, group by tradition
+  const crossFacetId = facetId === 'tradition' ? 'domain'
+    : facetId === 'domain' ? 'tradition'
+    : facetId === 'sphere' ? 'tradition'
+    : facetId === 'era' ? 'tradition'
+    : facetId === 'form' ? 'domain'
+    : facetId === 'mode' ? 'domain'
+    : 'tradition';
+
+  const crossFacet = FACETS.find((f) => f.id === crossFacetId)!;
+  const crossDbField = facetDbField(crossFacet);
+
+  const groups = new Map<string, BookItem[]>();
+  const ungrouped: BookItem[] = [];
+
+  for (const book of books) {
+    const crossValues = (book as Record<string, unknown>).faceted_tags as Record<string, string[]> | undefined;
+    const tags = crossValues?.[crossDbField] || [];
+    if (tags.length > 0) {
+      const primary = tags[0];
+      if (!groups.has(primary)) groups.set(primary, []);
+      groups.get(primary)!.push(book as unknown as BookItem);
+    } else {
+      ungrouped.push(book as unknown as BookItem);
+    }
+  }
+
+  // Sort groups by size
+  const sortedGroups = Array.from(groups.entries())
+    .sort((a, b) => b[1].length - a[1].length);
+
+  // Get languages
+  const languages = new Map<string, number>();
+  for (const book of books) {
+    const lang = (book as Record<string, unknown>).language as string || 'Unknown';
+    languages.set(lang, (languages.get(lang) || 0) + 1);
+  }
+
+  // Get other facet tag counts for the "Refine" sidebar
+  const refineFacets: Array<{ facetId: string; label: string; values: Array<{ id: string; label: string; count: number }> }> = [];
+  for (const f of FACETS) {
+    if (f.id === facetId) continue;
+    const counts = new Map<string, number>();
+    for (const book of books) {
+      const tags = ((book as Record<string, unknown>).faceted_tags as Record<string, string[]> | undefined)?.[facetDbField(f)] || [];
+      for (const t of tags) counts.set(t, (counts.get(t) || 0) + 1);
+    }
+    const sorted = Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([id, count]) => {
+        const v = f.values.find((fv) => fv.id === id);
+        return { id, label: v?.label || id, count };
+      });
+    if (sorted.length > 0) {
+      refineFacets.push({ facetId: f.id, label: f.label, values: sorted });
+    }
+  }
+
+  return {
+    facet,
+    value,
+    totalBooks: books.length,
+    groups: sortedGroups,
+    crossFacet,
+    ungrouped,
+    languages: Array.from(languages.entries()).sort((a, b) => b[1] - a[1]).slice(0, 6),
+    refineFacets,
+  };
+}
+
+async function fetchClusterData(slug: string) {
+  const db = await getReadDb();
+
+  const allClusters = await db.collection('books').aggregate([
+    { $match: { visible: true, 'taxonomy.cluster': { $exists: true, $ne: null } } },
+    { $group: { _id: '$taxonomy.cluster', cluster_id: { $first: '$taxonomy.cluster_id' } } },
+  ]).toArray();
+
+  const match = allClusters.find((c) => topicSlug(c._id) === slug);
+  if (!match) return null;
+
+  const clusterName = match._id;
+
+  const books = await db.collection('books')
+    .find({ visible: true, 'taxonomy.cluster': clusterName }, {
+      projection: {
+        _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, language: 1,
+        pages_count: 1, pages_translated: 1, read_count: 1, thumbnail: 1, thumbnail_blob: 1, 'taxonomy.subcluster': 1,
+      },
+    })
+    .sort({ pages_translated: -1, title: 1 })
+    .toArray();
+
+  const subclusters = new Map<string, BookItem[]>();
+  const uncategorized: BookItem[] = [];
+  for (const book of books) {
+    const sub = book.taxonomy?.subcluster;
+    if (sub) {
+      if (!subclusters.has(sub)) subclusters.set(sub, []);
+      subclusters.get(sub)!.push(book as unknown as BookItem);
+    } else {
+      uncategorized.push(book as unknown as BookItem);
+    }
+  }
+
+  const sortBooks = (arr: BookItem[]) =>
+    arr.sort((a, b) => ((b.read_count || 0) + (b.pages_translated || 0)) - ((a.read_count || 0) + (a.pages_translated || 0)));
+  for (const [, books] of subclusters) sortBooks(books);
+  sortBooks(uncategorized);
+
+  const languages = new Map<string, number>();
+  for (const book of books) {
+    const lang = book.language || 'Unknown';
+    languages.set(lang, (languages.get(lang) || 0) + 1);
+  }
+
+  return {
+    clusterName,
+    totalBooks: books.length,
+    subclusters: Array.from(subclusters.entries()).sort((a, b) => b[1].length - a[1].length),
+    uncategorized,
+    languages: Array.from(languages.entries()).sort((a, b) => b[1] - a[1]).slice(0, 6),
+  };
+}
+
+// ─── Components ──────────────────────────────────────────────────
+
+function BookCard({ book }: { book: BookItem }) {
+  const title = book.display_title || book.title;
+  const thumb = getBookThumbnailUrl(book);
+  const pagesOcr = book.pages_ocr || book.pages_count || 0;
+  const denom = Math.max(pagesOcr - (book.pages_blank || 0), 1);
+  const translationPercent =
+    pagesOcr && book.pages_translated
+      ? Math.round((book.pages_translated / denom) * 100)
+      : 0;
+
+  return (
+    <Link
+      href={bookUrl({ id: book.id, slug: book.slug })}
+      className="group flex gap-3 p-3 rounded-lg bg-white border border-border-light hover:border-accent-rust/30 hover:shadow-md transition-all"
+    >
+      <div className="w-14 flex-shrink-0">
+        <div className="aspect-[3/4] relative rounded overflow-hidden bg-warm">
+          {thumb ? (
+            <Image
+              src={thumb}
+              alt=""
+              fill
+              className="object-cover group-hover:scale-105 transition-transform duration-300"
+              sizes="56px"
+              unoptimized
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <BookOpen className="w-5 h-5 text-muted" />
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="flex-1 min-w-0 py-0.5">
+        <h3 className="text-sm font-semibold text-primary group-hover:text-accent-rust transition-colors line-clamp-2 leading-snug mb-0.5 font-display">
+          {title}
+        </h3>
+        <p className="text-xs text-muted truncate">
+          {book.author || 'Unknown author'}
+          {book.language ? ` · ${book.language}` : ''}
+        </p>
+        {translationPercent > 0 && (
+          <p className="text-[11px] text-accent-rust mt-0.5">
+            {translationPercent}% translated
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────
+
+export default async function TopicDetailPage({ params }: Props) {
+  const { slug } = await params;
+
+  // Try facet route first
+  const facetParsed = parseFacetSlug(slug);
+
+  if (facetParsed) {
+    const data = await fetchFacetData(facetParsed.facetId, facetParsed.valueId);
+
+    return (
+      <div className="min-h-screen bg-cream">
+        <SiteHeader variant="dark" />
+        {/* Hero */}
+        <div className="bg-gradient-to-b from-[#2a1f17] to-[#1a1612] text-white">
+          <div className="max-w-5xl mx-auto px-6 pt-8 pb-12">
+            <p className="text-sm text-white/40 mb-2">{data.facet.label}</p>
+            <h1 className="text-3xl sm:text-4xl md:text-5xl text-white font-semibold leading-tight mb-3 font-display">
+              {data.value.label}
+            </h1>
+            <p className="text-white/60 text-sm max-w-xl mb-4">
+              {data.value.differentia}
+            </p>
+
+            <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
+              <span>{data.totalBooks.toLocaleString()} books</span>
+              {data.languages.length > 0 && (
+                <>
+                  <span className="w-px h-4 bg-white/20" />
+                  <span>
+                    {data.languages.map(([lang]) => lang).join(', ')}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="max-w-5xl mx-auto px-6 py-10">
+          <div className="flex flex-col lg:flex-row gap-8">
+            {/* Main content */}
+            <div className="flex-1 min-w-0">
+              {data.groups.map(([groupValue, books]) => {
+                const crossValue = data.crossFacet.values.find((v) => v.id === groupValue);
+                return (
+                  <div key={groupValue} className="mb-10">
+                    <div className="flex items-center gap-3 mb-4">
+                      <h2 className="text-lg font-display font-semibold text-primary">
+                        {crossValue?.label || groupValue}
+                      </h2>
+                      <span className="text-xs text-muted bg-warm px-2 py-0.5 rounded-full">
+                        {books.length}
+                      </span>
+                    </div>
+                    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+                      {books.slice(0, 20).map((book) => (
+                        <BookCard key={book.id || book.slug} book={book} />
+                      ))}
+                    </div>
+                    {books.length > 20 && (
+                      <p className="text-xs text-muted mt-3">
+                        + {books.length - 20} more
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+
+              {data.ungrouped.length > 0 && (
+                <div className="mb-10">
+                  <h2 className="text-lg font-display font-semibold text-primary mb-4">Other</h2>
+                  <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+                    {data.ungrouped.slice(0, 20).map((book) => (
+                      <BookCard key={book.id || book.slug} book={book} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Refine sidebar */}
+            <div className="lg:w-64 flex-shrink-0">
+              <div className="sticky top-8">
+                <h3 className="text-sm font-semibold text-primary mb-4">Refine</h3>
+                {data.refineFacets.map((rf) => (
+                  <div key={rf.facetId} className="mb-6">
+                    <p className="text-xs text-muted mb-2 uppercase tracking-wide">{rf.label}</p>
+                    <div className="space-y-1">
+                      {rf.values.map((v) => (
+                        <Link
+                          key={v.id}
+                          href={`/topics/${rf.facetId}--${v.id}`}
+                          className="flex items-center justify-between text-sm text-secondary hover:text-accent-rust transition-colors py-0.5"
+                        >
+                          <span className="truncate">{v.label}</span>
+                          <span className="text-xs text-muted ml-2">{v.count}</span>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Fall back to old cluster view
+  const clusterData = await fetchClusterData(slug);
+  if (!clusterData) notFound();
+
+  const { clusterName, totalBooks, subclusters, uncategorized, languages } = clusterData;
+
+  return (
+    <div className="min-h-screen bg-cream">
+      <SiteHeader variant="dark" />
+      <div className="bg-gradient-to-b from-[#2a1f17] to-[#1a1612] text-white">
+        <div className="max-w-5xl mx-auto px-6 pt-8 pb-12">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl text-white font-semibold leading-tight mb-3 font-display">
+            {clusterName}
+          </h1>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
+            <span>{totalBooks} books</span>
+            {subclusters.length > 0 && (
+              <>
+                <span className="w-px h-4 bg-white/20" />
+                <span>{subclusters.length} subtopics</span>
+              </>
+            )}
+            {languages.length > 0 && (
+              <>
+                <span className="w-px h-4 bg-white/20" />
+                <span>{languages.map(([lang]) => lang).join(', ')}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 py-10">
+        {subclusters.map(([name, books]) => (
+          <div key={name} className="mb-10">
+            <div className="flex items-center gap-3 mb-4">
+              <h2 className="text-lg font-display font-semibold text-primary">{name}</h2>
+              <span className="text-xs text-muted bg-warm px-2 py-0.5 rounded-full">{books.length}</span>
+            </div>
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {books.map((book) => (
+                <BookCard key={book.id || book.slug} book={book} />
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {uncategorized.length > 0 && subclusters.length > 0 && (
+          <div className="mb-10">
+            <h2 className="text-lg font-display font-semibold text-primary mb-4">Other</h2>
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {uncategorized.map((book) => (
+                <BookCard key={book.id || book.slug} book={book} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -1,0 +1,194 @@
+import { getReadDb } from '@/lib/mongodb';
+import Link from 'next/link';
+import Image from 'next/image';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import type { Metadata } from 'next';
+
+export const revalidate = false;
+
+export const metadata: Metadata = {
+  title: 'AI-Discovered Topic Clusters | Source Library',
+  description: 'Explore 6,000 historical texts organized into 48 topics discovered by machine learning embedding analysis.',
+  alternates: { canonical: '/topics/clusters' },
+};
+
+function topicSlug(name: string): string {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+interface TopicSummary {
+  name: string;
+  slug: string;
+  cluster_id: number;
+  count: number;
+  languages: string[];
+  thumbnails: string[];
+  top_terms: string[];
+  has_subclusters: boolean;
+}
+
+async function fetchTopics(): Promise<{ topics: TopicSummary[]; totalBooks: number }> {
+  const db = await getReadDb();
+
+  const pipeline = [
+    {
+      $match: {
+        visible: true,
+        'taxonomy.cluster': { $exists: true, $ne: null },
+      },
+    },
+    {
+      $group: {
+        _id: '$taxonomy.cluster',
+        cluster_id: { $first: '$taxonomy.cluster_id' },
+        count: { $sum: 1 },
+        languages: { $addToSet: '$language' },
+        thumbnails: {
+          $push: {
+            $cond: [
+              { $and: [{ $ne: ['$thumbnail', null] }, { $ne: ['$thumbnail', ''] }] },
+              '$thumbnail',
+              '$$REMOVE',
+            ],
+          },
+        },
+        subclusters: { $addToSet: '$taxonomy.subcluster' },
+        // Collect top index terms for display
+        all_terms: {
+          $push: {
+            $cond: [
+              { $gt: [{ $size: { $ifNull: ['$index.entries', []] } }, 0] },
+              { $slice: ['$index.entries', 3] },
+              '$$REMOVE',
+            ],
+          },
+        },
+      },
+    },
+    { $sort: { count: -1 as const } },
+  ];
+
+  const results = await db
+    .collection('books')
+    .aggregate(pipeline, { allowDiskUse: true, maxTimeMS: 30000 })
+    .toArray()
+    .catch(() => [] as Record<string, unknown>[]);
+
+  let totalBooks = 0;
+  const topics: TopicSummary[] = results.map((r) => {
+    totalBooks += r.count;
+    // Flatten and deduplicate terms
+    const termSet = new Set<string>();
+    for (const entries of r.all_terms || []) {
+      if (Array.isArray(entries)) {
+        for (const e of entries) {
+          if (e?.term && termSet.size < 6) termSet.add(e.term);
+        }
+      }
+    }
+
+    // Filter out null subclusters
+    const realSubclusters = (r.subclusters || []).filter((s: string | null) => s != null);
+
+    return {
+      name: r._id,
+      slug: topicSlug(r._id),
+      cluster_id: r.cluster_id,
+      count: r.count,
+      languages: (r.languages || []).filter(Boolean).slice(0, 4),
+      thumbnails: (r.thumbnails || [])
+        .filter((t: string) => t.startsWith('http'))
+        .slice(0, 4),
+      top_terms: Array.from(termSet),
+      has_subclusters: realSubclusters.length > 1,
+    };
+  });
+
+  return { topics, totalBooks };
+}
+
+export default async function TopicsPage() {
+  const { topics, totalBooks } = await fetchTopics();
+
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Browse by Topic"
+          subtitle={`${totalBooks.toLocaleString()} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
+        />
+      }
+    >
+
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        {topics.map((topic) => (
+          <Link
+            key={topic.slug}
+            href={`/topics/${topic.slug}`}
+            className="group relative block overflow-hidden rounded-lg border border-border-light bg-white hover:border-accent-rust/30 hover:shadow-md transition-all"
+          >
+            {/* Thumbnail strip */}
+            {topic.thumbnails.length > 0 && (
+              <div className="flex h-24 overflow-hidden">
+                {topic.thumbnails.slice(0, 4).map((url, i) => (
+                  <div
+                    key={i}
+                    className="relative flex-1 overflow-hidden"
+                  >
+                    <Image
+                      src={url}
+                      alt=""
+                      fill
+                      sizes="(max-width: 640px) 25vw, 15vw"
+                      className="object-cover group-hover:scale-105 transition-transform duration-500"
+                      unoptimized
+                    />
+                  </div>
+                ))}
+                <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-white" />
+              </div>
+            )}
+
+            {/* Content */}
+            <div className="p-4">
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <h2 className="font-display text-base font-semibold text-primary group-hover:text-accent-rust transition-colors leading-tight">
+                  {topic.name}
+                </h2>
+                <span className="text-xs text-muted whitespace-nowrap flex-shrink-0">
+                  {topic.count} books
+                </span>
+              </div>
+
+              {/* Keywords preview */}
+              {topic.top_terms.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {topic.top_terms.slice(0, 4).map((term) => (
+                    <span
+                      key={term}
+                      className="text-[11px] px-2 py-0.5 rounded-full bg-warm text-secondary"
+                    >
+                      {term}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Languages */}
+              {topic.languages.length > 0 && (
+                <p className="text-[11px] text-muted mt-2">
+                  {topic.languages.join(', ')}
+                </p>
+              )}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </ContentPageLayout>
+  );
+}

--- a/src/app/topics/loading.tsx
+++ b/src/app/topics/loading.tsx
@@ -1,0 +1,36 @@
+import SiteHeader from '@/components/layout/SiteHeader';
+
+export default function TopicsLoading() {
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <SiteHeader variant="light" />
+
+      {/* Hero */}
+      <div className="relative overflow-hidden text-white py-16 md:py-20">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#2a1f17] to-[#1a1612]" />
+        <div className="relative max-w-[var(--container-standard)] mx-auto px-6">
+          <div className="h-12 w-48 bg-white/15 rounded-lg animate-pulse mb-4" />
+          <div className="h-6 w-96 max-w-full bg-white/10 rounded animate-pulse" />
+        </div>
+      </div>
+
+      <div className="max-w-[var(--container-standard)] mx-auto px-6 py-12 space-y-12">
+        {/* Facet sections */}
+        {Array.from({ length: 3 }).map((_, s) => (
+          <div key={s}>
+            <div className="h-7 w-40 bg-stone-200 rounded animate-pulse mb-2" />
+            <div className="h-4 w-64 bg-stone-100 rounded animate-pulse mb-4" />
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="rounded-lg border border-stone-200 bg-white p-4">
+                  <div className="h-5 w-3/4 bg-stone-200 rounded animate-pulse mb-2" />
+                  <div className="h-3 w-1/3 bg-stone-100 rounded animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -1,0 +1,258 @@
+import { getReadDb } from '@/lib/mongodb';
+import Link from 'next/link';
+import Image from 'next/image';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import type { Metadata } from 'next';
+import { FACETS, DOMAIN_GROUPS, facetDbField } from '@/lib/taxonomy/faceted-vocabulary';
+import DomainTreemap, { type SubDomain } from '@/components/topics/DomainTreemap';
+
+// ISR: rebuild every 6 hours. Allow 60s for first-hit generation.
+export const revalidate = 21600;
+export const maxDuration = 60;
+
+export const metadata: Metadata = {
+  title: 'Browse by Topic | Source Library',
+  description: 'Explore historical texts across six dimensions: tradition, domain, form, cultural sphere, era, and epistemic mode. Filter and combine to find exactly what you\'re looking for.',
+  alternates: { canonical: '/topics' },
+};
+
+function facetSlug(facetId: string, valueId: string): string {
+  return `${facetId}--${valueId}`;
+}
+
+interface FacetCount {
+  id: string;
+  label: string;
+  count: number;
+  thumbnails: string[];
+}
+
+interface FacetGroup {
+  id: string;
+  label: string;
+  question: string;
+  values: FacetCount[];
+}
+
+async function fetchFacetCounts(): Promise<{ groups: FacetGroup[]; totalBooks: number }> {
+  const db = await getReadDb();
+  const maxTimeMS = 30000;
+  const baseMatch = { faceted_tags: { $exists: true }, visible: true };
+
+  // Single $facet aggregation — one collection scan for all 6 facets
+  const facetStages: Record<string, object[]> = {};
+  for (const facet of FACETS) {
+    const field = `faceted_tags.${facetDbField(facet)}`;
+    facetStages[facet.id] = [
+      { $unwind: `$${field}` },
+      { $group: { _id: `$${field}`, count: { $sum: 1 }, sample_thumb: { $first: '$thumbnail_blob' } } },
+      { $sort: { count: -1 } },
+    ];
+  }
+  facetStages['_total'] = [{ $count: 'n' }];
+
+  const [result] = await db.collection('books').aggregate([
+    { $match: baseMatch },
+    { $facet: facetStages },
+  ], { maxTimeMS, allowDiskUse: true }).toArray();
+
+  const totalBooks = result._total?.[0]?.n ?? 0;
+
+  const groups: FacetGroup[] = FACETS.map((facet) => {
+    const results = (result[facet.id] || []) as Array<{ _id: string; count: number; sample_thumb?: string }>;
+    const values: FacetCount[] = results.map((r) => {
+      const vocabValue = facet.values.find((v) => v.id === r._id);
+      return {
+        id: r._id,
+        label: vocabValue?.label || r._id,
+        count: r.count,
+        thumbnails: r.sample_thumb ? [r.sample_thumb] : [],
+      };
+    });
+    return { id: facet.id, label: facet.label, question: facet.question, values };
+  });
+
+  return { groups, totalBooks };
+}
+
+
+/** Single aggregation: all domain co-occurrences in one pass */
+async function fetchDomainCrossTab(): Promise<Map<string, SubDomain[]>> {
+  const db = await getReadDb();
+  // Efficient: project array as two copies, unwind both, filter out self-pairs
+  const results = await db.collection('books').aggregate([
+    { $match: { 'faceted_tags.knowledge_domain.1': { $exists: true }, visible: true } },
+    { $project: { a: '$faceted_tags.knowledge_domain', b: '$faceted_tags.knowledge_domain' } },
+    { $unwind: '$a' },
+    { $unwind: '$b' },
+    { $match: { $expr: { $gt: ['$b', '$a'] } } },  // ordered pairs only (avoids dupes)
+    { $group: { _id: { d1: '$a', d2: '$b' }, count: { $sum: 1 } } },
+    { $sort: { count: -1 } },
+  ], { allowDiskUse: true, maxTimeMS: 8000 }).toArray();
+
+  const map = new Map<string, SubDomain[]>();
+  const labelify = (s: string) => s.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
+  for (const r of results) {
+    const d1 = r._id.d1 as string;
+    const d2 = r._id.d2 as string;
+    const count = r.count as number;
+    if (count < 5) continue;
+    // Add to both domains (symmetric)
+    for (const [domain, coDomain] of [[d1, d2], [d2, d1]]) {
+      const arr = map.get(domain) || [];
+      if (arr.length < 8) {
+        arr.push({ id: coDomain, label: labelify(coDomain), count });
+      }
+      map.set(domain, arr);
+    }
+  }
+  return map;
+}
+
+function FacetValueCard({ value, facetId }: { value: FacetCount; facetId: string }) {
+  return (
+    <Link
+      href={`/topics/${facetId}--${value.id}`}
+      className="group relative block overflow-hidden rounded-lg border border-border-light bg-white hover:border-accent-rust/30 hover:shadow-md transition-all"
+    >
+      {value.thumbnails.length > 0 && (
+        <div className="flex h-16 overflow-hidden">
+          {value.thumbnails.slice(0, 4).map((url, i) => (
+            <div key={i} className="relative flex-1 overflow-hidden">
+              <Image
+                src={url}
+                alt=""
+                fill
+                sizes="(max-width: 640px) 25vw, 12vw"
+                className="object-cover group-hover:scale-105 transition-transform duration-500"
+                unoptimized
+              />
+            </div>
+          ))}
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-white" />
+        </div>
+      )}
+      <div className="p-3">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="font-display text-sm font-semibold text-primary group-hover:text-accent-rust transition-colors leading-tight">
+            {value.label}
+          </h3>
+          <span className="text-xs text-muted whitespace-nowrap flex-shrink-0">
+            {value.count.toLocaleString()}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function FacetGrid({ values, facetId }: { values: FacetCount[]; facetId: string }) {
+  return (
+    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {values.map((value) => (
+        <FacetValueCard key={value.id} value={value} facetId={facetId} />
+      ))}
+    </div>
+  );
+}
+
+function DomainGroupedGrid({ values, facetId }: { values: FacetCount[]; facetId: string }) {
+  const valueMap = new Map(values.map(v => [v.id, v]));
+
+  // Filter to groups that have at least one domain with books
+  const activeGroups = DOMAIN_GROUPS
+    .map(g => ({
+      ...g,
+      domainValues: g.domains
+        .map(id => valueMap.get(id))
+        .filter((v): v is FacetCount => !!v && v.count > 0),
+    }))
+    .filter(g => g.domainValues.length > 0);
+
+  return (
+    <div className="space-y-8">
+      {activeGroups.map((group) => (
+        <div key={group.id}>
+          <h3 className="font-display text-base text-secondary mb-3">
+            {group.label}
+          </h3>
+          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {group.domainValues.map((value) => (
+              <FacetValueCard key={value.id} value={value} facetId={facetId} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default async function TopicsPage() {
+  const { groups, totalBooks } = await fetchFacetCounts().catch((err) => {
+    console.error('Facet counts fetch failed:', err);
+    return { groups: [] as FacetGroup[], totalBooks: 0 };
+  });
+
+  // Cross-tab is optional — don't let it block the page
+  const crossTab = await fetchDomainCrossTab().catch((err) => {
+    console.error('Cross-tab fetch failed (non-fatal):', err?.message);
+    return new Map<string, SubDomain[]>();
+  });
+
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="Browse the Library"
+          subtitle={`${totalBooks.toLocaleString()} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
+        />
+      }
+    >
+
+      <div className="space-y-12">
+        {groups.map((group) => (
+          <section key={group.id}>
+            <div className="mb-4">
+              <h2 className="font-display text-xl md:text-2xl text-primary">
+                {group.label}
+              </h2>
+              <p className="text-sm text-muted mt-1">{group.question}</p>
+            </div>
+
+            {/* Domain facet: treemap only */}
+            {group.id === 'domain' ? (
+              <DomainTreemap
+                  domains={group.values
+                    .filter(v => v.count > 0)
+                    .map(v => {
+                      const dg = DOMAIN_GROUPS.find(g => g.domains.includes(v.id));
+                      return {
+                        id: v.id,
+                        label: v.label,
+                        count: v.count,
+                        groupId: dg?.id || 'reference',
+                        groupLabel: dg?.label || 'Other',
+                      };
+                    })}
+                  totalBooks={totalBooks}
+                />
+            ) : (
+              <FacetGrid values={group.values} facetId={group.id} />
+            )}
+          </section>
+        ))}
+      </div>
+
+      {/* Link to old cluster view */}
+      <div className="mt-16 pt-8 border-t border-border-light">
+        <p className="text-sm text-muted">
+          Looking for the AI-discovered topic clusters?{' '}
+          <Link href="/topics/clusters" className="text-accent-rust hover:underline">
+            Browse 48 clusters
+          </Link>{' '}
+          found by embedding analysis.
+        </p>
+      </div>
+    </ContentPageLayout>
+  );
+}


### PR DESCRIPTION
## Summary
The tenant routing refactor (4f15488f) moved all routes to `[tenant]/` but never restored root copies for these public pages, causing them all to 307 redirect to `/`:

- `/languages` (+ `/languages/[code]`, loading states)
- `/timeline` (+ TimelineClient component)
- `/topics` (+ `/topics/[slug]`, `/topics/clusters`, loading states)
- `/favorites`
- `/categories` (+ `/categories/[id]`, layout, OG images)
- `/reading-history`

## Test plan
- [ ] Visit each route — should render, not redirect
- [ ] `/languages/Latin` loads the Latin language page
- [ ] `/topics` shows topic clusters
- [ ] `/categories` shows category listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)