### PR TITLE
Fix BPH tenant subdomain missing X-Tenant-Slug header

### DIFF
--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -14,7 +14,16 @@ const NON_TENANT_SEGMENTS = new Set([
 ]);
 
 function getTenantSlugFromPathname(pathname: string): string | null {
-  const slug = pathname.split('/')[1] || '';
+  const segments = pathname.split('/').filter(Boolean);
+  // Handle /embed/{tenant}/... paths (tenant subdomains rewrite to /embed/bph/...)
+  if (segments[0] === 'embed' && segments[1]) {
+    const embedTenant = segments[1];
+    if (/^[a-z0-9-]+$/.test(embedTenant) && !NON_TENANT_SEGMENTS.has(embedTenant)) {
+      return embedTenant;
+    }
+    return null;
+  }
+  const slug = segments[0] || '';
   if (!slug) return null;
   if (!/^[a-z0-9-]+$/.test(slug)) return null;
   if (NON_TENANT_SEGMENTS.has(slug)) return null;


### PR DESCRIPTION
## Summary
- BPH subdomain pages live at `/embed/bph/...` but the API client only checked the first path segment for tenant slug
- `embed` is in `NON_TENANT_SEGMENTS`, so no `X-Tenant-Slug` header was sent on any API call from `bph.sourcelibrary.org`
- This caused collection chips to show (0) counts and search/loading console errors
- Fix: when first segment is `embed`, extract tenant slug from the second segment

## Test plan
- [ ] Visit https://bph.sourcelibrary.org on the preview deploy
- [ ] Verify collection chips show correct non-zero counts
- [ ] Verify search works without console errors
- [ ] Verify browse mode loads BPH books correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)