### PR TITLE
Add editor collection API for external curators

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,11 @@
       "mcp__claude-conversation-search__summarize_session",
       "mcp__claude-conversation-search__get_session_messages",
       "mcp__claude-conversation-search__reindex",
-      "mcp__claude-conversation-search__get_messages"
+      "mcp__claude-conversation-search__get_messages",
+      "mcp__claude_ai_Source_Library__search_translations",
+      "mcp__claude_ai_Source_Library__search_within_book",
+      "mcp__claude_ai_Source_Library__search_library",
+      "mcp__claude_ai_Source_Library__get_book_text"
     ]
   }
 }

--- a/.claude/skills/curate-collection-editor.md
+++ b/.claude/skills/curate-collection-editor.md
@@ -1,0 +1,78 @@
+# Collection Curator Skill (Editor)
+
+Create and curate Source Library collections via the editor API.
+
+## Setup
+
+Set your API key as an environment variable:
+```
+export SL_API_KEY="sl_editor_..."
+```
+
+## Workflow
+
+### 1. Research — Find books for the collection
+Use the Source Library MCP tools to search:
+- `search_library` — find books by topic
+- `get_book` — check a specific book's details
+- `search_within_book` — verify content relevance
+
+### 2. Create — Make the collection
+```bash
+curl -X POST https://sourcelibrary.org/api/editor/collections \
+  -H "Authorization: Bearer $SL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Collection Name",
+    "description": "A concise description of the collection.",
+    "subtitle": "One-line summary for card display",
+    "parent": "parent-collection-slug",
+    "bookIds": ["book-id-1", "book-id-2"]
+  }'
+```
+
+Response includes a `preview_url` — open it to see the draft.
+
+### 3. Curate — Add highlights and editorial content
+```bash
+curl -X PATCH https://sourcelibrary.org/api/editor/collections \
+  -H "Authorization: Bearer $SL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "slug": "collection-slug",
+    "expanded_description": "Longer editorial prose about the collection...",
+    "highlighted_books": [
+      {"book_id": "id", "tier": 1, "rank": 1, "title": "Start Here Book", "note": "Why this is essential"},
+      {"book_id": "id", "tier": 2, "rank": 2, "title": "Essential Reading"},
+      {"book_id": "id", "tier": 3, "rank": 3, "title": "Also Notable"}
+    ],
+    "addBookIds": ["more-book-id"],
+    "removeBookIds": ["wrong-book-id"]
+  }'
+```
+
+### 4. Publish — Make it live
+```bash
+curl -X POST https://sourcelibrary.org/api/editor/collections/SLUG/publish \
+  -H "Authorization: Bearer $SL_API_KEY"
+```
+
+Validates the collection has a name, description, and at least one book before publishing.
+
+### 5. List your collections
+```bash
+curl https://sourcelibrary.org/api/editor/collections \
+  -H "Authorization: Bearer $SL_API_KEY"
+```
+
+## Highlight tiers
+- **Tier 1**: "Start here" — the single most important book, shown prominently
+- **Tier 2**: "Essential Reading" — 3-5 core texts
+- **Tier 3**: "Also Notable" — 5-10 additional works
+
+## Tips
+- Collections start as drafts (`visible: false`) — preview at the URL before publishing
+- The slug is auto-generated from the name but can be overridden
+- Featured images are auto-picked from book illustrations
+- Use `parent` to place the collection as a subcollection
+- You can only edit collections you created

