### PR TITLE
Episode pages: inline sources + evidence, cropped hero images

### DIFF
--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -11,24 +11,44 @@ interface Props {
   params: Promise<{ threadId: string }>;
 }
 
+interface Finding {
+  quote: string;
+  note: string;
+  source: {
+    bookId: string;
+    bookTitle: string;
+    bookAuthor: string;
+    bookSlug?: string;
+    pageNumber?: number;
+  };
+}
+
+interface SourceBook {
+  id: string;
+  title: string;
+  author: string;
+  slug?: string;
+  thumbnail: string | null;
+  findingCount: number;
+}
+
 interface EpisodeData {
   threadId: string;
   title: string;
   topic: string;
-  creatorName: string;
   audioUrl: string;
-  format: string;
   formatLabel: string;
   findingCount: number;
   generatedAt: string;
   script: string | null;
-  bookIds: string[];
   heroImage: {
     url: string;
     description: string;
     bookId: string;
     bookTitle: string;
   } | null;
+  findings: Finding[];
+  sourceBooks: SourceBook[];
 }
 
 const FORMAT_LABELS: Record<string, string> = {
@@ -45,39 +65,53 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
 
     const thread = await db.collection('embassy_threads').findOne(
       { _id: new ObjectId(threadId) },
-      { projection: { title: 1, creatorName: 1, podcasts: 1, podcast: 1, heroImage: 1 } },
+      { projection: { title: 1, podcasts: 1, podcast: 1, heroImage: 1 } },
     );
     if (!thread) return null;
 
-    // Find the best podcast format available
     let podcast: { topic: string; audioUrl: string; findingCount?: number; generatedAt: string; script?: string } | null = null;
     let format = 'deep-dive';
-    const formats = ['deep-dive', 'brief', 'critique', 'guided-reading'];
-    for (const f of formats) {
+    for (const f of ['deep-dive', 'brief', 'critique', 'guided-reading']) {
       const p = thread.podcasts?.[f];
-      if (p?.audioUrl) {
-        podcast = p;
-        format = f;
-        break;
-      }
+      if (p?.audioUrl) { podcast = p; format = f; break; }
     }
-    if (!podcast && thread.podcast?.audioUrl) {
-      podcast = thread.podcast;
-    }
+    if (!podcast && thread.podcast?.audioUrl) podcast = thread.podcast;
     if (!podcast) return null;
 
-    // Get book IDs from research notebook
+    // Load findings from research notebook
     const notebook = await db.collection('research_notebooks').findOne(
       { threadId: new ObjectId(threadId) },
       { projection: { findings: 1 } },
     );
-    const bookIds = [...new Set(
-      (notebook?.findings || [])
-        .map((f: { source: { bookId: string } }) => f.source?.bookId)
-        .filter(Boolean),
-    )] as string[];
+    const findings: Finding[] = (notebook?.findings || []).map((f: Finding) => ({
+      quote: f.quote,
+      note: f.note,
+      source: f.source,
+    }));
 
-    // Check for manually set hero image on the thread first
+    // Build source books list with thumbnails
+    const bookIds = [...new Set(findings.map(f => f.source?.bookId).filter(Boolean))];
+    let sourceBooks: SourceBook[] = [];
+    if (bookIds.length > 0) {
+      const bookDocs = await db.collection('books')
+        .find({ id: { $in: bookIds } })
+        .project({ id: 1, title: 1, author: 1, slug: 1, thumbnail: 1, thumbnail_blob: 1 })
+        .toArray();
+      const bookMap = new Map(bookDocs.map(b => [b.id, b]));
+      sourceBooks = bookIds.map(bid => {
+        const b = bookMap.get(bid);
+        return {
+          id: bid,
+          title: b?.title || 'Unknown',
+          author: b?.author || '',
+          slug: b?.slug,
+          thumbnail: b?.thumbnail_blob || b?.thumbnail || null,
+          findingCount: findings.filter(f => f.source?.bookId === bid).length,
+        };
+      }).sort((a, b) => b.findingCount - a.findingCount);
+    }
+
+    // Hero image
     let heroImage: EpisodeData['heroImage'] = null;
     if (thread.heroImage?.url) {
       const book = thread.heroImage.bookId
@@ -90,28 +124,20 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
         bookTitle: book?.title || '',
       };
     }
-
-    // Fall back to best gallery image from referenced books
     if (!heroImage && bookIds.length > 0) {
       const bestImage = await db.collection('gallery_images')
         .findOne(
-          { book_id: { $in: bookIds }, gallery_quality: { $gte: 0.7 } },
-          { sort: { gallery_quality: -1 }, projection: { thumbnail_url: 1, image_url: 1, description: 1, book_id: 1 } },
+          { book_id: { $in: bookIds }, thumbnail_url: { $exists: true, $ne: null }, gallery_quality: { $gte: 0.7 } },
+          { sort: { gallery_quality: -1 }, projection: { thumbnail_url: 1, description: 1, book_id: 1 } },
         );
-      if (bestImage) {
-        const imageUrl = bestImage.thumbnail_url || bestImage.image_url;
-        if (imageUrl) {
-          const book = await db.collection('books').findOne(
-            { id: bestImage.book_id },
-            { projection: { title: 1 } },
-          );
-          heroImage = {
-            url: imageUrl,
-            description: bestImage.description || '',
-            bookId: bestImage.book_id,
-            bookTitle: book?.title || 'Unknown',
-          };
-        }
+      if (bestImage?.thumbnail_url) {
+        const book = await db.collection('books').findOne({ id: bestImage.book_id }, { projection: { title: 1 } });
+        heroImage = {
+          url: bestImage.thumbnail_url,
+          description: bestImage.description || '',
+          bookId: bestImage.book_id,
+          bookTitle: book?.title || 'Unknown',
+        };
       }
     }
 
@@ -119,15 +145,14 @@ async function getEpisode(threadId: string): Promise<EpisodeData | null> {
       threadId,
       title: thread.title || podcast.topic,
       topic: podcast.topic,
-      creatorName: thread.creatorName || 'Anonymous',
       audioUrl: podcast.audioUrl,
-      format,
       formatLabel: FORMAT_LABELS[format] || 'Deep Dive',
       findingCount: podcast.findingCount || 0,
       generatedAt: podcast.generatedAt,
       script: podcast.script || null,
-      bookIds,
       heroImage,
+      findings,
+      sourceBooks,
     };
   } catch (err) {
     console.error('[podcast] Failed to load episode:', err);
@@ -175,13 +200,17 @@ export default async function EpisodePage({ params }: Props) {
             <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent px-5 pb-4 pt-10">
               <p className="text-white/80 text-[11px] font-sans">
                 {episode.heroImage.description}
-                {' — '}
-                <Link
-                  href={`/book/${episode.heroImage.bookId}`}
-                  className="text-white/90 underline hover:text-white"
-                >
-                  {episode.heroImage.bookTitle}
-                </Link>
+                {episode.heroImage.bookTitle && (
+                  <>
+                    {' — '}
+                    <Link
+                      href={`/book/${episode.heroImage.bookId}`}
+                      className="text-white/90 underline hover:text-white"
+                    >
+                      {episode.heroImage.bookTitle}
+                    </Link>
+                  </>
+                )}
               </p>
             </div>
           </div>
@@ -210,24 +239,91 @@ export default async function EpisodePage({ params }: Props) {
           preload="metadata"
         />
 
-        {/* Actions */}
-        <div className="flex items-center gap-4 mb-8 pb-8 border-b border-[#e8e4dc]">
-          <Link
-            href={`/librarian/thread/${episode.threadId}`}
-            className="text-[13px] text-[#9e4a3a] font-sans hover:underline"
-          >
-            View research &amp; sources
-          </Link>
-          {episode.script && <TranscriptToggle script={episode.script} />}
-        </div>
+        {/* Transcript */}
+        {episode.script && (
+          <div className="mb-8">
+            <TranscriptToggle script={episode.script} />
+          </div>
+        )}
+
+        {/* Source books */}
+        {episode.sourceBooks.length > 0 && (
+          <div className="mb-8 pt-8 border-t border-[#e8e4dc]">
+            <h2 className="text-[15px] font-serif text-[#1a1612] mb-4" style={{ fontWeight: 400 }}>
+              Sources ({episode.sourceBooks.length} book{episode.sourceBooks.length !== 1 ? 's' : ''})
+            </h2>
+            <div className="space-y-3">
+              {episode.sourceBooks.map(book => (
+                <Link
+                  key={book.id}
+                  href={`/book/${book.slug || book.id}`}
+                  className="flex items-center gap-3 p-3 rounded-lg hover:bg-[#f5f2ec] transition-colors group"
+                >
+                  {book.thumbnail ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={`/api/image?url=${encodeURIComponent(book.thumbnail)}&w=80&q=75`}
+                      alt=""
+                      className="w-10 h-14 object-cover rounded flex-shrink-0 bg-[#f0ece4]"
+                    />
+                  ) : (
+                    <div className="w-10 h-14 rounded flex-shrink-0 bg-[#e8e4dc]" />
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-[14px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors truncate">
+                      {book.title}
+                    </p>
+                    <p className="text-[11px] text-[#8a8480] font-sans mt-0.5 truncate">
+                      {book.author}
+                      {book.findingCount > 1 && ` — ${book.findingCount} passages cited`}
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Key findings / evidence */}
+        {episode.findings.length > 0 && (
+          <div className="mb-8 pt-8 border-t border-[#e8e4dc]">
+            <h2 className="text-[15px] font-serif text-[#1a1612] mb-4" style={{ fontWeight: 400 }}>
+              Key Evidence ({episode.findings.length} passage{episode.findings.length !== 1 ? 's' : ''})
+            </h2>
+            <div className="space-y-6">
+              {episode.findings.map((finding, i) => (
+                <div key={i} className="pl-4 border-l-2 border-[#c9a86c]/40">
+                  <blockquote className="text-[14px] font-body text-[#333] leading-relaxed italic">
+                    &ldquo;{finding.quote}&rdquo;
+                  </blockquote>
+                  <p className="text-[12px] text-[#6b6560] font-body mt-2 leading-relaxed">
+                    {finding.note}
+                  </p>
+                  <p className="text-[11px] text-[#8a8480] font-sans mt-1.5">
+                    <Link
+                      href={`/book/${finding.source.bookSlug || finding.source.bookId}${finding.source.pageNumber ? `?page=${finding.source.pageNumber}` : ''}`}
+                      className="text-[#9e4a3a] hover:underline"
+                    >
+                      {finding.source.bookTitle}
+                      {finding.source.pageNumber && `, p. ${finding.source.pageNumber}`}
+                    </Link>
+                    {finding.source.bookAuthor && ` — ${finding.source.bookAuthor}`}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Back link */}
-        <Link
-          href="/podcast"
-          className="text-[13px] text-[#6b6560] font-sans hover:text-[#1a1612] transition-colors"
-        >
-          &larr; All episodes
-        </Link>
+        <div className="pt-8 border-t border-[#e8e4dc]">
+          <Link
+            href="/podcast"
+            className="text-[13px] text-[#6b6560] font-sans hover:text-[#1a1612] transition-colors"
+          >
+            &larr; All episodes
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/app/podcast/[threadId]/page.tsx
+++ b/src/app/podcast/[threadId]/page.tsx
@@ -168,7 +168,7 @@ export default async function EpisodePage({ params }: Props) {
           <div className="relative rounded-xl overflow-hidden bg-[#1a1612]">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={`/api/image?url=${encodeURIComponent(episode.heroImage.url)}&w=960&q=85`}
+              src={`/api/image?url=${encodeURIComponent(episode.heroImage.url)}&w=1440&q=85`}
               alt={episode.heroImage.description}
               className="w-full max-h-[480px] object-contain"
             />

--- a/src/app/podcast/page.tsx
+++ b/src/app/podcast/page.tsx
@@ -128,25 +128,25 @@ export default async function PodcastPage() {
             <p className="text-[#8a8480] font-body">No episodes yet. Research a topic with the Librarian to generate one.</p>
           </div>
         ) : (
-          <div className="space-y-5">
+          <div className="space-y-4">
             {episodes.map((ep, i) => (
               <Link
                 key={`${ep.threadId}-${ep.format}-${i}`}
                 href={`/podcast/${ep.threadId}`}
-                className="block group rounded-xl overflow-hidden border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors bg-white"
+                className="flex group rounded-xl overflow-hidden border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors bg-white"
               >
                 {ep.heroImageUrl && (
-                  <div className="bg-[#1a1612] overflow-hidden">
+                  <div className="flex-shrink-0 w-[180px] md:w-[220px] bg-[#1a1612] overflow-hidden">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
-                      src={`/api/image?url=${encodeURIComponent(ep.heroImageUrl)}&w=720&q=80`}
+                      src={`/api/image?url=${encodeURIComponent(ep.heroImageUrl)}&w=440&q=85`}
                       alt=""
-                      className="w-full h-[200px] object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+                      className="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity"
                       loading="lazy"
                     />
                   </div>
                 )}
-                <div className="p-5">
+                <div className="flex-1 p-5 flex flex-col justify-center min-w-0">
                   <h2
                     className="text-[17px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors"
                     style={{ fontWeight: 400 }}


### PR DESCRIPTION
## Summary
- All hero images switched to cropped gallery thumbnails for consistency
- Episode pages now show sources and evidence inline:
  - Source books section with thumbnails, titles, authors, finding counts
  - Key evidence section with quotes, scholarly notes, and page-level book citations
- Removed broken "View research & sources" link (librarian thread page shows "thread not found")
- Gallery image fallback now requires `thumbnail_url` (cropped extraction only)

## Test plan
- [ ] /podcast — cropped images on all cards
- [ ] Episode pages — hero image, audio, sources, evidence all render
- [ ] Book links from sources/evidence go to correct book pages

Generated with [Claude Code](https://claude.com/claude-code)