### PR TITLE
Podcast: horizontal card layout + higher res images

### DIFF
--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -168,7 +168,7 @@ export default async function EpisodePage({ params }: Props) {
           <div className="relative rounded-xl overflow-hidden bg-[#1a1612]">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={`/api/image?url=${encodeURIComponent(episode.heroImage.url)}&w=960&q=85`}
+              src={`/api/image?url=${encodeURIComponent(episode.heroImage.url)}&w=1440&q=85`}
               alt={episode.heroImage.description}
               className="w-full max-h-[480px] object-contain"
             />

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -128,25 +128,25 @@ export default async function PodcastPage() {
             <p className="text-[#8a8480] font-body">No episodes yet. Research a topic with the Librarian to generate one.</p>
           </div>
         ) : (
-          <div className="space-y-5">
+          <div className="space-y-4">
             {episodes.map((ep, i) => (
               <Link
                 key={`${ep.threadId}-${ep.format}-${i}`}
                 href={`/podcast/${ep.threadId}`}
-                className="block group rounded-xl overflow-hidden border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors bg-white"
+                className="flex group rounded-xl overflow-hidden border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors bg-white"
               >
                 {ep.heroImageUrl && (
-                  <div className="bg-[#1a1612] overflow-hidden">
+                  <div className="flex-shrink-0 w-[180px] md:w-[220px] bg-[#1a1612] overflow-hidden">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
-                      src={`/api/image?url=${encodeURIComponent(ep.heroImageUrl)}&w=720&q=80`}
+                      src={`/api/image?url=${encodeURIComponent(ep.heroImageUrl)}&w=440&q=85`}
                       alt=""
-                      className="w-full h-[200px] object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+                      className="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity"
                       loading="lazy"
                     />
                   </div>
                 )}
-                <div className="p-5">
+                <div className="flex-1 p-5 flex flex-col justify-center min-w-0">
                   <h2
                     className="text-[17px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors"
                     style={{ fontWeight: 400 }}


### PR DESCRIPTION
## Summary
- Listing page: image on the left (220px), text on the right — horizontal card layout
- Listing images served at 440px (2x retina for 220px element)
- Episode hero images bumped to 1440px (retina for 960px container)

## Test plan
- [ ] /podcast — horizontal cards with image left, text right
- [ ] Episode pages — sharp hero images

Generated with [Claude Code](https://claude.com/claude-code)