### PR TITLE
Fix old-pipeline split pages showing full spread instead of cropped half

### DIFF
--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -471,7 +471,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
       // NEVER store /api/image?url= wrappers — they crash Next.js Image during SSR.
       // Split-from-spread pages: use photo directly (no legacy fallback)
       const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string; enhanced_photo?: string };
-      const directUrl = page.split_from_spread
+      const directUrl = (page.split_from_spread || (page as any).crop)
         ? page.photo
         : (typedPage.enhanced_photo || typedPage.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
       if (directUrl) {

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -79,7 +79,7 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
       // For the main thumbnail, prefer cropped_photo (split pages) > archived_photo > direct source URL.
       // NEVER store /api/image?url= wrappers — they crash Next.js Image during SSR.
       const typedPageWithCrop = page as Page & { archived_photo?: string; cropped_photo?: string; enhanced_photo?: string };
-      const directUrl = page.split_from_spread
+      const directUrl = (page.split_from_spread || page.crop)
         ? page.photo
         : (typedPageWithCrop.enhanced_photo || typedPageWithCrop.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
       if (directUrl) {

--- a/src/components/reader/BookOverview.tsx
+++ b/src/components/reader/BookOverview.tsx
@@ -34,6 +34,8 @@ function getThumbUrl(page: OverviewPage): string | null {
 }
 
 function getHiresUrl(page: OverviewPage): string | null {
+  // Split pages: use photo directly (the cropped half), not the full spread
+  if (page.split_from_spread || page.crop) return page.photo || null;
   // Best available high-res: archived R2 > display > original > photo
   if (page.archived_photo) return page.archived_photo;
   if (page.display_photo) return page.display_photo;

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -258,7 +258,9 @@ export interface DetectedImage {
  * For split-from-spread pages, uses photo directly (skip legacy fallback).
  */
 export function pageImageUrl(page: Partial<Page>): string {
-  if ((page as any).split_from_spread) return page.photo || '';
+  // Split pages: use photo directly (the cropped half), skip legacy fallback
+  // which would show the full spread via archived_photo/photo_original
+  if ((page as any).split_from_spread || (page as any).crop) return page.photo || '';
   return (page as any).enhanced_photo
     || (page as any).cropped_photo
     || page.archived_photo


### PR DESCRIPTION
## Summary

- Pages split by the old BPH pipeline have `crop` coordinates and `split_from` fields, but not `split_from_spread`
- The image URL fallback chain (`pageImageUrl`, `getHiresUrl`, cover picker) prioritized `archived_photo` (the full spread) over `photo` (the cropped half)
- Result: clicking into a page on BPH showed the full two-page spread, not the individual page
- Fix: check for `crop` data in addition to `split_from_spread` — use `photo` directly for any split page
- Affects ~1,200+ BPH books split by the original pipeline

## Also done (DB fix, no code change)

- Updated 18 BPH book covers that still pointed to spread thumbnails

## Test plan

- [ ] Visit https://sourcelibrary.org/bph/book/on-the-secrets-of-women-on-the-virtues-of-herbs-stones-and-magnus
- [ ] Click into page 2 — should show cropped half (portrait), not full spread (landscape)
- [ ] Check page grid thumbnails still load correctly
- [ ] Check non-BPH books are unaffected (no `crop` field = same behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)