### PR TITLE
Add client-side broken image reporter

### DIFF
--- a/src/app/api/analytics/broken-image/route.ts
+++ b/src/app/api/analytics/broken-image/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * Log broken image reports from the client.
+ * Fire-and-forget — never fails to the client.
+ *
+ * POST /api/analytics/broken-image
+ * Body: { urls: string[], page: string, timestamp: string }
+ */
+const DB_TIMEOUT_MS = 3000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const { urls, page, timestamp } = await request.json();
+    if (!Array.isArray(urls) || urls.length === 0) {
+      return NextResponse.json({ ok: true });
+    }
+
+    // Cap at 20 per report to prevent abuse
+    const capped = urls.slice(0, 20);
+
+    const ua = request.headers.get('user-agent') || '';
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+
+    const dbWork = (async () => {
+      const db = await getDb();
+      await db.collection('broken_image_reports').insertOne({
+        urls: capped,
+        page,
+        reported_at: timestamp ? new Date(timestamp) : new Date(),
+        ip: ip.replace(/\.\d+$/, '.0'), // anonymize last octet
+        ua: ua.slice(0, 200),
+        created_at: new Date(),
+      });
+    })();
+
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), DB_TIMEOUT_MS)
+    );
+
+    await Promise.race([dbWork, timeout]);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
 import PageTracker from "@/components/reader/PageTracker";
+import BrokenImageReporter from "@/components/BrokenImageReporter";
 import SiteModeIndicator from "@/components/providers/SiteModeIndicator";
 import ClientToaster from "@/components/providers/ClientToaster";
 import CookieConsent from "@/components/providers/CookieConsent";
@@ -113,7 +114,7 @@ export default async function RootLayout({
         <CookieConsent />
         <AnalyticsScripts />
         <PageTracker />
-
+        <BrokenImageReporter />
       </body>
     </html>
   );

--- a/src/components/BrokenImageReporter.tsx
+++ b/src/components/BrokenImageReporter.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Global broken image reporter. Listens for image load errors
+ * across the entire page and reports them to the analytics endpoint.
+ *
+ * Debounces and deduplicates: reports at most one batch per page load,
+ * and never reports the same URL twice per session.
+ */
+
+const reported = new Set<string>();
+let pending: string[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flush() {
+  if (pending.length === 0) return;
+  const urls = [...pending];
+  pending = [];
+  flushTimer = null;
+
+  // Fire and forget — never block UI
+  fetch('/api/analytics/broken-image', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      urls,
+      page: window.location.pathname,
+      timestamp: new Date().toISOString(),
+    }),
+  }).catch(() => {}); // swallow errors
+}
+
+function handleError(e: Event) {
+  const el = e.target;
+  if (!(el instanceof HTMLImageElement)) return;
+
+  const src = el.currentSrc || el.src;
+  if (!src || reported.has(src)) return;
+
+  // Only report images from our own domain
+  if (!src.includes('images.sourcelibrary.org') && !src.includes('/api/image')) return;
+
+  reported.add(src);
+  pending.push(src);
+
+  // Batch: wait 2s after last error to flush (catches cascading failures)
+  if (flushTimer) clearTimeout(flushTimer);
+  flushTimer = setTimeout(flush, 2000);
+}
+
+export default function BrokenImageReporter() {
+  useEffect(() => {
+    // Capture phase so we catch errors before any component swallows them
+    document.addEventListener('error', handleError, true);
+    return () => document.removeEventListener('error', handleError, true);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Global `BrokenImageReporter` component captures all image load errors via document-level error listener (capture phase)
- Reports to `/api/analytics/broken-image` which logs to `broken_image_reports` MongoDB collection
- Only tracks failures on `images.sourcelibrary.org` — ignores external images

## How it works
- Uses `document.addEventListener('error', handler, true)` to catch failures before components swallow them
- Deduplicates per session (Set of reported URLs)
- Batches with 2s debounce to catch cascading failures
- Caps at 20 URLs per report
- Fire-and-forget on both client and server

## Querying reports
```js
db.broken_image_reports.find().sort({ created_at: -1 }).limit(20)
```

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Deploy, browse a few collection pages, check `broken_image_reports` collection

Generated with [Claude Code](https://claude.com/claude-code)