### PR TITLE
Quoted search: show passages + books in All tab

### DIFF
--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -456,15 +456,39 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
           .catch(() => setSemanticResults([]))
           .finally(() => setSemanticLoading(false));
 
-        // For quoted phrases, also search page content to find exact passages
+        // For quoted phrases, also search page content to find exact passages.
+        // Use unquoted query for full-text search (finds pages with both words),
+        // then try phrase search for exact contiguous matches and promote those.
         const isPhrase = /^".*"$/.test(q.trim());
         if (isPhrase) {
+          const unquoted = q.trim().slice(1, -1);
           setPassageLoading(true);
-          searchApi.search(q, { limit: 10, search_content: 'true' })
-            .then(data => {
-              // Only keep page-level results (not book-level)
-              const pages = (data.results || []).filter((r: SearchResult) => r.type === 'page');
+          Promise.all([
+            // Full-text search (both words on same page)
+            searchApi.search(unquoted, { limit: 15, search_content: 'true' }),
+            // Phrase search (exact contiguous match)
+            searchApi.search(q, { limit: 10, search_content: 'true' }).catch(() => ({ results: [] })),
+          ])
+            .then(([fullData, phraseData]) => {
+              const fullResults = fullData.results || [];
+              const phraseIds = new Set((phraseData.results || []).map((r: SearchResult) => r.id));
+              // Mark phrase matches, then sort them first
+              const pages = fullResults
+                .filter((r: SearchResult) => r.type === 'page')
+                .sort((a: SearchResult, b: SearchResult) => {
+                  const aPhrase = phraseIds.has(a.id) ? 1 : 0;
+                  const bPhrase = phraseIds.has(b.id) ? 1 : 0;
+                  return bPhrase - aPhrase;
+                });
               setPassageResults(pages);
+              // Backfill book results if unified found none
+              if (bookResults.length === 0) {
+                const books = fullResults.filter((r: SearchResult) => r.type === 'book');
+                if (books.length > 0) {
+                  setBookResults(books);
+                  setBookTotal(books.length);
+                }
+              }
             })
             .catch(() => setPassageResults([]))
             .finally(() => setPassageLoading(false));
@@ -1347,7 +1371,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
             <>
               <h2 className="text-xs font-medium text-muted uppercase tracking-wide flex items-center gap-2 mt-6">
                 <span className="w-1.5 h-1.5 rounded-full bg-accent-sage" />
-                Exact passages
+                Passages
               </h2>
               {passageLoading ? (
                 <div className="flex items-center gap-2 text-sm text-muted py-3">


### PR DESCRIPTION
## Summary

Fixes quoted phrase search to actually show results in the All tab:

1. **Full-text + phrase search**: For `"venus humanitas"`, searches for pages containing both words (not just as a contiguous phrase), then promotes exact phrase matches to the top
2. **Book backfill**: When unified search finds no book-title matches (common for quoted phrases), backfills with book results from the full-text search
3. **Section label**: "Passages" instead of "Exact passages"

## Why

Quoted searches like `"venus humanitas"` returned nothing in the All tab because:
- No book title contains "venus humanitas"  
- Atlas Search `phrase` operator requires words to be adjacent, but Ficino writes "Venus not as lust, but as *Humanitas*"

Now it finds the right pages and shows them.

## Test plan

- [ ] Search `"venus humanitas"` — should show Passages section with Ficino page hits + book results
- [ ] Search `"transmutation of metals"` — should show contiguous phrase matches promoted to top
- [ ] Unquoted searches should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)