### PR TITLE
Infer crop data for uncropped pages in spread books

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -372,7 +372,32 @@ async function getBook(id: string, tenantId?: string): Promise<{ book: Book; pag
 
   // Serialize MongoDB objects to plain JavaScript objects
   const serializedBook = JSON.parse(JSON.stringify(book));
-  const serializedPages = JSON.parse(JSON.stringify(pagesRaw));
+  const serializedPages = JSON.parse(JSON.stringify(pagesRaw)) as Page[];
+
+  // Infer crop data for uncropped pages in spread books.
+  // The crop pipeline skips covers/blanks, leaving them as full spreads.
+  // Detect the book's parity convention from existing crops, then fill gaps.
+  const pagesWithCrop = serializedPages.filter(p => p.crop?.xStart !== undefined);
+  if (pagesWithCrop.length > 2) {
+    // Determine convention: do odd pages use left or right half?
+    let oddLeft = 0, oddRight = 0;
+    for (const p of pagesWithCrop) {
+      if (p.page_number % 2 === 1) {
+        (p.crop!.xStart as number) > 400 ? oddRight++ : oddLeft++;
+      }
+    }
+    const oddIsLeft = oddLeft >= oddRight;
+
+    for (const p of serializedPages) {
+      if (p.crop || p.split_from_spread) continue;
+      const isOdd = p.page_number % 2 === 1;
+      const useLeft = oddIsLeft ? isOdd : !isOdd;
+      (p as any).crop = useLeft
+        ? { xStart: 0, xEnd: 510 }
+        : { xStart: 490, xEnd: 1000 };
+    }
+  }
+
   const galleryImagesParsed = JSON.parse(JSON.stringify(galleryImagesRaw)) as (GalleryImagePreview & { gallery_quality: number; book_id: string })[];
   const galleryImages = deduplicateByDHash(galleryImagesParsed).slice(0, 8) as GalleryImagePreview[];
   const bookCollections = JSON.parse(JSON.stringify(bookCollectionsRaw)) as BookCollectionPreview[];


### PR DESCRIPTION
## Summary

1,020 books use crop-based splits but have gaps — pages (covers, blanks) where the crop pipeline didn't run, leaving them as full-width spreads in the grid.

Server-side inference: detect each book's parity convention from existing crops (odd=left vs odd=right varies per book), then fill gaps with default crop coordinates. Applied after serialization so all rendering picks it up automatically.

Fixes ~5,991 pages across 1,020 books.

## Test plan

- [ ] https://bph.sourcelibrary.org/book/the-strife-of-love-in-a-dream-or-the-discourse-of-the-dream-colonna — cover page should now be cropped like the rest
- [ ] Main site books with crop data — no regression
- [ ] Books without any crop data — unaffected (guard: `pagesWithCrop.length > 2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)