### PR TITLE
Podcast episode pages with hero images

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,12 @@
 {
   "permissions": {
     "allow": [
-      "Bash(npx tsc:*)"
+      "Bash(npx tsc:*)",
+      "mcp__claude-conversation-search__search_conversations",
+      "mcp__claude-conversation-search__summarize_session",
+      "mcp__claude-conversation-search__get_session_messages",
+      "mcp__claude-conversation-search__reindex",
+      "mcp__claude-conversation-search__get_messages"
     ]
   }
 }

--- a/src/app/[tenant]/podcast/[threadId]/page.tsx
+++ b/src/app/[tenant]/podcast/[threadId]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../podcast/[threadId]/page';

--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -45,7 +45,7 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
 
     const thread = await db.collection('embassy_threads').findOne(
       { _id: new ObjectId(threadId) },
-      { projection: { title: 1, creatorName: 1, podcasts: 1, podcast: 1 } },
+      { projection: { title: 1, creatorName: 1, podcasts: 1, podcast: 1, heroImage: 1 } },
     );
     if (!thread) return null;
 
@@ -77,9 +77,22 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
         .filter(Boolean),
     )] as string[];
 
-    // Find best gallery image from referenced books
+    // Check for manually set hero image on the thread first
     let heroImage: EpisodeData['heroImage'] = null;
