### PR TITLE
Add body-text fallback for digitizer detection

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -36,9 +36,14 @@ function extractPageType(text) {
   return match ? match[1].toLowerCase().trim() : null;
 }
 
-/** Check if OCR classified this page as a digitizer insert (trusts the AI model's page-type tag). */
-function isDigitizerPage(pageType) {
-  return pageType === 'digitizer-insert';
+/** Check if this page is a digitizer insert — via OCR tag or body-text fallback. */
+function isDigitizerPage(pageType, ocrText) {
+  if (pageType === 'digitizer-insert') return true;
+  if (!ocrText) return false;
+  // Fallback: match full-page Google/IA notices in body text (not <meta> descriptions)
+  const bodyText = ocrText.replace(/<meta>[\s\S]*?<\/meta>/g, '');
+  return /this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText) ||
+    /inserted by the internet archive/i.test(bodyText);
 }
 
 function extractColumns(text) {
@@ -228,12 +233,12 @@ async function processOneJob(db, job) {
           updated_at: now,
         };
         if (isMultiPage) setObj['ocr.pages_per_request'] = job.pages_per_request;
-        // Trust the OCR model's page-type classification
-        if (pageType) {
+        // Trust the OCR model's page-type classification, with body-text fallback
+        if (isDigitizerPage(pageType, text)) {
+          setObj.page_type = 'digitizer-insert';
+          setObj.hidden = true;
+        } else if (pageType) {
           setObj.page_type = pageType;
-          if (isDigitizerPage(pageType)) {
-            setObj.hidden = true;
-          }
         }
         if (columns) setObj.columns = columns;
         if (detectedImages.length > 0) setObj.detected_images = detectedImages;

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -185,9 +185,13 @@ function extractPageType(text) {
   return match ? match[1].toLowerCase().trim() : null;
 }
 
-/** Check if OCR classified this page as a digitizer insert (trusts the AI model's page-type tag). */
-function isDigitizerPage(pageType) {
-  return pageType === 'digitizer-insert';
+/** Check if this page is a digitizer insert — via OCR tag or body-text fallback. */
+function isDigitizerPage(pageType, ocrText) {
+  if (pageType === 'digitizer-insert') return true;
+  if (!ocrText) return false;
+  const bodyText = ocrText.replace(/<meta>[\s\S]*?<\/meta>/g, '');
+  return /this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText) ||
+    /inserted by the internet archive/i.test(bodyText);
 }
 
 function extractColumns(text) {
@@ -261,7 +265,7 @@ async function processPage(page, promptText, db) {
             source: 'ai',
             prompt_version: TARGET_PROMPT,
           },
-          ...(pageType ? { page_type: pageType, ...(isDigitizerPage(pageType) && { hidden: true }) } : {}),
+          ...(isDigitizerPage(pageType, result.text) ? { page_type: 'digitizer-insert', hidden: true } : pageType ? { page_type: pageType } : {}),
           ...(columns && { columns }),
           ...(detectedImages.length > 0 && { detected_images: detectedImages }),
           updated_at: new Date(),

--- a/scripts/maintenance/backfill-digitizer-pages.mjs
+++ b/scripts/maintenance/backfill-digitizer-pages.mjs
@@ -31,17 +31,14 @@ const BATCH_SIZE = 100;
 
 function isDigitizerNotice(text) {
   if (!text) return false;
-  // If OCR tagged this as real content, trust it
-  const realTypes = /title-page|text|frontispiece|preface|dedication|colophon|toc|index|front-matter|illustration|map|errata|appendix|diagram|privilege|notes|front-cover/;
+  // Trust the OCR model's page-type tag first
   const pageTypeMatch = text.match(/<page-type>([^<]+)<\/page-type>/);
-  if (pageTypeMatch && realTypes.test(pageTypeMatch[1])) return false;
+  if (pageTypeMatch?.[1] === 'digitizer-insert') return true;
 
-  // Strip <meta> tags — descriptions of stamps/labels are not digitizer notices
-  const start = text.substring(0, 1500).replace(/<meta>[\s\S]*?<\/meta>/g, '');
-  return /google\s+logo|digitized\s+by\s+google|scanned\s+by\s+google|this\s+is\s+a\s+digital\s+copy/i.test(start) ||
-    /preserved\s+for\s+generations\s+on\s+library\s+shelves/i.test(start) ||
-    /inserted\s+by\s+the\s+internet\s+archive|digitization\s+(credit|notice)/i.test(start) ||
-    /not\s+part\s+of\s+the\s+original\s+book|scanner\s+barcode/i.test(start);
+  // Body-text fallback: match full-page Google/IA notices (strip <meta> descriptions first)
+  const bodyText = text.substring(0, 2000).replace(/<meta>[\s\S]*?<\/meta>/g, '');
+  return /this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText) ||
+    /inserted by the internet archive/i.test(bodyText);
 }
 
 const client = new MongoClient(process.env.MONGODB_URI, {


### PR DESCRIPTION
## Summary

Follow-up to #1485. After removing the overly broad regex, spot-checking revealed 742 actual Google Books/IA digitizer insert pages that the OCR model had misclassified as `text` or `preface`.

Adds a body-text fallback that matches very specific full-page notice phrases (stripping `<meta>` tags first):
- "this is a digital copy of a book" (Google Books)
- "reproduction of a library book that was digitized" (Google Books)  
- "digitized by google as part of an ongoing" (Google Books)
- "inserted by the internet archive" (IA)

These phrases only appear as body text on dedicated digitizer notice pages, never as incidental descriptions on real content.

Applied to all 3 OCR processors: `collect-batch-results.mjs`, `realtime-ocr.mjs`, `backfill-digitizer-pages.mjs`.

**Data fix**: 742 actual digitizer inserts re-hidden in production.

## Test plan

- [x] Scanned 76,133 edge pages — 719 Google/IA inserts found and hidden
- [x] Scanned 46,727 last pages — 23 more found
- [x] Verified no false positives: pages with "Digitized by Google" only in `<meta>` tags are not affected
- [x] Spot-checked restored pages: 5,236 checked, only 545 were actual inserts (all caught by new fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)