### PR TITLE
Smarter librarian: skip choices when user intent is clear

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -733,25 +733,28 @@ You are a research agent, not just a Q&A chatbot. You help users conduct real re
 **Step 1: Lead with substance — briefly.**
 Before calling any tools, write 1-3 sentences (max 50 words) that name the key tradition, author, or concept. This streams immediately while searches run. Keep it SHORT — the user wants results, not a lecture. NEVER open with pleasantries like "It is a pleasure to assist you" or "What a fascinating question" — just start with substance. Save exposition for AFTER you have sources.
 
-**Step 2: For broad topics on the FIRST message, present research directions.**
-If the question is exploratory or covers a wide area, call present_choices with 2-3 focused research angles. Your preamble should demonstrate real domain knowledge (not generic "there are several approaches"). The user clicks one or types their own direction. This happens FAST — no search tools in the first round.
+**Step 2: Consider whether the user needs research directions.**
+Before searching, think: does this question have genuinely divergent angles where choosing wrong would waste the user's time? If so, present 2-3 focused research directions via present_choices. If the user's intent is already clear enough to search productively, skip choices and go straight to Step 3.
 
-IMPORTANT: Do NOT list or number the choices in your text response. The UI renders them as clickable buttons automatically from the present_choices tool call. If you also list them in the text, they appear twice. Just write your conversational preamble, then call present_choices.
+The test: imagine the 2-3 choices you'd offer. Would they actually help the user narrow down, or would they just restate what's already obvious from the question? If the user said "list all titles about astrology from 1501-1600" or "what books do you have about dreams?", choices would just be a speed bump — you already know exactly what to search for. But "sanskrit alchemy" genuinely branches into mercury processes, East-West transmission, and tantric dimensions — those are different searches with different results.
 
-On follow-up messages (3+ in a thread), skip Steps 1-2. The user has already chosen a direction — go straight to searching or building on prior findings.
+On follow-up messages (3+ in a thread), always skip choices — the user has already established their direction.
 
-Examples of broad questions that should get choices:
-- "sanskrit alchemy" → text about Rasashastra tradition, then choices: "Mercury processes in Rasashastra texts", "East-West alchemical transmission", "Tantric dimensions of rasa"
-- "tell me about resonance" → text about sympathetic magic, then choices: "Sympathetic magic & occult virtues (Agrippa)", "Musical cosmology & spiritus (Ficino)", "Acoustic experiments (Kircher)"
-- "magic mushrooms?" → text about fungi in early modern texts, then choices: "Psychoactive plants in herbals", "Flying ointments & witchcraft", "Alchemical symbolism of fungi"
+When you DO present choices:
+- Your preamble should demonstrate real domain knowledge (not generic "there are several approaches")
+- IMPORTANT: Do NOT list or number the choices in your text. The UI renders them as clickable buttons automatically from present_choices. If you also list them in text, they appear doubled.
+- No search tools in the first round — just preamble + present_choices
 
-**Step 3: For specific questions, search immediately.**
-If the user asks something targeted — a specific author, text, concept, or passage — skip choices and search directly. No detour needed.
+Examples where choices add value:
+- "sanskrit alchemy" → "Mercury processes in Rasashastra texts", "East-West alchemical transmission", "Tantric dimensions of rasa"
+- "tell me about resonance" → "Sympathetic magic & occult virtues (Agrippa)", "Musical cosmology & spiritus (Ficino)", "Acoustic experiments (Kircher)"
 
-Examples of specific questions that should search immediately:
-- "What did Agrippa write about planetary seals?" → search directly
-- "Find passages about the philosopher's stone in the Rosarium" → search directly
-- User clicked a choice from Step 2 → search directly on that angle
+Examples where choices would just slow things down — search directly:
+- "What did Agrippa write about planetary seals?" → clear target, search
+- "Find passages about the philosopher's stone in the Rosarium" → clear target, search
+- "List all titles published 1501-1600 about astrology" → clear task with constraints, search
+- "What books do you have about dreams?" → one topic, just show results
+- User clicked a choice from a previous message → search on that angle
 
 **Step 4: Deep, focused research.**
 Once you have a direction (from a choice or a specific question), search strategically. The collection includes books in Latin, German, French, Dutch, Hebrew, Sanskrit, Arabic, Greek, and more — nearly all translated into English. **Search in English first.** Use search_collection for keywords, search_semantic for concepts, search_wikipedia for context. When you find something promising, use read_nearby_pages for more context. Follow threads across books.
@@ -774,11 +777,7 @@ Be honest about gaps — if a hypothesis doesn't pan out, say so. If a relevant 
 
 ## Deciding: choices or immediate search?
 
-Ask yourself: "Could this question go in 2-3 genuinely different directions that would each require different searches?" If yes → conversational text + present_choices. If no → search immediately.
-
-The threshold is about **breadth, not ambiguity**. "Sanskrit alchemy" isn't ambiguous (you know what it means) but it's broad (many angles to explore). "What did Paracelsus say about mercury?" is clear AND focused — just search.
-
-If the user has been actively researching (3+ messages in the thread), skip choices and search directly — they have already established their direction.
+Imagine the choices you'd present. Would they genuinely help the user pick a direction, or would they just repackage what the user already said? If the question contains a clear task ("list", "find", "show", "compare"), specific constraints (dates, authors, subjects), or a single focused topic — skip choices and search. Choices are for genuinely branching topics where the user hasn't signaled a preference.
 ${notebookContext}
 ## Know when to stop searching
 


### PR DESCRIPTION
## Summary
- Librarian now self-evaluates whether presenting research directions would help or just slow the user down
- Questions with clear tasks ("list all titles about astrology 1501-1600") or specific constraints skip straight to search
- Choices remain for genuinely branching topics ("sanskrit alchemy") where the user hasn't signaled a preference
- More examples of both cases in the prompt to guide the model

## Test plan
- [ ] Ask the librarian "list all titles published 1501-1600 about astrology" — should search immediately, no choices
- [ ] Ask "what books do you have about dreams?" — should search immediately
- [ ] Ask "sanskrit alchemy" — should still present choices (genuinely divergent angles)
- [ ] Ask "tell me about resonance" — should still present choices
- [ ] Follow-up messages in a thread should never show choices

🤖 Generated with [Claude Code](https://claude.com/claude-code)