### PR TITLE
Image loading performance: 1yr cache, blur placeholders, optimized sizes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,9 @@ const nextConfig: NextConfig = {
   images: {
     formats: ['image/avif', 'image/webp'],
     qualities: [75, 80, 85, 90],
+    minimumCacheTTL: 31536000, // 1 year — R2 images are immutable, maximize CDN cache hits
+    deviceSizes: [640, 828, 1200, 1920], // Matches grid breakpoints: mobile, tablet, desktop, wide
+    imageSizes: [150, 400, 800], // Matches thumbnail tiers: thumb, card, display
     remotePatterns: [
       // Cloudflare R2 (primary image storage)
       { protocol: 'https', hostname: 'images.sourcelibrary.org' },

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -78,7 +78,7 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
                 'object-cover group-hover:scale-105 transition-transform duration-300',
                 priority ? 'opacity-100' : (imageLoaded ? 'opacity-100' : 'opacity-0')
               )}
-              sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 20vw"
               onLoad={() => setImageLoaded(true)}
               onError={() => {
                 if (!useFallback && fallbackUrl) {
@@ -89,6 +89,8 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
               }}
               priority={priority}
               loading={priority ? 'eager' : 'lazy'}
+              placeholder="blur"
+              blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMyIgaGVpZ2h0PSI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIzIiBoZWlnaHQ9IjQiIGZpbGw9IiNlN2UyZGUiLz48L3N2Zz4="
             />
           ) : (
             <div className="absolute inset-0 flex items-center justify-center">

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -129,7 +129,7 @@ export default function BookCard({ book, priority = false }: BookCardProps) {
               fill
               quality={85}
               className="object-cover group-hover:scale-105 transition-transform duration-300"
-              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"
               onLoad={handleImageLoad}
               onError={() => {
                 if (!useFallback && fallbackUrl) {
@@ -140,6 +140,8 @@ export default function BookCard({ book, priority = false }: BookCardProps) {
               }}
               priority={priority}
               loading={priority ? 'eager' : 'lazy'}
+              placeholder="blur"
+              blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMyIgaGVpZ2h0PSI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIzIiBoZWlnaHQ9IjQiIGZpbGw9IiNlN2UyZGUiLz48L3N2Zz4="
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -352,7 +352,7 @@ export default function CollectionAllBooks({
         /* Art gallery grid — masonry layout with natural aspect ratios */
         <div className={`bg-stone-950 -mx-4 sm:-mx-6 md:-mx-8 px-1 pt-1 pb-4 ${loading ? 'opacity-50 pointer-events-none' : ''}`}>
           <div className="columns-2 sm:columns-3 lg:columns-4 xl:columns-5 gap-1">
-            {displayBooks.map((book) => {
+            {displayBooks.map((book, i) => {
               const thumb = getBookThumbnailUrl(book, 'thumb') || book.photo;
               const title = bookTitle(book);
               const year = book.year || parseInt(book.published || '', 10) || 0;
@@ -368,7 +368,11 @@ export default function CollectionAllBooks({
                       src={thumb}
                       alt={title}
                       className="w-full h-auto block group-hover:opacity-90 transition-opacity duration-300"
-                      loading="lazy"
+                      loading={i < 10 ? 'eager' : 'lazy'}
+                      decoding="async"
+                      fetchPriority={i < 5 ? 'high' : 'auto'}
+                      width={400}
+                      height={500}
                     />
                   ) : (
                     <div className="aspect-[3/4] bg-stone-900 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- **1-year cache TTL** for Vercel Image Optimization — R2 images are immutable, no reason to re-fetch
- **Custom device/image sizes** matching actual layout breakpoints (640/828/1200/1920 + 150/400/800) — fewer cache variants = higher hit rate
- **Blur placeholders** on BookCard and CollectionBookCard — inline SVG shows warm-gray fill instantly, eliminating layout shift
- **Art masonry grid** — `fetchPriority="high"` on first 5, eager loading on first 10, `decoding="async"`, width/height hints for browser layout
- **Corrected `sizes` prop** — 25vw → 20vw for 5-column grids (prevents Vercel from serving oversized images)

## Expected impact
- **LCP improvement**: Blur placeholder renders immediately, image starts loading sooner with correct size hints
- **Bandwidth reduction**: Tighter `sizes` + fewer `deviceSizes` = smaller images served
- **Cache hit rate**: 1yr TTL + fewer size variants = more CDN hits

## Test plan
- [ ] Homepage loads with blur placeholder visible briefly before images
- [ ] Collection pages show images without layout shift
- [ ] Art masonry grid loads first images quickly
- [ ] No broken images on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)