### PR TITLE
Expand BPH catalog: full 28k import, advanced search, /catalog route

### DIFF
--- a/scripts/migration/expand-bph-works-schema.sql
+++ b/scripts/migration/expand-bph-works-schema.sql
@@ -1,0 +1,113 @@
+-- Expand bph_works to hold the full Vitec Memorix BPH catalog export (BibliotheekExportTest.csv).
+-- Source: ~/Downloads/BibliotheekExportTest.csv (~28,813 rows, 49 columns).
+-- Mapping covers Paul Dijstelberge's "Model Catalogus" spec + admin/internal fields.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/expand-bph-works-schema.sql
+
+ALTER TABLE bph_works
+  -- Title family (Paul §3 — short, full transcription, variant)
+  ADD COLUMN IF NOT EXISTS parallel_title       TEXT, -- Full title-page transcription
+  ADD COLUMN IF NOT EXISTS uniform_title        TEXT, -- Variant / engraved / French title
+  -- Author family (Paul §1 — title-page form + standard form; standard already in `author`)
+  ADD COLUMN IF NOT EXISTS variant_author       TEXT, -- "Variant author's name" — title-page form
+  ADD COLUMN IF NOT EXISTS pseudonym            TEXT,
+  -- Secondary author (Paul §2)
+  ADD COLUMN IF NOT EXISTS editor               TEXT, -- standard editor/translator name
+  ADD COLUMN IF NOT EXISTS variant_editor       TEXT, -- title-page form
+  -- Imprint variants (Paul §4 — printer/publisher already exist as standard form)
+  ADD COLUMN IF NOT EXISTS variant_printer      TEXT,
+  ADD COLUMN IF NOT EXISTS variant_publisher    TEXT,
+  -- Location (Paul §10 — Location + Cabinet)
+  ADD COLUMN IF NOT EXISTS present_location     TEXT, -- e.g. "Leeszaal", "Depot"
+  ADD COLUMN IF NOT EXISTS state_shelf_mark     TEXT, -- "BPH State Collection shelf mark"
+  -- Hierarchy
+  ADD COLUMN IF NOT EXISTS series_title         TEXT,
+  ADD COLUMN IF NOT EXISTS volume_title         TEXT,
+  -- Notes (Paul §9)
+  ADD COLUMN IF NOT EXISTS bibliography         TEXT,
+  ADD COLUMN IF NOT EXISTS remarks              TEXT,
+  ADD COLUMN IF NOT EXISTS internal_remarks     TEXT, -- admin
+  -- Physical (Paul §7, §8)
+  ADD COLUMN IF NOT EXISTS number_of_copies     INTEGER,
+  ADD COLUMN IF NOT EXISTS object_size_cm       TEXT,
+  ADD COLUMN IF NOT EXISTS binding              TEXT,
+  ADD COLUMN IF NOT EXISTS bound_with           TEXT,
+  -- Provenance / Collection (Paul §11)
+  ADD COLUMN IF NOT EXISTS provenance           TEXT,
+  -- Admin (Paul §13)
+  ADD COLUMN IF NOT EXISTS picturae_barcode     TEXT,
+  ADD COLUMN IF NOT EXISTS uuid                 TEXT,
+  ADD COLUMN IF NOT EXISTS work_status          TEXT, -- raw "Status" column (e.g. "avail. ...", "neen")
+  ADD COLUMN IF NOT EXISTS acquisition_date     TEXT, -- kept TEXT, source data is messy (mix of years/dates/null)
+  ADD COLUMN IF NOT EXISTS acquisition_source   TEXT,
+  ADD COLUMN IF NOT EXISTS price                TEXT, -- TEXT — values include currency / "neen" / blanks
+  ADD COLUMN IF NOT EXISTS fully_approved       TEXT,
+  ADD COLUMN IF NOT EXISTS delivered_to_customer TEXT,
+  ADD COLUMN IF NOT EXISTS publish_scan         TEXT,
+  ADD COLUMN IF NOT EXISTS file_count           INTEGER,
+  ADD COLUMN IF NOT EXISTS thumbnail            TEXT,
+  ADD COLUMN IF NOT EXISTS modified_time        TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS modified_by_username TEXT,
+  ADD COLUMN IF NOT EXISTS modified_by_email    TEXT,
+  -- Bridge to Source Library (filled by enrichment, not from CSV)
+  ADD COLUMN IF NOT EXISTS sl_book_id           TEXT,
+  ADD COLUMN IF NOT EXISTS sl_book_slug         TEXT,
+  -- Generated full-text search vector across all public-facing fields
+  ADD COLUMN IF NOT EXISTS search_tsv           TSVECTOR;
+
+-- Recompute search_tsv for full simple-search coverage (every field a user might type)
+CREATE OR REPLACE FUNCTION bph_works_search_tsv_update() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.search_tsv :=
+    setweight(to_tsvector('simple', coalesce(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(NEW.parallel_title, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(NEW.uniform_title, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(NEW.author, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(NEW.variant_author, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(NEW.pseudonym, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.editor, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(NEW.variant_editor, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.place, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.printer, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.publisher, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.variant_printer, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.variant_publisher, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.keywords, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(NEW.language, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.shelf_mark, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.state_shelf_mark, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.present_location, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.series_title, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.volume_title, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.bibliography, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.remarks, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.provenance, '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce(NEW.binding, '')), 'D') ||
+    setweight(to_tsvector('simple', coalesce(NEW.bound_with, '')), 'D');
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS bph_works_search_tsv_trigger ON bph_works;
+CREATE TRIGGER bph_works_search_tsv_trigger
+  BEFORE INSERT OR UPDATE ON bph_works
+  FOR EACH ROW EXECUTE FUNCTION bph_works_search_tsv_update();
+
+-- Indexes for advanced search + filters
+CREATE INDEX IF NOT EXISTS bph_works_search_tsv_idx        ON bph_works USING GIN (search_tsv);
+CREATE INDEX IF NOT EXISTS bph_works_year_idx              ON bph_works (year);
+CREATE INDEX IF NOT EXISTS bph_works_language_idx          ON bph_works (language);
+CREATE INDEX IF NOT EXISTS bph_works_author_trgm_idx       ON bph_works USING GIN (author gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS bph_works_title_trgm_idx        ON bph_works USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS bph_works_place_trgm_idx        ON bph_works USING GIN (place gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS bph_works_printer_trgm_idx      ON bph_works USING GIN (printer gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS bph_works_publisher_trgm_idx    ON bph_works USING GIN (publisher gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS bph_works_provenance_idx        ON bph_works (provenance);
+CREATE INDEX IF NOT EXISTS bph_works_sl_book_id_idx        ON bph_works (sl_book_id) WHERE sl_book_id IS NOT NULL;
+
+-- pg_trgm must be enabled (no-op if already)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- After running this, run scripts/migration/import-bph-catalog.mjs to upsert all 28,813 rows.
+-- Then run UPDATE bph_works SET ubn = ubn; to backfill search_tsv on existing rows.

--- a/scripts/migration/import-bph-catalog.mjs
+++ b/scripts/migration/import-bph-catalog.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Import the full BPH catalog (Vitec Memorix export) into Supabase bph_works.
+ *
+ * Source: ~/Downloads/BibliotheekExportTest.csv (~28,813 rows, 49 columns).
+ * Run AFTER expand-bph-works-schema.sql.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/import-bph-catalog.mjs --csv ~/Downloads/BibliotheekExportTest.csv [--dry-run] [--limit N]
+ *
+ * Idempotent: upserts on UBN. Run again to refresh from a newer export.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+import { parseArgs } from 'util';
+
+const { values: args } = parseArgs({
+  options: {
+    csv: { type: 'string' },
+    'dry-run': { type: 'boolean', default: false },
+    limit: { type: 'string' },
+  },
+});
+
+if (!args.csv) {
+  console.error('Usage: node import-bph-catalog.mjs --csv <path> [--dry-run] [--limit N]');
+  process.exit(1);
+}
+
+const DRY_RUN = args['dry-run'];
+const LIMIT = args.limit ? parseInt(args.limit, 10) : Infinity;
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// ---- CSV parsing (handles quoted fields with embedded commas, newlines, escaped quotes) ----
+function parseCSV(text) {
+  const rows = [];
+  let cur = '', row = [], inQ = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQ) {
+      if (c === '"') {
+        if (text[i + 1] === '"') { cur += '"'; i++; }
+        else { inQ = false; }
+      } else {
+        cur += c;
+      }
+    } else {
+      if (c === '"') inQ = true;
+      else if (c === ',') { row.push(cur); cur = ''; }
+      else if (c === '\n') { row.push(cur); rows.push(row); row = []; cur = ''; }
+      else if (c === '\r') {
+        // skip
+      } else cur += c;
+    }
+  }
+  if (cur.length > 0 || row.length > 0) { row.push(cur); rows.push(row); }
+  return rows;
+}
+
+function clean(s) {
+  if (!s) return null;
+  const t = String(s).trim();
+  return t === '' ? null : t;
+}
+
+function parseInt0(s) {
+  const v = clean(s);
+  if (!v) return null;
+  const n = parseInt(v, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function parseYear(s) {
+  const v = clean(s);
+  if (!v) return null;
+  const m = v.match(/(\d{4})/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function parseTimestamp(s) {
+  const v = clean(s);
+  if (!v) return null;
+  // Vitec format: "2024-04-03 12:09:33.530749" — Postgres-friendly already
+  const t = new Date(v.replace(' ', 'T') + 'Z');
+  return Number.isNaN(t.getTime()) ? null : t.toISOString();
+}
+
+async function main() {
+  console.log(`Loading CSV: ${args.csv}`);
+  const text = readFileSync(args.csv, 'utf8');
+  const rows = parseCSV(text);
+  const headers = rows.shift().map(h => h.trim());
+
+  // Build header → index map (header strings are exact CSV column names)
+  const idx = {};
+  headers.forEach((h, i) => { idx[h] = i; });
+  const get = (row, key) => clean(row[idx[key]]);
+
+  console.log(`Headers (${headers.length}): ${headers.slice(0, 5).join(', ')}…`);
+  console.log(`Rows: ${rows.length}`);
+
+  // Drop blank trailing rows
+  const data = rows.filter(r => r.some(c => c && c.trim()));
+  console.log(`Non-empty rows: ${data.length}`);
+
+  const records = [];
+  let skipped = 0;
+  for (const r of data) {
+    const ubn = get(r, 'UBN');
+    if (!ubn) { skipped++; continue; }
+    records.push({
+      ubn: ubn.replace(/\.0$/, ''),
+      uuid: get(r, 'uuid'),
+      picturae_barcode: get(r, 'Picturae barcode'),
+      title: get(r, 'Title'),
+      parallel_title: get(r, 'Parallel title'),
+      uniform_title: get(r, 'Uniform title'),
+      author: get(r, 'Author'),
+      variant_author: get(r, "Variant author’s name") ?? get(r, "Variant author's name"),
+      pseudonym: get(r, 'Pseudonym'),
+      editor: get(r, 'Editor'),
+      variant_editor: get(r, "Variant editor’s name") ?? get(r, "Variant editor's name"),
+      place: get(r, 'Place of publication'),
+      printer: get(r, 'Printer'),
+      publisher: get(r, 'Publisher'),
+      variant_printer: get(r, "Variant printer’s name") ?? get(r, "Variant printer's name"),
+      variant_publisher: get(r, "Variant publisher’s name") ?? get(r, "Variant publisher's name"),
+      year: parseYear(get(r, 'Year of publication')),
+      shelf_mark: get(r, 'Shelf mark'),
+      keywords: get(r, 'Keywords'),
+      language: get(r, 'Language'),
+      present_location: get(r, 'Present location'),
+      series_title: get(r, 'Series title'),
+      volume_title: get(r, 'Volume title'),
+      bibliography: get(r, 'Bibliography'),
+      remarks: get(r, 'Remarks'),
+      internal_remarks: get(r, 'Internal remarks'),
+      number_of_copies: parseInt0(get(r, 'Number of copies')),
+      work_status: get(r, 'Status'),
+      state_shelf_mark: get(r, 'BPH State Collection shelf mark'),
+      object_size_cm: get(r, 'Object size in cm'),
+      provenance: get(r, 'Provenance'),
+      binding: get(r, 'Binding'),
+      bound_with: get(r, 'Bound with') ?? get(r, 'bound_with'),
+      acquisition_date: get(r, 'Acquisition date'),
+      price: get(r, 'Price'),
+      acquisition_source: get(r, 'Acquisition source'),
+      fully_approved: get(r, 'Fully approved'),
+      delivered_to_customer: get(r, 'Delivered to customer'),
+      publish_scan: get(r, 'Publish scan'),
+      file_count: parseInt0(get(r, 'file-count')),
+      thumbnail: get(r, 'thumbnail'),
+      modified_time: parseTimestamp(get(r, 'modified_time')),
+      modified_by_username: get(r, 'modified_by-username'),
+      modified_by_email: get(r, 'modified_by-email'),
+    });
+    if (records.length >= LIMIT) break;
+  }
+
+  console.log(`Prepared ${records.length} records (skipped ${skipped} with no UBN)`);
+  if (records[0]) {
+    console.log('Sample:', JSON.stringify(records[0], null, 2).slice(0, 800));
+  }
+
+  if (DRY_RUN) {
+    console.log('DRY RUN — exiting without writing.');
+    return;
+  }
+
+  // Upsert in batches of 500
+  const BATCH = 500;
+  let written = 0;
+  for (let i = 0; i < records.length; i += BATCH) {
+    const slice = records.slice(i, i + BATCH);
+    const { error } = await supabase
+      .from('bph_works')
+      .upsert(slice, { onConflict: 'ubn' });
+    if (error) {
+      console.error(`Batch ${i / BATCH} failed:`, error.message);
+      console.error('First record in failing batch:', JSON.stringify(slice[0]).slice(0, 300));
+      process.exit(1);
+    }
+    written += slice.length;
+    if ((i / BATCH) % 5 === 0) console.log(`  upserted ${written}/${records.length}`);
+  }
+  console.log(`Done — upserted ${written} rows.`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -31,7 +31,6 @@ import CategoryPicker from '@/components/ui/CategoryPicker';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import ExpandableGuide from '@/components/book/ExpandableGuide';
 import { linkEntities, buildEntityList } from '@/lib/link-entities';
-import { BookShare } from '@/components/ui/ShareButton';
 import LikeButton from '@/components/ui/LikeButton';
 import CiteButton from '@/components/ui/CiteButton';
 import { AuthCheck } from '@/components/auth/AuthCheck';
@@ -802,17 +801,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                         className="text-stone-300"
                       />
                     </div>
-                    <span className="hidden sm:block w-px h-5 bg-white/10 mx-1" />
-                    <BookShare
-                      title={book.display_title || book.title}
-                      author={book.author}
-                      year={book.published}
-                      bookId={book.slug || book.id}
-                      doi={book.doi}
-                      label="Share"
-                      tenantSlug={tenantSlug || undefined}
-                      className="text-stone-300 hover:text-white hover:bg-white/10"
-                    />
                   </div>
                 </div>
 

--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -724,7 +724,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
   const hasActiveFilters = language || category || collection || dateFrom || dateTo || hasDoi || hasTranslation || firstTranslation || (library && library !== defaultLibrary) || sortBy !== 'relevance';
 
   return (
-    <div className="min-h-screen bg-cream">
+    <div className="bg-cream">
       <SiteHeader variant="dark" />
 
       {/* Search Bar */}

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -5,37 +5,117 @@ export const dynamic = 'force-dynamic';
 
 const PER_PAGE = 50;
 
+// Fields exposed to the public catalog UI.
+const PUBLIC_FIELDS = [
+  'ubn',
+  'title', 'parallel_title', 'uniform_title',
+  'author', 'variant_author', 'pseudonym',
+  'editor', 'variant_editor',
+  'place', 'printer', 'publisher', 'variant_printer', 'variant_publisher',
+  'year',
+  'shelf_mark', 'state_shelf_mark', 'present_location',
+  'keywords', 'language',
+  'series_title', 'volume_title',
+  'bibliography', 'remarks',
+  'number_of_copies', 'object_size_cm', 'binding', 'bound_with',
+  'provenance',
+  'thumbnail', 'file_count',
+  'sl_book_id', 'sl_book_slug',
+  'ia_identifier', 'ustc_sn',
+].join(', ');
+
 export async function GET(req: NextRequest) {
   const sp = req.nextUrl.searchParams;
-  const q = sp.get('q') || '';
-  const keyword = sp.get('keyword') || '';
+
+  // Simple search — searches all fields via tsvector.
+  const q = sp.get('q')?.trim() || '';
+
+  // Per-field advanced search.
+  const author = sp.get('author')?.trim() || '';
+  const title = sp.get('title')?.trim() || '';
+  const place = sp.get('place')?.trim() || '';
+  const printer = sp.get('printer')?.trim() || '';
+  const publisher = sp.get('publisher')?.trim() || '';
+  const editor = sp.get('editor')?.trim() || '';
+  const keyword = sp.get('keyword')?.trim() || '';
+  const language = sp.get('language')?.trim() || '';
+  const shelfMark = sp.get('shelf_mark')?.trim() || '';
+  const provenance = sp.get('provenance')?.trim() || '';
+
+  // Year range (USTC-style).
+  const yearFrom = sp.get('yearFrom') ? parseInt(sp.get('yearFrom')!, 10) : null;
+  const yearTo = sp.get('yearTo') ? parseInt(sp.get('yearTo')!, 10) : null;
+
+  // Filters.
+  const digitized = sp.get('digitized'); // 'true' | 'false' | 'sl' | null
+
   const sort = sp.get('sort') || 'title';
-  const offset = Math.max(0, parseInt(sp.get('offset') || '0') || 0);
-  const digitized = sp.get('digitized'); // 'true' | 'false' | null
+  const offset = Math.max(0, parseInt(sp.get('offset') || '0', 10) || 0);
+  const limit = Math.min(200, Math.max(1, parseInt(sp.get('limit') || String(PER_PAGE), 10) || PER_PAGE));
 
   let query = supabase
     .from('bph_works')
-    .select('ubn, title, author, year, shelf_mark, keywords, ia_identifier, ustc_sn, place, publisher, printer', { count: 'exact' });
+    .select(PUBLIC_FIELDS, { count: 'exact' });
 
-  // Text search
+  // Simple search — full-text across all fields.
   if (q.length >= 2) {
     const safe = sanitizeFilterValue(q);
-    query = query.or(`title.ilike.%${safe}%,author.ilike.%${safe}%,shelf_mark.ilike.%${safe}%`);
+    // Quote each token, join with & for AND-match in plainto_tsquery semantics.
+    // websearch_to_tsquery handles user input safely (quotes, OR, -word).
+    query = query.textSearch('search_tsv', safe, { type: 'websearch', config: 'simple' });
   }
 
-  // Keyword filter
-  if (keyword) {
-    query = query.eq('keywords', keyword);
-  }
+  // Per-field ilike filters (advanced search).
+  // Each filter is treated as a substring match for resilience to spelling/spacing variants.
+  const ilikeFilter = (col: string, val: string) => {
+    if (!val) return;
+    // Match either the standard column or its variant counterpart.
+    const safe = sanitizeFilterValue(val);
+    if (col === 'author') {
+      query = query.or(`author.ilike.%${safe}%,variant_author.ilike.%${safe}%,pseudonym.ilike.%${safe}%`);
+    } else if (col === 'title') {
+      query = query.or(`title.ilike.%${safe}%,parallel_title.ilike.%${safe}%,uniform_title.ilike.%${safe}%`);
+    } else if (col === 'editor') {
+      query = query.or(`editor.ilike.%${safe}%,variant_editor.ilike.%${safe}%`);
+    } else if (col === 'printer') {
+      query = query.or(`printer.ilike.%${safe}%,variant_printer.ilike.%${safe}%`);
+    } else if (col === 'publisher') {
+      query = query.or(`publisher.ilike.%${safe}%,variant_publisher.ilike.%${safe}%`);
+    } else if (col === 'shelf_mark') {
+      query = query.or(`shelf_mark.ilike.%${safe}%,state_shelf_mark.ilike.%${safe}%`);
+    } else {
+      query = query.ilike(col, `%${safe}%`);
+    }
+  };
+  ilikeFilter('author', author);
+  ilikeFilter('title', title);
+  ilikeFilter('editor', editor);
+  ilikeFilter('place', place);
+  ilikeFilter('printer', printer);
+  ilikeFilter('publisher', publisher);
+  ilikeFilter('shelf_mark', shelfMark);
 
-  // Digitized filter
+  if (keyword) query = query.eq('keywords', keyword);
+  if (language) query = query.eq('language', language);
+  if (provenance) query = query.eq('provenance', provenance);
+
+  // Year range.
+  if (yearFrom !== null && !Number.isNaN(yearFrom)) query = query.gte('year', yearFrom);
+  if (yearTo !== null && !Number.isNaN(yearTo)) query = query.lte('year', yearTo);
+
+  // Digitization filters.
+  //   true → has any digitized link (Source Library OR Internet Archive)
+  //   sl   → digitized on Source Library specifically
+  //   false → not digitized anywhere
   if (digitized === 'true') {
-    query = query.not('ia_identifier', 'is', null);
+    query = query.or('sl_book_id.not.is.null,ia_identifier.not.is.null');
+  } else if (digitized === 'sl') {
+    query = query.not('sl_book_id', 'is', null);
   } else if (digitized === 'false') {
-    query = query.is('ia_identifier', null);
+    query = query.is('sl_book_id', null).is('ia_identifier', null);
   }
 
-  // Sort
+  // Sort.
   switch (sort) {
     case 'year_asc':
       query = query.order('year', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
@@ -53,13 +133,17 @@ export async function GET(req: NextRequest) {
       query = query.order('title', { ascending: true });
   }
 
-  query = query.range(offset, offset + PER_PAGE - 1);
+  query = query.range(offset, offset + limit - 1);
 
   const { data, count, error } = await query;
-
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json({ works: data || [], total: count || 0 });
+  return NextResponse.json({
+    works: data || [],
+    total: count || 0,
+    offset,
+    limit,
+  });
 }

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -1,24 +1,67 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useDebouncedCallback } from 'use-debounce';
-import { Search, X, ChevronLeft, ChevronRight, BookMarked } from 'lucide-react';
+import { Search, X, ChevronLeft, ChevronRight, BookMarked, SlidersHorizontal } from 'lucide-react';
 import { tenantBookUrl } from '@/lib/slugify';
 
 interface BphWork {
   ubn: string;
-  title: string;
+  title: string | null;
+  parallel_title: string | null;
+  uniform_title: string | null;
   author: string | null;
+  variant_author: string | null;
+  pseudonym: string | null;
+  editor: string | null;
+  variant_editor: string | null;
+  place: string | null;
+  printer: string | null;
+  publisher: string | null;
+  variant_printer: string | null;
+  variant_publisher: string | null;
   year: number | null;
   shelf_mark: string | null;
+  state_shelf_mark: string | null;
+  present_location: string | null;
   keywords: string | null;
-  place: string | null;
-  publisher: string | null;
-  printer: string | null;
+  language: string | null;
+  series_title: string | null;
+  volume_title: string | null;
+  bibliography: string | null;
+  remarks: string | null;
+  number_of_copies: number | null;
+  object_size_cm: string | null;
+  binding: string | null;
+  bound_with: string | null;
+  provenance: string | null;
+  thumbnail: string | null;
+  file_count: number | null;
+  sl_book_id: string | null;
+  sl_book_slug: string | null;
   ia_identifier: string | null;
   ustc_sn: string | null;
 }
+
+interface AdvancedFilters {
+  author: string;
+  title: string;
+  editor: string;
+  place: string;
+  printer: string;
+  publisher: string;
+  shelf_mark: string;
+  language: string;
+  yearFrom: string;
+  yearTo: string;
+  digitized: '' | 'true' | 'sl' | 'false';
+}
+
+const EMPTY_ADV: AdvancedFilters = {
+  author: '', title: '', editor: '', place: '', printer: '', publisher: '',
+  shelf_mark: '', language: '', yearFrom: '', yearTo: '', digitized: '',
+};
 
 const PER_PAGE = 50;
 
@@ -56,13 +99,15 @@ const KEYWORD_OPTIONS = [
 
 interface Props {
   basePath: string;
-  /** Map of UBN → { id, slug } for BPH books that exist on Source Library */
+  /** Map of UBN → { id, slug } for BPH books that exist on Source Library (overrides sl_book_id from row) */
   digitizedUbns: Record<string, { id: string; slug: string }>;
   /** Optional tenant slug to include in book URLs */
   tenantSlug?: string;
+  /** When true, defaults to advanced search expanded */
+  defaultAdvanced?: boolean;
 }
 
-export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug }: Props) {
+export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug, defaultAdvanced = false }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -70,6 +115,20 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
   const initialSort = searchParams.get('csort') || 'title';
   const initialKeyword = searchParams.get('ckeyword') || '';
   const initialOffset = parseInt(searchParams.get('coffset') || '0') || 0;
+  const initialAdv: AdvancedFilters = {
+    author: searchParams.get('cauthor') || '',
+    title: searchParams.get('ctitle') || '',
+    editor: searchParams.get('ceditor') || '',
+    place: searchParams.get('cplace') || '',
+    printer: searchParams.get('cprinter') || '',
+    publisher: searchParams.get('cpublisher') || '',
+    shelf_mark: searchParams.get('cshelf') || '',
+    language: searchParams.get('clang') || '',
+    yearFrom: searchParams.get('cyfrom') || '',
+    yearTo: searchParams.get('cyto') || '',
+    digitized: (searchParams.get('cdig') || '') as AdvancedFilters['digitized'],
+  };
+  const hasAnyAdv = Object.values(initialAdv).some(v => v !== '');
 
   const [works, setWorks] = useState<BphWork[]>([]);
   const [total, setTotal] = useState(0);
@@ -78,15 +137,33 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
   const [sort, setSort] = useState(initialSort);
   const [keyword, setKeyword] = useState(initialKeyword);
   const [offset, setOffset] = useState(initialOffset);
+  const [adv, setAdv] = useState<AdvancedFilters>(initialAdv);
+  const [showAdvanced, setShowAdvanced] = useState(defaultAdvanced || hasAnyAdv);
 
-  const fetchWorks = useCallback(async (q: string, s: string, kw: string, off: number) => {
+  const buildParams = useCallback((q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (s) params.set('sort', s);
+    if (kw) params.set('keyword', kw);
+    if (off) params.set('offset', String(off));
+    if (a.author) params.set('author', a.author);
+    if (a.title) params.set('title', a.title);
+    if (a.editor) params.set('editor', a.editor);
+    if (a.place) params.set('place', a.place);
+    if (a.printer) params.set('printer', a.printer);
+    if (a.publisher) params.set('publisher', a.publisher);
+    if (a.shelf_mark) params.set('shelf_mark', a.shelf_mark);
+    if (a.language) params.set('language', a.language);
+    if (a.yearFrom) params.set('yearFrom', a.yearFrom);
+    if (a.yearTo) params.set('yearTo', a.yearTo);
+    if (a.digitized) params.set('digitized', a.digitized);
+    return params;
+  }, []);
+
+  const fetchWorks = useCallback(async (q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
     setLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (q) params.set('q', q);
-      if (s) params.set('sort', s);
-      if (kw) params.set('keyword', kw);
-      if (off) params.set('offset', String(off));
+      const params = buildParams(q, s, kw, off, a);
       const res = await fetch(`/api/catalog/bph?${params}`);
       const data = await res.json();
       setWorks(data.works || []);
@@ -97,26 +174,41 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [buildParams]);
 
-  // Sync URL params
-  const updateUrl = useCallback((q: string, s: string, kw: string, off: number) => {
+  // Sync URL params (using c-prefixed keys so they don't collide with parent page params)
+  const updateUrl = useCallback((q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
     const params = new URLSearchParams(searchParams.toString());
-    if (q) params.set('cq', q); else params.delete('cq');
-    if (s && s !== 'title') params.set('csort', s); else params.delete('csort');
-    if (kw) params.set('ckeyword', kw); else params.delete('ckeyword');
-    if (off) params.set('coffset', String(off)); else params.delete('coffset');
+    const setOrDel = (key: string, val: string) => {
+      if (val) params.set(key, val);
+      else params.delete(key);
+    };
+    setOrDel('cq', q);
+    setOrDel('csort', s !== 'title' ? s : '');
+    setOrDel('ckeyword', kw);
+    setOrDel('coffset', off ? String(off) : '');
+    setOrDel('cauthor', a.author);
+    setOrDel('ctitle', a.title);
+    setOrDel('ceditor', a.editor);
+    setOrDel('cplace', a.place);
+    setOrDel('cprinter', a.printer);
+    setOrDel('cpublisher', a.publisher);
+    setOrDel('cshelf', a.shelf_mark);
+    setOrDel('clang', a.language);
+    setOrDel('cyfrom', a.yearFrom);
+    setOrDel('cyto', a.yearTo);
+    setOrDel('cdig', a.digitized);
     router.replace(`${basePath}?${params}`, { scroll: false });
   }, [searchParams, router, basePath]);
 
   useEffect(() => {
-    fetchWorks(initialQ, initialSort, initialKeyword, initialOffset);
+    fetchWorks(initialQ, initialSort, initialKeyword, initialOffset, initialAdv);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const debouncedSearch = useDebouncedCallback((value: string) => {
     setOffset(0);
-    fetchWorks(value, sort, keyword, 0);
-    updateUrl(value, sort, keyword, 0);
+    fetchWorks(value, sort, keyword, 0, adv);
+    updateUrl(value, sort, keyword, 0, adv);
   }, 300);
 
   const handleSearchChange = (value: string) => {
@@ -127,38 +219,62 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
   const handleSortChange = (newSort: string) => {
     setSort(newSort);
     setOffset(0);
-    fetchWorks(searchQuery, newSort, keyword, 0);
-    updateUrl(searchQuery, newSort, keyword, 0);
+    fetchWorks(searchQuery, newSort, keyword, 0, adv);
+    updateUrl(searchQuery, newSort, keyword, 0, adv);
   };
 
   const handleKeywordChange = (newKw: string) => {
     setKeyword(newKw);
     setOffset(0);
-    fetchWorks(searchQuery, sort, newKw, 0);
-    updateUrl(searchQuery, sort, newKw, 0);
+    fetchWorks(searchQuery, sort, newKw, 0, adv);
+    updateUrl(searchQuery, sort, newKw, 0, adv);
   };
 
   const handlePage = (newOffset: number) => {
     setOffset(newOffset);
-    fetchWorks(searchQuery, sort, keyword, newOffset);
-    updateUrl(searchQuery, sort, keyword, newOffset);
+    fetchWorks(searchQuery, sort, keyword, newOffset, adv);
+    updateUrl(searchQuery, sort, keyword, newOffset, adv);
   };
 
+  const applyAdvanced = () => {
+    setOffset(0);
+    fetchWorks(searchQuery, sort, keyword, 0, adv);
+    updateUrl(searchQuery, sort, keyword, 0, adv);
+  };
+
+  const clearAll = () => {
+    setSearchQuery('');
+    setKeyword('');
+    setAdv(EMPTY_ADV);
+    setOffset(0);
+    fetchWorks('', sort, '', 0, EMPTY_ADV);
+    updateUrl('', sort, '', 0, EMPTY_ADV);
+  };
+
+  const advCount = useMemo(() => Object.values(adv).filter(v => v !== '').length, [adv]);
   const currentPage = Math.floor(offset / PER_PAGE) + 1;
   const totalPages = Math.ceil(total / PER_PAGE);
 
+  // Resolve digitized status: prefer parent-supplied map (live MongoDB), fall back to row.sl_book_id.
+  const resolveDigitized = (w: BphWork) => {
+    const fromMap = digitizedUbns[w.ubn];
+    if (fromMap) return fromMap;
+    if (w.sl_book_id) return { id: w.sl_book_id, slug: w.sl_book_slug || w.sl_book_id };
+    return null;
+  };
+
   return (
     <div>
-      {/* Filters row */}
-      <div className="flex flex-wrap items-center gap-3 mb-4">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
+      {/* Simple search row */}
+      <div className="flex flex-wrap items-center gap-3 mb-3">
+        <div className="relative flex-1 min-w-[14rem] max-w-xl">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => handleSearchChange(e.target.value)}
-            placeholder="Search catalog..."
-            className="text-sm border border-border-light rounded-md pl-8 pr-8 py-1.5 bg-white text-primary w-56 focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+            placeholder="Search across all fields…"
+            className="w-full text-sm border border-border-light rounded-md pl-9 pr-9 py-2 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
           />
           {searchQuery && (
             <button
@@ -173,7 +289,7 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
         <select
           value={keyword}
           onChange={(e) => handleKeywordChange(e.target.value)}
-          className="text-sm border border-border-light rounded-md px-3 py-1.5 bg-white text-primary"
+          className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
         >
           {KEYWORD_OPTIONS.map(o => (
             <option key={o.value} value={o.value}>{o.label}</option>
@@ -183,17 +299,97 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
         <select
           value={sort}
           onChange={(e) => handleSortChange(e.target.value)}
-          className="text-sm border border-border-light rounded-md px-3 py-1.5 bg-white text-primary"
+          className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
         >
           {SORT_OPTIONS.map(o => (
             <option key={o.value} value={o.value}>{o.label}</option>
           ))}
         </select>
 
+        <button
+          onClick={() => setShowAdvanced(s => !s)}
+          className="inline-flex items-center gap-1.5 text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary hover:bg-warm transition-colors"
+        >
+          <SlidersHorizontal className="w-3.5 h-3.5" />
+          Advanced
+          {advCount > 0 && (
+            <span className="ml-1 inline-flex items-center justify-center w-5 h-5 text-xs rounded-full bg-accent-rust text-white">
+              {advCount}
+            </span>
+          )}
+        </button>
+
         <span className="text-sm text-muted ml-auto">
           {total.toLocaleString()} works
         </span>
       </div>
+
+      {/* Advanced search panel */}
+      {showAdvanced && (
+        <div className="mb-4 p-4 bg-warm border border-border-light rounded-lg">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <AdvField label="Author" value={adv.author} onChange={v => setAdv({ ...adv, author: v })} placeholder="Behme, Böhme, …" />
+            <AdvField label="Title" value={adv.title} onChange={v => setAdv({ ...adv, title: v })} />
+            <AdvField label="Editor / translator" value={adv.editor} onChange={v => setAdv({ ...adv, editor: v })} />
+            <AdvField label="Place of publication" value={adv.place} onChange={v => setAdv({ ...adv, place: v })} placeholder="London, Lyon, Amsterdam…" />
+            <AdvField label="Printer" value={adv.printer} onChange={v => setAdv({ ...adv, printer: v })} />
+            <AdvField label="Publisher" value={adv.publisher} onChange={v => setAdv({ ...adv, publisher: v })} />
+            <AdvField label="Shelfmark" value={adv.shelf_mark} onChange={v => setAdv({ ...adv, shelf_mark: v })} />
+            <AdvField label="Language" value={adv.language} onChange={v => setAdv({ ...adv, language: v })} placeholder="Latin, German, English…" />
+            <div>
+              <label className="block text-xs text-muted mb-1">Year range</label>
+              <div className="flex gap-2">
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  value={adv.yearFrom}
+                  onChange={(e) => setAdv({ ...adv, yearFrom: e.target.value })}
+                  placeholder="from"
+                  className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+                />
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  value={adv.yearTo}
+                  onChange={(e) => setAdv({ ...adv, yearTo: e.target.value })}
+                  placeholder="to"
+                  className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-xs text-muted mb-1">Digitization</label>
+              <select
+                value={adv.digitized}
+                onChange={(e) => setAdv({ ...adv, digitized: e.target.value as AdvancedFilters['digitized'] })}
+                className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
+              >
+                <option value="">All</option>
+                <option value="sl">On Source Library</option>
+                <option value="true">Digitized anywhere</option>
+                <option value="false">Not digitized</option>
+              </select>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 mt-4">
+            <button
+              onClick={applyAdvanced}
+              className="px-4 py-1.5 text-sm rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 transition-colors"
+            >
+              Apply
+            </button>
+            <button
+              onClick={clearAll}
+              className="px-3 py-1.5 text-sm text-muted hover:text-primary transition-colors"
+            >
+              Clear all
+            </button>
+            <span className="text-xs text-muted ml-auto">
+              Tip: simple search above queries every field at once.
+            </span>
+          </div>
+        </div>
+      )}
 
       {/* Table */}
       <div className="border border-border-light rounded-lg overflow-hidden bg-white">
@@ -204,6 +400,7 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
                 <th className="text-left px-3 py-2.5 font-medium text-secondary">Title</th>
                 <th className="text-left px-3 py-2.5 font-medium text-secondary hidden sm:table-cell">Author</th>
                 <th className="text-left px-3 py-2.5 font-medium text-secondary w-16">Year</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Place</th>
                 <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Shelfmark</th>
                 <th className="text-left px-3 py-2.5 font-medium text-secondary hidden lg:table-cell">Subject</th>
                 <th className="text-center px-3 py-2.5 font-medium text-secondary w-10" title="On Source Library">SL</th>
@@ -211,40 +408,50 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
             </thead>
             <tbody className={loading ? 'opacity-50' : ''}>
               {works.map((w) => {
-                const digitized = digitizedUbns[w.ubn];
+                const digitized = resolveDigitized(w);
+                const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
+                const displayAuthor = w.author || w.variant_author || w.pseudonym;
                 return (
                   <tr
                     key={w.ubn}
                     className="border-b border-border-light last:border-0 hover:bg-cream/50 transition-colors"
                   >
-                    <td className="px-3 py-2">
+                    <td className="px-3 py-2 align-top">
                       <div className="font-medium text-primary leading-snug">
                         {digitized ? (
                           <a
                             href={tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug)}
                             className="hover:text-accent-rust transition-colors"
                           >
-                            {w.title}
+                            {displayTitle}
                           </a>
                         ) : (
-                          w.title
+                          displayTitle
                         )}
                       </div>
                       {/* Mobile: show author + place inline */}
                       <div className="text-xs text-muted sm:hidden mt-0.5">
-                        {w.author}{w.place ? ` · ${w.place}` : ''}
+                        {displayAuthor}{w.place ? ` · ${w.place}` : ''}
                       </div>
+                      {w.printer && (
+                        <div className="text-[11px] text-muted mt-0.5 hidden md:block">
+                          {w.printer}{w.publisher && w.publisher !== w.printer ? ` / ${w.publisher}` : ''}
+                        </div>
+                      )}
                     </td>
-                    <td className="px-3 py-2 text-secondary hidden sm:table-cell">
-                      {w.author || <span className="text-muted">—</span>}
+                    <td className="px-3 py-2 align-top text-secondary hidden sm:table-cell">
+                      {displayAuthor || <span className="text-muted">—</span>}
                     </td>
-                    <td className="px-3 py-2 text-secondary tabular-nums">
+                    <td className="px-3 py-2 align-top text-secondary tabular-nums">
                       {w.year || <span className="text-muted">—</span>}
                     </td>
-                    <td className="px-3 py-2 text-secondary font-mono text-xs hidden md:table-cell">
+                    <td className="px-3 py-2 align-top text-secondary hidden md:table-cell">
+                      {w.place || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 align-top text-secondary font-mono text-xs hidden md:table-cell">
                       {w.shelf_mark || <span className="text-muted">—</span>}
                     </td>
-                    <td className="px-3 py-2 hidden lg:table-cell">
+                    <td className="px-3 py-2 align-top hidden lg:table-cell">
                       {w.keywords ? (
                         <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-cream border border-border-light text-secondary capitalize">
                           {w.keywords}
@@ -253,7 +460,7 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
                         <span className="text-muted">—</span>
                       )}
                     </td>
-                    <td className="px-3 py-2 text-center">
+                    <td className="px-3 py-2 align-top text-center">
                       {digitized ? (
                         <a
                           href={tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug)}
@@ -270,7 +477,7 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
               })}
               {!loading && works.length === 0 && (
                 <tr>
-                  <td colSpan={6} className="px-3 py-12 text-center text-muted">
+                  <td colSpan={7} className="px-3 py-12 text-center text-muted">
                     No works found matching your search.
                   </td>
                 </tr>
@@ -302,6 +509,21 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug 
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+function AdvField({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (v: string) => void; placeholder?: string }) {
+  return (
+    <div>
+      <label className="block text-xs text-muted mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+      />
     </div>
   );
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -349,7 +349,9 @@ export async function proxy(request: NextRequest) {
         url.pathname = `/embed/${tenant}${pathname}`;
       }
     } else if (pathname === '/catalog') {
+      // Catalog page on tenant subdomain — show the full library catalog (e.g. all 28k BPH works)
       url.pathname = `/embed/${tenant}`;
+      url.searchParams.set('view', 'catalog');
     } else if (pathname.startsWith('/gallery')) {
       // Gallery doesn't have tenant-specific embeds — redirect to main site
       const mainUrl = request.nextUrl.clone();


### PR DESCRIPTION
## Summary

EFM/Chiara asked for the entire BPH catalog (28,813 works) to be searchable, with simple + advanced search (USTC-style). This PR delivers:

- **Full 47-field schema** for `bph_works` matching the Vitec Memorix export (`BibliotheekExportTest.csv`).
- **Simple + advanced search** in `BphCatalogBrowser` (collapsible advanced panel: author, title, editor, place, printer, publisher, shelfmark, language, year range, digitization filter).
- **Two distinct surfaces** on the bph subdomain:
  - `bph.sourcelibrary.org/` → **digital collection** (digitized books only)
  - `bph.sourcelibrary.org/catalog` → **digital catalog** (full 28,813 works)
- **Cross-link** from any catalog row whose UBN matches a Source Library book → "Read on Source Library".
- **Quick wins** requested in the same conversation:
  - Removed broken Share button from `/book/[id]`
  - Removed empty space below short search results (replaced `min-h-screen` with body-driven height)

## Field coverage vs Paul Dijstelberge's Model Catalogus

~80% covered. Remaining gaps (deferred to librarian pass):
- Impressum literal text (can reconstruct from place/printer/publisher/year)
- Original language pair (e.g. "Latin → German")
- Bibliographic format / collation (e.g. "In-4 : A-Ff4")

## Run after merge

```bash
psql "$DATABASE_URL" -f scripts/migration/expand-bph-works-schema.sql

set -a; source .env.production.local; set +a
node scripts/migration/import-bph-catalog.mjs --csv ~/Downloads/BibliotheekExportTest.csv
```

The importer is idempotent (UBN upsert). Re-run when BPH sends a fresh export.

## Test plan

- [ ] Apply schema migration and run importer in a non-prod environment first; verify ~28,813 rows.
- [ ] On `/libraries/bph`, simple search returns expected works.
- [ ] On `/libraries/bph`, advanced panel filters by author + year range correctly.
- [ ] On `bph.sourcelibrary.org/` (or its preview), only digitized books are shown.
- [ ] On `bph.sourcelibrary.org/catalog`, full 28k catalog browser renders with advanced search.
- [ ] Catalog rows whose UBN matches a Source Library book link to that book.
- [ ] `/book/[id]` no longer shows a Share button.
- [ ] Search page with short results no longer has a big empty cream area below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)