### PR TITLE
Strip tenant prefix from book URLs (fix ?page=N drop)

### DIFF
--- a/src/app/[tenant]/book/[id]/page-number/[num]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page-number/[num]/page.tsx
@@ -35,5 +35,5 @@ export default async function PageNumberRedirect({ params }: Props) {
   }
 
   const pageId = page.id || page._id?.toString();
-  redirect(`/${tenant}/book/${bookSlug}/page/${pageId}`);
+  redirect(`/book/${bookSlug}/page/${pageId}`);
 }

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -172,7 +172,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (description.length > 155) {
     description = `${title} by ${author}${year}`.slice(0, 152) + '...';
   }
-  const bookUrl = tenant ? `/${tenant}/book/${book.slug || book.id}` : `/book/${book.slug || book.id}`;
+  const bookUrl = `/book/${book.slug || book.id}`;
 
   // Get publication date for OG tags
   const currentEdition = (book.editions as TranslationEdition[] | undefined)?.find(e => e.status === 'published') || (book.editions as TranslationEdition[] | undefined)?.find(e => e.status === 'draft');
@@ -1024,7 +1024,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
               Pages
             </h2>
             <Link
-              href={`/${tenantSlug}/book/${book.slug || book.id}/overview`}
+              href={`/book/${book.slug || book.id}/overview`}
               className="text-sm text-stone-400 hover:text-accent-gold transition-colors flex items-center gap-1.5"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="opacity-70">

--- a/src/app/[tenant]/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/[tenant]/book/[id]/page/[pageId]/layout.tsx
@@ -71,7 +71,7 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 
   // Always use slug for canonical URL, even if accessed via hex ObjectId
   const bookPath = (book as unknown as { slug?: string }).slug || id;
-  const pageUrl = `/${tenant}/book/${bookPath}/page/${pageId}`;
+  const pageUrl = `/book/${bookPath}/page/${pageId}`;
 
   return {
     title: `${title} - Source Library`,

--- a/src/components/reader/BookOverview.tsx
+++ b/src/components/reader/BookOverview.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 interface OverviewPage {
   id: string;
@@ -60,8 +60,7 @@ export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: Boo
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
-  const params = useParams<{ tenant: string }>();
-  const tenantPrefix = params?.tenant ? `/${params.tenant}` : '';
+  // Book URLs are tenant-agnostic — the proxy resolves the tenant. No prefix here.
 
   // Camera state (not React state — updated every frame)
   const camRef = useRef({ x: 0, y: 0, zoom: 1 });
@@ -347,7 +346,7 @@ export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: Boo
           const idx = hitTest(sx, sy);
           if (idx >= 0) {
             const page = pagesWithImages[idx];
-            const bookPath = `${tenantPrefix}/book/${bookSlug || bookId}`;
+            const bookPath = `/book/${bookSlug || bookId}`;
             router.push(`${bookPath}/page/${page.id}`);
           }
         }
@@ -411,7 +410,7 @@ export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: Boo
           const idx = hitTest(sx, sy);
           if (idx >= 0) {
             const page = pagesWithImages[idx];
-            const bookPath = `${tenantPrefix}/book/${bookSlug || bookId}`;
+            const bookPath = `/book/${bookSlug || bookId}`;
             router.push(`${bookPath}/page/${page.id}`);
           }
         }
@@ -469,7 +468,7 @@ export default function BookOverview({ bookId, bookSlug, bookTitle, pages }: Boo
     dirtyRef.current = true;
   };
 
