### PR TITLE
Fix auth hydration flicker on book pages

### DIFF
--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -21,8 +21,10 @@ export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
   const { data: session, status } = useSession();
 
   if (status === 'loading') {
-    // Render children invisibly to reserve layout space and prevent jitter
-    return <div style={{ visibility: 'hidden' }}>{children}</div>;
+    // During loading, show fallback (the safe, non-interactive default).
+    // This avoids invisible → visible flash since fallback is visually
+    // identical to the authenticated view (e.g. same cover image, just not clickable).
+    return <>{fallback}</>;
   }
 
   if (!session?.user) {

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -25,8 +25,13 @@ export default function UserMenu({ variant = 'default' }: UserMenuProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // Show sign-in link for anonymous users AND during loading.
-  // This ensures the link is visible in SSR and survives hydration failures.
+  // During loading, render an invisible placeholder the same size as the avatar
+  // to prevent layout shift. SSR also hits this path (no session during SSR).
+  if (status === 'loading') {
+    return <div className="w-8 h-8" />;
+  }
+
+  // Show sign-in link for anonymous users.
   if (!session) {
     const textColor = variant === 'hero' ? 'text-white/80 hover:text-white' : '';
     const textStyle = variant === 'hero' ? {} : { color: 'var(--text-muted)' };


### PR DESCRIPTION
## Summary
- **AuthCheck**: Render fallback during session loading instead of hiding children with `visibility:hidden`. Eliminates invisible→visible flash on cover images and prevents admin-only UI from flickering.
- **UserMenu**: Render avatar-sized placeholder during loading instead of "Sign in" text, preventing content jump when session resolves.

Fixes three symptoms on book pages (e.g. /bodleian/book/commentary-on-plato-symposium-ficino):
1. Cover image flicker (invisible during auth loading)
2. Edit button turning on/off
3. Profile avatar not appearing on initial load

## Test plan
- [ ] Load a book page while logged in — cover should appear immediately without flash
- [ ] Admin-only buttons (Publish, BookHistory) should not flicker
- [ ] UserMenu should transition smoothly from placeholder to avatar
- [ ] Load while logged out — cover should show static, sign-in link appears after brief placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)