-    if (bookIds.length > 0) {
+    if (thread.heroImage?.url) {
+      const book = thread.heroImage.bookId
+        ? await db.collection('books').findOne({ id: thread.heroImage.bookId }, { projection: { title: 1 } })
+        : null;
+      heroImage = {
+        url: thread.heroImage.url,
+        description: thread.heroImage.description || '',
+        bookId: thread.heroImage.bookId || '',
+        bookTitle: book?.title || '',
+      };
+    }
+
+    // Fall back to best gallery image from referenced books
+    if (!heroImage && bookIds.length > 0) {
       const bestImage = await db.collection('gallery_images')
         .findOne(
           { book_id: { $in: bookIds }, gallery_quality: { $gte: 0.7 } },

--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -1,0 +1,221 @@
+import { connectToDatabase } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+import { notFound } from 'next/navigation';
+import SiteHeader from '@/components/layout/SiteHeader';
+import Link from 'next/link';
+import TranscriptToggle from '../TranscriptToggle';
+
+export const revalidate = 3600;
+
+interface Props {
+  params: Promise<{ threadId: string }>;
+}
+
+interface EpisodeData {
+  threadId: string;
+  title: string;
+  topic: string;
+  creatorName: string;
+  audioUrl: string;
+  format: string;
+  formatLabel: string;
+  findingCount: number;
+  generatedAt: string;
+  script: string | null;
+  bookIds: string[];
+  heroImage: {
+    url: string;
+    description: string;
+    bookId: string;
+    bookTitle: string;
+  } | null;
+}
+
+const FORMAT_LABELS: Record<string, string> = {
+  'deep-dive': 'Deep Dive',
+  'brief': 'The Brief',
+  'critique': 'The Critique',
+  'guided-reading': 'Guided Reading',
+};
+
+async function getEpisode(threadId: string): Promise<EpisodeData | null> {
+  try {
+    if (!ObjectId.isValid(threadId)) return null;
+    const { db } = await connectToDatabase();
+
+    const thread = await db.collection('embassy_threads').findOne(
+      { _id: new ObjectId(threadId) },
+      { projection: { title: 1, creatorName: 1, podcasts: 1, podcast: 1 } },
+    );
+    if (!thread) return null;
+
+    // Find the best podcast format available
+    let podcast: { topic: string; audioUrl: string; findingCount?: number; generatedAt: string; script?: string } | null = null;
+    let format = 'deep-dive';
+    const formats = ['deep-dive', 'brief', 'critique', 'guided-reading'];
+    for (const f of formats) {
+      const p = thread.podcasts?.[f];
+      if (p?.audioUrl) {
+        podcast = p;
+        format = f;
+        break;
+      }
+    }
+    if (!podcast && thread.podcast?.audioUrl) {
+      podcast = thread.podcast;
+    }
+    if (!podcast) return null;
+
+    // Get book IDs from research notebook
+    const notebook = await db.collection('research_notebooks').findOne(
+      { threadId: new ObjectId(threadId) },
+      { projection: { findings: 1 } },
+    );
+    const bookIds = [...new Set(
+      (notebook?.findings || [])
+        .map((f: { source: { bookId: string } }) => f.source?.bookId)
+        .filter(Boolean),
+    )] as string[];
+
+    // Find best gallery image from referenced books
+    let heroImage: EpisodeData['heroImage'] = null;
+    if (bookIds.length > 0) {
+      const bestImage = await db.collection('gallery_images')
+        .findOne(
+          { book_id: { $in: bookIds }, gallery_quality: { $gte: 0.7 } },
+          { sort: { gallery_quality: -1 }, projection: { thumbnail_url: 1, image_url: 1, description: 1, book_id: 1 } },
+        );
+      if (bestImage) {
+        const imageUrl = bestImage.thumbnail_url || bestImage.image_url;
+        if (imageUrl) {
+          const book = await db.collection('books').findOne(
+            { id: bestImage.book_id },
+            { projection: { title: 1 } },
+          );
+          heroImage = {
+            url: imageUrl,
+            description: bestImage.description || '',
+            bookId: bestImage.book_id,
+            bookTitle: book?.title || 'Unknown',
+          };
+        }
+      }
+    }
+
+    return {
+      threadId,
+      title: thread.title || podcast.topic,
+      topic: podcast.topic,
+      creatorName: thread.creatorName || 'Anonymous',
+      audioUrl: podcast.audioUrl,
+      format,
+      formatLabel: FORMAT_LABELS[format] || 'Deep Dive',
+      findingCount: podcast.findingCount || 0,
+      generatedAt: podcast.generatedAt,
+      script: podcast.script || null,
+      bookIds,
+      heroImage,
+    };
+  } catch (err) {
+    console.error('[podcast] Failed to load episode:', err);
+    return null;
+  }
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+}
+
+export async function generateMetadata({ params }: Props) {
+  const { threadId } = await params;
+  const episode = await getEpisode(threadId);
+  if (!episode) return { title: 'Episode Not Found' };
+  return {
+    title: `${episode.title} — Source Library Deep Dive`,
+    description: `${episode.formatLabel}: ${episode.topic}. AI-generated scholarly podcast grounded in primary sources.`,
+  };
+}
+
+export default async function EpisodePage({ params }: Props) {
+  const { threadId } = await params;
+  const episode = await getEpisode(threadId);
+  if (!episode) notFound();
+
+  return (
+    <div className="min-h-screen bg-[#fdfcf9]">
+      <SiteHeader variant="light" breadcrumbs={[
+        { label: 'Podcast', href: '/podcast' },
+        { label: episode.title, href: '#' },
+      ]} />
+
+      {/* Hero image */}
+      {episode.heroImage && (
+        <div className="relative w-full max-w-[960px] mx-auto mt-6 px-6">
+          <div className="relative rounded-xl overflow-hidden bg-[#1a1612]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`/api/image?url=${encodeURIComponent(episode.heroImage.url)}&w=960&q=85`}
+              alt={episode.heroImage.description}
+              className="w-full max-h-[480px] object-contain"
+            />
+            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent px-5 pb-4 pt-10">
+              <p className="text-white/80 text-[11px] font-sans">
+                {episode.heroImage.description}
+                {' — '}
+                <Link
+                  href={`/book/${episode.heroImage.bookId}`}
+                  className="text-white/90 underline hover:text-white"
+                >
+                  {episode.heroImage.bookTitle}
+                </Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="max-w-[720px] mx-auto px-6 py-10 md:py-16">
+        {/* Title & meta */}
+        <div className="mb-8">
+          <h1
+            className="text-2xl md:text-3xl font-serif text-[#1a1612] mb-2"
+            style={{ fontWeight: 400 }}
+          >
+            {episode.title}
+          </h1>
+          <p className="text-[13px] text-[#8a8480] font-sans">
+            {episode.formatLabel} &middot; {episode.findingCount} sources &middot; {formatDate(episode.generatedAt)}
+          </p>
+        </div>
+
+        {/* Audio player */}
+        <audio
+          controls
+          src={episode.audioUrl}
+          className="w-full mb-6"
+          preload="metadata"
+        />
+
+        {/* Actions */}
+        <div className="flex items-center gap-4 mb-8 pb-8 border-b border-[#e8e4dc]">
+          <Link
+            href={`/librarian/thread/${episode.threadId}`}
+            className="text-[13px] text-[#9e4a3a] font-sans hover:underline"
+          >
+            View research &amp; sources
+          </Link>
+          {episode.script && <TranscriptToggle script={episode.script} />}
+        </div>
+
+        {/* Back link */}
+        <Link
+          href="/podcast"
+          className="text-[13px] text-[#6b6560] font-sans hover:text-[#1a1612] transition-colors"
+        >
+          &larr; All episodes
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -1,8 +1,6 @@
 import { connectToDatabase } from '@/lib/mongodb';
-import { ObjectId } from 'mongodb';
 import SiteHeader from '@/components/layout/SiteHeader';
 import Link from 'next/link';
-import TranscriptToggle from './TranscriptToggle';
 
 export const revalidate = 3600; // 1h ISR
 
@@ -11,30 +9,18 @@ export const metadata = {
   description: 'AI-generated scholarly podcasts exploring rare books from the 15th-18th centuries. Alchemy, Hermetica, Kabbalah, and the Western esoteric tradition — grounded in primary sources.',
 };
 
-interface BookThumb {
-  id: string;
-  thumbnail: string | null;
-}
-
 interface PodcastEpisode {
   threadId: string;
   title: string;
-  topic: string;
-  creatorName: string;
-  audioUrl: string;
   format: string;
   findingCount: number;
   generatedAt: string;
-  bookIds: string[];
-  bookThumbs: BookThumb[];
-  script: string | null;
 }
 
 async function getEpisodes(): Promise<PodcastEpisode[]> {
   try {
     const { db } = await connectToDatabase();
 
-    // Find all threads with podcasts
     const threads = await db.collection('embassy_threads')
       .find({
         $or: [
@@ -44,81 +30,33 @@ async function getEpisodes(): Promise<PodcastEpisode[]> {
       })
       .sort({ 'podcasts.deep-dive.generatedAt': -1, 'podcast.generatedAt': -1 })
       .limit(50)
-      .project({ _id: 1, title: 1, creatorName: 1, podcasts: 1, podcast: 1 })
+      .project({ _id: 1, title: 1, podcasts: 1, podcast: 1 })
       .toArray();
 
     const episodes: PodcastEpisode[] = [];
 
     for (const thread of threads) {
-      const formats = ['deep-dive', 'brief', 'critique', 'guided-reading'];
+      const formats = ['deep-dive', 'brief', 'critique', 'guided-reading'] as const;
       for (const format of formats) {
         const p = thread.podcasts?.[format];
         if (p?.audioUrl) {
           episodes.push({
             threadId: thread._id.toString(),
             title: thread.title || p.topic,
-            topic: p.topic,
-            creatorName: thread.creatorName || 'Anonymous',
-            audioUrl: p.audioUrl,
             format,
             findingCount: p.findingCount || 0,
             generatedAt: p.generatedAt,
-            bookIds: [],
-            bookThumbs: [],
-            script: p.script || null,
           });
         }
       }
-      // Legacy single podcast
       if (thread.podcast?.audioUrl && !thread.podcasts?.['deep-dive']) {
         episodes.push({
           threadId: thread._id.toString(),
           title: thread.title || thread.podcast.topic,
-          topic: thread.podcast.topic,
-          creatorName: thread.creatorName || 'Anonymous',
-          audioUrl: thread.podcast.audioUrl,
           format: 'deep-dive',
           findingCount: thread.podcast.findingCount || 0,
           generatedAt: thread.podcast.generatedAt,
-          bookIds: [],
-          bookThumbs: [],
-          script: thread.podcast.script || null,
         });
-      }
-    }
-
-    // Load notebook finding counts for book thumbnails
-    const threadIds = [...new Set(episodes.map(e => e.threadId))];
-    const notebooks = await db.collection('research_notebooks')
-      .find({ threadId: { $in: threadIds.map(id => new ObjectId(id)) } })
-      .project({ threadId: 1, findings: 1 })
-      .toArray();
-
-    const notebookMap = new Map(notebooks.map(n => [
-      n.threadId.toString(),
-      [...new Set((n.findings || []).map((f: { source: { bookId: string } }) => f.source.bookId))],
-    ]));
-
-    for (const ep of episodes) {
-      ep.bookIds = (notebookMap.get(ep.threadId) || []) as string[];
-    }
-
-    // Load actual thumbnail URLs for referenced books
-    const allBookIds = [...new Set(episodes.flatMap(e => e.bookIds))];
-    if (allBookIds.length > 0) {
-      const bookDocs = await db.collection('books')
-        .find({ id: { $in: allBookIds } })
-        .project({ id: 1, thumbnail: 1, thumbnail_blob: 1 })
-        .toArray();
-      const thumbMap = new Map(bookDocs.map(b => [
-        b.id,
-        (b.thumbnail_blob || b.thumbnail || null) as string | null,
-      ]));
-      for (const ep of episodes) {
-        ep.bookThumbs = ep.bookIds.map(bid => ({
-          id: bid,
-          thumbnail: thumbMap.get(bid) || null,
-        }));
       }
     }
 
@@ -186,63 +124,23 @@ export default async function PodcastPage() {
             <p className="text-[#8a8480] font-body">No episodes yet. Research a topic with the Librarian to generate one.</p>
           </div>
         ) : (
-          <div className="space-y-6">
+          <div className="divide-y divide-[#e8e4dc]">
             {episodes.map((ep, i) => (
-              <article
+              <Link
                 key={`${ep.threadId}-${ep.format}-${i}`}
-                className="p-5 bg-white rounded-xl border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors"
+                href={`/podcast/${ep.threadId}`}
+                className="block py-5 group"
               >
-                {/* Book cover thumbnails */}
-                {ep.bookThumbs.filter(b => b.thumbnail).length > 0 && (
-                  <div className="flex gap-1.5 mb-3 overflow-hidden">
-                    {ep.bookThumbs.filter(b => b.thumbnail).slice(0, 5).map(b => (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        key={b.id}
-                        src={`/api/image?url=${encodeURIComponent(b.thumbnail!)}&w=60&q=75`}
-                        alt=""
-                        className="w-8 h-12 object-cover rounded flex-shrink-0 bg-[#f0ece4]"
-                        loading="lazy"
-                      />
-                    ))}
-                    {ep.bookThumbs.filter(b => b.thumbnail).length > 5 && (
-                      <span className="text-[10px] text-[#8a8480] font-sans self-end mb-1">+{ep.bookThumbs.filter(b => b.thumbnail).length - 5}</span>
-                    )}
-                  </div>
-                )}
-
-                <div className="flex items-start justify-between gap-3 mb-3">
-                  <div>
-                    <Link
-                      href={`/librarian/thread/${ep.threadId}`}
-                      className="text-[16px] font-serif text-[#1a1612] leading-snug hover:text-[#9e4a3a] transition-colors"
-                      style={{ fontWeight: 400 }}
-                    >
-                      {ep.title}
-                    </Link>
-                    <p className="text-[11px] text-[#8a8480] font-sans mt-1">
-                      {FORMAT_LABELS[ep.format] || 'Deep Dive'} &middot; {ep.findingCount} sources &middot; {formatDate(ep.generatedAt)}
-                    </p>
-                  </div>
-                </div>
-
-                <audio
-                  controls
-                  src={ep.audioUrl}
-                  className="w-full"
-                  preload="metadata"
-                />
-
-                <div className="mt-2 flex items-center justify-between">
-                  <Link
-                    href={`/librarian/thread/${ep.threadId}`}
-                    className="text-[11px] text-[#9e4a3a] font-sans hover:underline"
-                  >
-                    View research &amp; sources
-                  </Link>
-                  {ep.script && <TranscriptToggle script={ep.script} />}
-                </div>
-              </article>
+                <h2
+                  className="text-[17px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors"
+                  style={{ fontWeight: 400 }}
+                >
+                  {ep.title}
+                </h2>
+                <p className="text-[12px] text-[#8a8480] font-sans mt-1.5">
+                  {FORMAT_LABELS[ep.format] || 'Deep Dive'} &middot; {ep.findingCount} sources &middot; {formatDate(ep.generatedAt)}
+                </p>
+              </Link>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- **Listing page** (`/podcast`): Stripped thumbnails and inline audio players. Clean text-only list of episodes — title, format, source count, date. Each links to its own page.
- **Episode pages** (`/podcast/[threadId]`): New detail page with hero image at top, pulled from the best gallery extraction (highest `gallery_quality` score) across the episode's referenced books. Includes audio player, transcript toggle, and link back to research thread.
- Tenant-scoped route re-exports the root route as usual.

## Test plan
- [ ] Visit https://sourcelibrary.org/podcast — should show clean text list, no thumbnails
- [ ] Click an episode — should open `/podcast/{threadId}` with hero image, audio, transcript
- [ ] Episodes without gallery images should still render cleanly (no hero, just title + player)
- [ ] Breadcrumbs work: Podcast > Episode Title

Generated with [Claude Code](https://claude.com/claude-code)