### PR TITLE
Fix production build: wrap EmbedHistoryPatch in Suspense

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import "./globals.css";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
@@ -102,7 +103,7 @@ export default async function RootLayout({
         <Providers>
           <EmbedLinkInterceptor />
           <EmbedHostNavigationListener />
-          <EmbedHistoryPatch />
+          <Suspense><EmbedHistoryPatch /></Suspense>
           <div id="main-content" className="flex-1">
             {children}
           </div>


### PR DESCRIPTION
## Summary
`EmbedHistoryPatch` uses `useSearchParams()` and was added to the root layout in a8cbcea0. This caused **every production build to fail** because Next.js 16 Turbopack requires `useSearchParams` to be wrapped in `<Suspense>` for static prerendering.

One-line fix: wrap `<EmbedHistoryPatch />` in `<Suspense>` in `layout.tsx`.

## Test plan
- [ ] Production build succeeds
- [ ] All pages render correctly
- [ ] Embed functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)