### PR TITLE
Fix build: define revalidate directly instead of re-exporting

### DIFF
--- a/src/app/gallery/collections/[slug]/page.tsx
+++ b/src/app/gallery/collections/[slug]/page.tsx
@@ -1,4 +1,6 @@
-export { revalidate, generateMetadata } from '../../../[tenant]/gallery/collections/[slug]/page';
+export { generateMetadata } from '../../../[tenant]/gallery/collections/[slug]/page';
 import GalleryCollectionPage from '../../../[tenant]/gallery/collections/[slug]/page';
+
+export const revalidate = 86400;
 
 export default GalleryCollectionPage;

--- a/src/app/gallery/collections/page.tsx
+++ b/src/app/gallery/collections/page.tsx
@@ -1,4 +1,6 @@
-export { metadata, revalidate } from '../../[tenant]/gallery/collections/page';
+export { metadata } from '../../[tenant]/gallery/collections/page';
 import GalleryCollectionsPage from '../../[tenant]/gallery/collections/page';
+
+export const revalidate = 86400;
 
 export default GalleryCollectionsPage;


### PR DESCRIPTION
## Summary
Turbopack requires `revalidate` (and other route segment config) to be defined directly in the file — re-exporting from `[tenant]` routes fails the build.

Two files affected:
- `src/app/gallery/collections/page.tsx`
- `src/app/gallery/collections/[slug]/page.tsx`

**This is blocking all production deploys** — every build since the gallery subroutes were added has failed.

## Test plan
- [ ] Build succeeds on Vercel
- [ ] All restored routes (/catalog, /languages, /favorites, etc.) now work

🤖 Generated with [Claude Code](https://claude.com/claude-code)