### PR TITLE
Add /for-researchers page with academic access form

### DIFF
--- a/src/app/api/research-access/route.ts
+++ b/src/app/api/research-access/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+
+/**
+ * POST /api/research-access — Public endpoint for academic access applications
+ *
+ * Body: { name, email, institution, role, research_area, intended_use, access_needs }
+ */
+export async function POST(request: NextRequest) {
+  const rl = checkRateLimit({ name: 'research-access', limit: 3, windowSeconds: 3600 }, getClientIp(request));
+  if (!rl.allowed) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } });
+  }
+
+  const body = await request.json();
+  const { name, email, institution, role, research_area, intended_use, access_needs } = body;
+
+  if (!name || !email || !research_area || !intended_use) {
+    return NextResponse.json(
+      { error: 'name, email, research_area, and intended_use are required' },
+      { status: 400 },
+    );
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json(
+      { error: 'Invalid email address' },
+      { status: 400 },
+    );
+  }
+
+  const db = await getDb();
+
+  // Check for existing pending application from same email
+  const existing = await db.collection('research_access_requests').findOne({
+    email: email.toLowerCase(),
+    status: 'pending',
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: 'You already have a pending application. We\'ll be in touch.' },
+      { status: 409 },
+    );
+  }
+
+  const doc = {
+    name,
+    email: email.toLowerCase(),
+    institution: institution || null,
+    role: role || null,
+    research_area,
+    intended_use,
+    access_needs: Array.isArray(access_needs) ? access_needs : [],
+    status: 'pending' as const,
+    created_at: new Date(),
+    reviewed_at: null,
+    reviewed_by: null,
+    notes: null,
+  };
+
+  await db.collection('research_access_requests').insertOne(doc);
+
+  return NextResponse.json({
+    message: 'Application received. We\'ll review it and get back to you within a few days.',
+    status: 'pending',
+  }, { status: 201 });
+}

