### PR TITLE
Improve constellation zoom, pan, click, and touch

### DIFF
--- a/src/components/explore/ConstellationCanvas.tsx
+++ b/src/components/explore/ConstellationCanvas.tsx
@@ -49,9 +49,11 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
   const containerRef = useRef<HTMLDivElement>(null);
   const transformRef = useRef<Transform>({ x: 0, y: 0, scale: 1 });
   const draggingRef = useRef(false);
+  const dragDistRef = useRef(0);
   const lastMouseRef = useRef({ x: 0, y: 0 });
   const rafRef = useRef<number>(0);
   const [hovered, setHovered] = useState<HoveredPoint | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [highlightedIds, setHighlightedIds] = useState<Set<string> | null>(null);
   const [selectedLang, setSelectedLang] = useState<string | null>(null);
@@ -180,31 +182,141 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
   // Redraw on state changes
   useEffect(() => { draw(); }, [draw]);
 
-  // Mouse handlers
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    const t = transformRef.current;
-    const factor = e.deltaY > 0 ? 0.9 : 1.1;
-    const newScale = Math.max(0.3, Math.min(100, t.scale * factor));
+  // Wheel zoom — must be a native non-passive listener so preventDefault works
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-    // Zoom toward cursor
-    const canvas = canvasRef.current!;
-    const rect = canvas.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
-    const mx = (e.clientX - rect.left) * dpr;
-    const my = (e.clientY - rect.top) * dpr;
-    const cx = canvas.width / 2;
-    const cy = canvas.height / 2;
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const t = transformRef.current;
+      const factor = e.deltaY > 0 ? 0.9 : 1.1;
+      const newScale = Math.max(0.3, Math.min(100, t.scale * factor));
 
-    t.x = (mx - cx) / newScale + t.x - (mx - cx) / t.scale;
-    t.y = (my - cy) / newScale + t.y - (my - cy) / t.scale;
-    t.scale = newScale;
-    draw();
-  }, [draw]);
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      const mx = (e.clientX - rect.left) * dpr;
+      const my = (e.clientY - rect.top) * dpr;
+      const cx = canvas.width / 2;
+      const cy = canvas.height / 2;
+
+      t.x = (mx - cx) / newScale + t.x - (mx - cx) / t.scale;
+      t.y = (my - cy) / newScale + t.y - (my - cy) / t.scale;
+      t.scale = newScale;
+      draw();
+    };
+
+    canvas.addEventListener('wheel', handleWheel, { passive: false });
+
+    // Touch support: drag and pinch-zoom
+    let lastTouches: { x: number; y: number }[] = [];
+    let lastPinchDist = 0;
+    let touchDragDist = 0;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      e.preventDefault();
+      touchDragDist = 0;
+      lastTouches = Array.from(e.touches).map(t => ({ x: t.clientX, y: t.clientY }));
+      if (e.touches.length === 2) {
+        lastPinchDist = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY,
+        );
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const t = transformRef.current;
+      const dpr = window.devicePixelRatio || 1;
+
+      if (e.touches.length === 1 && lastTouches.length >= 1) {
+        const dx = (e.touches[0].clientX - lastTouches[0].x) * dpr;
+        const dy = (e.touches[0].clientY - lastTouches[0].y) * dpr;
+        touchDragDist += Math.abs(dx) + Math.abs(dy);
+        t.x += dx / t.scale;
+        t.y += dy / t.scale;
+        draw();
+      } else if (e.touches.length === 2) {
+        const dist = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY,
+        );
+        if (lastPinchDist > 0) {
+          const factor = dist / lastPinchDist;
+          const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+          const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+          const rect = canvas.getBoundingClientRect();
+          const mx = (midX - rect.left) * dpr;
+          const my = (midY - rect.top) * dpr;
+          const cx = canvas.width / 2;
+          const cy = canvas.height / 2;
+          const newScale = Math.max(0.3, Math.min(100, t.scale * factor));
+          t.x = (mx - cx) / newScale + t.x - (mx - cx) / t.scale;
+          t.y = (my - cy) / newScale + t.y - (my - cy) / t.scale;
+          t.scale = newScale;
+          draw();
+        }
+        lastPinchDist = dist;
+      }
+      lastTouches = Array.from(e.touches).map(t => ({ x: t.clientX, y: t.clientY }));
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      // Tap to select — single finger, minimal drag
+      if (e.changedTouches.length === 1 && touchDragDist < 10) {
+        const touch = e.changedTouches[0];
+        const rect = canvas.getBoundingClientRect();
+        const dpr = window.devicePixelRatio || 1;
+        const sx = (touch.clientX - rect.left) * dpr;
+        const sy = (touch.clientY - rect.top) * dpr;
+        const tt = transformRef.current;
+        const size = Math.min(canvas.width, canvas.height) * 0.45;
+        const px = (sx - canvas.width / 2) / tt.scale / size - tt.x / size;
+        const py = (sy - canvas.height / 2) / tt.scale / size - tt.y / size;
+        const searchRadius = 12 / (tt.scale * size);
+
+        let nearest: { idx: number; dist: number } | null = null;
+        const gx = Math.floor(px / GRID_CELL);
+        const gy = Math.floor(py / GRID_CELL);
+        for (let dx = -1; dx <= 1; dx++) {
+          for (let dy = -1; dy <= 1; dy++) {
+            const indices = gridRef.current.get(`${gx + dx},${gy + dy}`);
+            if (!indices) continue;
+            for (const i of indices) {
+              const p = points[i];
+              const d = Math.hypot(p.x - px, p.z - py);
+              if (d < searchRadius && (!nearest || d < nearest.dist)) {
+                nearest = { idx: i, dist: d };
+              }
+            }
+          }
+        }
+        if (nearest) {
+          window.location.href = `/book/${points[nearest.idx].id}`;
+        }
+      }
+      lastTouches = Array.from(e.touches).map(t => ({ x: t.clientX, y: t.clientY }));
+      if (e.touches.length < 2) lastPinchDist = 0;
+    };
+
+    canvas.addEventListener('touchstart', handleTouchStart, { passive: false });
+    canvas.addEventListener('touchmove', handleTouchMove, { passive: false });
+    canvas.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      canvas.removeEventListener('wheel', handleWheel);
+      canvas.removeEventListener('touchstart', handleTouchStart);
+      canvas.removeEventListener('touchmove', handleTouchMove);
+      canvas.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [draw, points]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     draggingRef.current = true;
+    dragDistRef.current = 0;
     lastMouseRef.current = { x: e.clientX, y: e.clientY };
