### PR TITLE
Artwork display overhaul: Rijksmuseum-inspired layout

### DIFF
--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -20,14 +20,22 @@ interface ArtworkHeroProps {
   isLandscape: boolean;
   prevWork?: ArtworkNavItem | null;
   nextWork?: ArtworkNavItem | null;
+  institution?: string;
 }
 
-export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork }: ArtworkHeroProps) {
-  const [fitHeight, setFitHeight] = useState(false);
+export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullResUrl, license, isLandscape, prevWork, nextWork, institution }: ArtworkHeroProps) {
+  const [fitWidth, setFitWidth] = useState(false);
+  const [showChrome, setShowChrome] = useState(true);
   const hasThumb = !!thumbUrl && thumbUrl !== imageUrl;
   const hasHiRes = !!hiResUrl && hiResUrl !== imageUrl;
-  const [medReady, setMedReady] = useState(!hasThumb); // if no thumb, medium is already the starting point
+  const [medReady, setMedReady] = useState(!hasThumb);
   const [hiResReady, setHiResReady] = useState(false);
+
+  // Auto-hide chrome after 3s
+  useEffect(() => {
+    const timer = setTimeout(() => setShowChrome(false), 3000);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Background-load medium blob
   useEffect(() => {
@@ -45,12 +53,10 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
     img.src = hiResUrl!;
   }, [medReady, hasHiRes, hiResUrl]);
 
-  // Best loaded source — upgrades instantly, no transitions
   const displaySrc = hiResReady && hiResUrl ? hiResUrl
     : medReady ? imageUrl
     : thumbUrl || imageUrl;
 
-  // Best available for magnifier zoom
   const magnifierSrc = hiResReady && hiResUrl ? hiResUrl : imageUrl;
 
   // Keyboard navigation
@@ -66,20 +72,26 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
     return () => window.removeEventListener('keydown', handleKey);
   }, [prevWork, nextWork]);
 
+  const captionText = [institution, license].filter(Boolean).join(' · ');
+
   return (
-    <div className="bg-stone-900 relative">
-      {/* Image container */}
-      <div className={`max-w-[var(--container-wide)] mx-auto ${fitHeight ? 'py-2' : isLandscape ? 'py-4 sm:py-8' : 'py-4 sm:py-8 max-w-3xl'}`}>
+    <div
+      className="bg-black relative group/hero"
+      onMouseEnter={() => setShowChrome(true)}
+      onMouseLeave={() => setShowChrome(false)}
+    >
+      {/* Image container — viewport-height by default, natural proportions */}
+      <div className="flex items-center justify-center" style={{ minHeight: 'calc(100vh - 64px)' }}>
         <div
-          className={`relative mx-auto ${fitHeight ? '' : isLandscape ? 'aspect-[16/10]' : 'aspect-[3/4]'}`}
-          style={fitHeight ? { height: 'calc(100vh - 120px)' } : undefined}
+          className={`relative ${fitWidth ? 'w-full' : 'max-h-[calc(100vh-64px)]'}`}
+          style={fitWidth ? undefined : { maxWidth: '100%' }}
         >
           <ImageWithMagnifier
             src={displaySrc}
             thumbnail={displaySrc}
             highResSrc={magnifierSrc}
             alt={title}
-            className="w-full h-full"
+            className={`${fitWidth ? 'w-full h-auto' : 'max-h-[calc(100vh-64px)] w-auto'} mx-auto`}
             magnifierSize={240}
             zoomLevel={3}
             darkMode
@@ -87,21 +99,21 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
         </div>
       </div>
 
-      {/* Fit-to-height toggle */}
+      {/* Fit toggle — appears on hover */}
       <button
-        onClick={() => setFitHeight(!fitHeight)}
-        className="absolute top-4 right-4 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/60 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-colors z-10"
-        title={fitHeight ? 'Fit to width' : 'Fit to screen height'}
+        onClick={() => setFitWidth(!fitWidth)}
+        className={`absolute top-4 right-4 flex items-center gap-1.5 px-2.5 py-1.5 bg-black/60 hover:bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm transition-all z-10 ${showChrome ? 'opacity-100' : 'opacity-0'}`}
+        title={fitWidth ? 'Fit to screen' : 'Fit to width'}
       >
-        {fitHeight ? <Minimize className="w-3.5 h-3.5" /> : <Maximize className="w-3.5 h-3.5" />}
-        {fitHeight ? 'Fit width' : 'Fit height'}
+        {fitWidth ? <Minimize className="w-3.5 h-3.5" /> : <Maximize className="w-3.5 h-3.5" />}
+        {fitWidth ? 'Fit screen' : 'Full width'}
       </button>
 
-      {/* Prev/Next navigation */}
+      {/* Prev/Next navigation — appears on hover */}
       {prevWork && (
         <Link
           href={`/artwork/${prevWork.slug}`}
-          className="absolute left-2 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-3 bg-black/40 hover:bg-black/70 text-white rounded-lg backdrop-blur-sm transition-colors z-10 group"
+          className={`absolute left-2 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-3 bg-black/40 hover:bg-black/70 text-white rounded-lg backdrop-blur-sm transition-all z-10 group ${showChrome ? 'opacity-100' : 'opacity-0'}`}
           title={prevWork.title}
         >
           <ChevronLeft className="w-5 h-5" />
@@ -111,7 +123,7 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
       {nextWork && (
         <Link
           href={`/artwork/${nextWork.slug}`}
-          className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-3 bg-black/40 hover:bg-black/70 text-white rounded-lg backdrop-blur-sm transition-colors z-10 group"
+          className={`absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-3 bg-black/40 hover:bg-black/70 text-white rounded-lg backdrop-blur-sm transition-all z-10 group ${showChrome ? 'opacity-100' : 'opacity-0'}`}
           title={nextWork.title}
         >
           <span className="hidden sm:block text-xs max-w-[120px] truncate opacity-0 group-hover:opacity-100 transition-opacity">{nextWork.title}</span>
@@ -119,11 +131,11 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
         </Link>
       )}
 
-      {/* Caption bar */}
-      <div className="border-t border-stone-800">
-        <div className="max-w-[var(--container-standard)] mx-auto px-6 md:px-12 py-3 flex items-center justify-between">
-          <p className="text-xs text-stone-500">
-            Wikimedia Commons · {license} · Hover to magnify, click for fullscreen
+      {/* Caption bar — appears on hover */}
+      <div className={`absolute bottom-0 left-0 right-0 transition-all ${showChrome ? 'opacity-100' : 'opacity-0'}`}>
+        <div className="bg-gradient-to-t from-black/80 to-transparent px-6 md:px-12 py-4 flex items-center justify-between">
+          <p className="text-xs text-stone-400">
+            {captionText || 'Hover to magnify'}
           </p>
           <a
             href={fullResUrl}

--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -113,6 +113,7 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
           isLandscape={isLandscape}
           prevWork={prevWork}
           nextWork={nextWork}
+          institution={holdingMuseum}
         />
       )}
 

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -349,63 +349,63 @@ export default function CollectionAllBooks({
           collectionType={collectionType}
         />
       ) : isArt ? (
-        /* Art gallery grid — image-forward layout */
-        <div className={`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 ${loading ? 'opacity-50 pointer-events-none' : ''}`}>
-          {displayBooks.map((book) => {
-            const thumb = getBookThumbnailUrl(book, 'thumb') || book.photo;
-            const title = bookTitle(book);
-            const year = book.year || parseInt(book.published || '', 10) || 0;
-            return (
-              <Link
-                key={book.id}
-                href={`/artwork/${book.slug || book.id}`}
-                className="group relative aspect-[3/4] rounded-lg overflow-hidden bg-stone-100"
-              >
-                {thumb ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img
-                    src={thumb}
-                    alt={title}
-                    className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="absolute inset-0 flex items-center justify-center">
-                    <LayoutGrid className="w-8 h-8 text-muted" />
+        /* Art gallery grid — masonry layout with natural aspect ratios */
+        <div className={`bg-stone-950 -mx-4 sm:-mx-6 md:-mx-8 px-1 pt-1 pb-4 ${loading ? 'opacity-50 pointer-events-none' : ''}`}>
+          <div className="columns-2 sm:columns-3 lg:columns-4 xl:columns-5 gap-1">
+            {displayBooks.map((book) => {
+              const thumb = getBookThumbnailUrl(book, 'thumb') || book.photo;
+              const title = bookTitle(book);
+              const year = book.year || parseInt(book.published || '', 10) || 0;
+              return (
+                <Link
+                  key={book.id}
+                  href={`/artwork/${book.slug || book.id}`}
+                  className="group block break-inside-avoid mb-1 relative overflow-hidden"
+                >
+                  {thumb ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={thumb}
+                      alt={title}
+                      className="w-full h-auto block group-hover:opacity-90 transition-opacity duration-300"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="aspect-[3/4] bg-stone-900 flex items-center justify-center">
+                      <LayoutGrid className="w-8 h-8 text-stone-700" />
+                    </div>
+                  )}
+                  <div className="px-1.5 py-1.5 bg-stone-950">
+                    <h3
+                      className="text-xs font-medium text-stone-300 leading-tight line-clamp-1"
+                      style={{ fontFamily: 'var(--font-serif)' }}
+                    >
+                      {title}
+                    </h3>
+                    <p className="text-[10px] text-stone-500 line-clamp-1 mt-0.5">
+                      {book.author}{year > 0 ? `, ${year}` : ''}
+                    </p>
                   </div>
-                )}
-                {/* Hover overlay with title/artist */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-                <div className="absolute inset-x-0 bottom-0 p-3 translate-y-2 group-hover:translate-y-0 opacity-0 group-hover:opacity-100 transition-all duration-300">
-                  <h3
-                    className="text-sm font-semibold text-white leading-tight line-clamp-2 mb-0.5"
-                    style={{ fontFamily: 'var(--font-serif)' }}
-                  >
-                    {title}
-                  </h3>
-                  <p className="text-xs text-white/70 line-clamp-1">
-                    {book.author}{year > 0 ? `, ${year}` : ''}
-                  </p>
-                </div>
-              </Link>
-            );
-          })}
+                </Link>
+              );
+            })}
 
-          {/* "See all" card in compact view */}
-          {showSeeAllCard && (
-            <button
-              onClick={handleExpand}
-              className="group relative aspect-[3/4] rounded-lg overflow-hidden bg-stone-100 flex flex-col items-center justify-center gap-2 cursor-pointer hover:bg-stone-200 transition-colors"
-            >
-              <div className="w-10 h-10 rounded-full bg-accent-rust/10 flex items-center justify-center group-hover:bg-accent-rust/15 transition-colors">
-                <ArrowRight className="w-5 h-5 text-accent-rust" />
-              </div>
-              <span className="text-sm font-medium text-primary group-hover:text-accent-rust transition-colors">
-                See all {total.toLocaleString()}
-              </span>
-              <span className="text-xs text-muted">{itemLabel}</span>
-            </button>
-          )}
+            {/* "See all" card in compact view */}
+            {showSeeAllCard && (
+              <button
+                onClick={handleExpand}
+                className="group block break-inside-avoid mb-1 aspect-[3/4] bg-stone-900 flex flex-col items-center justify-center gap-2 cursor-pointer hover:bg-stone-800 transition-colors"
+              >
+                <div className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center group-hover:bg-white/10 transition-colors">
+                  <ArrowRight className="w-5 h-5 text-stone-400" />
+                </div>
+                <span className="text-sm font-medium text-stone-300 group-hover:text-white transition-colors">
+                  See all {total.toLocaleString()}
+                </span>
+                <span className="text-xs text-stone-500">{itemLabel}</span>
+              </button>
+            )}
+          </div>
         </div>
       ) : (
         <div className={`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 ${loading ? 'opacity-50 pointer-events-none' : ''}`}>


### PR DESCRIPTION
## Summary
- **Hero**: Viewport-height by default, natural aspect ratios, full-bleed black bg, auto-hiding chrome (nav/caption/toggle appear on hover), institution name in caption
- **Grid**: CSS columns masonry (natural proportions, no cropping), dark bg, 1px gaps, sharp corners, labels always visible below images
- **Caption**: Shows holding institution (Met, Rijksmuseum, etc.) instead of hardcoded "Wikimedia Commons"

Closes #1507

## Preview
Push triggers Vercel preview — check any artwork collection and individual artwork pages.

## Test plan
- [ ] Artwork detail page (e.g. `/artwork/the-milkmaid`) — image fills viewport, natural proportions
- [ ] Hover shows nav arrows and caption, auto-hides after 3s
- [ ] "Full width" toggle works (expands to full container width)
- [ ] Artwork collection grid — masonry layout, no cropping, dark background
- [ ] Labels (title, artist, year) visible below each image without hovering
- [ ] Keyboard nav (left/right arrows) still works
- [ ] Progressive image loading (thumb → medium → hi-res) still works
- [ ] Mobile: grid collapses to 2 columns, hero fits screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)