--- a/src/app/api/editor/collections/[slug]/publish/route.ts
+++ b/src/app/api/editor/collections/[slug]/publish/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { authenticateEditor, checkCollectionOwnership } from '@/lib/editor-auth';
+import { revalidatePath } from 'next/cache';
+
+export const maxDuration = 15;
+
+/**
+ * POST /api/editor/collections/[slug]/publish
+ * Make a draft collection visible. Validates minimum requirements.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const auth = await authenticateEditor(request, 'collections:write');
+  if (auth instanceof NextResponse) return auth;
+
+  const { slug } = await params;
+
+  const { owned, collection } = await checkCollectionOwnership(slug, auth);
+  if (!collection) {
+    return NextResponse.json({ error: `Collection "${slug}" not found` }, { status: 404 });
+  }
+  if (!owned) {
+    return NextResponse.json({ error: 'You can only publish collections you created' }, { status: 403 });
+  }
+
+  // Validate minimum requirements
+  const issues: string[] = [];
+  if (!collection.name) issues.push('name is required');
+  if (!collection.description && !collection.expanded_description) issues.push('description is required');
+
+  const db = await getDb();
+  const bookCount = await db.collection('books').countDocuments({
+    collections: slug, deleted: { $ne: true },
+  });
+  if (bookCount === 0) issues.push('at least one book must be assigned');
+
+  if (issues.length > 0) {
+    return NextResponse.json({
+      error: 'Collection is not ready to publish',
+      issues,
+    }, { status: 400 });
+  }
+
+  // Auto-backfill featured_images if missing
+  const fi = collection.featured_images;
+  if (!fi || fi.length < 3) {
+    const bookIds = await db.collection('books').distinct('id', {
+      collections: slug, deleted: { $ne: true },
+    });
+    const gallery = await db.collection('gallery_images').find({
+      book_id: { $in: bookIds },
+      gallery_quality: { $gte: 0.7 },
+      $or: [{ thumbnail_url: { $exists: true, $ne: null } }, { extracted_url: { $exists: true, $ne: null } }],
+    }).sort({ gallery_quality: -1 }).limit(6).project({
+      thumbnail_url: 1, extracted_url: 1, image_url: 1, description: 1, book_title: 1, book_id: 1,
+    }).toArray();
+
+    if (gallery.length > 0) {
+      await db.collection('collections').updateOne({ slug }, {
+        $set: { featured_images: gallery },
+      });
+    }
+  }
+
+  await db.collection('collections').updateOne({ slug }, {
+    $set: {
+      visible: true,
+      book_count: bookCount,
+      published_at: new Date(),
+      updated_at: new Date(),
+    },
+  });
+
+  // Bust ISR cache
+  try {
+    revalidatePath('/collections');
+    revalidatePath(`/collections/${slug}`);
+  } catch {
+    // revalidatePath may fail outside request context
+  }
+
+  return NextResponse.json({
+    success: true,
+    slug,
+    url: `https://sourcelibrary.org/collections/${slug}`,
+    book_count: bookCount,
+  });
+}

--- a/src/app/api/editor/collections/route.ts
+++ b/src/app/api/editor/collections/route.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { authenticateEditor, checkCollectionOwnership } from '@/lib/editor-auth';
+
+export const maxDuration = 30;
+
+/**
+ * GET /api/editor/collections
+ * List collections created by the authenticated editor.
+ */
+export async function GET(request: NextRequest) {
+  const auth = await authenticateEditor(request, 'collections:read');
+  if (auth instanceof NextResponse) return auth;
+
+  const db = await getDb();
+  const { searchParams } = new URL(request.url);
+  const all = searchParams.get('all') === 'true' && (auth.role === 'admin' || auth.role === 'superadmin');
+
+  const filter = all ? {} : { created_by: auth.email };
+  const collections = await db.collection('collections')
+    .find(filter)
+    .project({ _id: 0, slug: 1, name: 1, subtitle: 1, visible: 1, book_count: 1, artwork_count: 1, created_by: 1, created_at: 1, health_score: 1 })
+    .sort({ created_at: -1 })
+    .toArray();
+
+  return NextResponse.json({ collections });
+}
+
+/**
+ * POST /api/editor/collections
+ * Create a new collection. Starts as draft (visible: false).
+ *
+ * Body: { name, slug?, description?, subtitle?, parent?, bookIds?: string[] }
+ */
+export async function POST(request: NextRequest) {
+  const auth = await authenticateEditor(request, 'collections:write');
+  if (auth instanceof NextResponse) return auth;
+
+  const body = await request.json();
+  const { name, description, subtitle, parent, bookIds } = body;
+
+  if (!name) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+
+  // Generate slug from name
+  const slug = body.slug || name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 60);
+
+  const db = await getDb();
+
+  // Check uniqueness
+  const existing = await db.collection('collections').findOne({ slug });
+  if (existing) {
+    return NextResponse.json({ error: `Collection "${slug}" already exists` }, { status: 409 });
+  }
+
+  // Validate parent exists if specified
+  if (parent) {
+    const parentCol = await db.collection('collections').findOne({ slug: parent });
+    if (!parentCol) {
+      return NextResponse.json({ error: `Parent collection "${parent}" not found` }, { status: 400 });
+    }
+  }
+
+  // Tag books
+  let booksTagged = 0;
+  const languages: { lang: string; count: number }[] = [];
+
+  if (bookIds?.length) {
+    const result = await db.collection('books').updateMany(
+      { $or: [{ id: { $in: bookIds } }, { slug: { $in: bookIds } }], deleted: { $ne: true } },
+      { $addToSet: { collections: slug } }
+    );
+    booksTagged = result.modifiedCount;
+
+    // Compute languages
+    const langAgg = await db.collection('books').aggregate([
+      { $match: { collections: slug, deleted: { $ne: true }, language: { $exists: true, $ne: null } } },
+      { $group: { _id: '$language', count: { $sum: 1 } } },
+      { $match: { _id: { $nin: ['Unknown', 'Visual', 'undefined', ''] }, count: { $gte: 1 } } },
+      { $sort: { count: -1 } },
+    ]).toArray();
+    langAgg.forEach(l => languages.push({ lang: l._id, count: l.count }));
+  }
+
+  const bookCount = await db.collection('books').countDocuments({
+    collections: slug, deleted: { $ne: true },
+  });
+
+  // Auto-pick featured images from gallery
+  let featured_images: any[] = [];
+  if (bookIds?.length) {
+    const gallery = await db.collection('gallery_images').find({
+      book_id: { $in: bookIds },
+      gallery_quality: { $gte: 0.7 },
+      $or: [{ thumbnail_url: { $exists: true, $ne: null } }, { extracted_url: { $exists: true, $ne: null } }],
+    }).sort({ gallery_quality: -1 }).limit(6).project({
+      thumbnail_url: 1, extracted_url: 1, image_url: 1, description: 1, book_title: 1, book_id: 1,
+    }).toArray();
+    featured_images = gallery;
+  }
+
+  const now = new Date();
+  const doc = {
+    slug,
+    name,
+    subtitle: subtitle || '',
+    description: description || '',
+    expanded_description: description || '',
+    parent: parent || undefined,
+    visible: false, // Always start as draft
+    book_count: bookCount,
+    languages,
+    featured_images,
+    created_by: auth.email,
+    created_at: now,
+    updated_at: now,
+  };
+
+  await db.collection('collections').insertOne(doc);
+
+  const previewUrl = `https://sourcelibrary.org/collections/${slug}`;
+
+  return NextResponse.json({
+    success: true,
+    slug,
+    preview_url: previewUrl,
+    books_tagged: booksTagged,
+    featured_images: featured_images.length,
+  }, { status: 201 });
+}
+
+/**
+ * PATCH /api/editor/collections
+ * Update a collection the editor owns.
+ *
+ * Body: { slug, name?, description?, subtitle?, expanded_description?, highlighted_books?, addBookIds?, removeBookIds? }
+ */
+export async function PATCH(request: NextRequest) {
+  const auth = await authenticateEditor(request, 'collections:write');
+  if (auth instanceof NextResponse) return auth;
+
+  const body = await request.json();
+  const { slug, addBookIds, removeBookIds, ...fields } = body;
+
+  if (!slug) {
+    return NextResponse.json({ error: 'slug is required' }, { status: 400 });
+  }
+
+  // Ownership check
+  const { owned, collection } = await checkCollectionOwnership(slug, auth);
+  if (!collection) {
+    return NextResponse.json({ error: `Collection "${slug}" not found` }, { status: 404 });
+  }
+  if (!owned) {
+    return NextResponse.json({ error: 'You can only edit collections you created' }, { status: 403 });
+  }
+
+  const db = await getDb();
+  const updates: Record<string, any> = { updated_at: new Date() };
+
+  // Safe fields that editors can update
+  const allowedFields = ['name', 'subtitle', 'description', 'expanded_description', 'highlighted_books', 'parent'];
+  for (const key of allowedFields) {
+    if (fields[key] !== undefined) updates[key] = fields[key];
+  }
+
+  // Add books
+  if (addBookIds?.length) {
+    await db.collection('books').updateMany(
+      { $or: [{ id: { $in: addBookIds } }, { slug: { $in: addBookIds } }], deleted: { $ne: true } },
+      { $addToSet: { collections: slug } }
+    );
+  }
+
+  // Remove books
+  if (removeBookIds?.length) {
+    await db.collection('books').updateMany(
+      { $or: [{ id: { $in: removeBookIds } }, { slug: { $in: removeBookIds } }] },
+      { $pull: { collections: slug } as any }
+    );
+  }
+
+  // Recount
+  if (addBookIds?.length || removeBookIds?.length) {
+    updates.book_count = await db.collection('books').countDocuments({
+      collections: slug, deleted: { $ne: true },
+    });
+
+    // Refresh languages
+    const langAgg = await db.collection('books').aggregate([
+      { $match: { collections: slug, deleted: { $ne: true }, language: { $exists: true, $ne: null } } },
+      { $group: { _id: '$language', count: { $sum: 1 } } },
+      { $match: { _id: { $nin: ['Unknown', 'Visual', 'undefined', ''] }, count: { $gte: 1 } } },
+      { $sort: { count: -1 } },
+    ]).toArray();
+    updates.languages = langAgg.map((l: any) => ({ lang: l._id, count: l.count }));
+  }
+
+  await db.collection('collections').updateOne({ slug }, { $set: updates });
+
+  return NextResponse.json({ success: true, slug, updated: Object.keys(updates) });
+}

