### PR TITLE
Fix book page 500: remove searchParams that broke ISR

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -67,7 +67,6 @@ export async function generateStaticParams() {
 
 interface PageProps {
   params: Promise<{ tenant: string; id: string }>;
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
 
 // Cached book lookup — deduplicates between generateMetadata and BookInfo
@@ -1041,11 +1040,12 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
   );
 }
 
-export default async function BookDetailPage({ params, searchParams }: PageProps) {
+export default async function BookDetailPage({ params }: PageProps) {
   const { id, tenant } = await params;
-  const sp = searchParams ? await searchParams : {};
-  const isEmbedded = typeof sp.embed === 'string' ? sp.embed === '1' : false;
-  const embedPolicy = getEmbedUiPolicy(isEmbedded);
+  // Embed policy is always non-embedded for server-rendered pages.
+  // Client components read embed state from EmbedContext (set in TenantLayoutWrapper).
+  // IMPORTANT: Do NOT add searchParams here — it forces dynamic rendering and breaks ISR.
+  const embedPolicy = getEmbedUiPolicy(false);
   // Use cached tenant lookup instead of headers() to preserve ISR
   const tenantId = await getCachedTenantId(tenant);
   const tenantSlug = tenant;

--- a/src/app/[tenant]/layout.tsx
+++ b/src/app/[tenant]/layout.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { getDb } from '@/lib/mongodb';
 import { TenantSessionUpdater } from '@/components/auth/TenantSessionUpdater';
 import { resolveTenantId } from '@/lib/tenant-context';
-import { cache } from 'react';
+import { cache, Suspense } from 'react';
 import EmbedResizeReporter from '@/components/embed/EmbedResizeReporter';
 import { TenantLayoutWrapper } from '@/components/tenant/TenantLayoutWrapper';
 
@@ -75,7 +75,10 @@ export default async function TenantLayout({
       {/* Trigger JWT update with tenant context for role resolution + activate pending memberships */}
       <TenantSessionUpdater tenantSlug={slug} />
       <EmbedResizeReporter />
-      <TenantLayoutWrapper>{children}</TenantLayoutWrapper>
+      {/* Suspense required: TenantLayoutWrapper uses useSearchParams() */}
+      <Suspense>
+        <TenantLayoutWrapper>{children}</TenantLayoutWrapper>
+      </Suspense>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- All book pages are 500ing in production since commit 82d3f77b (embed system changes)
- Root cause: `searchParams` was added to the book page component, forcing dynamic rendering which conflicts with `revalidate = 86400` (ISR)
- The `TenantLayoutWrapper` using `useSearchParams()` also lacked a required `<Suspense>` boundary

## Changes
- Remove `searchParams` from book page — always use non-embedded policy for server rendering
- Wrap `TenantLayoutWrapper` in `<Suspense>` as required by `useSearchParams()`
- Embed detection for client components still works via `EmbedContext` from `TenantLayoutWrapper`

## Test plan
- [ ] Book pages load without 500 errors
- [ ] Homepage still works
- [ ] Embedded tenant pages (`?embed=1`) still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)