### PR TITLE
Fix artwork progressive image loading

### DIFF
--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -68,8 +68,8 @@ interface ArtworkInfoProps {
 }
 
 export default function ArtworkInfo({ book, collections, prevWork, nextWork, relatedBooks = [] }: ArtworkInfoProps) {
-  const displayImage = (book as any).thumbnail_blob || book.thumbnail || '';
-  const thumbImage = book.thumbnail || '';
+  const displayImage = book.thumbnail || (book as any).thumbnail_blob || '';
+  const thumbImage = (book as any).thumbnail_blob || '';
   const commonsUrl = (book as any).commons_url || '';
   const commonsFullUrl = (book as any).commons_full_url || '';
   const commonsLicense = (book as any).commons_license || 'Public domain';


### PR DESCRIPTION
## Summary
- Artwork hero images were downgrading before upgrading: showed R2 1200px → switched to tiny thumb → then loaded Wikimedia original
- `displayImage` and `thumbImage` were swapped in ArtworkInfo
- Now correctly: tiny thumb (fast) → R2 1200px (medium) → Wikimedia original (full res for magnifier)

## Test plan
- [ ] Visit https://sourcelibrary.org/artwork/natgallery-london-philippe-de-champaigne-josefs-traum
- [ ] Verify image loads progressively without visible downgrade
- [ ] Magnifier should show full-res detail from Wikimedia original

🤖 Generated with [Claude Code](https://claude.com/claude-code)