### PR TITLE
Move collection tags from hero to content section

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -715,30 +715,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 </div>
               )}
 
-              {/* Collections — visible in both modes, clickable only when not embedded */}
-              {bookCollections.length > 0 && (
-                <div className="flex flex-wrap items-center gap-2 mt-3">
-                  {bookCollections.map(col =>
-                    embedPolicy.enableBookCollectionNavigation ? (
-                      <Link
-                        key={col.slug}
-                        href={`/collections/${col.slug}`}
-                        className="text-xs text-stone-400 hover:text-white bg-white/5 hover:bg-white/10 px-2.5 py-1 rounded-full transition-colors"
-                      >
-                        {col.name}
-                      </Link>
-                    ) : (
-                      <span
-                        key={col.slug}
-                        className="text-xs text-stone-400 bg-white/5 px-2.5 py-1 rounded-full"
-                      >
-                        {col.name}
-                      </span>
-                    )
-                  )}
-                </div>
-              )}
-
               {/* Dedication */}
               <div className="mt-3">
                 <BookDedication bookId={book.id} dedication={(book as any).dedication || null} />
@@ -997,6 +973,35 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   })}
                 </div>
               </div>
+            )}
+
+            {/* Collections */}
+            {bookCollections.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium mb-3" style={{ color: 'var(--text-secondary)' }}>Collections</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {bookCollections.map(col =>
+                      embedPolicy.enableBookCollectionNavigation ? (
+                        <Link
+                          key={col.slug}
+                          href={`/collections/${col.slug}`}
+                          className="text-xs px-2.5 py-1 rounded-full transition-colors"
+                          style={{ color: 'var(--text-secondary)', backgroundColor: 'var(--bg-tertiary)' }}
+                        >
+                          {col.name}
+                        </Link>
+                      ) : (
+                        <span
+                          key={col.slug}
+                          className="text-xs px-2.5 py-1 rounded-full"
+                          style={{ color: 'var(--text-secondary)', backgroundColor: 'var(--bg-tertiary)' }}
+                        >
+                          {col.name}
+                        </span>
+                      )
+                    )}
+                  </div>
+                </div>
             )}
 
             {/* Related Books — pre-computed, zero extra queries */}


### PR DESCRIPTION
## Summary
- Removes the collection tag chips from the book hero/header area
- Adds them as a "Collections" section below the book content, next to Related Books
- Cleaner hero, collection links are contextual navigation not primary metadata

## Test plan
- [ ] Check book page layout on desktop and mobile
- [ ] Verify collection links still work
- [ ] Check BPH tenant book pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)