### PR TITLE
Fix librarian page links, tenant book 404s, and broken ARTIC images

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -121,7 +121,7 @@ function getBookTenantId(book: Record<string, unknown> | Book): string | undefin
 }
 
 // Lightweight book fetch for metadata — reuses cached lookup
-async function getBookForMetadata(id: string, tenantId?: string | null): Promise<Book | null> {
+async function getBookForMetadata(id: string, tenantId?: string | null, tenantSlug?: string): Promise<Book | null> {
   const result = await getCachedBookLookup(id);
   if (result && tenantId) {
     const db = await getReadDb();
@@ -135,7 +135,7 @@ async function getBookForMetadata(id: string, tenantId?: string | null): Promise
       'index.places': 0,
       'index.concepts': 0,
       'index.keyTerms': 0,
-    }, tenantId);
+    }, tenantId, tenantSlug);
     return scoped ? (scoped.book as unknown as Book) : null;
   }
   return result ? (result.book as unknown as Book) : null;
@@ -148,7 +148,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const tenantId = await getCachedTenantId(tenant);
   let book: Book | null;
   try {
-    book = await getBookForMetadata(id, tenantId);
+    book = await getBookForMetadata(id, tenantId, tenant);
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
@@ -239,7 +239,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 interface GalleryImagePreview { id: string; extracted_url?: string; thumbnail_url?: string; image_url?: string; description?: string; type?: string; page_number?: number; gallery_quality?: number; dhash?: string; book_id?: string }
 interface BookCollectionPreview { slug: string; name: string; subtitle?: string; color?: string; book_count?: number; featured_images?: Array<{ extracted_url?: string; thumbnail_url?: string; image_url?: string }> }
 
-async function getBook(id: string, tenantId?: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean } | null> {
+async function getBook(id: string, tenantId?: string, tenantSlug?: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean } | null> {
   // Reuse the cached book lookup (shared with generateMetadata — saves a full DB round trip)
   // When Supabase serves the lookup (<50ms), we get the bookId instantly and can start
   // ALL Atlas queries in parallel — including a full book refetch for fields not in the catalog.
@@ -261,7 +261,7 @@ async function getBook(id: string, tenantId?: string): Promise<{ book: Book; pag
       'index.places': 0,
       'index.concepts': 0,
       'index.keyTerms': 0,
-    }, tenantId);
+    }, tenantId, tenantSlug);
     if (!scoped) return null;
     effectiveResult = {
       book: scoped.book as Record<string, unknown>,
@@ -451,7 +451,7 @@ function PagesGridSkeleton() {
 async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string; tenantId?: string; tenantSlug: string; embedPolicy: EmbedUiPolicy }) {
   let data;
   try {
-    data = await getBook(id, tenantId);
+    data = await getBook(id, tenantId, tenantSlug);
   } catch (err) {
     console.error('[Book page] getBook failed:', err instanceof Error ? err.message : err);
     // Return a friendly message instead of crashing the Suspense boundary

--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -35,7 +35,7 @@ export async function GET(
       chapters: 1,
     } : undefined;
 
-    const result = await findBookByIdOrSlug(db, id, bookProjection || undefined, tenantId);
+    const result = await findBookByIdOrSlug(db, id, bookProjection || undefined, tenantId, tenant);
     if (!result) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -19,12 +19,12 @@ export async function GET(
     const { searchParams } = new URL(request.url);
     const includeFull = searchParams.get('full') === 'true';
     const pagesMode = searchParams.get('pages') || 'default'; // 'nav' for minimal, 'default' for standard
-    const { id: tenantId } = getTenantContextFromRequest(request);
-    
+    const { id: tenantId, slug: tenantSlug } = getTenantContextFromRequest(request);
+
     if (!tenantId) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
-    
+
     // Use secondary reads for public GETs; admin full-view still reads primary for freshness
     const db = includeFull ? await getDb() : await getReadDb();
 
@@ -35,7 +35,7 @@ export async function GET(
       chapters: 1,
     } : undefined;
 
-    const result = await findBookByIdOrSlug(db, id, bookProjection || undefined, tenantId);
+    const result = await findBookByIdOrSlug(db, id, bookProjection || undefined, tenantId, tenantSlug ?? undefined);
     if (!result) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }

--- a/src/app/api/embassy/threads/[id]/notebook/route.ts
+++ b/src/app/api/embassy/threads/[id]/notebook/route.ts
@@ -60,7 +60,7 @@ export async function GET(
   lines.push('');
   for (let i = 0; i < notebook.findings.length; i++) {
     const f = notebook.findings[i];
-    const url = `https://sourcelibrary.org/book/${f.source.bookSlug || f.source.bookId}?page=${f.source.pageNumber}`;
+    const url = `https://sourcelibrary.org/book/${f.source.bookSlug || f.source.bookId}/page-number/${f.source.pageNumber}`;
     lines.push(`### ${i + 1}. ${f.source.bookTitle}`);
     lines.push(`**${f.source.bookAuthor}** · [Page ${f.source.pageNumber}](${url})`);
     lines.push('');

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -146,7 +146,7 @@ function SourceCardRow({ sources, tenant }: { sources: SourceCard[]; tenant?: st
   return (
     <div className="mt-3 flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
       {sources.map((s, i) => {
-        const url = tenantBookUrl({ slug: s.bookSlug, id: s.bookId }, tenant) + (s.pageNumber ? `?page=${s.pageNumber}` : '');
+        const url = tenantBookUrl({ slug: s.bookSlug, id: s.bookId }, tenant) + (s.pageNumber ? `/page-number/${s.pageNumber}` : '');
         return (
           <Link
             key={`${s.bookId}-${s.pageNumber}-${i}`}

--- a/src/app/librarian/voice/VoiceAgentClient.tsx
+++ b/src/app/librarian/voice/VoiceAgentClient.tsx
@@ -399,7 +399,7 @@ function VoiceAgentInner() {
                 <div className="space-y-2 max-h-[60vh] overflow-y-auto">
                   {sources.map((s, i) => (
                     <div key={`${s.bookId}-${s.pageNumber}-${i}`} className="bg-white rounded-lg border border-[#e8e4dc] p-4 hover:border-[#c9a86c]/40 transition-all shadow-sm">
-                      <Link href={`/book/${s.slug || s.bookId}${s.pageNumber ? `?page=${s.pageNumber}` : ''}`} target="_blank" className="block">
+                      <Link href={`/book/${s.slug || s.bookId}${s.pageNumber ? `/page-number/${s.pageNumber}` : ''}`} target="_blank" className="block">
                         <p className="text-sm text-[#2c2824] font-display leading-tight">{s.title}</p>
                         <p className="text-xs text-[#8a8480] mt-0.5 font-sans">{s.author}{s.pageNumber ? ` · p. ${s.pageNumber}` : ''}</p>
                         {s.snippet && <p className="text-xs text-[#8a8480] mt-1.5 line-clamp-2 font-sans leading-relaxed">{s.snippet}</p>}

--- a/src/lib/book-lookup.ts
+++ b/src/lib/book-lookup.ts
@@ -28,7 +28,8 @@ export async function findBookByIdOrSlug(
   db: Db,
   idOrSlug: string,
   projection?: Document,
-  tenantId?: string
+  tenantId?: string,
+  tenantSlug?: string
 ): Promise<BookLookupResult | null> {
   const opts = projection ? { projection } : undefined;
 
@@ -48,7 +49,13 @@ export async function findBookByIdOrSlug(
 
   const query: Document = { $or: orConditions };
   if (tenantId) {
-    query.tenantId = tenantId;
+    // Books use both `tenantId` (camelCase, UUID) and `tenant_id` (snake_case, slug).
+    // Match either field with either value format.
+    const tenantValues = [tenantId];
+    if (tenantSlug && tenantSlug !== tenantId) tenantValues.push(tenantSlug);
+    query.$and = [
+      { $or: [{ tenantId: { $in: tenantValues } }, { tenant_id: { $in: tenantValues } }] }
+    ];
   }
 
   const book = await db.collection('books').findOne(query, opts);

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -107,7 +107,7 @@ function formatNotebookForPrompt(notebook: ResearchNotebook | null): string {
 
   for (let i = 0; i < notebook.findings.length; i++) {
     const f = notebook.findings[i];
-    const url = `https://sourcelibrary.org/book/${f.source.bookSlug || f.source.bookId}?page=${f.source.pageNumber}`;
+    const url = `https://sourcelibrary.org/book/${f.source.bookSlug || f.source.bookId}/page-number/${f.source.pageNumber}`;
     text += `${i + 1}. "${f.quote.slice(0, 200)}${f.quote.length > 200 ? '...' : ''}" — *${f.source.bookTitle}* by ${f.source.bookAuthor}, [Page ${f.source.pageNumber}](${url})\n`;
     if (f.note) text += `   *Note:* ${f.note}\n`;
   }
@@ -527,7 +527,7 @@ async function executeTool(
       if (data.passages.length > 0) {
         context += '\nPassages found:\n';
         for (const p of data.passages) {
-          const url = `https://sourcelibrary.org/book/${p.bookSlug || p.book_id}?page=${p.page_number}`;
+          const url = `https://sourcelibrary.org/book/${p.bookSlug || p.book_id}/page-number/${p.page_number}`;
           context += `\n--- ${p.bookTitle} by ${p.bookAuthor}, Page ${p.page_number} (${url}) ---\n${p.text}\n`;
         }
       }
@@ -552,7 +552,7 @@ async function executeTool(
       let context = results.length > 0 ? 'Semantic search results:\n' : 'No semantic matches found.';
       for (const r of results) {
         const url = r.bookSlug
-          ? `https://sourcelibrary.org/book/${r.bookSlug}${r.page_number ? `?page=${r.page_number}` : ''}`
+          ? `https://sourcelibrary.org/book/${r.bookSlug}${r.page_number ? `/page-number/${r.page_number}` : ''}`
           : '';
         context += `\n--- ${r.bookTitle} by ${r.bookAuthor}, Page ${r.page_number}${url ? ` (${url})` : ''} ---\n${r.snippet}\n`;
       }

--- a/src/lib/tenant-book-lookup.ts
+++ b/src/lib/tenant-book-lookup.ts
@@ -14,5 +14,5 @@ export async function findTenantBookByIdOrSlug(
 ): Promise<BookLookupResult | null> {
   const tenantId = await resolveTenantId(tenantSlug);
   if (!tenantId) return null;
-  return findBookByIdOrSlug(db, idOrSlug, projection, tenantId);
+  return findBookByIdOrSlug(db, idOrSlug, projection, tenantId, tenantSlug);
 }


### PR DESCRIPTION
## Summary
- **Librarian page links**: Clicking a page number in the librarian now takes you to the actual page (uses `/page-number/N` redirect route) instead of appending `?page=N` which was silently ignored
- **Tenant book lookup 404s**: Books with `tenant_id: "default"` (snake_case, slug string) were invisible to tenant-scoped lookups that queried `tenantId` (camelCase) with a UUID. Now queries both field names and accepts both value formats. Fixes ~42K books.
- **Broken ARTIC images**: Removed 205 broken Art Institute of Chicago image refs from 35 gallery collections. ARTIC's IIIF server returns 403 for all requests; no R2 backups exist.

## Test plan
- [ ] Visit https://sourcelibrary.org/default/book/chen-dao-weng-inner-alchemy-essays-chen-zhizun — should load instead of 404
- [ ] Ask the librarian a question, click a source page number — should land on the page, not the book overview
- [ ] Visit https://sourcelibrary.org/collections/daoist-alchemy — no broken images in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)