### PR TITLE
Hide Wikimedia upload dates from artwork display (#1560)

### DIFF
--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -152,10 +152,19 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
               </p>
 
               <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-5 text-sm text-stone-400">
-                {book.published && (
+                {/* Show published date, but filter out Wikimedia upload timestamps
+                    (ISO format like "2014-10-22 07:56:19" — not artwork creation dates) */}
+                {book.published && !/^\d{4}-\d{2}-\d{2}/.test(book.published) && (
                   <div className="flex items-center gap-1.5">
                     <Calendar className="w-4 h-4 text-stone-500" />
                     {book.published}
+                  </div>
+                )}
+                {/* Show enrichment period when no real published date */}
+                {(!book.published || /^\d{4}-\d{2}-\d{2}/.test(book.published)) && enrichment?.period && (
+                  <div className="flex items-center gap-1.5">
+                    <Calendar className="w-4 h-4 text-stone-500" />
+                    {enrichment.period}
                   </div>
                 )}
                 {medium && (
@@ -191,7 +200,7 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
               <BookShare
                 title={book.display_title || book.title}
                 author={book.author}
-                year={book.published}
+                year={book.published && !/^\d{4}-\d{2}-\d{2}/.test(book.published) ? book.published : enrichment?.period || undefined}
                 bookId={book.id}
                 label="Share"
                 className="text-stone-300 hover:text-white hover:bg-white/10"

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -355,7 +355,12 @@ export default function CollectionAllBooks({
             {displayBooks.map((book, i) => {
               const thumb = getBookThumbnailUrl(book, 'thumb') || book.photo;
               const title = bookTitle(book);
-              const year = book.year || parseInt(book.published || '', 10) || 0;
+              // For artworks, book.published is often the Wikimedia upload date (e.g. 2014),
+              // not the creation date. Only use book.year (set by enrichment) for artworks.
+              const isArtwork = !!book.resource_type;
+              const year = isArtwork
+                ? (book.year || 0)
+                : (book.year || parseInt(book.published || '', 10) || 0);
               return (
                 <Link
                   key={book.id}

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeText, isUsableImageUrl, isArchiveFailed, getPageImageUrl } from '@/lib/utils';
+import { normalizeText, isUsableImageUrl, isArchiveFailed, getPageImageUrl, getBookThumbnailUrl } from '@/lib/utils';
 
 describe('normalizeText', () => {
   it('lowercases text', () => {
@@ -107,5 +107,93 @@ describe('getPageImageUrl', () => {
 
   it('returns null when no images available', () => {
     expect(getPageImageUrl({})).toBeNull();
+  });
+});
+
+describe('getBookThumbnailUrl', () => {
+  // Artwork URLs: -thumb vs -full routing
+  it('returns -thumb.jpg for artwork URLs in thumb mode', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/artwork/goltzius-full.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/artwork/goltzius-thumb.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/artwork/goltzius-thumb.jpg');
+  });
+
+  it('returns -full.jpg for artwork URLs in display mode', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/artwork/goltzius-full.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/artwork/goltzius-thumb.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/artwork/goltzius-full.jpg');
+  });
+
+  it('rewrites artwork -thumb to -full in display mode', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/artwork/durer-thumb.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/artwork/durer-thumb.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/artwork/durer-full.jpg');
+  });
+
+  it('rewrites artwork -full to -thumb in thumb mode', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/artwork/durer-full.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/artwork/durer-full.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/artwork/durer-thumb.jpg');
+  });
+
+  // Archived book URLs: rewrite to /pages/ with size suffix
+  it('rewrites /archived/ URLs to /pages/ with -thumb suffix', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/archived/abc123/5.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/archived/abc123/5.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/pages/abc123/0005-thumb.jpg');
+  });
+
+  it('rewrites /archived/ URLs to /pages/ display size', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/archived/abc123/5.jpg',
+    };
+    expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/pages/abc123/0005.jpg');
+  });
+
+  // Wikimedia: rewrite to thumb.php
+  it('rewrites Wikimedia URLs to thumb.php', () => {
+    const book = {
+      thumbnail: 'https://upload.wikimedia.org/wikipedia/commons/a/ab/Image.jpg',
+    };
+    const result = getBookThumbnailUrl(book, 'thumb');
+    expect(result).toContain('thumb.php');
+    expect(result).toContain('w=400');
+  });
+
+  // Artwork URLs without -thumb or -full suffix should pass through
+  it('passes through artwork URLs without size suffix', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/artwork/some-image.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/artwork/some-image.jpg',
+    };
+    // Display: no -thumb to rewrite, passes through
+    expect(getBookThumbnailUrl(book, 'display')).toBe('https://images.sourcelibrary.org/artwork/some-image.jpg');
+    // Thumb: no -full to rewrite, passes through
+    expect(getBookThumbnailUrl(book, 'thumb')).toBe('https://images.sourcelibrary.org/artwork/some-image.jpg');
+  });
+
+  // Default size is 'display'
+  it('defaults to display size', () => {
+    const book = {
+      thumbnail: 'https://images.sourcelibrary.org/artwork/test-full.jpg',
+      thumbnail_blob: 'https://images.sourcelibrary.org/artwork/test-thumb.jpg',
+    };
+    expect(getBookThumbnailUrl(book)).toBe('https://images.sourcelibrary.org/artwork/test-full.jpg');
+  });
+
+  // Null handling
+  it('returns null when no thumbnail', () => {
+    expect(getBookThumbnailUrl({}, 'display')).toBeNull();
+    expect(getBookThumbnailUrl({ thumbnail: null, thumbnail_blob: null }, 'thumb')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Artwork `published` fields often contain the Wikimedia Commons upload timestamp (e.g. "2014-10-22 07:56:19"), not the artwork's creation date. This showed up as "2014" on artwork cards and detail pages.

**Changes:**
- `CollectionAllBooks.tsx`: Artworks only show `book.year` (set by enrichment), never parsed `published`
- `ArtworkInfo.tsx`: Filter out ISO timestamps from date display, show `enrichment.period` (e.g. "Baroque") as fallback
- `BookShare` year prop: Same filter

## Test plan
- [ ] Visit https://sourcelibrary.org/artwork/an-explosion-in-a-laboratory-oil-painting — should show "Baroque" not "2014"
- [ ] Visit an artwork collection grid — no upload dates visible
- [ ] Books with real published dates (e.g. "1617") still display correctly

Partial fix for #1560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)