### PR TITLE
Fix art collection grids: exclude hidden artworks, conditional image optimization

### DIFF
--- a/src/app/[tenant]/gallery/collections/[slug]/CollectionImageCard.tsx
+++ b/src/app/[tenant]/gallery/collections/[slug]/CollectionImageCard.tsx
@@ -21,6 +21,9 @@ export interface CollectionImageProps {
 export default function CollectionImageCard({ item, priority = false }: { item: CollectionImageProps; priority?: boolean }) {
   const [imageError, setImageError] = useState(false);
   const displayUrl = item.thumbnailUrl || item.extractedUrl || item.imageUrl;
+  // Only bypass Next.js optimization for pre-generated R2 thumbnails (already small).
+  // Fallback URLs (extractedUrl, imageUrl) can be 2MB+ and need optimization.
+  const isPreGenerated = !!item.thumbnailUrl;
 
   return (
     <div className="relative group bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-all hover:-translate-y-0.5">
@@ -34,7 +37,7 @@ export default function CollectionImageCard({ item, priority = false }: { item: 
               className="object-contain group-hover:scale-105 transition-transform duration-300"
               sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 16vw"
               onError={() => setImageError(true)}
-              unoptimized
+              unoptimized={isPreGenerated}
               priority={priority}
               loading={priority ? 'eager' : 'lazy'}
             />

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -214,13 +214,14 @@ async function fetchCollectionData(id: string, provider?: string) {
   const filter: Record<string, unknown> = isArtCollection
     ? {
       collections: id,
-      resource_type: { $exists: true },
+      resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES },
+      hidden: { $ne: true },
     }
     : {
       collections: id,
       $or: [
         { visible: true, pages_count: { $gt: 0 }, pages_translated: { $gt: 0 } },
-        { resource_type: { $exists: true } },
+        { resource_type: { $exists: true }, hidden: { $ne: true } },
       ],
     };
   // Provider filter — restrict to a specific library's books.
@@ -262,7 +263,7 @@ async function fetchCollectionData(id: string, provider?: string) {
     ? withTimeout(
       db.collection('books')
         .find(
-          { collections: id, resource_type: { $exists: true } },
+          { collections: id, resource_type: { $exists: true }, hidden: { $ne: true } },
           {
             projection: {
               _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1,
@@ -289,6 +290,7 @@ async function fetchCollectionData(id: string, provider?: string) {
       const artFilter = {
         collections: id,
         resource_type: { $exists: true, $nin: ART_EXCLUDED_RESOURCE_TYPES },
+        hidden: { $ne: true },
       };
       const [docs, artCount] = await Promise.all([
         withTimeout(
@@ -762,7 +764,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         fill
                         sizes="(max-width: 640px) 50vw, 25vw"
                         className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
-                        unoptimized
+                        unoptimized={heroUrl.includes('images.sourcelibrary.org')}
                       />
                     ) : (
                       <div className="absolute inset-0 bg-gradient-to-br from-[#3d3529] to-[#2a2318]" />
@@ -823,7 +825,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         fill
                         className="object-cover group-hover:scale-105 transition-transform duration-300"
                         sizes="(min-width: 1024px) 200px, (min-width: 640px) 160px, 120px"
-                        unoptimized
+                        unoptimized={thumb.includes('images.sourcelibrary.org')}
                       />
                     )}
                     <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2 pt-6 opacity-0 group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
## Summary
- Filter `hidden: { $ne: true }` in all SSR art collection queries — stops hidden artworks (duplicates, exhibition photos, tourist shots) from appearing in grids. Affects all 26 art collections.
- Make `unoptimized` conditional in CollectionImageCard and collection page — only bypass Next.js optimization for pre-generated R2 thumbnails. Fallback URLs get proper optimization.

Part of #1567 (collection recuration).

## Test plan
- [ ] Visit /collections/school-of-athens — should show ~43 visible artworks, no exhibition photos or duplicates
- [ ] Visit /collections/thought-forms — should show 7 items, not 14
- [ ] Visit /collections/erotic-art — hidden duplicates should not appear
- [ ] Gallery collection images should still load fast (R2 thumbs bypass optimization, fallbacks get optimized)

Generated with [Claude Code](https://claude.com/claude-code)