### PR TITLE
Fix Cleveland CDN pattern in image archive scripts

### DIFF
--- a/scripts/archive-museum-gallery-images.mjs
+++ b/scripts/archive-museum-gallery-images.mjs
@@ -21,6 +21,7 @@ const EXTERNAL_PATTERNS = [
   'artic.edu',
   'images.metmuseum.org',
   'openaccess-api.clevelandart.org',
+  'openaccess-cdn.clevelandart.org',
 ];
 
 const UA = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@sourcelibrary.org) bot';

--- a/scripts/lint-external-images.mjs
+++ b/scripts/lint-external-images.mjs
@@ -15,6 +15,14 @@ import { MongoClient } from 'mongodb';
 
 const R2_DOMAIN = 'images.sourcelibrary.org';
 
+// Known external museum domains to flag
+const MUSEUM_DOMAINS = [
+  'artic.edu',
+  'images.metmuseum.org',
+  'openaccess-api.clevelandart.org',
+  'openaccess-cdn.clevelandart.org',
+];
+
 // Allowed external patterns (data URIs, placeholders, etc.)
 const ALLOWED_PATTERNS = [
   'data:image/',


### PR DESCRIPTION
## Summary

The Cleveland Museum of Art uses `openaccess-cdn.clevelandart.org` (not `openaccess-api`). Fixes the pattern in both the archive script and lint script.

Follow-up to #1590. All 26 Cleveland images already archived successfully using the corrected pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)