### PR TITLE
Search fixes: broken images, quoted phrase matching, XML cleanup

### DIFF
--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -1223,33 +1223,9 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
         {noResults && aiResults.length > 0 && (
           <div className="space-y-3">
             <p className="text-sm text-muted">Related results from AI-expanded search:</p>
-            {aiResults.map(result => {
-              const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
-              const text = result.snippet || result.summary;
-              return (
-                <Link
-                  key={result.id}
-                  href={result.type === 'page' ? `/book/${result.slug || result.book_id}/page-number/${result.page_number}` : `/book/${result.slug || result.book_id}`}
-                  className="flex items-start gap-3 p-4 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
-                >
-                  {cover && (
-                    <Image src={cover} alt="" width={48} height={68} className="rounded shadow-sm flex-shrink-0 object-cover" />
-                  )}
-                  <div className="min-w-0">
-                    <h3 className="font-serif font-medium text-primary text-sm leading-tight">
-                      {result.display_title || result.title}
-                    </h3>
-                    <p className="text-xs text-muted mt-0.5">
-                      {result.author}{result.published ? `, ${result.published}` : ''}
-                      {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
-                    </p>
-                    {text && (
-                      <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
-                    )}
-                  </div>
-                </Link>
-              );
-            })}
+            {aiResults.map(result => (
+              <RelatedResultCard key={result.id} result={result} tenant={tenant} />
+            ))}
           </div>
         )}
 
@@ -1488,33 +1464,9 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           <section className="mt-12 pt-8 border-t border-border-light">
             <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-4">Related in the Library</h2>
             <div className="space-y-3">
-              {aiResults.map(result => {
-                const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
-                const text = result.snippet || result.summary;
-                return (
-                  <Link
-                    key={result.id}
-                    href={result.type === 'page' ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}` : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant)}
-                    className="flex items-start gap-3 p-3 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
-                  >
-                    {cover && (
-                      <Image src={cover} alt="" width={48} height={68} className="rounded shadow-sm flex-shrink-0 object-cover" />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <h3 className="font-serif font-medium text-primary text-sm leading-tight line-clamp-1">
-                        {result.display_title || result.title}
-                      </h3>
-                      <p className="text-xs text-muted mt-0.5">
-                        {result.author}{result.published ? `, ${result.published}` : ''}
-                        {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
-                      </p>
-                      {text && (
-                        <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
-                      )}
-                    </div>
-                  </Link>
-                );
-              })}
+              {aiResults.map(result => (
+                <RelatedResultCard key={result.id} result={result} tenant={tenant} />
+              ))}
             </div>
           </section>
         )}
@@ -1766,6 +1718,38 @@ function SemanticResultCard({ result, query }: { result: any; query: string }) {
         </div>
       </Link>
     </div>
+  );
+}
+
+function RelatedResultCard({ result, tenant }: { result: SearchResult; tenant?: string }) {
+  const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
+  const text = result.snippet || result.summary;
+  const [imgError, setImgError] = useState(false);
+  return (
+    <Link
+      href={result.type === 'page' ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}` : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant)}
+      className="flex items-start gap-3 p-3 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
+    >
+      {cover && !imgError ? (
+        <Image src={cover} alt="" width={48} height={68} className="rounded shadow-sm flex-shrink-0 object-cover" unoptimized onError={() => setImgError(true)} />
+      ) : (
+        <div className="w-[48px] h-[68px] rounded bg-warm-hover flex items-center justify-center flex-shrink-0">
+          <Book className="w-5 h-5 text-border-medium" />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <h3 className="font-serif font-medium text-primary text-sm leading-tight line-clamp-1">
+          {result.display_title || result.title}
+        </h3>
+        <p className="text-xs text-muted mt-0.5">
+          {result.author}{result.published ? `, ${result.published}` : ''}
+          {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
+        </p>
+        {text && (
+          <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
+        )}
+      </div>
+    </Link>
   );
 }
 

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -23,9 +23,11 @@ function escapeRegex(str: string): string {
 /** Strip XML/HTML tags and clean up formatting artifacts */
 function cleanText(text: string): string {
   return text
-    .replace(/<[^>]+>/g, '')
-    .replace(/\*\*([^*]+)\*\*/g, '$1')
-    .replace(/\s+/g, ' ')
+    .replace(/<[^>]+>/g, '')                    // strip all XML/HTML tags
+    .replace(/\*\*([^*]+)\*\*/g, '$1')          // strip markdown bold
+    .replace(/\*([^*]+)\*/g, '$1')              // strip markdown italic
+    .replace(/original:\s*[^;]+;?\s*/gi, '')    // strip "original: Latin;" annotations
+    .replace(/\s+/g, ' ')                       // collapse whitespace
     .trim();
 }
 
@@ -84,6 +86,9 @@ export async function GET(
     }
 
     const trimmedQuery = query.trim();
+    // Strip surrounding quotes for matching — buildPageSearchStage handles phrase detection internally
+    const isPhrase = /^".*"$/.test(trimmedQuery);
+    const matchQuery = isPhrase ? trimmedQuery.slice(1, -1) : trimmedQuery;
     const db = await getDb();
 
     // Run keyword search and semantic search in parallel
@@ -111,7 +116,7 @@ export async function GET(
           ], { maxTimeMS: 10000 }).toArray();
           usedAtlas = true;
         } catch {
-          const regex = new RegExp(escapeRegex(trimmedQuery), 'i');
+          const regex = new RegExp(escapeRegex(matchQuery), 'i');
           const regexFilter: Record<string, unknown> = {
             book_id: bookId,
             $or: [
@@ -136,18 +141,18 @@ export async function GET(
           if (usedAtlas && Array.isArray(page.highlights) && page.highlights.length > 0) {
             for (const hl of page.highlights as Array<{ path: string; texts: Array<{ value: string; type: string }> }>) {
               const field: 'ocr' | 'translation' = hl.path === 'translation.data' ? 'translation' : 'ocr';
-              const snippet = hl.texts.map(t => t.value).join('');
+              const snippet = cleanText(hl.texts.map(t => t.value).join(''));
               matches.push({ field, snippet, position: 0 });
             }
           } else {
             const ocr = page.ocr as { data?: string } | undefined;
             const translation = page.translation as { data?: string } | undefined;
             if (ocr?.data) {
-              const ocrMatches = generateSnippet(ocr.data, trimmedQuery);
+              const ocrMatches = generateSnippet(ocr.data, matchQuery);
               matches.push(...ocrMatches.map(m => ({ ...m, field: 'ocr' as const })));
             }
             if (translation?.data) {
-              const translationMatches = generateSnippet(translation.data, trimmedQuery);
+              const translationMatches = generateSnippet(translation.data, matchQuery);
               matches.push(...translationMatches.map(m => ({ ...m, field: 'translation' as const })));
             }
           }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -72,6 +72,10 @@ export async function GET(request: NextRequest) {
       }, { status: 400 });
     }
 
+    // Strip surrounding quotes for matching (phrase detection handled by subsystems)
+    const isPhrase = /^".*"$/.test(query.trim());
+    const matchQuery = isPhrase ? query.trim().slice(1, -1) : query;
+
     const db = await getReadDb();
     const results: SearchResult[] = [];
     const seenBooks = new Set<string>();
@@ -137,7 +141,7 @@ export async function GET(request: NextRequest) {
         is_first_translation: !!(typedBook as any).is_first_translation,
         doi: typedBook.doi,
         categories: typedBook.categories,
-        summary: summaryText ? extractSnippet(summaryText, query) : undefined,
+        summary: summaryText ? extractSnippet(summaryText, matchQuery) : undefined,
         snippet_type: summaryText ? 'summary' : undefined,
         thumbnail: (typedBook as any).thumbnail,
         thumbnail_blob: (typedBook as any).thumbnail_blob,
@@ -173,7 +177,7 @@ export async function GET(request: NextRequest) {
         // Only fires when Supabase found nothing (avoids slow regex on common queries)
         if (books.length === 0) {
           const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
-          const words = query.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
+          const words = matchQuery.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
           if (words.length >= 2) {
             const wordRegexes = words.map((w: string) => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
             books = await db.collection('books')
@@ -271,7 +275,7 @@ export async function GET(request: NextRequest) {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          const books = await semanticBookSearch(query, MAX_PAGE_RESULTS, {
+          const books = await semanticBookSearch(matchQuery, MAX_PAGE_RESULTS, {
             language: language || undefined,
             tenantId: tenantId || undefined,
           });
@@ -297,7 +301,7 @@ export async function GET(request: NextRequest) {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          return await semanticPageSearchGlobal(query, 15, tenantId || undefined);
+          return await semanticPageSearchGlobal(matchQuery, 15, tenantId || undefined);
         } catch {
           return [];
         }
@@ -350,7 +354,7 @@ export async function GET(request: NextRequest) {
           const ocrText = page.ocr?.data as string || '';
           const snippetSource = translationText || ocrText;
           snippetType = translationText ? 'translation' : 'ocr';
-          snippet = extractSnippet(snippetSource, query);
+          snippet = extractSnippet(snippetSource, matchQuery);
         }
 
         const pageResult: SearchResult = {
@@ -429,7 +433,7 @@ export async function GET(request: NextRequest) {
             has_doi: !!(book as any).doi,
             doi: (book as any).doi,
             categories: book.categories as string[],
-            summary: summaryText ? extractSnippet(summaryText, query) : undefined,
+            summary: summaryText ? extractSnippet(summaryText, matchQuery) : undefined,
             snippet_type: summaryText ? 'summary' : undefined,
             thumbnail: book.thumbnail as string | undefined,
             thumbnail_blob: book.thumbnail_blob as string | undefined,
@@ -521,7 +525,7 @@ export async function GET(request: NextRequest) {
       // Default: canon-weighted relevance
       // Priority: books > pages, title match, original language, older editions, quality
       const ENGLISH = 'English';
-      const queryLower = query.toLowerCase();
+      const queryLower = matchQuery.toLowerCase();
 
       results.sort((a, b) => {
         // 1. Books before pages

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -29,8 +29,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ results: [], query: '' });
   }
 
+  // Strip surrounding quotes for semantic search (embedding doesn't need them)
+  const searchQuery = /^".*"$/.test(query) ? query.slice(1, -1) : query;
+
   try {
-    const books = await semanticBookSearch(query, limit, {
+    const books = await semanticBookSearch(searchQuery, limit, {
       language,
       yearMin,
       yearMax,

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -98,7 +98,10 @@ export async function GET(request: NextRequest) {
     }
 
     const db = await getDb();
-    const queryRegex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    // Strip surrounding quotes for regex/semantic matching (phrase detection handled by each subsystem)
+    const isPhrase = /^".*"$/.test(query.trim());
+    const matchQuery = isPhrase ? query.trim().slice(1, -1) : query;
+    const queryRegex = new RegExp(matchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
 
     // Build Atlas Search filters
     const searchFilters: BookSearchFilters = {};
@@ -152,17 +155,17 @@ export async function GET(request: NextRequest) {
     const [booksResultRaw, indexResult, galleryResult, visualResult, semanticResultRaw, artworkResult, collectionsResult] = await Promise.all([
       withTimeout(searchBooks(query, limit, searchFilters, library), emptyBooks, 'books'),
       withTimeout(
-        searchIndex(db, query, limit, tenantContext.id || undefined).catch((err) => {
+        searchIndex(db, matchQuery, limit, tenantContext.id || undefined).catch((err) => {
           console.error('Index search error:', err);
           return emptyIndex;
         }),
         emptyIndex, 'index',
       ),
-      withTimeout(searchGallery(db, query, queryRegex, galleryLimit, tenantContext.id || undefined), emptyGallery, 'gallery'),
-      withTimeout(searchVisual(query, galleryLimit), emptyGallery, 'visual', 5000),
+      withTimeout(searchGallery(db, matchQuery, queryRegex, galleryLimit, tenantContext.id || undefined), emptyGallery, 'gallery'),
+      withTimeout(searchVisual(matchQuery, galleryLimit), emptyGallery, 'visual', 5000),
       // Semantic search: book-level discovery via book_embeddings (HNSW, ~17K rows)
       withTimeout(
-        semanticBookSearch(query, 12, { tenantId: tenantContext.id || undefined })
+        semanticBookSearch(matchQuery, 12, { tenantId: tenantContext.id || undefined })
           .then(books => {
             const results = books.map(b => {
               // Extract clean summary (strip metadata lines like "Topics:", "People:", etc.)
@@ -200,7 +203,7 @@ export async function GET(request: NextRequest) {
       ),
       // Artwork semantic search: dedicated artwork_embeddings table (3072 dims)
       withTimeout(
-        semanticArtworkSearch(query, 4)
+        semanticArtworkSearch(matchQuery, 4)
           .then(artworks => ({
             results: artworks.map(a => ({
               book_id: a.book_id,
@@ -219,7 +222,7 @@ export async function GET(request: NextRequest) {
       ),
       // Collection search: match collection names/descriptions (~300 docs, fast)
       withTimeout(
-        searchCollections(db, queryRegex, query).catch(() => emptyCollections),
+        searchCollections(db, queryRegex, matchQuery).catch(() => emptyCollections),
         emptyCollections, 'collections', 2000,
       ),
     ]);
@@ -369,7 +372,8 @@ async function searchBooks(
   });
 
   // Canon-weighted reranking: older editions first, original language preferred
-  const queryLower = query.toLowerCase();
+  const stripped = /^".*"$/.test(query.trim()) ? query.trim().slice(1, -1) : query;
+  const queryLower = stripped.toLowerCase();
   books.sort((a: any, b: any) => {
     // 1. Title match (strongest signal)
     const aTitle = (a.display_title || a.title || '').toLowerCase();

--- a/src/lib/atlas-search.ts
+++ b/src/lib/atlas-search.ts
@@ -99,17 +99,26 @@ export function buildBookSearchStage(query: string, filters: BookSearchFilters =
  * Optionally filters by book_id (single or array via $in).
  */
 export function buildPageSearchStage(query: string, bookIds?: string | string[]): Document {
+  // Detect quoted phrase: "venus humanitas" → exact phrase match
+  const isPhrase = /^".*"$/.test(query.trim());
+  const searchQuery = isPhrase ? query.trim().slice(1, -1) : query;
+
   // Use fuzzy matching for single long words to catch morphological variants
   // (e.g. "masturbation" matches "masturbator", "extraterrestrial" matches "extraterrestrials")
-  const words = query.trim().split(/\s+/);
-  const fuzzy = words.length === 1 && words[0].length >= 6
+  const words = searchQuery.trim().split(/\s+/);
+  const fuzzy = !isPhrase && words.length === 1 && words[0].length >= 6
     ? { maxEdits: 1, prefixLength: 4 }
     : undefined;
 
-  const should: Document[] = [
-    { text: { query, path: 'translation.data', score: { boost: { value: 2 } }, ...(fuzzy && { fuzzy }) } },
-    { text: { query, path: 'ocr.data', ...(fuzzy && { fuzzy }) } },
-  ];
+  const should: Document[] = isPhrase
+    ? [
+        { phrase: { query: searchQuery, path: 'translation.data', score: { boost: { value: 2 } } } },
+        { phrase: { query: searchQuery, path: 'ocr.data' } },
+      ]
+    : [
+        { text: { query: searchQuery, path: 'translation.data', score: { boost: { value: 2 } }, ...(fuzzy && { fuzzy }) } },
+        { text: { query: searchQuery, path: 'ocr.data', ...(fuzzy && { fuzzy }) } },
+      ];
 
   const filter: Document[] = [];
   if (bookIds) {

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -326,15 +326,22 @@ export async function searchBooksCatalog(
 ): Promise<CatalogBookDetail[]> {
   const limit = opts?.limit || 20;
 
+  // Detect quoted phrase: "venus humanitas" → exact phrase only, no word splitting
+  const isPhrase = /^".*"$/.test(text.trim());
+  const searchText = isPhrase ? text.trim().slice(1, -1) : text;
+
   // Build OR filter — same logic as searchBookIds
-  const safe = sanitizeFilterValue(text);
+  const safe = sanitizeFilterValue(searchText);
   const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
   const words = safe.trim().split(/\s+/).filter(w => w.length >= 2);
   const contentWords = words.filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
   const phraseFilters = `title.ilike.%${safe}%,display_title.ilike.%${safe}%,author.ilike.%${safe}%`;
 
+  // For quoted phrases, only do exact phrase matching — no word splitting or cross-field matching
   let orFilter = phraseFilters;
-  if (words.length >= 2) {
+  if (isPhrase) {
+    // Exact phrase only — already handled by phraseFilters
+  } else if (words.length >= 2) {
     const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');
     orFilter += `,and(${titleAnds}),and(${displayAnds})`;
@@ -393,9 +400,13 @@ export async function searchBookIds(
 ): Promise<string[]> {
   const limit = opts?.limit || 500;
 
+  // Detect quoted phrase: "venus humanitas" → exact phrase only
+  const isPhrase = /^".*"$/.test(text.trim());
+  const searchText = isPhrase ? text.trim().slice(1, -1) : text;
+
   // Build OR filter: exact phrase match + word-level AND matches
   // "mathematical magick" should match "Mathematicall Magick" by matching each word
-  const safe = sanitizeFilterValue(text);
+  const safe = sanitizeFilterValue(searchText);
   const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
   const words = safe.trim().split(/\s+/).filter(w => w.length >= 2);
   const contentWords = words.filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
@@ -403,8 +414,11 @@ export async function searchBookIds(
   // full-table scans and Supabase statement timeouts (no trigram indexes)
   const phraseFilters = `title.ilike.%${safe}%,display_title.ilike.%${safe}%,author.ilike.%${safe}%`;
 
+  // For quoted phrases, only do exact phrase matching
   let orFilter = phraseFilters;
-  if (words.length >= 2) {
+  if (isPhrase) {
+    // Exact phrase only — already handled by phraseFilters
+  } else if (words.length >= 2) {
     // Add word-level AND: title contains ALL words (handles spelling variants)
     const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');


### PR DESCRIPTION
## Summary

- **Broken images** in "Related in the Library" results — extracted `RelatedResultCard` component with `onError` handler and Book icon fallback (was using raw `<Image>` without error handling)
- **Quoted phrase matching** — `"venus humanitas"` now does exact phrase search instead of fuzzy/word-split matching. Applies across all search surfaces: library-wide (Supabase), within-book (Atlas Search `phrase` operator), unified, and semantic
- **XML in search snippets** — within-book search highlights from Atlas Search now pass through `cleanText()` to strip `<note>`, `</note>`, markdown formatting, etc.

## Files changed

- `src/app/[tenant]/search/page.tsx` — new `RelatedResultCard` component
- `src/lib/atlas-search.ts` — phrase detection in `buildPageSearchStage`
- `src/lib/books-catalog.ts` — quote stripping in `searchBooksCatalog` and `searchBookIds`
- `src/app/api/search/unified/route.ts` — quote stripping for all search lanes
- `src/app/api/search/route.ts` — quote stripping for global search
- `src/app/api/search/semantic/route.ts` — quote stripping
- `src/app/api/books/[id]/search/route.ts` — `cleanText()` on highlights + quote handling

## Test plan

- [ ] Search `"venus humanitas"` — should show exact phrase matches only (may be zero book-level results, but within-book search in Ficino should find exact phrase)
- [ ] Search `venus humanitas` (no quotes) — should show fuzzy/semantic results as before
- [ ] Check "Related in the Library" section — broken image icons should be replaced with Book icon fallback
- [ ] Within-book search should not show `<note>` tags or `*italic*` markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)