### PR TITLE
Fix BPH page reader: lazy-load via next/dynamic

### DIFF
--- a/src/app/embed/bph/book/[slug]/p/[pageId]/EmbedPageReaderWrapper.tsx
+++ b/src/app/embed/bph/book/[slug]/p/[pageId]/EmbedPageReaderWrapper.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { Book, Page } from '@/lib/types';
+
+const PageEditorClient = dynamic(
+  () => import('@/components/book/PageEditorClient'),
+  { ssr: false, loading: () => <div className="flex items-center justify-center min-h-screen"><div className="animate-pulse text-stone-400">Loading page reader...</div></div> }
+);
+
+interface Props {
+  book: Book;
+  page: Page;
+  pageList: Page[];
+}
+
+export default function EmbedPageReaderWrapper({ book, page, pageList }: Props) {
+  return (
+    <PageEditorClient
+      initialBook={book}
+      initialPage={page}
+      initialPageList={pageList}
+    />
+  );
+}

--- a/src/app/embed/bph/book/[slug]/p/[pageId]/page.tsx
+++ b/src/app/embed/bph/book/[slug]/p/[pageId]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import type { Book, Page } from '@/lib/types';
-import PageEditorClient from '@/components/book/PageEditorClient';
+import EmbedPageReaderWrapper from './EmbedPageReaderWrapper';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 
 export const revalidate = 86400;
@@ -17,9 +17,9 @@ const BOOK_NAV_PROJECTION = {
 };
 
 /**
- * BPH embed page reader — self-contained data fetching to avoid
- * cross-route-tree RSC imports. Uses /p/ directory to avoid
- * Next.js page.tsx naming collision.
+ * BPH embed page reader — self-contained data fetching.
+ * Uses a local wrapper with next/dynamic to lazy-load PageEditorClient,
+ * avoiding build-time chunk resolution failures in the embed route tree.
  */
 export default async function EmbedPageRoute({ params }: { params: Promise<{ slug: string; pageId: string }> }) {
   const { slug, pageId } = await params;
@@ -55,10 +55,10 @@ export default async function EmbedPageRoute({ params }: { params: Promise<{ slu
   return (
     <>
       <EmbedNavigationReporter book={book.slug || book.id} page={pageId} />
-      <PageEditorClient
-        initialBook={book}
-        initialPage={serializedPage}
-        initialPageList={serializedNavPages}
+      <EmbedPageReaderWrapper
+        book={book}
+        page={serializedPage}
+        pageList={serializedNavPages}
       />
     </>
   );


### PR DESCRIPTION
Direct import of PageEditorClient crashes the embed route build. Lazy-load with next/dynamic instead.