--- a/src/lib/editor-auth.ts
+++ b/src/lib/editor-auth.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from './mongodb';
+
+export interface EditorContext {
+  email: string;
+  userId: string;
+  role: string;
+  scopes: string[];
+}
+
+/**
+ * Authenticate an editor API request via Bearer token (API key).
+ * Returns the editor context or a 401/403 response.
+ */
+export async function authenticateEditor(
+  request: NextRequest,
+  requiredScope: string
+): Promise<EditorContext | NextResponse> {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json(
+      { error: 'Missing Authorization header. Use: Bearer <api_key>' },
+      { status: 401 }
+    );
+  }
+
+  const key = authHeader.slice(7);
+  const db = await getDb();
+
+  const apiKey = await db.collection('api_keys').findOne({
+    key,
+    active: true,
+  });
+
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Invalid or inactive API key' }, { status: 401 });
+  }
+
+  if (!apiKey.scopes?.includes(requiredScope)) {
+    return NextResponse.json(
+      { error: `API key lacks required scope: ${requiredScope}` },
+      { status: 403 }
+    );
+  }
+
+  return {
+    email: apiKey.email,
+    userId: apiKey.userId,
+    role: apiKey.role,
+    scopes: apiKey.scopes,
+  };
+}
+
+/**
+ * Check if an editor owns a collection (created_by matches their email).
+ * Admins bypass this check.
+ */
+export async function checkCollectionOwnership(
+  slug: string,
+  editor: EditorContext
+): Promise<{ owned: boolean; collection: any | null }> {
+  const db = await getDb();
+  const col = await db.collection('collections').findOne({ slug });
+
+  if (!col) return { owned: false, collection: null };
+
+  // Admins can edit any collection
+  if (editor.role === 'admin' || editor.role === 'superadmin') {
+    return { owned: true, collection: col };
+  }
+
+  // Editors can only edit collections they created
+  if (col.created_by === editor.email) {
+    return { owned: true, collection: col };
+  }
+
+  return { owned: false, collection: col };
+}


