### PR TITLE
Gate book processing history to inner circle and above

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -1036,7 +1036,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
           }
           return <BookPagesSection bookId={book.id} bookTitle={book.display_title || book.title} pages={pages} totalPageCount={book.pages_count || pages.length} displayBrightness={(book as unknown as { display_brightness?: number }).display_brightness} />;
         })()}
-        <AuthCheck role="admin">
+        <AuthCheck role="inner_circle">
           <BookHistory bookId={book.id} />
         </AuthCheck>
       </main>

--- a/src/app/api/[tenant]/books/[id]/history/route.ts
+++ b/src/app/api/[tenant]/books/[id]/history/route.ts
@@ -3,35 +3,38 @@ import { getDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { assembleBookHistory, BOOK_HISTORY_PROJECTION } from '@/lib/book-history';
+import { withAuth } from '@/lib/auth-helpers';
 
 /**
  * GET /api/[tenant]/books/[id]/history
- * Same payload as the non-tenant route. The tenant slug is used to resolve
- * the book within the tenant's catalog; event sources (gemini_usage, jobs,
- * audit_log, changelog) are queried by `book_id` only — none of those
- * collections currently store `tenantId`. See `src/lib/book-history.ts`.
+ * Inner circle (editor) and above only — exposes prompt versions, model
+ * identities, costs, and admin actions. Same payload as the non-tenant route.
  */
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ tenant: string; id: string }> },
-) {
-  try {
-    const { tenant, id: bookId } = await params;
-    const db = await getDb();
-    const tenantId = await resolveTenantId(tenant);
-    if (!tenantId) {
-      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
-    }
+export const GET = withAuth(
+  async (
+    _request: NextRequest,
+    _session,
+    { params }: { params: Promise<{ tenant: string; id: string }> },
+  ) => {
+    try {
+      const { tenant, id: bookId } = await params;
+      const db = await getDb();
+      const tenantId = await resolveTenantId(tenant);
+      if (!tenantId) {
+        return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+      }
 
-    const result = await findBookByIdOrSlug(db, bookId, BOOK_HISTORY_PROJECTION, tenantId);
-    if (!result) {
-      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
-    }
+      const result = await findBookByIdOrSlug(db, bookId, BOOK_HISTORY_PROJECTION, tenantId);
+      if (!result) {
+        return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+      }
 
-    const response = await assembleBookHistory(db, result.book);
-    return NextResponse.json(response);
-  } catch (error) {
-    console.error('Error fetching book history:', error);
-    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 });
-  }
-}
+      const response = await assembleBookHistory(db, result.book);
+      return NextResponse.json(response);
+    } catch (error) {
+      console.error('Error fetching book history:', error);
+      return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 });
+    }
+  },
+  { minRole: 'editor' },
+);

--- a/src/app/api/books/[id]/history/route.ts
+++ b/src/app/api/books/[id]/history/route.ts
@@ -2,29 +2,35 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { assembleBookHistory, BOOK_HISTORY_PROJECTION } from '@/lib/book-history';
+import { withAuth } from '@/lib/auth-helpers';
 
 /**
  * GET /api/books/[id]/history
- * Returns the provenance timeline for a book. See `src/lib/book-history.ts`
- * for the data sources, schema, and known gaps.
+ * Returns the provenance timeline for a book. Inner circle (editor) and above only —
+ * exposes prompt versions, model identities, costs, and admin actions.
+ * See `src/lib/book-history.ts` for data sources and schema.
  */
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  try {
-    const { id: bookId } = await params;
-    const db = await getDb();
+export const GET = withAuth(
+  async (
+    _request: NextRequest,
+    _session,
+    { params }: { params: Promise<{ id: string }> },
+  ) => {
+    try {
+      const { id: bookId } = await params;
+      const db = await getDb();
 
-    const result = await findBookByIdOrSlug(db, bookId, BOOK_HISTORY_PROJECTION);
-    if (!result) {
-      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+      const result = await findBookByIdOrSlug(db, bookId, BOOK_HISTORY_PROJECTION);
+      if (!result) {
+        return NextResponse.json({ error: 'Book not found' }, { status: 404 });
+      }
+
+      const response = await assembleBookHistory(db, result.book);
+      return NextResponse.json(response);
+    } catch (error) {
+      console.error('Error fetching book history:', error);
+      return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 });
     }
-
-    const response = await assembleBookHistory(db, result.book);
-    return NextResponse.json(response);
-  } catch (error) {
-    console.error('Error fetching book history:', error);
-    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 });
-  }
-}
+  },
+  { minRole: 'editor' },
+);


### PR DESCRIPTION
## Summary

Both the history API and the UI mount were misaligned and exposing too much:

- **API was fully public**: \`/api/books/[id]/history\` and the tenant variant returned prompt versions, model identities, per-book AI cost, admin actions, and metadata changelogs to anyone. Now wrapped with \`withAuth({ minRole: 'editor' })\` — 403 for everyone below editor.
- **UI was admin-only**: BookHistory was wrapped in \`<AuthCheck role=\"admin\">\`, hiding the panel from inner-circle members who should be able to see it. Loosened to \`role=\"inner_circle\"\`.

Inner circle maps to \`editor\` in the new role model (\`src/lib/auth-helpers.ts:14\`), so both gates are now consistent.

## Test plan

- [ ] Logged out: \`curl /api/books/<id>/history\` returns 401
- [ ] Reader: returns 403; BookHistory panel hidden on book detail page
- [ ] Inner circle / editor: returns the timeline; panel renders
- [ ] Admin / superadmin: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)