### PR TITLE
Fix AuthCheck jitter: use visibility:hidden during session loading

### DIFF
--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -21,7 +21,8 @@ export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
   const { data: session, status } = useSession();
 
   if (status === 'loading') {
-    return <>{fallback}</>;
+    // Render children invisibly to reserve layout space and prevent jitter
+    return <div style={{ visibility: 'hidden' }}>{children}</div>;
   }
 
   if (!session?.user) {

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1049,7 +1049,7 @@ export default function TranslationEditor({
 
 
               {/* Mode Toggle - admin and inner circle */}
-              <AuthCheck role="inner_circle" fallback={<div className="w-[68px] sm:w-[140px]" />}>
+              <AuthCheck role="inner_circle">
                 <div className="flex items-center rounded-lg p-0.5 sm:p-1" style={{ background: 'var(--bg-warm)' }}>
                   <button
                     onClick={() => setMode('read')}

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -109,6 +109,12 @@ function BookSearchBar({ bookId, tenantPrefix }: { bookId: string; tenantPrefix?
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => query.trim() && setShowResults(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && query.trim()) {
+              e.preventDefault();
+              window.location.href = `${tenantPrefix || ''}/book/${bookId}/search?q=${encodeURIComponent(query.trim())}`;
+            }
+          }}
           placeholder="Search this book..."
           aria-label="Search within this book"
           className="bg-transparent outline-none text-xs w-full"
@@ -1043,7 +1049,7 @@ export default function TranslationEditor({
 
 
               {/* Mode Toggle - admin and inner circle */}
-              <AuthCheck role="inner_circle">
+              <AuthCheck role="inner_circle" fallback={<div className="w-[68px] sm:w-[140px]" />}>
                 <div className="flex items-center rounded-lg p-0.5 sm:p-1" style={{ background: 'var(--bg-warm)' }}>
                   <button
                     onClick={() => setMode('read')}


### PR DESCRIPTION
## Summary
- Follow-up to #1453 — the fixed-width placeholder didn't match actual button sizes
- Instead, render children with `visibility: hidden` during auth loading to reserve exact layout space
- Removes the hardcoded placeholder width from TranslationEditor

## Test plan
- [ ] Open any book page — toolbar should not jitter when auth resolves
- [ ] Sign out — Read/Edit toggle disappears cleanly (no phantom space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)