### PR TITLE
Fix normalizeRole to map legacy inner_circle/curator roles

### DIFF
--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -11,6 +11,7 @@ function normalizeRole(role: unknown): Role {
     return role;
   }
   // Backward compatibility with older role labels.
+  if (role === 'inner_circle' || role === 'curator') return 'editor';
   if (role === 'user') return 'reader';
   return 'reader';
 }


### PR DESCRIPTION
## Summary
- Legacy role labels `inner_circle` and `curator` were not mapped in `normalizeRole()`, causing them to fall through to `reader`
- This broke cover picker (and any other editor-gated PATCH) for users with these old roles in their session
- Maps both to `editor` which matches their intended permission level

## Context
Also added `PLATFORM_ADMIN_EMAILS=dereklomas@gmail.com` to Vercel env and inserted a superadmin membership record for Derek — the auth migration from `admin_users` to `memberships` collection had left the owner without proper access.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Sign out/in on sourcelibrary.org, verify cover picker works on BPH books

🤖 Generated with [Claude Code](https://claude.com/claude-code)