### PR TITLE
Mirror book metadata edits to books_catalog immediately on PATCH

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -7,6 +7,7 @@ import { logAuditEvent } from '@/lib/audit-logger';
 import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { mirrorBookToCatalog } from '@/lib/books-catalog';
 
 export const preferredRegion = 'fra1';
 
@@ -260,6 +261,10 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
 
     const bookId = book.id || book._id.toString();
     const changedFields = Object.keys(updates).filter(k => k !== 'updated_at');
+
+    // Mirror to Supabase books_catalog so cover/title/author edits surface
+    // immediately instead of waiting for the 5-min Hetzner sync cron.
+    await mirrorBookToCatalog(bookId, updates);
     if (changedFields.length > 0) {
       logAuditEvent({
         action: 'book_metadata_updated',

--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -8,7 +8,7 @@
  * via the Hetzner supabase-sync cron.
  */
 
-import { supabase, sanitizeFilterValue } from '@/lib/supabase';
+import { supabase, supabaseAdmin, sanitizeFilterValue } from '@/lib/supabase';
 
 export interface CatalogBook {
   id: string;
@@ -540,4 +540,43 @@ export async function getBookDetail(idOrSlug: string): Promise<{ book: CatalogBo
   }
 
   return null;
+}
+
+/**
+ * Mirror a subset of changed book fields to Supabase books_catalog immediately.
+ * Used by /api/books/[id] PATCH so cover/title/author edits surface in <1s
+ * instead of waiting up to 5 min for the Hetzner sync cron.
+ *
+ * Only mirrors fields that exist in books_catalog. Silently no-ops if no
+ * mirrored fields changed, or if supabaseAdmin is unavailable (e.g., local
+ * dev without service-role key).
+ */
+const CATALOG_MIRROR_FIELDS = [
+  'title', 'display_title', 'author', 'thumbnail', 'thumbnail_blob',
+  'language', 'published', 'categories', 'publisher', 'place_published', 'doi',
+] as const;
+
+export async function mirrorBookToCatalog(
+  bookId: string,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  if (!supabaseAdmin) return;
+
+  const mirrored: Record<string, unknown> = {};
+  for (const field of CATALOG_MIRROR_FIELDS) {
+    if (field in updates) mirrored[field] = updates[field];
+  }
+  if (Object.keys(mirrored).length === 0) return;
+
+  mirrored.updated_at = new Date().toISOString();
+
+  const { error } = await supabaseAdmin
+    .from('books_catalog')
+    .update(mirrored)
+    .eq('id', bookId);
+
+  if (error) {
+    // Non-fatal — the next cron sync will pick up the change.
+    console.warn(`[books-catalog mirror] failed for ${bookId}:`, error.message);
+  }
 }


### PR DESCRIPTION
## Summary
- Cover/title/author edits via `/api/books/[id]` updated MongoDB but the Supabase `books_catalog` mirror only refreshed on the 5-min Hetzner sync cron — admins saw stale covers until the next sync.
- Add an inline Supabase UPDATE for mirrored fields right after the Mongo write so changes surface in <1s.
- Mirrors `title, display_title, author, thumbnail, thumbnail_blob, language, published, categories, publisher, place_published, doi`. Failures are logged but non-fatal (cron will reconcile).

## Test plan
- [ ] Edit a cover via `CoverImagePicker` on a recently-imported book and confirm the new cover renders on `/book/{slug}` and listing pages without waiting for the cron
- [ ] Edit `title` via admin and confirm books_catalog row updates immediately (`select title from books_catalog where id = '...'`)
- [ ] Verify the existing 5-min cron still runs (the inline mirror is best-effort; cron remains the source-of-truth backstop)
- [ ] Confirm no regression on PATCH responses (still returns `{success, updated}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)