### PR TITLE
Fix gallery showing bleed-through by preferring extracted_url

### DIFF
--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -294,8 +294,11 @@ export async function GET(
       highResUrl = `/api/crop-image?${highResCropParams}`;
     }
 
-    // Prefer highest-resolution pre-generated crop, fall back to standard crop, then on-the-fly
-    const croppedUrl = detection.hires_url || detection.extracted_url || cropUrl || imageUrl;
+    // Prefer extracted_url (generated during detection, always from the correct page).
+    // hires_url is higher resolution but may be stale — the hires backfill generates crops
+    // from archived_photo which can be a bleed-through page if the detection landed on the
+    // wrong side of a spread. extracted_url is the authoritative crop.
+    const croppedUrl = detection.extracted_url || detection.hires_url || cropUrl || imageUrl;
 
     // Build the response
     const response = {


### PR DESCRIPTION
## Summary
The gallery image viewer was showing bleed-through (ghosted ink from facing pages) instead of the actual illustration. Root cause:

1. Image detection sometimes lands on the **bleed-through page** (e.g., page 82) instead of the actual illustration page (page 83)
2. The initial **extraction pipeline** is smart enough to generate correct thumbnail/extracted crops
3. The **hires backfill** naively crops from `page.archived_photo`, which is the bleed-through page
4. The gallery API prioritized `hires_url` over `extracted_url`

Fix: swap priority so `extracted_url` (authoritative, from detection time) wins over `hires_url` (may be stale/wrong source).

**Scope**: ~30,070 adjacent-page detection pairs across 1,472 books may be affected. The Emblems of Love book had all 41 gallery images showing bleed-through in the viewer while thumbnails were correct.

**Follow-up needed**: The hires backfill should detect bleed-through pages and source from the adjacent page instead.

## Test plan
- [ ] Visit https://sourcelibrary.org/internet-archive/gallery/image/69b1de43a205bd982d828550-0 — should show sharp emblem, not faded bleed-through
- [ ] Check other gallery images — should show extracted crops, not hires

🤖 Generated with [Claude Code](https://claude.com/claude-code)