### PR TITLE
Fix AuthCheck to recognize superadmin and editor roles

### DIFF
--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -32,12 +32,14 @@ export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
   }
 
   const userRole = (session.user as any).role;
+  const ROLE_LEVEL: Record<string, number> = { reader: 1, inner_circle: 2, editor: 2, admin: 3, superadmin: 4 };
+  const level = ROLE_LEVEL[userRole] ?? 0;
 
-  if (role === 'admin' && userRole !== 'admin') {
+  if (role === 'admin' && level < 3) {
     return <>{fallback}</>;
   }
 
-  if (role === 'inner_circle' && userRole !== 'admin' && userRole !== 'inner_circle') {
+  if (role === 'inner_circle' && level < 2) {
     return <>{fallback}</>;
   }
 


### PR DESCRIPTION
## Summary
- `AuthCheck` only matched literal `admin` and `inner_circle` role strings
- `superadmin` users (like Derek after the memberships migration) saw no admin UI
- Switch to numeric role levels matching the backend `ROLE_LEVEL` system

Follows #1584 which fixed the backend `normalizeRole`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Sign in as superadmin, verify cover picker visible on BPH book pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)