### PR TITLE
Fix BPH embed: server-side embed detection eliminates flash and stale links

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -3,7 +3,6 @@ import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { HideWhenEmbedded } from '@/components/embed/HideWhenEmbedded';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { deduplicateByDHash } from '@/lib/dhash';
@@ -68,6 +67,7 @@ export async function generateStaticParams() {
 
 interface PageProps {
   params: Promise<{ tenant: string; id: string }>;
+  isEmbedded?: boolean;
 }
 
 // Cached book lookup — deduplicates between generateMetadata and BookInfo
@@ -617,7 +617,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   {totalPages} pages
                 </div>
                 {embedPolicy.showGalleryImages && imageCount > 0 && (
-                  <HideWhenEmbedded>
                     <Link
                       href={`/${tenantSlug}/gallery?bookId=${book.id}`}
                       className="flex items-center gap-2 text-accent-gold hover:text-accent-gold transition-colors"
@@ -626,7 +625,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                       <Images className="w-4 h-4" />
                       {imageCount} images
                     </Link>
-                  </HideWhenEmbedded>
                 )}
               </div>
 
@@ -696,8 +694,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                             .filter((t: string) => t !== 'make_determination')
                             .map((t: string) => t.replace('search_', '').replace(/_/g, ' '))
                             .join(', ')}
-                          {' '}&middot;{' '}
-                          <a href="/blog/first-translation-methodology" className="underline hover:text-stone-500">methodology</a>
+                          {embedPolicy.showExternalLinks && <>{' '}&middot;{' '}<a href="/blog/first-translation-methodology" className="underline hover:text-stone-500">methodology</a></>}
                         </p>
                       )}
                     </div>
@@ -750,7 +747,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 const skipTo = totalPages >= 20 ? 4 : totalPages >= 10 ? 2 : 0;
                 const readPage = firstChapterPage || pages[skipTo] || pages[0];
                 return (
-                  <HideWhenEmbedded>
                     <div className="mt-5">
                       <Link
                         href={`/book/${bookSlug}/page/${readPage.id}`}
@@ -760,7 +756,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                         Read This Book
                       </Link>
                     </div>
-                  </HideWhenEmbedded>
                 );
               })()}
 
@@ -844,8 +839,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 book={book}
                 pagesCount={totalPages}
                 hasTranslations={translatedCount > 0}
-                showTranslationMethodologyLink={true}
-                showExternalLinks={true}
+                showTranslationMethodologyLink={embedPolicy.showTranslationMethodologyLink}
+                showExternalLinks={embedPolicy.showExternalLinks}
               >
                 {(book as unknown as { work_id?: string }).work_id && (
                   <Suspense fallback={null}>
@@ -954,7 +949,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
 
             {/* Gallery Images Preview */}
             {embedPolicy.showGalleryImages && galleryImages.length > 0 && (
-              <HideWhenEmbedded>
                 <div className="card p-6 mt-6">
                   <div className="flex items-center justify-between mb-4">
                     <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
@@ -994,14 +988,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     })}
                   </div>
                 </div>
-              </HideWhenEmbedded>
             )}
 
             {/* Related Books — pre-computed, zero extra queries */}
             {embedPolicy.showBookRelatedBooks && book.related_books && (book.related_books.direct?.length > 0 || book.related_books.shared?.length > 0) && (
-              <HideWhenEmbedded>
                 <RelatedBooks relatedBooks={book.related_books} />
-              </HideWhenEmbedded>
             )}
           </div>
         );
@@ -1049,20 +1040,16 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
   );
 }
 
