### PR TITLE
Fix author route build: inline route segment config

### DIFF
--- a/src/app/author/[name]/page.tsx
+++ b/src/app/author/[name]/page.tsx
@@ -1,4 +1,10 @@
 // Root-level author page — same as tenant-scoped version.
 // Author pages query the global books collection (not tenant-filtered),
 // so the same component works at both /author/[name] and /[tenant]/author/[name].
-export { default, generateMetadata, generateStaticParams, revalidate, dynamicParams } from '@/app/[tenant]/author/[name]/page';
+//
+// Route segment config must be declared directly (Next.js can't parse re-exports).
+export const revalidate = 86400;
+export const dynamicParams = true;
+export async function generateStaticParams() { return []; }
+
+export { default, generateMetadata } from '@/app/[tenant]/author/[name]/page';


### PR DESCRIPTION
## Summary
Next.js can't statically parse re-exported route segment config (`revalidate`, `dynamicParams`). Declare them directly in the file, only re-export the component and `generateMetadata`.

Fixes build failure from #1547.

## Test plan
- [ ] Build succeeds
- [ ] `/author/Marsilio-Ficino` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)