### PR TITLE
Add page-content search for quoted phrases

### DIFF
--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -77,6 +77,10 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
   const [semanticResults, setSemanticResults] = useState<any[]>([]);
   const [semanticLoading, setSemanticLoading] = useState(false);
 
+  // Page-content passage results (for quoted phrase searches)
+  const [passageResults, setPassageResults] = useState<SearchResult[]>([]);
+  const [passageLoading, setPassageLoading] = useState(false);
+
   // Track when the base search has set image results, so AI imgTerms callback
   // doesn't add images that get immediately overwritten by the base search completing.
   const baseImagesSet = useRef(false);
@@ -451,6 +455,22 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           })
           .catch(() => setSemanticResults([]))
           .finally(() => setSemanticLoading(false));
+
+        // For quoted phrases, also search page content to find exact passages
+        const isPhrase = /^".*"$/.test(q.trim());
+        if (isPhrase) {
+          setPassageLoading(true);
+          searchApi.search(q, { limit: 10, search_content: 'true' })
+            .then(data => {
+              // Only keep page-level results (not book-level)
+              const pages = (data.results || []).filter((r: SearchResult) => r.type === 'page');
+              setPassageResults(pages);
+            })
+            .catch(() => setPassageResults([]))
+            .finally(() => setPassageLoading(false));
+        } else {
+          setPassageResults([]);
+        }
       } else if (mode === 'books') {
         const data = await searchApi.search(q, {
           language: language || undefined,
@@ -629,7 +649,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
 
   // Fuzzy suggestions on zero results
   const totalResults = bookTotal + indexTotal + imageTotal;
-  const noResults = query.length >= 2 && !loading && !semanticLoading && totalResults === 0 && semanticResults.length === 0;
+  const noResults = query.length >= 2 && !loading && !semanticLoading && !passageLoading && totalResults === 0 && semanticResults.length === 0 && passageResults.length === 0;
   useEffect(() => {
     if (!noResults || query.length < 3) { setSuggestion(null); return; }
     let cancelled = false;
@@ -1230,7 +1250,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
         )}
 
         {/* ==================== UNIFIED VIEW — ADAPTIVE LAYOUT ==================== */}
-        {viewMode === 'unified' && !loading && query.length >= 2 && (totalResults > 0 || semanticResults.length > 0 || semanticLoading) && (() => {
+        {viewMode === 'unified' && !loading && query.length >= 2 && (totalResults > 0 || semanticResults.length > 0 || semanticLoading || passageResults.length > 0 || passageLoading) && (() => {
           const keywordIds = new Set(bookResults.map(b => b.id || (b as any).book_id));
           const uniqueSemantic = semanticResults.filter((sem: any) => !keywordIds.has(sem.book_id));
           const hasBoth = bookResults.length > 0 && uniqueSemantic.length > 0;
@@ -1323,6 +1343,25 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
             </>
           );
 
+          const passageSection = (passageResults.length > 0 || passageLoading) && (
+            <>
+              <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-6">
+                <span className="w-1.5 h-1.5 rounded-full bg-accent-sage" />
+                Exact passages
+              </h2>
+              {passageLoading ? (
+                <div className="flex items-center gap-2 text-sm text-muted py-3">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Searching page content...
+                </div>
+              ) : (
+                passageResults.map((result, idx) => (
+                  <BookResultCard key={result.id} result={result} query={query} tenant={tenant} autoPassages={idx === 0} mobileCompact />
+                ))
+              )}
+            </>
+          );
+
           const collectionCards = collectionResults.length > 0 && (
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {collectionResults.map(col => (
@@ -1333,6 +1372,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
 
           return (
             <div className="space-y-3">
+              {passageSection}
               {collectionCards}
               {narrationBlock}
               {displayHint === 'images_first' ? (

--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -1223,33 +1223,9 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
         {noResults && aiResults.length > 0 && (
           <div className="space-y-3">
             <p className="text-sm text-muted">Related results from AI-expanded search:</p>
-            {aiResults.map(result => {
-              const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
-              const text = result.snippet || result.summary;
-              return (
-                <Link
-                  key={result.id}
-                  href={result.type === 'page' ? `/book/${result.slug || result.book_id}/page-number/${result.page_number}` : `/book/${result.slug || result.book_id}`}
-                  className="flex items-start gap-3 p-4 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
-                >
-                  {cover && (
-                    <Image src={cover} alt="" width={48} height={68} className="rounded shadow-sm flex-shrink-0 object-cover" />
-                  )}
-                  <div className="min-w-0">
-                    <h3 className="font-serif font-medium text-primary text-sm leading-tight">
-                      {result.display_title || result.title}
-                    </h3>
-                    <p className="text-xs text-muted mt-0.5">
-                      {result.author}{result.published ? `, ${result.published}` : ''}
-                      {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
-                    </p>
-                    {text && (
-                      <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
-                    )}
-                  </div>
-                </Link>
-              );
-            })}
+            {aiResults.map(result => (
+              <RelatedResultCard key={result.id} result={result} tenant={tenant} />
+            ))}
           </div>
         )}
 
@@ -1488,33 +1464,9 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           <section className="mt-12 pt-8 border-t border-border-light">
             <h2 className="text-sm font-medium text-muted uppercase tracking-wide mb-4">Related in the Library</h2>
             <div className="space-y-3">
-              {aiResults.map(result => {
-                const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
-                const text = result.snippet || result.summary;
-                return (
-                  <Link
-                    key={result.id}
-                    href={result.type === 'page' ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}` : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant)}
-                    className="flex items-start gap-3 p-3 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
-                  >
-                    {cover && (
-                      <Image src={cover} alt="" width={48} height={68} className="rounded shadow-sm flex-shrink-0 object-cover" />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <h3 className="font-serif font-medium text-primary text-sm leading-tight line-clamp-1">
-                        {result.display_title || result.title}
-                      </h3>
-                      <p className="text-xs text-muted mt-0.5">
-                        {result.author}{result.published ? `, ${result.published}` : ''}
-                        {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
-                      </p>
-                      {text && (
-                        <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
-                      )}
-                    </div>
-                  </Link>
-                );
-              })}
+              {aiResults.map(result => (
+                <RelatedResultCard key={result.id} result={result} tenant={tenant} />
+              ))}
             </div>
           </section>
         )}
@@ -1766,6 +1718,38 @@ function SemanticResultCard({ result, query }: { result: any; query: string }) {
         </div>
       </Link>
     </div>
+  );
+}
+
+function RelatedResultCard({ result, tenant }: { result: SearchResult; tenant?: string }) {
+  const cover = getBookThumbnailUrl({ thumbnail: result.thumbnail, thumbnail_blob: (result as any).thumbnail_blob });
+  const text = result.snippet || result.summary;
+  const [imgError, setImgError] = useState(false);
+  return (
+    <Link
+      href={result.type === 'page' ? tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant) + `/page-number/${result.page_number}` : tenantBookUrl({ slug: result.slug, id: result.book_id }, tenant)}
+      className="flex items-start gap-3 p-3 bg-warm rounded-lg hover:bg-warm-hover transition-colors"
+    >
+      {cover && !imgError ? (
+        <Image src={cover} alt="" width={48} height={68} className="rounded shadow-sm flex-shrink-0 object-cover" unoptimized onError={() => setImgError(true)} />
+      ) : (
+        <div className="w-[48px] h-[68px] rounded bg-warm-hover flex items-center justify-center flex-shrink-0">
+          <Book className="w-5 h-5 text-border-medium" />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <h3 className="font-serif font-medium text-primary text-sm leading-tight line-clamp-1">
+          {result.display_title || result.title}
+        </h3>
+        <p className="text-xs text-muted mt-0.5">
+          {result.author}{result.published ? `, ${result.published}` : ''}
+          {result.type === 'page' && result.page_number && <span> &middot; p. {result.page_number}</span>}
+        </p>
+        {text && (
+          <p className="text-xs text-secondary mt-1 line-clamp-2">{text}</p>
+        )}
+      </div>
+    </Link>
   );
 }
 

--- a/src/app/api/books/[id]/search/route.ts
+++ b/src/app/api/books/[id]/search/route.ts
@@ -23,9 +23,11 @@ function escapeRegex(str: string): string {
 /** Strip XML/HTML tags and clean up formatting artifacts */
 function cleanText(text: string): string {
   return text
-    .replace(/<[^>]+>/g, '')
-    .replace(/\*\*([^*]+)\*\*/g, '$1')
-    .replace(/\s+/g, ' ')
+    .replace(/<[^>]+>/g, '')                    // strip all XML/HTML tags
+    .replace(/\*\*([^*]+)\*\*/g, '$1')          // strip markdown bold
+    .replace(/\*([^*]+)\*/g, '$1')              // strip markdown italic
+    .replace(/original:\s*[^;]+;?\s*/gi, '')    // strip "original: Latin;" annotations
+    .replace(/\s+/g, ' ')                       // collapse whitespace
     .trim();
 }
 
@@ -84,6 +86,9 @@ export async function GET(
     }
 
     const trimmedQuery = query.trim();
+    // Strip surrounding quotes for matching — buildPageSearchStage handles phrase detection internally
+    const isPhrase = /^".*"$/.test(trimmedQuery);
+    const matchQuery = isPhrase ? trimmedQuery.slice(1, -1) : trimmedQuery;
     const db = await getDb();
 
     // Run keyword search and semantic search in parallel
@@ -111,7 +116,7 @@ export async function GET(
           ], { maxTimeMS: 10000 }).toArray();
           usedAtlas = true;
         } catch {
-          const regex = new RegExp(escapeRegex(trimmedQuery), 'i');
+          const regex = new RegExp(escapeRegex(matchQuery), 'i');
           const regexFilter: Record<string, unknown> = {
             book_id: bookId,
             $or: [
@@ -136,18 +141,18 @@ export async function GET(
           if (usedAtlas && Array.isArray(page.highlights) && page.highlights.length > 0) {
             for (const hl of page.highlights as Array<{ path: string; texts: Array<{ value: string; type: string }> }>) {
               const field: 'ocr' | 'translation' = hl.path === 'translation.data' ? 'translation' : 'ocr';
-              const snippet = hl.texts.map(t => t.value).join('');
+              const snippet = cleanText(hl.texts.map(t => t.value).join(''));
               matches.push({ field, snippet, position: 0 });
             }
           } else {
             const ocr = page.ocr as { data?: string } | undefined;
             const translation = page.translation as { data?: string } | undefined;
             if (ocr?.data) {
-              const ocrMatches = generateSnippet(ocr.data, trimmedQuery);
+              const ocrMatches = generateSnippet(ocr.data, matchQuery);
               matches.push(...ocrMatches.map(m => ({ ...m, field: 'ocr' as const })));
             }
             if (translation?.data) {
-              const translationMatches = generateSnippet(translation.data, trimmedQuery);
+              const translationMatches = generateSnippet(translation.data, matchQuery);
               matches.push(...translationMatches.map(m => ({ ...m, field: 'translation' as const })));
             }
           }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -72,6 +72,10 @@ export async function GET(request: NextRequest) {
       }, { status: 400 });
     }
 
+    // Strip surrounding quotes for matching (phrase detection handled by subsystems)
+    const isPhrase = /^".*"$/.test(query.trim());
+    const matchQuery = isPhrase ? query.trim().slice(1, -1) : query;
+
     const db = await getReadDb();
     const results: SearchResult[] = [];
     const seenBooks = new Set<string>();
@@ -137,7 +141,7 @@ export async function GET(request: NextRequest) {
         is_first_translation: !!(typedBook as any).is_first_translation,
         doi: typedBook.doi,
         categories: typedBook.categories,
-        summary: summaryText ? extractSnippet(summaryText, query) : undefined,
+        summary: summaryText ? extractSnippet(summaryText, matchQuery) : undefined,
         snippet_type: summaryText ? 'summary' : undefined,
         thumbnail: (typedBook as any).thumbnail,
         thumbnail_blob: (typedBook as any).thumbnail_blob,
@@ -173,7 +177,7 @@ export async function GET(request: NextRequest) {
         // Only fires when Supabase found nothing (avoids slow regex on common queries)
         if (books.length === 0) {
           const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
-          const words = query.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
+          const words = matchQuery.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
           if (words.length >= 2) {
             const wordRegexes = words.map((w: string) => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
             books = await db.collection('books')
@@ -271,7 +275,7 @@ export async function GET(request: NextRequest) {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          const books = await semanticBookSearch(query, MAX_PAGE_RESULTS, {
+          const books = await semanticBookSearch(matchQuery, MAX_PAGE_RESULTS, {
             language: language || undefined,
             tenantId: tenantId || undefined,
           });
@@ -297,7 +301,7 @@ export async function GET(request: NextRequest) {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          return await semanticPageSearchGlobal(query, 15, tenantId || undefined);
+          return await semanticPageSearchGlobal(matchQuery, 15, tenantId || undefined);
         } catch {
           return [];
         }
@@ -350,7 +354,7 @@ export async function GET(request: NextRequest) {
           const ocrText = page.ocr?.data as string || '';
           const snippetSource = translationText || ocrText;
           snippetType = translationText ? 'translation' : 'ocr';
-          snippet = extractSnippet(snippetSource, query);
+          snippet = extractSnippet(snippetSource, matchQuery);
         }
 
         const pageResult: SearchResult = {
@@ -429,7 +433,7 @@ export async function GET(request: NextRequest) {
             has_doi: !!(book as any).doi,
             doi: (book as any).doi,
             categories: book.categories as string[],
-            summary: summaryText ? extractSnippet(summaryText, query) : undefined,
+            summary: summaryText ? extractSnippet(summaryText, matchQuery) : undefined,
             snippet_type: summaryText ? 'summary' : undefined,
             thumbnail: book.thumbnail as string | undefined,
             thumbnail_blob: book.thumbnail_blob as string | undefined,
@@ -521,7 +525,7 @@ export async function GET(request: NextRequest) {
       // Default: canon-weighted relevance
       // Priority: books > pages, title match, original language, older editions, quality
       const ENGLISH = 'English';
-      const queryLower = query.toLowerCase();
+      const queryLower = matchQuery.toLowerCase();
 
       results.sort((a, b) => {
         // 1. Books before pages

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -29,8 +29,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ results: [], query: '' });
   }
 
+  // Strip surrounding quotes for semantic search (embedding doesn't need them)
+  const searchQuery = /^".*"$/.test(query) ? query.slice(1, -1) : query;
+
   try {
-    const books = await semanticBookSearch(query, limit, {
+    const books = await semanticBookSearch(searchQuery, limit, {
       language,
       yearMin,
       yearMax,

--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -98,7 +98,10 @@ export async function GET(request: NextRequest) {
     }
 
     const db = await getDb();
-    const queryRegex = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    // Strip surrounding quotes for regex/semantic matching (phrase detection handled by each subsystem)
+    const isPhrase = /^".*"$/.test(query.trim());
+    const matchQuery = isPhrase ? query.trim().slice(1, -1) : query;
+    const queryRegex = new RegExp(matchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
 
     // Build Atlas Search filters
     const searchFilters: BookSearchFilters = {};
@@ -152,17 +155,17 @@ export async function GET(request: NextRequest) {
     const [booksResultRaw, indexResult, galleryResult, visualResult, semanticResultRaw, artworkResult, collectionsResult] = await Promise.all([
       withTimeout(searchBooks(query, limit, searchFilters, library), emptyBooks, 'books'),
       withTimeout(
-        searchIndex(db, query, limit, tenantContext.id || undefined).catch((err) => {
+        searchIndex(db, matchQuery, limit, tenantContext.id || undefined).catch((err) => {
           console.error('Index search error:', err);
           return emptyIndex;
         }),
         emptyIndex, 'index',
       ),
-      withTimeout(searchGallery(db, query, queryRegex, galleryLimit, tenantContext.id || undefined), emptyGallery, 'gallery'),
-      withTimeout(searchVisual(query, galleryLimit), emptyGallery, 'visual', 5000),
+      withTimeout(searchGallery(db, matchQuery, queryRegex, galleryLimit, tenantContext.id || undefined), emptyGallery, 'gallery'),
+      withTimeout(searchVisual(matchQuery, galleryLimit), emptyGallery, 'visual', 5000),
       // Semantic search: book-level discovery via book_embeddings (HNSW, ~17K rows)
       withTimeout(
-        semanticBookSearch(query, 12, { tenantId: tenantContext.id || undefined })
+        semanticBookSearch(matchQuery, 12, { tenantId: tenantContext.id || undefined })
           .then(books => {
             const results = books.map(b => {
               // Extract clean summary (strip metadata lines like "Topics:", "People:", etc.)
@@ -200,7 +203,7 @@ export async function GET(request: NextRequest) {
       ),
       // Artwork semantic search: dedicated artwork_embeddings table (3072 dims)
       withTimeout(
-        semanticArtworkSearch(query, 4)
+        semanticArtworkSearch(matchQuery, 4)
           .then(artworks => ({
             results: artworks.map(a => ({
               book_id: a.book_id,
@@ -219,7 +222,7 @@ export async function GET(request: NextRequest) {
       ),
       // Collection search: match collection names/descriptions (~300 docs, fast)
       withTimeout(
-        searchCollections(db, queryRegex, query).catch(() => emptyCollections),
+        searchCollections(db, queryRegex, matchQuery).catch(() => emptyCollections),
         emptyCollections, 'collections', 2000,
       ),
     ]);
@@ -369,7 +372,8 @@ async function searchBooks(
   });
 
   // Canon-weighted reranking: older editions first, original language preferred
-  const queryLower = query.toLowerCase();
+  const stripped = /^".*"$/.test(query.trim()) ? query.trim().slice(1, -1) : query;
+  const queryLower = stripped.toLowerCase();
   books.sort((a: any, b: any) => {
     // 1. Title match (strongest signal)
     const aTitle = (a.display_title || a.title || '').toLowerCase();

--- a/src/lib/atlas-search.ts
+++ b/src/lib/atlas-search.ts
@@ -99,17 +99,26 @@ export function buildBookSearchStage(query: string, filters: BookSearchFilters =
  * Optionally filters by book_id (single or array via $in).
  */
 export function buildPageSearchStage(query: string, bookIds?: string | string[]): Document {
+  // Detect quoted phrase: "venus humanitas" → exact phrase match
+  const isPhrase = /^".*"$/.test(query.trim());
+  const searchQuery = isPhrase ? query.trim().slice(1, -1) : query;
+
   // Use fuzzy matching for single long words to catch morphological variants
   // (e.g. "masturbation" matches "masturbator", "extraterrestrial" matches "extraterrestrials")
-  const words = query.trim().split(/\s+/);
-  const fuzzy = words.length === 1 && words[0].length >= 6
+  const words = searchQuery.trim().split(/\s+/);
+  const fuzzy = !isPhrase && words.length === 1 && words[0].length >= 6
     ? { maxEdits: 1, prefixLength: 4 }
     : undefined;
 
-  const should: Document[] = [
-    { text: { query, path: 'translation.data', score: { boost: { value: 2 } }, ...(fuzzy && { fuzzy }) } },
-    { text: { query, path: 'ocr.data', ...(fuzzy && { fuzzy }) } },
-  ];
+  const should: Document[] = isPhrase
+    ? [
+        { phrase: { query: searchQuery, path: 'translation.data', score: { boost: { value: 2 } } } },
+        { phrase: { query: searchQuery, path: 'ocr.data' } },
+      ]
+    : [
+        { text: { query: searchQuery, path: 'translation.data', score: { boost: { value: 2 } }, ...(fuzzy && { fuzzy }) } },
+        { text: { query: searchQuery, path: 'ocr.data', ...(fuzzy && { fuzzy }) } },
+      ];
 
   const filter: Document[] = [];
   if (bookIds) {

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -326,15 +326,22 @@ export async function searchBooksCatalog(
 ): Promise<CatalogBookDetail[]> {
   const limit = opts?.limit || 20;
 
+  // Detect quoted phrase: "venus humanitas" → exact phrase only, no word splitting
+  const isPhrase = /^".*"$/.test(text.trim());
+  const searchText = isPhrase ? text.trim().slice(1, -1) : text;
+
   // Build OR filter — same logic as searchBookIds
-  const safe = sanitizeFilterValue(text);
+  const safe = sanitizeFilterValue(searchText);
   const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
   const words = safe.trim().split(/\s+/).filter(w => w.length >= 2);
   const contentWords = words.filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
   const phraseFilters = `title.ilike.%${safe}%,display_title.ilike.%${safe}%,author.ilike.%${safe}%`;
 
+  // For quoted phrases, only do exact phrase matching — no word splitting or cross-field matching
   let orFilter = phraseFilters;
-  if (words.length >= 2) {
+  if (isPhrase) {
+    // Exact phrase only — already handled by phraseFilters
+  } else if (words.length >= 2) {
     const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');
     orFilter += `,and(${titleAnds}),and(${displayAnds})`;
@@ -393,9 +400,13 @@ export async function searchBookIds(
 ): Promise<string[]> {
   const limit = opts?.limit || 500;
 
+  // Detect quoted phrase: "venus humanitas" → exact phrase only
+  const isPhrase = /^".*"$/.test(text.trim());
+  const searchText = isPhrase ? text.trim().slice(1, -1) : text;
+
   // Build OR filter: exact phrase match + word-level AND matches
   // "mathematical magick" should match "Mathematicall Magick" by matching each word
-  const safe = sanitizeFilterValue(text);
+  const safe = sanitizeFilterValue(searchText);
   const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
   const words = safe.trim().split(/\s+/).filter(w => w.length >= 2);
   const contentWords = words.filter(w => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
@@ -403,8 +414,11 @@ export async function searchBookIds(
   // full-table scans and Supabase statement timeouts (no trigram indexes)
   const phraseFilters = `title.ilike.%${safe}%,display_title.ilike.%${safe}%,author.ilike.%${safe}%`;
 
+  // For quoted phrases, only do exact phrase matching
   let orFilter = phraseFilters;
-  if (words.length >= 2) {
+  if (isPhrase) {
+    // Exact phrase only — already handled by phraseFilters
+  } else if (words.length >= 2) {
     // Add word-level AND: title contains ALL words (handles spelling variants)
     const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');


### PR DESCRIPTION
## Summary

When searching with quotes like `"venus humanitas"`, the unified search now fires a parallel page-content search that finds exact phrase matches in book text (OCR + translations). Results appear as an "Exact passages" section at the top of the unified view.

Previously, quoted searches only matched book titles/authors — actual text content was only searchable via the Books tab drill-down.

## How it works

- Detects `"quoted phrase"` pattern in the search query
- Fires `/api/search?search_content=true` in parallel with the unified search
- Filters to page-level results only (not book-level duplicates)
- Renders using existing `BookResultCard` with auto-passage expansion

## Test plan

- [ ] Search `"venus humanitas"` — should show "Exact passages" section with page hits from Ficino
- [ ] Search `venus humanitas` (no quotes) — should NOT show passages section
- [ ] Search `"transmutation of metals"` — should show passage hits
- [ ] Verify no layout shift or loading jank

🤖 Generated with [Claude Code](https://claude.com/claude-code)