### PR TITLE
Fix ExhibitionLayout image resolution

### DIFF
--- a/src/app/[tenant]/collections/[id]/page.tsx
+++ b/src/app/[tenant]/collections/[id]/page.tsx
@@ -603,7 +603,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
   const imagePool: typeof galleryImages = [];
   const bookImageCounts = new Map<string, number>();
   for (const img of galleryImages) {
-    const thumb = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+    const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
     if (!thumb) continue;
     const bid = img.book_id || img.bookId;
     const count = bookImageCounts.get(bid) || 0;
@@ -828,7 +828,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
             </div>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4 mt-5">
               {diverseGalleryImages.map((img: { pageId?: string; page_id?: string; bookId?: string; book_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
-                const thumb = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+                const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
                 const pageId = img.pageId || img.page_id;
                 const bookId = img.bookId || img.book_id;
                 const detIdx = img.detectionIndex ?? img.detection_index;

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -578,7 +578,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
   const imagePool: typeof galleryImages = [];
   const bookImageCounts = new Map<string, number>();
   for (const img of galleryImages) {
-    const thumb = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+    const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
     if (!thumb) continue;
     const bid = img.book_id || img.bookId;
     const count = bookImageCounts.get(bid) || 0;
@@ -803,7 +803,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
             </div>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4 mt-5">
               {diverseGalleryImages.map((img: { pageId?: string; page_id?: string; bookId?: string; book_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
-                const thumb = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+                const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
                 const pageId = img.pageId || img.page_id;
                 const bookId = img.bookId || img.book_id;
                 const detIdx = img.detectionIndex ?? img.detection_index;

--- a/src/components/collections/ExhibitionLayout.tsx
+++ b/src/components/collections/ExhibitionLayout.tsx
@@ -63,7 +63,7 @@ function bookTitle(book: BookRef): string {
 }
 
 function imageUrl(img: GalleryImage): string {
-  return img.thumbnail_url || img.extracted_url || img.image_url || '';
+  return img.extracted_url || img.thumbnail_url || img.image_url || '';
 }
 
 function imagePageHref(img: GalleryImage): string {


### PR DESCRIPTION
## Summary
- ExhibitionLayout's `imageUrl()` was preferring 150px thumbnails over 1200px extracted images
- Swapped priority to match the collection gallery fix in #1562
- Also fixed courts-of-wonder curation data:
  - Reading wheel image was showing Ramelli's portrait instead of the actual book wheel (page 673)
  - Backfilled `extracted_url` for all 13 thumb-only images in thematic gallery clusters

## Test plan
- [ ] Visit https://sourcelibrary.org/collections/courts-of-wonder
- [ ] Verify the "Machines of Wonder" section shows the actual reading wheel, not the portrait
- [ ] Verify all gallery images are sharp/high-res

🤖 Generated with [Claude Code](https://claude.com/claude-code)