### PR TITLE
Fix duplicate AI narration in unified search view

### DIFF
--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -1155,8 +1155,8 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           <div className="py-8"><BookLoader size="xs" /></div>
         )}
 
-        {/* AI narration — only show here when unified view is NOT rendering its own narration block */}
-        {query.length >= 3 && (aiStreaming || aiNarration) && !(viewMode === 'unified' && !loading && (totalResults > 0 || semanticResults.length > 0 || semanticLoading)) && (
+        {/* AI narration — only for non-unified views, or unified while still loading (unified view has its own block once results render) */}
+        {query.length >= 3 && (aiStreaming || aiNarration) && (viewMode !== 'unified' || loading) && (
           <div className="mb-6 px-4 py-3 bg-warm rounded-lg border border-border-light">
             <p className="text-sm text-secondary italic leading-relaxed"
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
Follow-up to #1476. The conditional approach had a React state timing issue — `loading` and `totalResults` updated in different render cycles, causing both narration blocks to render simultaneously.

Simplified fix: the top-level narration block now only renders for non-unified views (`viewMode !== 'unified'`) or while the unified view is still loading. Once results render, the unified view's own narration block takes over — no duplicate possible.

## Test plan
- [ ] Search "bananas" — single narration box with pills, not duplicated
- [ ] Search "syriac" — single narration box
- [ ] Switch to Books/Index/Images tab — narration still shows there

🤖 Generated with [Claude Code](https://claude.com/claude-code)