### PR TITLE
Fix cover picker ISR cache for tenant paths

### DIFF
--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -301,9 +301,14 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
       revalidatePath(`/book/${bookSlug}`);
       revalidatePath(`/book/${bookSlug}`, 'layout');
       revalidatePath(`/book/${bookId}`);
+      // Also revalidate tenant-scoped paths (e.g. /bph/book/...)
+      revalidatePath(`/${tenant}/book/${bookSlug}`);
+      revalidatePath(`/${tenant}/book/${bookSlug}`, 'layout');
+      revalidatePath(`/${tenant}/book/${bookId}`);
       // Thumbnail/title changes also affect listing pages (home, collections, search)
       if (changedFields.some(f => ['thumbnail', 'thumbnail_blob', 'title', 'display_title', 'author'].includes(f))) {
         revalidatePath('/', 'layout');
+        revalidatePath(`/${tenant}`, 'layout');
       }
     }
 

--- a/src/app/api/admin/revalidate-book/[id]/route.ts
+++ b/src/app/api/admin/revalidate-book/[id]/route.ts
@@ -38,12 +38,29 @@ export async function POST(
   // Revalidate individual page routes via layout invalidation
   revalidatePath(`/book/${slug}`, 'layout');
 
+  const revalidated = [`/book/${slug}`, `/book/${id}`];
+
+  // Also revalidate tenant-scoped paths if book belongs to a tenant
+  if (book.tenantId) {
+    const tenant = await db.collection('tenants').findOne(
+      { id: book.tenantId },
+      { projection: { slug: 1 } }
+    );
+    if (tenant?.slug) {
+      revalidatePath(`/${tenant.slug}/book/${slug}`);
+      revalidatePath(`/${tenant.slug}/book/${slug}/search`);
+      revalidatePath(`/${tenant.slug}/book/${slug}`, 'layout');
+      revalidatePath(`/${tenant.slug}/book/${id}`);
+      revalidated.push(`/${tenant.slug}/book/${slug}`, `/${tenant.slug}/book/${id}`);
+    }
+  }
+
   // Purge Cloudflare edge cache for these paths too
-  await purgeCloudflareUrls([`/book/${slug}`, `/book/${slug}/search`, `/book/${id}`]);
+  await purgeCloudflareUrls(revalidated);
 
   return NextResponse.json({
     success: true,
-    revalidated: [`/book/${slug}`, `/book/${id}`],
+    revalidated,
     timestamp: new Date().toISOString(),
   });
 }

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -289,6 +289,18 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
       revalidatePath(`/book/${bookSlug}`);
       revalidatePath(`/book/${bookSlug}`, 'layout');
       revalidatePath(`/book/${bookId}`);
+      // Also revalidate tenant-scoped paths if book belongs to a tenant
+      if (book.tenantId) {
+        const tenant = await db.collection('tenants').findOne(
+          { id: book.tenantId },
+          { projection: { slug: 1 } }
+        );
+        if (tenant?.slug) {
+          revalidatePath(`/${tenant.slug}/book/${bookSlug}`);
+          revalidatePath(`/${tenant.slug}/book/${bookSlug}`, 'layout');
+          revalidatePath(`/${tenant.slug}/book/${bookId}`);
+        }
+      }
       // Thumbnail/title changes also affect listing pages (home, collections, search)
       if (changedFields.some(f => ['thumbnail', 'thumbnail_blob', 'title', 'display_title', 'author'].includes(f))) {
         revalidatePath('/', 'layout');


### PR DESCRIPTION
## Summary
- Adds tenant-scoped path revalidation (`/${tenant}/book/${slug}`) when book metadata is updated via PATCH
- Fixes both the tenant API route and non-tenant API route (with tenant lookup from book.tenantId)
- Also fixes the admin revalidate-book endpoint to include tenant paths + Cloudflare purge

Closes #1514

## Test plan
- [ ] Change a BPH book cover via CoverImagePicker
- [ ] Hard reload — new cover should appear immediately
- [ ] Verify non-tenant book cover changes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)