### PR TITLE
Sort book collections by relevance rank instead of popularity

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -311,12 +311,29 @@ async function fetchCollectionData(id: string, provider?: string) {
       return docs;
     }
 
+    // Use MongoDB with collection-specific ranking for the initial display.
+    // book_collection_rank combines relevance, quality, completeness, and engagement.
+    // Falls back to Supabase popular sort if MongoDB fails.
+    try {
+      const docs = await withTimeout(
+        db.collection('books')
+          .find(filter, { projection, maxTimeMS: 8000 })
+          .sort({ [`book_collection_rank.${id}`]: -1, read_count: -1, title: 1 })
+          .limit(COMPACT_LIMIT)
+          .toArray(),
+        15000, [],
+      );
+      if (docs.length > 0) return docs;
+    } catch {
+      // Fall through to Supabase
+    }
+
     try {
       const { books: sbBooks } = await browseBooks({
         collection: id,
         sort: 'popular',
         limit: COMPACT_LIMIT,
-        skipCount: true, // collection.book_count is cached — skip expensive Supabase count
+        skipCount: true,
         hasPages: isArtCollection ? false : undefined,
         hasResourceType: isArtCollection || undefined,
         provider: provider || undefined,
@@ -333,17 +350,7 @@ async function fetchCollectionData(id: string, provider?: string) {
         resource_type: b.resource_type,
       }));
     } catch {
-      // MongoDB fallback — if Supabase is down
-      console.warn(`[Collection ${id}] Supabase books query failed, falling back to MongoDB`);
-      const docs = await withTimeout(
-        db.collection('books')
-          .find(filter, { projection, maxTimeMS: 8000 })
-          .sort({ read_count: -1, title: 1 })
-          .limit(COMPACT_LIMIT)
-          .toArray(),
-        15000, [],
-      );
-      return docs;
+      return [];
     }
   }
 


### PR DESCRIPTION
## Summary
Collection page initial book display now sorts by `book_collection_rank` (MongoDB) instead of `read_count` (Supabase). Falls back to Supabase popular sort if MongoDB fails or returns empty.

36,346 book-collection rank pairs precomputed across 224 collections. Score (0-100) combines relevance to collection theme (40%), quality score (30%), translation completeness (20%), and engagement (10%).

Part of #1567 (collection recuration).

## Test plan
- [ ] Visit /collections/optics — Ars Magna Lucis et Umbrae should lead
- [ ] Visit /collections/freemasonry — masonic texts should outrank tangentially related philosophy
- [ ] Visit /collections/alchemy — Musaeum Hermeticum should appear early
- [ ] Verify fallback: if rank field is missing, page still loads (Supabase fallback)

Generated with [Claude Code](https://claude.com/claude-code)