### PR TITLE
Show full artwork images instead of cropping to viewport

### DIFF
--- a/src/components/artwork/ArtworkHero.tsx
+++ b/src/components/artwork/ArtworkHero.tsx
@@ -76,28 +76,23 @@ export default function ArtworkHero({ imageUrl, thumbUrl, hiResUrl, title, fullR
 
   return (
     <div
-      className="bg-black relative group/hero overflow-hidden"
-      style={{ maxHeight: fitWidth ? 'none' : 'calc(100vh - 64px)' }}
+      className="bg-black relative group/hero"
       onMouseEnter={() => setShowChrome(true)}
       onMouseLeave={() => setShowChrome(false)}
     >
       {/* Image container — viewport-height by default, natural proportions */}
-      <div className="flex items-center justify-center" style={{ minHeight: 'calc(100vh - 64px)' }}>
-        <div
-          className={`relative ${fitWidth ? 'w-full' : 'max-h-[calc(100vh-64px)]'}`}
-          style={fitWidth ? undefined : { maxWidth: '100%' }}
-        >
+      <div className="flex items-center justify-center" style={{ minHeight: fitWidth ? undefined : 'calc(100vh - 64px)' }}>
           <ImageWithMagnifier
             src={displaySrc}
             thumbnail={displaySrc}
             highResSrc={magnifierSrc}
             alt={title}
-            className={`${fitWidth ? 'w-full h-auto' : 'max-h-[calc(100vh-64px)] w-auto'} mx-auto`}
+            className={`${fitWidth ? 'w-full' : ''} mx-auto`}
+            imgClassName={fitWidth ? 'w-full' : 'max-h-[calc(100vh-64px)]'}
             magnifierSize={240}
             zoomLevel={3}
             darkMode
           />
-        </div>
       </div>
 
       {/* Fit toggle — appears on hover */}

--- a/src/components/ui/ImageWithMagnifier.tsx
+++ b/src/components/ui/ImageWithMagnifier.tsx
@@ -15,6 +15,7 @@ interface ImageWithMagnifierProps {
   fallbackSrc?: string; // Fallback if src fails to load (e.g. on-the-fly crop URL)
   darkMode?: boolean; // Dark skeleton/background for lightbox contexts
   onLoad?: () => void; // Called when the display image finishes loading
+  imgClassName?: string; // Override default img sizing classes (replaces h-full object-contain)
 }
 
 // Magnifier component for zooming into the source image
@@ -32,6 +33,7 @@ export default function ImageWithMagnifier({
   fallbackSrc,
   darkMode = false,
   onLoad,
+  imgClassName,
 }: ImageWithMagnifierProps) {
   const [showMagnifier, setShowMagnifier] = useState(false);
   const [magnifierPosition, setMagnifierPosition] = useState({ x: 0, y: 0 });
@@ -127,8 +129,8 @@ export default function ImageWithMagnifier({
 
     if (!naturalWidth || !naturalHeight) return { width: rect.width, height: rect.height };
 
-    if (scrollable) {
-      // Scrollable: image fills width, no object-contain — element box = content area
+    if (scrollable || imgClassName) {
+      // No object-contain — element box = content area
       return { width: rect.width, height: rect.height };
     }
 
@@ -261,7 +263,7 @@ export default function ImageWithMagnifier({
           src={displaySrc}
           alt={alt}
           loading="eager"
-          className={`w-full max-w-full transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'} ${isTouchDevice ? 'cursor-pointer' : 'cursor-crosshair'} ${scrollable ? '' : 'h-full object-contain'}`}
+          className={`max-w-full transition-opacity duration-300 ${isLoaded ? 'opacity-100' : 'opacity-0'} ${isTouchDevice ? 'cursor-pointer' : 'cursor-crosshair'} ${imgClassName ? imgClassName : scrollable ? 'w-full' : 'w-full h-full object-contain'}`}
           onLoad={() => {
             // Detect broken/tiny images (e.g. corrupt Blob uploads)
             // Real gallery crops are 300px+ wide; corrupt ones come through ≤150px


### PR DESCRIPTION
## Summary
- Removes `overflow-hidden` + `maxHeight` from artwork hero container (added in 6990d607) which was clipping all images to a viewport-sized box
- Constrains the `<img>` element directly via `max-h-[calc(100vh-64px)]` so images display at their natural aspect ratio, capped at viewport height — no cropping
- Adds `imgClassName` prop to `ImageWithMagnifier` for callers that need custom img sizing

Fixes the issue where artwork pages always showed a zoomed-in crop instead of the full image.

## Test plan
- [ ] Check portrait artwork (e.g. tall painting) — should show full image, not cropped
- [ ] Check landscape artwork — should fill width, height fits naturally
- [ ] Check square artwork — should show fully
- [ ] Click "Full width" toggle — image fills viewport width
- [ ] Magnifier still works correctly on hover
- [ ] Reading room pages unchanged (uses default h-full object-contain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)