### PR TITLE
Fix BPH embed page reader 500

### DIFF
--- a/src/app/embed/bph/book/[slug]/page/[pageId]/page.tsx
+++ b/src/app/embed/bph/book/[slug]/page/[pageId]/page.tsx
@@ -1,24 +1,64 @@
 import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
-import PageEditorPage from '@/app/[tenant]/book/[id]/page/[pageId]/page';
+import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import type { Book, Page } from '@/lib/types';
+import PageEditorClient from '@/app/[tenant]/book/[id]/page/[pageId]/PageEditorClient';
+import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 
 export const revalidate = 86400;
 export const preferredRegion = 'fra1';
 export const dynamicParams = true;
 export async function generateStaticParams() { return []; }
 
+const BOOK_NAV_PROJECTION = {
+  _id: 0, id: 1, slug: 1, title: 1, display_title: 1,
+  author: 1, published: 1, language: 1, doi: 1, chapters: 1,
+  cdli_witnesses: 1, etcsl_id: 1,
+};
+
 /**
- * BPH embed page reader — verifies the book exists, then renders the real page component.
+ * BPH embed page reader — self-contained to avoid cross-route-tree imports
+ * that cause Next.js RSC chunk resolution failures.
  */
 export default async function EmbedPageRoute({ params }: { params: Promise<{ slug: string; pageId: string }> }) {
   const { slug, pageId } = await params;
-
   const db = await getReadDb();
-  const exists = await db.collection('books').findOne(
-    { $or: [{ slug }, { id: slug }], visible: true, pages_count: { $gt: 0 } },
-    { projection: { _id: 1 } }
-  );
-  if (!exists) notFound();
 
-  return <PageEditorPage params={Promise.resolve({ tenant: 'bph', id: slug, pageId })} skipTenantScope />;
+  const currentPage = await db.collection('pages').findOne(
+    { id: pageId },
+    { projection: { detected_images: 0 } }
+  );
+  if (!currentPage) notFound();
+
+  const [bookResult, navPages] = await Promise.all([
+    findBookByIdOrSlug(db, slug, BOOK_NAV_PROJECTION),
+    db.collection('pages')
+      .find({ book_id: currentPage.book_id as string, page_number: { $gte: 0 } })
+      .project({ _id: 0, id: 1, page_number: 1, split_from: 1, page_type: 1 })
+      .sort({ page_number: 1 })
+      .maxTimeMS(15000)
+      .toArray()
+      .then(pages => pages.filter(p => p.page_type !== 'digitizer-insert' && p.page_type !== 'archived-spread' && (p.page_number == null || p.page_number >= 0)))
+      .catch(() => [{ id: pageId, page_number: currentPage.page_number }]),
+  ]);
+
+  if (!bookResult) notFound();
+
+  const book = bookResult.book as unknown as Book;
+  const scopedBookId = (book.id || (book as any)._id?.toString()) as string;
+  if ((currentPage.book_id as string) !== scopedBookId) notFound();
+
+  const serializedPage = JSON.parse(JSON.stringify(currentPage)) as Page;
+  const serializedNavPages = JSON.parse(JSON.stringify(navPages)) as Page[];
+
+  return (
+    <>
+      <EmbedNavigationReporter book={book.slug || book.id} page={pageId} />
+      <PageEditorClient
+        initialBook={book}
+        initialPage={serializedPage}
+        initialPageList={serializedNavPages}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

The BPH embed page reader (`/embed/bph/book/[slug]/page/[pageId]`) was returning 500 for ALL page views. Root cause: importing the full `PageEditorPage` server component from the `[tenant]` route tree caused Next.js RSC chunk resolution failures across route segment boundaries.

Fix: self-contained data fetching in the embed route using `findBookByIdOrSlug` directly, bypassing tenant resolution. Still imports `PageEditorClient` (client component) for the UI — client components don't have the same cross-route-tree issue.

## Test plan

- [ ] https://bph.sourcelibrary.org/book/veritatis-proscenium-fludd-1621/page/69d13ce1d26937e2d33d4bd7 — should render page reader
- [ ] Main site page reader unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)