### PR TITLE
Fix page reader links on BPH subdomain

### DIFF
--- a/src/components/book/PageEditorClient.tsx
+++ b/src/components/book/PageEditorClient.tsx
@@ -31,7 +31,8 @@ export default function PageEditorClient({
   const [currentPageId, setCurrentPageId] = useState<string>(initialPage.id);
   const [currentPage, setCurrentPage] = useState<Page>(initialPage);
   const params = useParams<{ tenant: string }>();
-  const tenantPrefix = params?.tenant ? `/${params.tenant}` : '';
+  const isOnTenantSubdomain = typeof window !== 'undefined' && /^[a-z]+\.sourcelibrary\.org$/.test(window.location.hostname);
+  const tenantPrefix = isOnTenantSubdomain ? '' : (params?.tenant ? `/${params.tenant}` : '');
 
   // Version pinning: detect ?v= param for citation-pinned reading
   const [pinnedVersion, setPinnedVersion] = useState<string | null>(null);

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -431,7 +431,10 @@ export default function TranslationEditor({
   const params = useParams<{ tenant: string }>();
   const searchParams = useSearchParams();
   const isEmbedded = searchParams.get('embed') === '1';
-  const tenantPrefix = params?.tenant ? `/${params.tenant}` : '';
+  // On tenant subdomains (bph.sourcelibrary.org), the proxy adds the tenant prefix,
+  // so links should use /book/... not /bph/book/...
+  const isOnTenantSubdomain = typeof window !== 'undefined' && /^[a-z]+\.sourcelibrary\.org$/.test(window.location.hostname);
+  const tenantPrefix = isOnTenantSubdomain ? '' : (params?.tenant ? `/${params.tenant}` : '');
   const embedSuffix = isEmbedded ? '?embed=1' : '';
   const [ocrText, setOcrText] = useState(page.ocr?.data || '');
   const [translationText, setTranslationText] = useState(page.translation?.data || '');


### PR DESCRIPTION
Strip tenant prefix on tenant subdomains — the proxy handles it.