### PR TITLE
Fix TypeScript error breaking production search

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -297,7 +297,7 @@ export async function GET(request: NextRequest) {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          return await semanticPageSearchGlobal(query, 15, tenantId);
+          return await semanticPageSearchGlobal(query, 15, tenantId || undefined);
         } catch {
           return [];
         }


### PR DESCRIPTION
## Summary
- `tenantId` (`string | null`) was passed to `semanticPageSearchGlobal` which expects `string | undefined`
- This type error was introduced in b0256e35 and has blocked all production deploys since
- The client-side fix (stop sending `X-Tenant-Slug: search` from `/search`) never made it live, so searching anything on the global search page returns empty results

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify search returns results for "bananas" after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)