### PR TITLE
Fix build: remove useSearchParams from EmbedHistoryPatch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import "./globals.css";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
@@ -102,7 +103,7 @@ export default async function RootLayout({
         <Providers>
           <EmbedLinkInterceptor />
           <EmbedHostNavigationListener />
-          <EmbedHistoryPatch />
+          <Suspense><EmbedHistoryPatch /></Suspense>
           <div id="main-content" className="flex-1">
             {children}
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import "./globals.css";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
@@ -103,7 +102,7 @@ export default async function RootLayout({
         <Providers>
           <EmbedLinkInterceptor />
           <EmbedHostNavigationListener />
-          <Suspense><EmbedHistoryPatch /></Suspense>
+          <EmbedHistoryPatch />
           <div id="main-content" className="flex-1">
             {children}
           </div>

--- a/src/components/embed/EmbedHistoryPatch.tsx
+++ b/src/components/embed/EmbedHistoryPatch.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
 
 /**
  * When embedded via embed.js (detected by embed=1 param), intercept
@@ -10,7 +9,6 @@ import { useSearchParams } from 'next/navigation';
  * the host embed script owns all history management.
  */
 export default function EmbedHistoryPatch() {
-    const searchParams = useSearchParams();
     const patchedRef = useRef(false);
 
     useEffect(() => {
@@ -19,12 +17,11 @@ export default function EmbedHistoryPatch() {
         if (patchedRef.current) return; // already patched
 
         // Only activate when embed=1 param is present (from embed.js)
-        const isEmbedded = searchParams.get('embed') === '1';
-        if (!isEmbedded) return;
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('embed') !== '1') return;
 
         patchedRef.current = true;
 
-        const originalPushState = history.pushState.bind(history);
         const originalReplaceState = history.replaceState.bind(history);
 
         // Intercept pushState and convert to replaceState when embedded
@@ -33,7 +30,7 @@ export default function EmbedHistoryPatch() {
         };
 
         // No cleanup - keep patch for entire session
-    }, [searchParams]);
+    }, []);
 
     return null;
 }


### PR DESCRIPTION
## Summary
`EmbedHistoryPatch` was using `useSearchParams()` in the root layout, which requires a Suspense boundary for static prerendering. Even wrapping in `<Suspense>` didn't resolve it in Next.js 16 Turbopack.

Fix: use `window.location.search` instead — this component only runs client-side inside iframes, so the React hook is unnecessary.

**This has been blocking ALL production deploys.**

## Test plan
- [ ] Production build succeeds
- [ ] Embed functionality still works (embed=1 param detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)