### PR DESCRIPTION
## Summary
API key-authenticated endpoints that let editors (like Mike Etherhill) create and curate collections without needing repo access, env vars, or Vercel deploys.

Closes #1597

## Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/editor/collections` | editor | List own collections |
| POST | `/api/editor/collections` | editor | Create draft collection |
| PATCH | `/api/editor/collections` | editor | Update own collection |
| POST | `/api/editor/collections/[slug]/publish` | editor | Publish with validation |

## How it works
1. Editor gets an API key (stored in `api_keys` collection with scopes)
2. All requests use `Authorization: Bearer sl_editor_...`
3. Collections start as drafts (`visible: false`) — preview via direct URL
4. Publish validates: name + description + at least 1 book
5. Editors can only modify collections where `created_by` matches their email

## Security
- API key auth via `editor-auth.ts`, separate from session auth
- Scoped: `collections:read` and `collections:write`
- Ownership enforcement — editors can't touch other people's collections
- Admin/superadmin bypass ownership check
- Safe field allowlist on PATCH (can't set `visible`, `order`, etc. directly)

## For Mike
- API key created in DB
- Claude Code skill doc at `.claude/skills/curate-collection-editor.md`
- Uses existing Source Library MCP for search, editor API for writes

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Test create: `curl -X POST .../api/editor/collections -H "Authorization: Bearer KEY" -d '{"name":"Test"}'`
- [ ] Test publish validation rejects empty collections
- [ ] Test ownership: can't PATCH another editor's collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)