-export default async function BookDetailPage({ params }: PageProps) {
+export default async function BookDetailPage({ params, isEmbedded = false }: PageProps) {
   const { id, tenant } = await params;
-  // Server always renders full UI. Client components read EmbedContext to hide
-  // features when embedded (ConditionalSiteHeader, SignUpCTA, etc.).
-  // This keeps ISR simple—no searchParams complexity.
-  const embedPolicy = getEmbedUiPolicy(false);
+  const embedPolicy = getEmbedUiPolicy(isEmbedded);
   // Use cached tenant lookup instead of headers() to preserve ISR
   const tenantId = await getCachedTenantId(tenant);
   const tenantSlug = tenant;
 
   return (
     <div className="min-h-screen bg-cream">
-      {/* Header - renders immediately (hidden when embedded) */}
-      <ConditionalSiteHeader variant="light" />
+      {!isEmbedded && <ConditionalSiteHeader variant="light" />}
 
       {/* Book content streams in */}
       <Suspense fallback={
@@ -1076,7 +1063,7 @@ export default async function BookDetailPage({ params }: PageProps) {
       }>
         <BookInfo id={id} tenantId={tenantId} tenantSlug={tenantSlug} embedPolicy={embedPolicy} />
       </Suspense>
-      <SignUpCTA />
+      {!isEmbedded && <SignUpCTA />}
     </div>
   );
 }

--- a/src/app/embed/bhutan/book/[slug]/page.tsx
+++ b/src/app/embed/bhutan/book/[slug]/page.tsx
@@ -22,5 +22,5 @@ export default async function BhutanBookPage({ params }: { params: Promise<{ slu
   );
   if (!isBhutan) notFound();
 
-  return <BookDetailPage params={Promise.resolve({ tenant: 'bhutan', id: slug })} />;
+  return <BookDetailPage params={Promise.resolve({ tenant: 'bhutan', id: slug })} isEmbedded />;
 }

--- a/src/app/embed/bph/book/[slug]/page.tsx
+++ b/src/app/embed/bph/book/[slug]/page.tsx
@@ -23,5 +23,5 @@ export default async function EmbedBookPage({ params }: { params: Promise<{ slug
   );
   if (!exists) notFound();
 
-  return <BookDetailPage params={Promise.resolve({ tenant: 'bph', id: slug })} />;
+  return <BookDetailPage params={Promise.resolve({ tenant: 'bph', id: slug })} isEmbedded />;
 }

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -8,7 +8,6 @@ import BookEditModal from './BookEditModal';
 import { useRouter } from 'next/navigation';
 import { AuthCheck } from '@/components/auth/AuthCheck';
 import { firstTranslationDescription } from '@/lib/first-translation-labels';
-import { HideWhenEmbedded } from '@/components/embed/HideWhenEmbedded';
 
 const FIELD_LABELS: Record<string, string> = {
   display_title: 'Display Title',
@@ -306,8 +305,7 @@ export default function BibliographicInfo({
                             {t.pub_year && <span className="text-stone-400"> ({t.pub_year})</span>}
                             {t.publisher && <span className="text-stone-500">, {t.publisher}</span>}
                           </div>
-                          {t.catalog_id && t.evidence_source && t.evidence_source !== 'llm_knowledge' ? (
-                            <HideWhenEmbedded>
+                          {showExternalLinks && t.catalog_id && t.evidence_source && t.evidence_source !== 'llm_knowledge' ? (
                               <a
                                 href={getCatalogUrl(t.evidence_source, t.catalog_id)}
                                 target="_blank"
@@ -317,9 +315,7 @@ export default function BibliographicInfo({
                                 View on {getCatalogLabel(t.evidence_source)}
                                 <ExternalLink className="w-3 h-3" />
                               </a>
-                            </HideWhenEmbedded>
-                          ) : t.url ? (
-                            <HideWhenEmbedded>
+                          ) : showExternalLinks && t.url ? (
                               <a
                                 href={t.url}
                                 target="_blank"
@@ -329,7 +325,6 @@ export default function BibliographicInfo({
                                 View source
                                 <ExternalLink className="w-3 h-3" />
                               </a>
-                            </HideWhenEmbedded>
                           ) : null}
                         </div>
                       ));
@@ -361,18 +356,16 @@ export default function BibliographicInfo({
                                 {book.translation_verification.translations_found!.map((t, i: number) => (
                                   <p key={i} className="text-stone-400 pl-2">
                                     {t.english_title}{t.translator ? `, trans. ${t.translator}` : ''}{t.pub_year ? ` (${t.pub_year})` : ''}
-                                    {t.url && (
-                                      <HideWhenEmbedded>
+                                    {showExternalLinks && t.url && (
                                         <>{' '}<a href={t.url} target="_blank" rel="noopener noreferrer" className="text-accent-gold hover:text-accent-gold/80 underline">source</a></>
-                                      </HideWhenEmbedded>
                                     )}
                                   </p>
                                 ))}
                               </div>
                             )}
                             <p className="text-stone-600 text-[10px]">
-                              Verified {book.translation_verification.verified_at ? new Date(book.translation_verification.verified_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''} via {book.translation_verification.model || 'AI'} &middot;{' '}
-                              <a href="/blog/first-translation-methodology" className="underline hover:text-stone-500">methodology</a>
+                              Verified {book.translation_verification.verified_at ? new Date(book.translation_verification.verified_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : ''} via {book.translation_verification.model || 'AI'}
+                              {showExternalLinks && <>{' '}&middot;{' '}<a href="/blog/first-translation-methodology" className="underline hover:text-stone-500">methodology</a></>}
                             </p>
                           </div>
                         </details>
@@ -397,8 +390,7 @@ export default function BibliographicInfo({
             </div>
 
             {/* USTC with link */}
-            {book.ustc_id && (
-              <HideWhenEmbedded>
+            {showExternalLinks && book.ustc_id && (
                 <div className="flex gap-2">
                   <span className="text-stone-500 w-24 flex-shrink-0">USTC:</span>
                   <a
@@ -411,7 +403,6 @@ export default function BibliographicInfo({
                     <ExternalLink className="w-3 h-3" />
                   </a>
                 </div>
-              </HideWhenEmbedded>
             )}
           </div>
 
@@ -426,8 +417,7 @@ export default function BibliographicInfo({
                 {book.image_source.provider_name && (
                   <div className="flex gap-2">
                     <span className="text-stone-500 w-24 flex-shrink-0">Source:</span>
-                    {book.image_source.source_url ? (
-                      <HideWhenEmbedded>
+                    {showExternalLinks && book.image_source.source_url ? (
                         <a
                           href={book.image_source.source_url}
                           target="_blank"
@@ -437,7 +427,6 @@ export default function BibliographicInfo({
                           {book.image_source.provider_name}
                           <ExternalLink className="w-3 h-3" />
                         </a>
-                      </HideWhenEmbedded>
                     ) : (
                       <span className="text-stone-200">{book.image_source.provider_name}</span>
                     )}
@@ -475,8 +464,7 @@ export default function BibliographicInfo({
                     <span className="text-stone-200">{book.image_source.shelfmark}</span>
                   </div>
                 )}
-                {book.image_source.iiif_manifest && (
-                  <HideWhenEmbedded>
+                {showExternalLinks && book.image_source.iiif_manifest && (
                     <div className="flex gap-2">
                       <span className="text-stone-500 w-24 flex-shrink-0">IIIF:</span>
                       <a
@@ -489,7 +477,6 @@ export default function BibliographicInfo({
                         <ExternalLink className="w-3 h-3" />
                       </a>
                     </div>
-                  </HideWhenEmbedded>
                 )}
               </div>
             </div>
@@ -502,11 +489,11 @@ export default function BibliographicInfo({
                 <span className="text-stone-500 w-24 flex-shrink-0">Translation:</span>
                 <span className="text-stone-200">
                   Source Library AI{' '}
-                  <HideWhenEmbedded>
+                  {showTranslationMethodologyLink && (
                     <a href="/about/research" className="text-accent-gold hover:text-accent-gold/80 text-xs ml-1">
                       How our translations work
                     </a>
-                  </HideWhenEmbedded>
+                  )}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **Fixes nav flash on BPH pages** — SiteHeader was rendering server-side then hiding after client JS hydration. Now it's simply not rendered for embed routes.
- **Fixes all Laura's reported issues** — collection tags no longer link, "How Our Translations Work" removed, Read Book button removed, related books section removed, gallery icon link removed — all for embed pages only.
- **Approach**: embed routes (`/embed/bph/book/`, `/embed/bhutan/book/`) pass `isEmbedded` prop to `BookDetailPage`, which uses `getEmbedUiPolicy(true)` to suppress elements at render time instead of relying on client-side `HideWhenEmbedded` wrappers.
- **Also converts BibliographicInfo** from client-side `HideWhenEmbedded` to prop-based rendering (`showExternalLinks`, `showTranslationMethodologyLink`).
- Net -26 lines (removed 46, added 20).

## Test plan

- [ ] Visit https://bph.sourcelibrary.org/book/[any-book] — no nav flash, no collection links, no Read button, no related books, no gallery icon
- [ ] Visit https://sourcelibrary.org/book/[any-book] — everything still renders normally (nav, links, buttons, related books)
- [ ] Check BibliographicInfo expanded section on both embed and main site

🤖 Generated with [Claude Code](https://claude.com/claude-code)