### PR TITLE
Auto-report 404 page hits

### DIFF
--- a/src/app/api/analytics/not-found/route.ts
+++ b/src/app/api/analytics/not-found/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+
+/**
+ * Auto-log 404 page hits.
+ * Fire-and-forget — never fails to the client.
+ *
+ * POST /api/analytics/not-found
+ * Body: { url: string, referrer?: string }
+ */
+const DB_TIMEOUT_MS = 3000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const { url, referrer } = await request.json();
+    if (!url || typeof url !== 'string') {
+      return NextResponse.json({ ok: true });
+    }
+
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const ua = request.headers.get('user-agent') || '';
+
+    const dbWork = (async () => {
+      const db = await getDb();
+
+      // Deduplicate: same URL + IP within 1 hour
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const anonIp = ip.replace(/\.\d+$/, '.0');
+
+      await db.collection('not_found_reports').findOneAndUpdate(
+        { url, ip: anonIp, created_at: { $gte: oneHourAgo } },
+        {
+          $setOnInsert: {
+            url,
+            referrer: referrer || null,
+            ip: anonIp,
+            ua: ua.slice(0, 200),
+            created_at: new Date(),
+          },
+          $inc: { hit_count: 1 },
+        },
+        { upsert: true },
+      );
+    })();
+
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), DB_TIMEOUT_MS)
+    );
+
+    await Promise.race([dbWork, timeout]);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+}

--- a/src/components/layout/NotFoundContent.tsx
+++ b/src/components/layout/NotFoundContent.tsx
@@ -66,6 +66,15 @@ export default function NotFoundContent() {
 
   useEffect(() => {
     setQuote(QUOTES[Math.floor(Math.random() * QUOTES.length)]);
+
+    // Auto-report the 404 — fire and forget
+    const url = window.location.pathname + window.location.search;
+    const referrer = document.referrer || undefined;
+    fetch('/api/analytics/not-found', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, referrer }),
+    }).catch(() => {});
   }, []);
 
   const handleSearch = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- 404 page now auto-logs the URL + referrer to `not_found_reports` collection on mount
- Deduplicates: same URL + anonymized IP within 1 hour, increments `hit_count`
- Fire-and-forget on both client and server

## Query
```js
// Top 404s
db.not_found_reports.aggregate([
  { $group: { _id: "$url", total: { $sum: "$hit_count" } } },
  { $sort: { total: -1 } },
  { $limit: 20 }
])

// Recent with referrers
db.not_found_reports.find({ referrer: { $ne: null } }).sort({ created_at: -1 }).limit(20)
```

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Visit a non-existent URL, check `not_found_reports` collection

Generated with [Claude Code](https://claude.com/claude-code)