-  const bookPath = `${tenantPrefix}/book/${bookSlug || bookId}`;
+  const bookPath = `/book/${bookSlug || bookId}`;
 
   return (
     <div ref={containerRef} className="relative w-full h-[calc(100vh-56px)] bg-[#0a0a0a]">

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -120,29 +120,26 @@ export async function generateUniqueBookSlug(
 }
 
 /**
- * Centralized book URL construction. Use this everywhere instead of
- * manually building `/book/${book.id}`.
+ * Centralized book URL construction. Always returns /book/{slug-or-id}.
+ *
+ * Book URLs are tenant-agnostic: the tenant slug never appears in the address
+ * bar. The proxy resolves the tenant internally from the book itself and
+ * rewrites the request to the [tenant]/book/[id] route. Tenant fields on the
+ * input are accepted (and ignored) for call-site compatibility.
  */
 export function bookUrl(book: { slug?: string; id: string; tenantSlug?: string | null; tenant_slug?: string | null }): string {
-  const path = `/book/${book.slug || book.id}`;
-  const tenantSlug =
-    (book as { tenantSlug?: string | null }).tenantSlug ||
-    (book as { tenant_slug?: string | null }).tenant_slug ||
-    null;
-  return tenantSlug ? `/${tenantSlug}${path}` : path;
+  return `/book/${book.slug || book.id}`;
 }
 
 /**
- * Tenant-aware book URL construction.
- * Use in tenant routes to keep navigation within the tenant path.
- * Falls back to root URL if no tenant is provided.
+ * Alias of bookUrl() that accepts a tenantSlug for call-site compatibility.
+ * The tenantSlug argument is intentionally ignored — see bookUrl().
  */
 export function tenantBookUrl(
   book: { slug?: string; id: string },
-  tenantSlug?: string | null
+  _tenantSlug?: string | null
 ): string {
-  const path = `/book/${book.slug || book.id}`;
-  return tenantSlug ? `/${tenantSlug}${path}` : path;
+  return `/book/${book.slug || book.id}`;
 }
 
 export function collectionUrl(collection: { slug: string }): string {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -363,17 +363,17 @@ export async function proxy(request: NextRequest) {
     return NextResponse.rewrite(url);
   }
 
-  // --- Legacy root route compatibility ---
-  // Root routes moved to /{tenant}/... but global surfaces still emit legacy URLs.
-  // Resolve tenant from the resource itself so mixed-tenant cards open correctly.
-  if (pathname.startsWith('/book/')) {
-    const segment = pathname.split('/')[2] || '';
-    const tenantSlug = await resolveTenantForBookSegment(segment)
-      || (await resolveTenantByExactSlug('default'))?.slug
-      || null;
-    if (tenantSlug) {
+  // --- Canonical book URLs ---
+  // Book URLs are tenant-agnostic: always /book/{slug} (no tenant prefix).
+  // Strip any leading /{tenant} from book paths so old links canonicalize.
+  const tenantBookMatch = pathname.match(/^\/([^/]+)(\/book(?:\/.*)?)$/);
+  if (tenantBookMatch) {
+    const tenantSegment = tenantBookMatch[1];
+    const bookSuffix = tenantBookMatch[2];
+    const directTenant = await resolveActiveTenant(tenantSegment);
+    if (directTenant) {
       const url = request.nextUrl.clone();
-      url.pathname = `/${tenantSlug}${pathname}`;
+      url.pathname = bookSuffix;
       return NextResponse.redirect(url, 308);
     }
   }
@@ -458,6 +458,22 @@ export async function proxy(request: NextRequest) {
       const url = request.nextUrl.clone();
       url.pathname = '/api/redirect/book-slug';
       url.searchParams.set('id', segment);
+      return NextResponse.rewrite(url);
+    }
+  }
+
+  // Internal tenant routing for /book/...:
+  // The route lives at [tenant]/book/[id] (3+ segments), but the public URL is
+  // /book/{id}. Rewrite (don't redirect) so the URL stays clean — no tenant
+  // prefix ever appears in the address bar.
+  if (pathname.startsWith('/book/')) {
+    const segment = pathname.split('/')[2] || '';
+    const tenantSlug = await resolveTenantForBookSegment(segment)
+      || (await resolveTenantByExactSlug('default'))?.slug
+      || null;
+    if (tenantSlug) {
+      const url = request.nextUrl.clone();
+      url.pathname = `/${tenantSlug}${pathname}`;
       return NextResponse.rewrite(url);
     }
   }


### PR DESCRIPTION
Closes part of #1496 (point 2: canonical URLs via slug).

## Summary

- **Bug fix:** `/book/{id}?page=N` was dropping the `?page=N` query because the proxy 308-redirected to `/{tenant}/book/{id}?page=N` first, and the page-redirect handler's regex required a non-tenant path. Reordered the proxy so the `?page=N` and id→slug handlers run first.
- **URL cleanup:** book URLs in the address bar are now always `/book/{slug}` — never `/{tenant}/book/{slug}`. Tenant resolution happens internally via `NextResponse.rewrite()`. Existing tenant-prefixed URLs 308 to the clean form.
- Updated `bookUrl()` / `tenantBookUrl()` and the remaining hardcoded `/${tenant}/book/...` templates to emit the tenant-less form.

This is the no-DB-change part of issue #1496. Points 1, 3, 4 (removing platform tenants from the DB, contributing_library backfill) remain open — they're riskier migrations and out of scope here.

## Test plan

- [ ] `/book/69ac42db0076a4e33e4fd778?page=188` → page reader for page 188, no tenant prefix in URL bar
- [ ] `/internet-archive/book/69ac42db0076a4e33e4fd778?page=188` → 308 to clean URL, then page redirect, no tenant prefix in URL bar
- [ ] Click any book from search/collection — URL bar shows `/book/{slug}`
- [ ] Page reader navigation (`/book/{slug}/page/{pageId}`) still works
- [ ] BPH subdomain (`bph.sourcelibrary.org/book/...`) embed routing still works (separate code path, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)