### PR TITLE
Fix session oscillation with useStableSession hook

### DIFF
--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 
 interface AuthCheckProps {
   children: React.ReactNode;
@@ -18,7 +18,7 @@ interface AuthCheckProps {
  * <AuthCheck role="admin">         // Admin-only (whitelist)
  */
 export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
-  const { data: session, status } = useSession();
+  const { data: session, status } = useStableSession();
 
   if (status === 'loading') {
     // During loading, show fallback (the safe, non-interactive default).

--- a/src/components/auth/SignUpCTA.tsx
+++ b/src/components/auth/SignUpCTA.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useSession } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 
 interface SignUpCTAProps {
@@ -9,7 +9,7 @@ interface SignUpCTAProps {
 }
 
 export default function SignUpCTA({ variant = 'section' }: SignUpCTAProps) {
-  const { status } = useSession();
+  const { status } = useStableSession();
   const [isEmbedded, setIsEmbedded] = useState(true); // Default to hidden until checked
 
   useEffect(() => {

--- a/src/components/book/BookDedication.tsx
+++ b/src/components/book/BookDedication.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 
 interface BookDedicationProps {
@@ -14,7 +14,7 @@ interface BookDedicationProps {
  * Shown on the book page, quiet and permanent — like a donor plaque.
  */
 export default function BookDedication({ bookId, dedication: initialDedication }: BookDedicationProps) {
-  const { data: session } = useSession();
+  const { data: session } = useStableSession();
   const isMember = (session?.user as any)?.membership != null;
   const [dedication, setDedication] = useState(initialDedication);
   const [dedicating, setDedicating] = useState(false);

--- a/src/components/book/EarlyAccessGate.tsx
+++ b/src/components/book/EarlyAccessGate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 
 interface EarlyAccessGateProps {
@@ -14,7 +14,7 @@ interface EarlyAccessGateProps {
  * explaining that the translation will be publicly available soon.
  */
 export default function EarlyAccessGate({ membersOnlyUntil, children }: EarlyAccessGateProps) {
-  const { data: session } = useSession();
+  const { data: session } = useStableSession();
   const isMember = (session?.user as any)?.membership != null;
 
   const until = new Date(membersOnlyUntil);

--- a/src/components/layout/HeroSection.tsx
+++ b/src/components/layout/HeroSection.tsx
@@ -2,7 +2,8 @@
 
 import { useRef, useState } from 'react';
 import Link from 'next/link';
-import { signIn, useSession } from 'next-auth/react';
+import { signIn } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 import { recordLoadingMetric } from '@/lib/analytics';
 import UnifiedSearch from '@/components/search/UnifiedSearch';
 import SiteHeader from '@/components/layout/SiteHeader';
@@ -88,7 +89,7 @@ function HeroSignUp() {
 }
 
 export default function HeroSection() {
-  const { status } = useSession();
+  const { status } = useStableSession();
   const hasRecorded = useRef(false);
   const [videoReady, setVideoReady] = useState(false);
 

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useSession, signOut } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 import { useState, useRef, useEffect, useCallback } from 'react';
 
@@ -9,7 +10,7 @@ interface UserMenuProps {
 }
 
 export default function UserMenu({ variant = 'default' }: UserMenuProps) {
-  const { data: session, status } = useSession();
+  const { data: session, status } = useStableSession();
   const [isOpen, setIsOpen] = useState(false);
   const [imgError, setImgError] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);

--- a/src/hooks/useIdentity.ts
+++ b/src/hooks/useIdentity.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
 import { useMemo } from 'react';
 
 const VISITOR_ID_KEY = 'sl_visitor_id';
@@ -31,7 +31,7 @@ export function getVisitorId(): string {
  * Anonymous users get a localStorage-based visitor_id.
  */
 export function useIdentity(): Identity {
-  const { data: session, status } = useSession();
+  const { data: session, status } = useStableSession();
 
   return useMemo(() => {
     if (status === 'loading') {

--- a/src/hooks/useStableSession.ts
+++ b/src/hooks/useStableSession.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useRef } from 'react';
+
+/**
+ * Wrapper around useSession that suppresses brief 'loading' blips
+ * after the session has already been authenticated.
+ *
+ * Problem: TenantSessionUpdater calls session.update() to attach
+ * tenant-scoped roles, which resets status to 'loading' momentarily.
+ * Every useSession() consumer re-renders, causing visible flicker
+ * (cover images, edit buttons, profile avatar all flash on/off).
+ *
+ * Solution: Once status has been 'authenticated', hold the previous
+ * session data and status during any subsequent loading transitions.
+ * The initial loading→authenticated transition works normally.
+ */
+export function useStableSession() {
+  const session = useSession();
+  const prevRef = useRef(session);
+
+  // Once we've been authenticated, cache that state
+  if (session.status === 'authenticated') {
+    prevRef.current = session;
+  }
+
+  // If we were previously authenticated but now briefly loading
+  // (e.g. from session.update()), return the cached authenticated state
+  if (session.status === 'loading' && prevRef.current.status === 'authenticated') {
+    return prevRef.current;
+  }
+
+  return session;
+}


### PR DESCRIPTION
## Summary
- New `useStableSession()` hook that wraps `useSession()` and suppresses brief loading blips after initial authentication
- Migrated all UI-facing session consumers to use it: AuthCheck, UserMenu, EarlyAccessGate, SignUpCTA, HeroSection, BookDedication, useIdentity

## Root cause
`TenantSessionUpdater` calls `session.update()` to attach tenant-scoped roles on tenant pages (e.g. `/bodleian/book/...`). This resets `useSession()` status to `'loading'` momentarily, causing every consumer to re-render. The full cycle is:

`loading → authenticated → loading (tenant update) → authenticated`

This produced visible oscillation: cover image flickering, edit button turning on/off, profile avatar disappearing.

## How the fix works
`useStableSession()` caches the last authenticated state. Once `status` has been `'authenticated'`, any subsequent `'loading'` state returns the cached data instead. The initial `loading → authenticated` transition works normally. `TenantSessionUpdater` keeps using raw `useSession()` since it needs to observe the actual state.

## Test plan
- [ ] Load a tenant book page while logged in — no flickering on cover, edit button, or profile
- [ ] Load the homepage — hero section sign-up form should show/hide cleanly
- [ ] Load while logged out — sign-in link appears normally, no oscillation
- [ ] Switch between tenant pages — tenant roles should still update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)