+    setIsDragging(true);
   }, []);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -215,6 +327,7 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
     if (draggingRef.current) {
       const dx = (e.clientX - lastMouseRef.current.x) * dpr;
       const dy = (e.clientY - lastMouseRef.current.y) * dpr;
+      dragDistRef.current += Math.abs(dx) + Math.abs(dy);
       transformRef.current.x += dx / transformRef.current.scale;
       transformRef.current.y += dy / transformRef.current.scale;
       lastMouseRef.current = { x: e.clientX, y: e.clientY };
@@ -264,14 +377,49 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
 
   const handleMouseUp = useCallback(() => {
     draggingRef.current = false;
+    setIsDragging(false);
   }, []);
 
-  const handleClick = useCallback(() => {
-    if (hovered) {
-      // Navigate to book page
-      router.push(`/book/${hovered.point.id}`);
+  const findNearestPoint = useCallback((clientX: number, clientY: number): ConstellationPoint | null => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const sx = (clientX - rect.left) * dpr;
+    const sy = (clientY - rect.top) * dpr;
+    const t = transformRef.current;
+    const size = Math.min(canvas.width, canvas.height) * 0.45;
+    const px = (sx - canvas.width / 2) / t.scale / size - t.x / size;
+    const py = (sy - canvas.height / 2) / t.scale / size - t.y / size;
+    const searchRadius = 8 / (t.scale * size);
+
+    let nearest: { idx: number; dist: number } | null = null;
+    const gx = Math.floor(px / GRID_CELL);
+    const gy = Math.floor(py / GRID_CELL);
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        const indices = gridRef.current.get(`${gx + dx},${gy + dy}`);
+        if (!indices) continue;
+        for (const i of indices) {
+          const p = points[i];
+          const d = Math.hypot(p.x - px, p.z - py);
+          if (d < searchRadius && (!nearest || d < nearest.dist)) {
+            nearest = { idx: i, dist: d };
+          }
+        }
+      }
     }
-  }, [hovered, router]);
+    return nearest ? points[nearest.idx] : null;
+  }, [points]);
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    // Ignore if this was a drag
+    if (dragDistRef.current > 5) return;
+    const point = findNearestPoint(e.clientX, e.clientY);
+    if (point) {
+      router.push(`/book/${point.id}`);
+    }
+  }, [findNearestPoint, router]);
 
   // Collect unique languages for legend
   const langCounts = useRef<Map<string, number>>(new Map());
@@ -363,8 +511,7 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
 
       <canvas
         ref={canvasRef}
-        className={`w-full h-full ${hovered ? 'cursor-pointer' : draggingRef.current ? 'cursor-grabbing' : 'cursor-grab'}`}
-        onWheel={handleWheel}
+        className={`w-full h-full ${isDragging ? 'cursor-grabbing' : hovered ? 'cursor-pointer' : 'cursor-grab'}`}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}


### PR DESCRIPTION
## Summary
- Fix scroll-to-zoom: wheel events were passive (React default), so `preventDefault()` was ignored and the page scrolled instead of zooming
- Fix click-to-open: find nearest point at the actual click position instead of relying on stale `hovered` state; skip clicks after drag gestures
- Add touch support: single-finger drag, pinch-to-zoom, tap-to-open
- Fix cursor feedback: use state instead of ref so cursor updates on drag start/end

## Test plan
- [ ] Visit https://sourcelibrary.org/explore/constellation
- [ ] Scroll wheel zooms toward cursor (page doesn't scroll)
- [ ] Drag pans the view
- [ ] Click a dot to navigate to the book page
- [ ] On mobile: drag, pinch-zoom, and tap all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)