### PR TITLE
Fix BPH page reader 404: correct tenant in proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -339,7 +339,7 @@ export async function proxy(request: NextRequest) {
       url.pathname = `/embed/${tenant}`;
     } else if (pathname.startsWith('/book/') && pathname.includes('/page/')) {
       // Page reader: rewrite to main site route (embed route tree has Next.js build issues)
-      url.pathname = `/default${pathname}`;
+      url.pathname = `/${tenant}${pathname}`;
     } else if (pathname.startsWith('/book/')) {
       url.pathname = `/embed/${tenant}${pathname}`;
     } else if (pathname.startsWith('/collections')) {


### PR DESCRIPTION
Use tenant slug instead of 'default' in page reader proxy rewrite.