### PR TITLE
Fix build: remove useSearchParams from all root layout components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import "./globals.css";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
@@ -102,7 +103,7 @@ export default async function RootLayout({
         <Providers>
           <EmbedLinkInterceptor />
           <EmbedHostNavigationListener />
-          <EmbedHistoryPatch />
+          <Suspense><EmbedHistoryPatch /></Suspense>
           <div id="main-content" className="flex-1">
             {children}
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import "./globals.css";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
@@ -103,7 +102,7 @@ export default async function RootLayout({
         <Providers>
           <EmbedLinkInterceptor />
           <EmbedHostNavigationListener />
-          <Suspense><EmbedHistoryPatch /></Suspense>
+          <EmbedHistoryPatch />
           <div id="main-content" className="flex-1">
             {children}
           </div>

--- a/src/components/auth/SignUpCTA.tsx
+++ b/src/components/auth/SignUpCTA.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
 interface SignUpCTAProps {
@@ -11,15 +10,15 @@ interface SignUpCTAProps {
 
 export default function SignUpCTA({ variant = 'section' }: SignUpCTAProps) {
   const { status } = useSession();
-  const searchParams = useSearchParams();
-  const embedParam = searchParams.get('embed') === '1';
   const [isEmbedded, setIsEmbedded] = useState(true); // Default to hidden until checked
 
   useEffect(() => {
     // Check if embedded (via param or iframe detection)
     const inIframe = typeof window !== 'undefined' && window.self !== window.top;
+    const params = new URLSearchParams(window.location.search);
+    const embedParam = params.get('embed') === '1';
     setIsEmbedded(embedParam || inIframe);
-  }, [embedParam]);
+  }, []);
 
   // Don't show when embedded, authenticated, or while loading
   if (isEmbedded || status !== 'unauthenticated') return null;

--- a/src/components/embed/EmbedHistoryPatch.tsx
+++ b/src/components/embed/EmbedHistoryPatch.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
 
 /**
  * When embedded via embed.js (detected by embed=1 param), intercept
@@ -10,7 +9,6 @@ import { useSearchParams } from 'next/navigation';
  * the host embed script owns all history management.
  */
 export default function EmbedHistoryPatch() {
-    const searchParams = useSearchParams();
     const patchedRef = useRef(false);
 
     useEffect(() => {
@@ -19,12 +17,11 @@ export default function EmbedHistoryPatch() {
         if (patchedRef.current) return; // already patched
 
         // Only activate when embed=1 param is present (from embed.js)
-        const isEmbedded = searchParams.get('embed') === '1';
-        if (!isEmbedded) return;
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('embed') !== '1') return;
 
         patchedRef.current = true;
 
-        const originalPushState = history.pushState.bind(history);
         const originalReplaceState = history.replaceState.bind(history);
 
         // Intercept pushState and convert to replaceState when embedded
@@ -33,7 +30,7 @@ export default function EmbedHistoryPatch() {
         };
 
         // No cleanup - keep patch for entire session
-    }, [searchParams]);
+    }, []);
 
     return null;
 }

--- a/src/components/providers/CookieConsent.tsx
+++ b/src/components/providers/CookieConsent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { getConsent, setConsent, type ConsentState } from '@/lib/consent';
 
@@ -9,16 +8,16 @@ import { getConsent, setConsent, type ConsentState } from '@/lib/consent';
  * Minimal cookie consent banner — thin bar at the bottom of the screen.
  * Appears once, stores choice in localStorage.
  * No dark patterns, no "manage 47 categories." Just accept or decline.
- * 
+ *
  * Hidden when embedded via embed script (embed=1 param).
  */
 export default function CookieConsent() {
   const [visible, setVisible] = useState(false);
-  const searchParams = useSearchParams();
-  const embedParam = searchParams.get('embed') === '1';
 
   useEffect(() => {
     // Check if embedded (via param or iframe detection)
+    const params = new URLSearchParams(window.location.search);
+    const embedParam = params.get('embed') === '1';
     const inIframe = typeof window !== 'undefined' && window.self !== window.top;
     const isEmbedded = embedParam || inIframe;
 
@@ -34,7 +33,7 @@ export default function CookieConsent() {
       const timer = setTimeout(() => setVisible(true), 800);
       return () => clearTimeout(timer);
     }
-  }, [embedParam]);
+  }, []);
 
   // Also listen for consent changes (e.g. from cookie settings link)
   useEffect(() => {

--- a/src/hooks/useEmbedContext.ts
+++ b/src/hooks/useEmbedContext.ts
@@ -1,7 +1,7 @@
 /**
  * Hook to detect if the current page is embedded in an iframe
  * and should use embed-specific styling/layout.
- * 
+ *
  * Checks for explicit embed=1 query param (from embed script)
  * as the primary signal, falling back to iframe detection if needed.
  */
@@ -9,17 +9,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 
 export function useEmbedContext() {
   const [isEmbedded, setIsEmbedded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const searchParams = useSearchParams();
 
   useEffect(() => {
     // Prefer explicit embed=1 param from embed script
-    const embedParam = searchParams.get('embed');
-    if (embedParam === '1') {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('embed') === '1') {
       setIsEmbedded(true);
       setIsLoading(false);
       return;
@@ -29,7 +27,7 @@ export function useEmbedContext() {
     const inIframe = typeof window !== 'undefined' && window.self !== window.top;
     setIsEmbedded(inIframe);
     setIsLoading(false);
-  }, [searchParams]);
+  }, []);
 
   return { isEmbedded, isLoading };
 }


### PR DESCRIPTION
## Summary
The embed refactor (a8cbcea0) added `useSearchParams()` to three components in the root layout tree, breaking ALL production builds. Replaced with `window.location.search` in `useEffect` — these only run client-side anyway.

Fixed components:
- `CookieConsent` — renders in root layout
- `useEmbedContext` — used by `EmbedLinkInterceptor` and `ConditionalFooter`
- `SignUpCTA` — used on homepage and collection pages

Combined with the previous `EmbedHistoryPatch` fix (#1461), this should unblock production deploys.

## Test plan
- [ ] Production build succeeds
- [ ] Cookie consent banner hidden in embeds
- [ ] Embed detection still works
- [ ] SignUpCTA hidden in embeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)