### PR TITLE
Fix duplicate collection tags and BPH page reader 500

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -630,36 +630,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 )}
               </div>
 
-              {/* Collections */}
-              {(book as unknown as { collections?: string[] }).collections && (book as unknown as { collections?: string[] }).collections!.length > 0 && (
-                <div className="flex flex-wrap items-center justify-center sm:justify-start gap-2 mt-3">
-                  {(book as unknown as { collections?: string[] }).collections!.map((slug: string) => {
-                    const label = slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-                    if (!embedPolicy.enableBookCollectionNavigation) {
-                      return (
-                        <span
-                          key={slug}
-                          aria-disabled="true"
-                          className="inline-flex items-center gap-1 px-2.5 py-0.5 bg-white/10 text-stone-300 rounded-full text-xs"
-                        >
-                          {label}
-                        </span>
-                      );
-                    }
-
-                    return (
-                      <Link
-                        key={slug}
-                        href={`/collections/${slug}`}
-                        className="inline-flex items-center gap-1 px-2.5 py-0.5 bg-white/10 hover:bg-white/20 text-stone-300 rounded-full text-xs transition-colors"
-                      >
-                        {label}
-                      </Link>
-                    );
-                  })}
-                </div>
-              )}
-
               {book.is_first_translation && (
                 <div className="mt-3">
                   <details className="group">

--- a/src/app/[tenant]/book/[id]/page/[pageId]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page/[pageId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import { findTenantBookByIdOrSlug } from '@/lib/tenant-book-lookup';
+import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import type { Book, Page } from '@/lib/types';
 import PageEditorClient from './PageEditorClient';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
@@ -10,6 +11,7 @@ export const revalidate = 86400;
 
 interface PageProps {
   params: Promise<{ tenant: string; id: string; pageId: string }>;
+  skipTenantScope?: boolean;
 }
 
 // Book projection: only fields needed by the reader
@@ -19,7 +21,7 @@ const BOOK_NAV_PROJECTION = {
   cdli_witnesses: 1, etcsl_id: 1,
 };
 
-export default async function PageEditorPage({ params }: PageProps) {
+export default async function PageEditorPage({ params, skipTenantScope = false }: PageProps) {
   const { tenant, id, pageId } = await params;
   const db = await getReadDb();
 
@@ -35,7 +37,9 @@ export default async function PageEditorPage({ params }: PageProps) {
 
   // Step 2: Book lookup + nav pages in parallel (both can start now)
   const [bookResult, navPages] = await Promise.all([
-    findTenantBookByIdOrSlug(db, tenant, id, BOOK_NAV_PROJECTION),
+    skipTenantScope
+      ? findBookByIdOrSlug(db, id, BOOK_NAV_PROJECTION)
+      : findTenantBookByIdOrSlug(db, tenant, id, BOOK_NAV_PROJECTION),
     db.collection('pages')
       .find({ book_id: currentPage.book_id as string, page_number: { $gte: 0 } })
       .project({ _id: 0, id: 1, page_number: 1, split_from: 1, page_type: 1 })

--- a/src/app/embed/bph/book/[slug]/page/[pageId]/page.tsx
+++ b/src/app/embed/bph/book/[slug]/page/[pageId]/page.tsx
@@ -20,5 +20,5 @@ export default async function EmbedPageRoute({ params }: { params: Promise<{ slu
   );
   if (!exists) notFound();
 
-  return <PageEditorPage params={Promise.resolve({ tenant: 'bph', id: slug, pageId })} />;
+  return <PageEditorPage params={Promise.resolve({ tenant: 'bph', id: slug, pageId })} skipTenantScope />;
 }


### PR DESCRIPTION
## Summary

- **Duplicate collection tags** — book page was rendering collections twice: once from raw slugs (ugly `jungs-library` format) and once from DB-fetched names (proper `Jung's Library`). Removed the slug-based duplicate.
- **BPH page reader 500** — all `/embed/bph/book/[slug]/page/[pageId]` routes returned 500. Root cause: `findTenantBookByIdOrSlug` calls `resolveTenantId` which uses `getDb()` (write DB connection) that can fail during Vercel ISR. Embed routes now pass `skipTenantScope` to bypass tenant resolution (the embed route already verified the book exists).

## Test plan

- [ ] BPH book page shows collection tags once (not duplicated)
- [ ] BPH page reader works: https://bph.sourcelibrary.org/book/veritatis-proscenium-fludd-1621/page/69d13ce1d26937e2d33d4bd7
- [ ] Main site page reader still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)