### PR TITLE
Fix remaining split_from_spread-only checks for old-pipeline pages

### DIFF
--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -471,7 +471,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
       // NEVER store /api/image?url= wrappers — they crash Next.js Image during SSR.
       // Split-from-spread pages: use photo directly (no legacy fallback)
       const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string; enhanced_photo?: string };
-      const directUrl = page.split_from_spread
+      const directUrl = (page.split_from_spread || (page as any).crop)
         ? page.photo
         : (typedPage.enhanced_photo || typedPage.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
       if (directUrl) {

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -79,7 +79,7 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
       // For the main thumbnail, prefer cropped_photo (split pages) > archived_photo > direct source URL.
       // NEVER store /api/image?url= wrappers — they crash Next.js Image during SSR.
       const typedPageWithCrop = page as Page & { archived_photo?: string; cropped_photo?: string; enhanced_photo?: string };
-      const directUrl = page.split_from_spread
+      const directUrl = (page.split_from_spread || page.crop)
         ? page.photo
         : (typedPageWithCrop.enhanced_photo || typedPageWithCrop.cropped_photo || typedPage.archived_photo || page.photo_original || page.photo);
       if (directUrl) {

--- a/src/components/book/CoverImagePicker.tsx
+++ b/src/components/book/CoverImagePicker.tsx
@@ -45,23 +45,15 @@ export default function CoverImagePicker({ bookId, currentThumbnail, currentThum
   }, [isOpen, handleClose]);
 
   const getPageImageUrl = (page: Page) => {
-    // Split-from-spread pages: use photo directly, skip legacy fallback
-    if (page.split_from_spread) return page.photo;
+    // Split pages: use photo directly (the cropped half), skip legacy fallback
+    if (page.split_from_spread || page.crop) return page.photo;
 
     // Prefer pre-generated R2 thumbnail (fast CDN)
     if (page.thumbnail_blob) return page.thumbnail_blob;
 
-    // For split pages, prefer pre-cropped Blob image (avoids proxy overhead)
     const typedPage = page as Page & { archived_photo?: string; cropped_photo?: string };
-    if (page.crop && typedPage.cropped_photo) {
-      return typedPage.cropped_photo;
-    }
-
     const baseUrl = typedPage.archived_photo || page.photo_original || page.photo;
     if (!baseUrl) return null;
-    if (page.crop?.xStart !== undefined && page.crop?.xEnd !== undefined) {
-      return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60&cx=${page.crop.xStart}&cw=${page.crop.xEnd}`;
-    }
     return `/api/image?url=${encodeURIComponent(baseUrl)}&w=150&q=60`;
   };
 

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -570,7 +570,7 @@ export default function TranslationEditor({
   const pageProxyUrl = getImageUrl(page, 'full');       // 2400px proxy (cropped if split)
   const pageDisplayUrl = getImageUrl(page, 'display'); // 1200px for initial display
   // Native-res: the original archived image — best available quality
-  const pageNativeUrl = page.split_from_spread
+  const pageNativeUrl = (page.split_from_spread || page.crop)
     ? pageProxyUrl // split pages: cropped image IS the full res
     : (isUsableImageUrl(page.archived_photo) ? page.archived_photo! : pageProxyUrl);
   // For the main view, use native-res if available (progressive: display → native)

--- a/src/components/reader/BookOverview.tsx
+++ b/src/components/reader/BookOverview.tsx
@@ -34,6 +34,8 @@ function getThumbUrl(page: OverviewPage): string | null {
 }
 
 function getHiresUrl(page: OverviewPage): string | null {
+  // Split pages: use photo directly (the cropped half), not the full spread
+  if (page.split_from_spread || page.crop) return page.photo || null;
   // Best available high-res: archived R2 > display > original > photo
   if (page.archived_photo) return page.archived_photo;
   if (page.display_photo) return page.display_photo;

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -258,7 +258,9 @@ export interface DetectedImage {
  * For split-from-spread pages, uses photo directly (skip legacy fallback).
  */
 export function pageImageUrl(page: Partial<Page>): string {
-  if ((page as any).split_from_spread) return page.photo || '';
+  // Split pages: use photo directly (the cropped half), skip legacy fallback
+  // which would show the full spread via archived_photo/photo_original
+  if ((page as any).split_from_spread || (page as any).crop) return page.photo || '';
   return (page as any).enhanced_photo
     || (page as any).cropped_photo
     || page.archived_photo


### PR DESCRIPTION
## Summary

Follow-up to #1495. Two more locations only checked `split_from_spread` but not `crop`:
- `CoverImagePicker` thumbnail URL — showed spread in admin picker
- `TranslationEditor` native-res URL — loaded full spread for translation view

Also cleans up dead crop-proxy code that was unreachable after the early return.

## Context

The old BPH pipeline used `crop` + `split_from` fields. The new pipeline uses `split_from_spread`. All image fallback chains need to check both. Full audit:

| Location | Field checked | Status |
|----------|--------------|--------|
| `pageImageUrl()` | `split_from_spread \|\| crop` | Fixed in #1495 |
| `getHiresUrl()` | `split_from_spread \|\| crop` | Fixed in #1495 |
| `BookPagesSection` cover | `split_from_spread \|\| crop` | Fixed in #1495 |
| `CoverImagePicker` cover | `split_from_spread \|\| crop` | Fixed in #1495 |
| `getPageImageUrl()` | handles `crop` via proxy at L181 | Already correct |
| `getPageDisplayUrl()` | handles `crop` via proxy at L181-184 | Already correct |
| `getPageThumbUrl()` | handles `crop` at L214 | Already correct |
| `CoverImagePicker` thumb | `split_from_spread` only | **Fixed here** |
| `TranslationEditor` | `split_from_spread` only | **Fixed here** |

All locations now handle both old and new pipeline split pages.

## Test plan
- [ ] Open translation editor for a BPH book — should show cropped half, not spread
- [ ] Open cover picker — thumbnails should show cropped halves

🤖 Generated with [Claude Code](https://claude.com/claude-code)