--- a/src/app/for-researchers/page.tsx
+++ b/src/app/for-researchers/page.tsx
@@ -1,0 +1,254 @@
+import Link from 'next/link';
+import { BookOpen, Database, Globe, FileText, GraduationCap, Search, Languages, Shield, Code2, Quote } from 'lucide-react';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import AcademicAccessForm from '@/components/researchers/AcademicAccessForm';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'For Researchers | Source Library',
+  description: 'Source Library provides free access to 17,000+ historical texts with AI translations and OCR transcriptions. Apply for API access, bulk data, and corpus downloads.',
+  alternates: {
+    canonical: '/for-researchers',
+  },
+};
+
+export default function ForResearchersPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="For Researchers"
+          subtitle="Source Library is a free, open-access digital library of historical texts with AI-generated translations. We make primary sources readable to scholars who don't read the original languages — and machine-readable to those building on them."
+          image="https://images.sourcelibrary.org/archived/695591547bd6d2cd1d618a62/154.jpg"
+          imageAlt="Historical manuscript page"
+        />
+      }
+      bg="bg-cream"
+    >
+      <div className="prose-content max-w-none">
+
+        {/* What's in the collection */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          The Collection
+        </h2>
+
+        <p className="text-xl text-secondary leading-relaxed mb-8">
+          Source Library holds over 17,000 digitized books spanning the 15th&ndash;19th centuries,
+          drawn from 50+ institutional partners including Internet Archive, Gallica,
+          the Bavarian State Library, the Embassy of the Free Mind, and others.
+          Subjects range from alchemy, natural philosophy, and theology to
+          early science, medicine, law, and world literature.
+        </p>
+
+        <div className="grid md:grid-cols-3 gap-4 mb-16">
+          <StatCard number="17,000+" label="Digitized books" icon={<BookOpen className="w-5 h-5" />} />
+          <StatCard number="30+" label="Languages" icon={<Globe className="w-5 h-5" />} />
+          <StatCard number="4M+" label="Pages translated" icon={<Languages className="w-5 h-5" />} />
+        </div>
+
+        {/* What researchers get */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          What We Offer Researchers
+        </h2>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-16">
+          <OfferCard
+            icon={<FileText className="w-5 h-5 text-blue-600" />}
+            iconBg="bg-blue-100"
+            title="Parallel Texts"
+            description="Every page is available as the original scan, an OCR transcription in the source language, and an English translation. Switch between views freely. The original is never hidden."
+          />
+          <OfferCard
+            icon={<Search className="w-5 h-5 text-violet-600" />}
+            iconBg="bg-violet-100"
+            title="Full-Text Search"
+            description="Semantic search across the entire corpus in English, with results linked to specific pages. Search translations, then verify against the original text."
+          />
+          <OfferCard
+            icon={<Quote className="w-5 h-5 text-accent-rust" />}
+            iconBg="bg-red-50"
+            title="Citable Editions"
+            description="Published editions receive DOIs via Zenodo with auto-generated Chicago, MLA, and BibTeX citations. Stable URLs for every page."
+          />
+          <OfferCard
+            icon={<Code2 className="w-5 h-5 text-green-600" />}
+            iconBg="bg-green-100"
+            title="API & MCP Access"
+            description="Programmatic access to book metadata, OCR text, translations, and images. An MCP server lets AI assistants query the library directly."
+          />
+          <OfferCard
+            icon={<Database className="w-5 h-5 text-amber-600" />}
+            iconBg="bg-amber-100"
+            title="Bulk Data"
+            description="Request corpus exports for computational analysis — full OCR and translation text, metadata, and image annotations in structured formats."
+          />
+          <OfferCard
+            icon={<Shield className="w-5 h-5 text-stone-600" />}
+            iconBg="bg-stone-100"
+            title="Transparent Methodology"
+            description="Every translation records the model, prompt version, and date. Quality signals include semantic alignment scores and inline OCR warnings. Nothing is a black box."
+          />
+        </div>
+
+        {/* How to cite */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          How to Cite
+        </h2>
+
+        <p className="text-secondary mb-6">
+          Source Library texts are AI translations, not human translations.
+          We recommend the following citation format for academic work:
+        </p>
+
+        <div className="bg-white rounded-xl border border-border-light p-6 mb-4">
+          <p className="text-sm text-muted mb-3">General citation format</p>
+          <p className="font-mono text-sm text-primary leading-relaxed">
+            [Author], <em>[Title]</em>, trans. Source Library AI (Gemini, [year]),
+            sourcelibrary.org/book/[slug], p. [N].
+          </p>
+        </div>
+
+        <div className="bg-white rounded-xl border border-border-light p-6 mb-4">
+          <p className="text-sm text-muted mb-3">Example</p>
+          <p className="font-mono text-sm text-primary leading-relaxed">
+            Agrippa, Heinrich Cornelius. <em>De Occulta Philosophia</em>, trans. Source Library AI
+            (Gemini, 2026), sourcelibrary.org/book/de-occulta-philosophia-agrippa, p. 42.
+          </p>
+        </div>
+
+        <p className="text-secondary text-[15px] leading-relaxed mb-16">
+          For DOI-backed editions, use the generated citation on the book page &mdash; it includes
+          a persistent identifier suitable for reference lists. We encourage researchers to
+          verify passages against the original text, which is always available alongside the translation.
+        </p>
+
+        {/* Transparency */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          AI Translation: What You Should Know
+        </h2>
+
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-6 mb-16">
+          <div className="space-y-4 text-stone-800 text-[15px] leading-relaxed">
+            <p>
+              <strong>These are AI translations.</strong> They are produced by Google Gemini models
+              reading directly from page scans. They have not been reviewed by human translators
+              on a per-book basis. They are designed to make texts <em>accessible</em>, not to replace
+              critical editions.
+            </p>
+            <p>
+              <strong>Quality varies by source material.</strong> Well-printed Latin and German texts
+              translate reliably. Damaged manuscripts, unusual scripts, and highly technical
+              alchemical vocabulary are more challenging. OCR warnings appear inline when the
+              model encounters difficulty.
+            </p>
+            <p>
+              <strong>The original is always present.</strong> Every page preserves the source-language
+              transcription alongside the translation. Switch to the &ldquo;Original&rdquo; tab to read
+              the OCR text, or view the scan directly.
+            </p>
+            <p>
+              For a detailed assessment of translation quality with benchmark comparisons,
+              see <Link href="/about/research" className="text-accent-rust hover:underline">How Our Translations Work</Link>.
+            </p>
+          </div>
+        </div>
+
+        {/* Use cases */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          Research Use Cases
+        </h2>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-16">
+          <UseCaseCard
+            title="History of Science & Ideas"
+            description="Trace concepts across centuries of natural philosophy, alchemy, and early science. Full-text search across translations lets you find thematic connections across works that were previously locked behind Latin, German, or Arabic."
+          />
+          <UseCaseCard
+            title="Digital Humanities"
+            description="Build corpora for computational text analysis, topic modeling, or network analysis of intellectual communities. Export structured text with metadata via the API."
+          />
+          <UseCaseCard
+            title="Religious & Theological Studies"
+            description="Access Hermetic, Kabbalistic, Rosicrucian, and theological texts in parallel with their originals. Many are first-ever English translations."
+          />
+          <UseCaseCard
+            title="Book History & Bibliography"
+            description="Explore printing history with scans linked to institutional catalogs. Each book tracks its source library, digitizer, and publication metadata."
+          />
+        </div>
+
+        {/* Application form */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6" id="apply">
+          <GraduationCap className="w-7 h-7 inline-block mr-2 -mt-1" />
+          Apply for Research Access
+        </h2>
+
+        <p className="text-secondary mb-8">
+          The library is free and open to everyone. If you need API access, bulk data exports,
+          or want to discuss a research collaboration, tell us about your work. We respond within
+          a few days.
+        </p>
+
+        <div className="bg-white rounded-xl border border-border-light p-6 md:p-8 mb-16">
+          <AcademicAccessForm />
+        </div>
+
+        {/* Related */}
+        <h2 className="text-2xl md:text-3xl text-primary mt-16 mb-6">Related</h2>
+
+        <div className="grid md:grid-cols-2 gap-4 mb-8">
+          <RelatedCard href="/about/research" title="How Our Translations Work" desc="Pipeline details, models, quality signals, and benchmark studies." />
+          <RelatedCard href="/developers" title="API & MCP Server" desc="Technical documentation for programmatic access." />
+          <RelatedCard href="/about/sources" title="Source Libraries" desc="The 50+ institutional partners we draw from." />
+          <RelatedCard href="/explore" title="Explore the Collection" desc="Browse by subject, period, language, or collection." />
+        </div>
+      </div>
+    </ContentPageLayout>
+  );
+}
+
+/* ── Subcomponents ── */
+
+function StatCard({ number, label, icon }: { number: string; label: string; icon: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-xl border border-border-light p-5 text-center">
+      <div className="flex justify-center mb-3">
+        <div className="p-2.5 bg-stone-100 rounded-lg text-stone-600">
+          {icon}
+        </div>
+      </div>
+      <div className="text-2xl font-semibold text-primary mb-1">{number}</div>
+      <div className="text-sm text-secondary">{label}</div>
+    </div>
+  );
+}
+
+function OfferCard({ icon, iconBg, title, description }: { icon: React.ReactNode; iconBg: string; title: string; description: string }) {
+  return (
+    <div className="bg-white rounded-xl border border-border-light p-5">
+      <div className="flex items-center gap-3 mb-3">
+        <div className={`p-2 rounded-lg ${iconBg}`}>{icon}</div>
+        <h3 className="font-semibold text-primary">{title}</h3>
+      </div>
+      <p className="text-secondary text-[15px] leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
+function UseCaseCard({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="bg-white rounded-xl border border-border-light p-5">
+      <h3 className="font-semibold text-primary mb-2">{title}</h3>
+      <p className="text-secondary text-[15px] leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
+function RelatedCard({ href, title, desc }: { href: string; title: string; desc: string }) {
+  return (
+    <Link href={href} className="block bg-white rounded-xl p-5 border border-border-light hover:border-accent-rust/30 transition-colors">
+      <div className="font-semibold text-primary">{title}</div>
+      <div className="text-sm text-muted mt-1">{desc}</div>
+    </Link>
+  );
+}

--- a/src/components/researchers/AcademicAccessForm.tsx
+++ b/src/components/researchers/AcademicAccessForm.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function AcademicAccessForm() {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    institution: '',
+    role: '',
+    research_area: '',
+    intended_use: '',
+    access_needs: [] as string[],
+  });
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  function toggleAccess(value: string) {
+    setForm(f => ({
+      ...f,
+      access_needs: f.access_needs.includes(value)
+        ? f.access_needs.filter(v => v !== value)
+        : [...f.access_needs, value],
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus('submitting');
+
+    try {
+      const res = await fetch('/api/research-access', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus('error');
+        setMessage(data.error || 'Something went wrong');
+        return;
+      }
+
+      setStatus('success');
+      setMessage(data.message);
+    } catch {
+      setStatus('error');
+      setMessage('Network error — please try again');
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+        <h3 className="text-lg font-semibold text-green-800 mb-2">Application received</h3>
+        <p className="text-green-700">{message}</p>
+      </div>
+    );
+  }
+
+  const accessOptions = [
+    { value: 'api', label: 'API access' },
+    { value: 'bulk_data', label: 'Bulk data / corpus export' },
+    { value: 'mcp', label: 'MCP server for AI tools' },
+    { value: 'collaboration', label: 'Research collaboration' },
+    { value: 'custom', label: 'Other (describe below)' },
+  ];
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Field label="Name" required>
+          <input
+            type="text"
+            required
+            value={form.name}
+            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+            className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+            placeholder="Your name"
+          />
+        </Field>
+        <Field label="Email" required>
+          <input
+            type="email"
+            required
+            value={form.email}
+            onChange={e => setForm(f => ({ ...f, email: e.target.value }))}
+            className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+            placeholder="you@university.edu"
+          />
+        </Field>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Field label="Institution">
+          <input
+            type="text"
+            value={form.institution}
+            onChange={e => setForm(f => ({ ...f, institution: e.target.value }))}
+            className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+            placeholder="University, institute, or independent"
+          />
+        </Field>
+        <Field label="Role">
+          <input
+            type="text"
+            value={form.role}
+            onChange={e => setForm(f => ({ ...f, role: e.target.value }))}
+            className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+            placeholder="PhD student, professor, librarian..."
+          />
+        </Field>
+      </div>
+
+      <Field label="Research area" required>
+        <input
+          type="text"
+          required
+          value={form.research_area}
+          onChange={e => setForm(f => ({ ...f, research_area: e.target.value }))}
+          className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust"
+          placeholder="e.g., History of alchemy, Renaissance philosophy, digital humanities"
+        />
+      </Field>
+
+      <Field label="What are you interested in?">
+        <div className="flex flex-wrap gap-2">
+          {accessOptions.map(opt => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => toggleAccess(opt.value)}
+              className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
+                form.access_needs.includes(opt.value)
+                  ? 'bg-accent-rust text-white border-accent-rust'
+                  : 'bg-white text-stone-600 border-stone-300 hover:border-stone-400'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      <Field label="Tell us about your research" required>
+        <textarea
+          required
+          rows={4}
+          value={form.intended_use}
+          onChange={e => setForm(f => ({ ...f, intended_use: e.target.value }))}
+          className="w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus:ring-accent-rust/30 focus:border-accent-rust resize-none"
+          placeholder="What are you working on? How would Source Library fit into your research?"
+        />
+      </Field>
+
+      {status === 'error' && (
+        <p className="text-sm text-red-600">{message}</p>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="px-6 py-2.5 bg-stone-800 text-white rounded-lg hover:bg-stone-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {status === 'submitting' ? 'Submitting...' : 'Submit Application'}
+      </button>
+
+      <p className="text-xs text-muted">
+        The library is free for everyone. This form is for researchers who need API access,
+        bulk exports, or want to discuss collaboration. We typically respond within a few days.
+      </p>
+    </form>
+  );
+}
+
+function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-stone-700 mb-1">
+        {label}{required && ' *'}
+      </label>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/for-researchers` landing page speaking directly to academics — what's in the collection, what researchers get, how to cite, AI translation transparency
- Application form for API access, bulk data, MCP, and research collaboration
- API route at `/api/research-access` writing to `research_access_requests` collection (rate-limited, deduped)

## What it covers
- Collection stats (17K+ books, 30+ languages, 4M+ pages)
- Six research offerings: parallel texts, full-text search, citable DOI editions, API/MCP, bulk data, transparent methodology
- Citation format guidance with examples
- Honest transparency section about AI translation limitations
- Four research use case cards (history of science, DH, religious studies, book history)
- Interactive form with toggle chips for access needs

## Test plan
- [ ] Visit preview URL `/for-researchers`
- [ ] Submit a test application and verify it appears in `research_access_requests` collection
- [ ] Check mobile responsiveness
- [ ] Verify rate limiting works (3 requests/hour)

Generated with [Claude Code](https://claude.com/claude-code)