### PR TITLE
Catalog detail: single column, SL digital-edition section, distinct links

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -1,11 +1,12 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import { ArrowLeft, BookMarked, ExternalLink } from 'lucide-react';
+import { ArrowLeft, BookMarked, ExternalLink, BookOpen } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { getReadDb } from '@/lib/mongodb';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import { tenantBookUrl } from '@/lib/slugify';
+import { formatAuthor } from '@/lib/utils';
 
 interface Props {
   params: Promise<{ tenant: string; ubn: string }>;
@@ -47,6 +48,26 @@ interface BphWorkRow {
   sl_book_slug: string | null;
 }
 
+interface SlBook {
+  id: string;
+  slug: string;
+  title?: string;
+  display_title?: string;
+  english_title?: string;
+  author?: string;
+  language?: string;
+  published?: string;
+  place_published?: string;
+  publisher?: string;
+  pages_count?: number;
+  pages_ocr?: number;
+  pages_translated?: number;
+  categories?: string[];
+  is_first_translation?: boolean;
+  doi?: string;
+  reading_summary?: { overview?: string };
+}
+
 async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
   const { data } = await supabase
     .from('bph_works')
@@ -65,15 +86,42 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
 }
 
 /** Look up the live Source Library book matching this UBN, if any. */
-async function fetchSlBook(ubn: string): Promise<{ id: string; slug: string } | null> {
+async function fetchSlBook(ubn: string): Promise<SlBook | null> {
   try {
     const db = await getReadDb();
     const book = await db.collection('books').findOne(
       { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': ubn },
-      { projection: { id: 1, slug: 1 }, maxTimeMS: 8_000 }
+      {
+        projection: {
+          id: 1, slug: 1, title: 1, display_title: 1, english_title: 1,
+          author: 1, language: 1, published: 1, place_published: 1, publisher: 1,
+          pages_count: 1, pages_ocr: 1, pages_translated: 1,
+          categories: 1, is_first_translation: 1, doi: 1,
+          'reading_summary.overview': 1,
+        },
+        maxTimeMS: 8_000,
+      }
     );
     if (!book) return null;
-    return { id: book.id as string, slug: (book.slug as string) || (book.id as string) };
+    return {
+      id: book.id as string,
+      slug: (book.slug as string) || (book.id as string),
+      title: book.title as string | undefined,
+      display_title: book.display_title as string | undefined,
+      english_title: book.english_title as string | undefined,
+      author: book.author as string | undefined,
+      language: book.language as string | undefined,
+      published: book.published as string | undefined,
+      place_published: book.place_published as string | undefined,
+      publisher: book.publisher as string | undefined,
+      pages_count: book.pages_count as number | undefined,
+      pages_ocr: book.pages_ocr as number | undefined,
+      pages_translated: book.pages_translated as number | undefined,
+      categories: book.categories as string[] | undefined,
+      is_first_translation: book.is_first_translation as boolean | undefined,
+      doi: book.doi as string | undefined,
+      reading_summary: book.reading_summary as { overview?: string } | undefined,
+    };
   } catch {
     return null;
   }
@@ -91,32 +139,38 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function CatalogEntryPage({ params }: Props) {
   const { tenant, ubn } = await params;
-  const work = await fetchWork(ubn);
+
+  // Fetch BPH catalog row + live SL book in parallel
+  const [work, slBook] = await Promise.all([
+    fetchWork(ubn),
+    fetchSlBook(ubn),
+  ]);
   if (!work) notFound();
 
-  // Bridge to a live SL book if one exists (prefer fresh MongoDB lookup over the cached sl_book_id column)
-  const slBook = (await fetchSlBook(ubn)) ?? (work.sl_book_id ? { id: work.sl_book_id, slug: work.sl_book_slug || work.sl_book_id } : null);
-
   const displayTitle = work.title || work.parallel_title || work.uniform_title || `(untitled — UBN ${work.ubn})`;
-  const backHref = `/catalog`;
+  const slBookHref = slBook ? tenantBookUrl({ id: slBook.id, slug: slBook.slug }, tenant) : null;
+  const canonicalAuthor = slBook?.author ? formatAuthor(slBook.author).name : null;
+  const translationPct = slBook && slBook.pages_translated && slBook.pages_ocr
+    ? Math.round((slBook.pages_translated / Math.max(slBook.pages_ocr, 1)) * 100)
+    : null;
 
   return (
     <div className="bg-cream">
       <ConditionalSiteHeader variant="dark" />
 
-      <div className="max-w-4xl mx-auto px-6 py-8">
+      <div className="max-w-2xl mx-auto px-6 py-8">
         <Link
-          href={backHref}
+          href="/catalog"
           className="inline-flex items-center gap-1.5 text-sm text-muted hover:text-primary mb-4 transition-colors"
         >
           <ArrowLeft className="w-4 h-4" />
           Back to catalog
         </Link>
 
+        {/* Identity */}
         <h1 className="text-3xl sm:text-4xl text-primary font-display leading-tight mb-2">
           {displayTitle}
         </h1>
-
         {work.parallel_title && work.parallel_title !== displayTitle && (
           <p className="text-base text-secondary italic mb-2 leading-snug">
             {work.parallel_title}
@@ -128,7 +182,6 @@ export default async function CatalogEntryPage({ params }: Props) {
             {work.uniform_title}
           </p>
         )}
-
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-secondary mb-6">
           {(work.author || work.variant_author) && (
             <span>{work.author || work.variant_author}</span>
@@ -138,87 +191,149 @@ export default async function CatalogEntryPage({ params }: Props) {
           {work.language && <span className="text-muted">{work.language}</span>}
         </div>
 
-        {slBook && (
-          <a
-            href={tenantBookUrl({ id: slBook.id, slug: slBook.slug }, tenant)}
-            className="inline-flex items-center gap-2 px-4 py-2 mb-8 rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 transition-colors"
-          >
-            <BookMarked className="w-4 h-4" />
-            Read on Source Library
-          </a>
+        {/* Source Library digital edition (when available) */}
+        {slBook && slBookHref && (
+          <section className="mb-8 p-5 rounded-lg border border-accent-rust/30 bg-white">
+            <div className="flex items-center gap-2 mb-3">
+              <BookMarked className="w-4 h-4 text-accent-rust" />
+              <h2 className="text-sm font-medium text-accent-rust uppercase tracking-wide">Digital edition on Source Library</h2>
+            </div>
+
+            {slBook.display_title && slBook.display_title !== work.title && (
+              <p className="text-lg text-primary font-display leading-snug mb-1">
+                {slBook.display_title}
+              </p>
+            )}
+            {slBook.english_title && slBook.english_title !== slBook.display_title && (
+              <p className="text-sm text-secondary mb-1">
+                <span className="text-xs uppercase tracking-wide mr-2 text-muted">English</span>
+                {slBook.english_title}
+              </p>
+            )}
+
+            <dl className="space-y-1.5 text-sm mb-4">
+              {canonicalAuthor && canonicalAuthor !== work.author && (
+                <Field label="Canonical author" value={canonicalAuthor} />
+              )}
+              {slBook.published && slBook.published !== String(work.year || '') && (
+                <Field label="Published" value={slBook.published} />
+              )}
+              {slBook.language && (
+                <Field label="Original language" value={slBook.language} />
+              )}
+              {slBook.pages_count != null && (
+                <Field label="Pages" value={String(slBook.pages_count)} />
+              )}
+              {translationPct != null && (
+                <Field label="Translation" value={`${translationPct}% translated to English`} />
+              )}
+              {slBook.is_first_translation && (
+                <FieldRaw label="Status">
+                  <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-accent-rust/10 text-accent-rust border border-accent-rust/30">
+                    First English translation
+                  </span>
+                </FieldRaw>
+              )}
+              {slBook.categories && slBook.categories.length > 0 && (
+                <Field label="Categories" value={slBook.categories.join(', ')} />
+              )}
+              {slBook.doi && (
+                <FieldRaw label="DOI">
+                  <a href={`https://doi.org/${slBook.doi}`} target="_blank" rel="noopener noreferrer" className="text-accent-rust hover:underline inline-flex items-center gap-1">
+                    {slBook.doi} <ExternalLink className="w-3 h-3" />
+                  </a>
+                </FieldRaw>
+              )}
+            </dl>
+
+            {slBook.reading_summary?.overview && (
+              <p className="text-sm text-secondary leading-relaxed mb-4 italic">
+                {slBook.reading_summary.overview.length > 380
+                  ? slBook.reading_summary.overview.slice(0, 380) + '…'
+                  : slBook.reading_summary.overview}
+              </p>
+            )}
+
+            <a
+              href={slBookHref}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 transition-colors"
+            >
+              <BookOpen className="w-4 h-4" />
+              Read full text on Source Library
+            </a>
+          </section>
         )}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-1 mb-8">
-          <Section title="Title">
-            <Field label="Short title" value={work.title} />
-            <Field label="Full title (transcription)" value={work.parallel_title} />
-            <Field label="Variant title" value={work.uniform_title} />
-            <Field label="Series" value={work.series_title} />
-            <Field label="Volume" value={work.volume_title} />
-          </Section>
+        {/* Catalog metadata — every public field, single column */}
+        <Section title="Title">
+          <Field label="Short title" value={work.title} />
+          <Field label="Full title (transcription)" value={work.parallel_title} />
+          <Field label="Variant title" value={work.uniform_title} />
+          <Field label="Series" value={work.series_title} />
+          <Field label="Volume" value={work.volume_title} />
+        </Section>
 
-          <Section title="Authorship">
-            <Field label="Author" value={work.author} />
-            <Field label="Author (as on title page)" value={work.variant_author} />
-            <Field label="Pseudonym" value={work.pseudonym} />
-            <Field label="Editor / translator" value={work.editor} />
-            <Field label="Editor (as on title page)" value={work.variant_editor} />
-          </Section>
+        <Section title="Authorship">
+          <Field label="Author (BPH)" value={work.author} />
+          <Field label="Author (as on title page)" value={work.variant_author} />
+          <Field label="Pseudonym" value={work.pseudonym} />
+          <Field label="Editor / translator" value={work.editor} />
+          <Field label="Editor (as on title page)" value={work.variant_editor} />
+        </Section>
 
-          <Section title="Imprint">
-            <Field label="Place of publication" value={work.place} />
-            <Field label="Year of publication" value={work.year ? String(work.year) : null} />
-            <Field label="Printer" value={work.printer} />
-            <Field label="Printer (variant)" value={work.variant_printer} />
-            <Field label="Publisher" value={work.publisher} />
-            <Field label="Publisher (variant)" value={work.variant_publisher} />
-          </Section>
+        <Section title="Imprint">
+          <Field label="Place of publication" value={work.place} />
+          <Field label="Year of publication" value={work.year ? String(work.year) : null} />
+          <Field label="Printer" value={work.printer} />
+          <Field label="Printer (variant)" value={work.variant_printer} />
+          <Field label="Publisher" value={work.publisher} />
+          <Field label="Publisher (variant)" value={work.variant_publisher} />
+        </Section>
 
-          <Section title="Subject & Language">
-            <Field label="Keywords" value={work.keywords} />
-            <Field label="Language" value={work.language} />
-          </Section>
+        <Section title="Subject & Language">
+          <Field label="Keywords" value={work.keywords} />
+          <Field label="Language" value={work.language} />
+        </Section>
 
-          <Section title="Physical">
-            <Field label="Object size" value={work.object_size_cm} />
-            <Field label="Number of copies held" value={work.number_of_copies != null ? String(work.number_of_copies) : null} />
-            <Field label="Binding" value={work.binding} />
-            <Field label="Bound with" value={work.bound_with} />
-          </Section>
+        <Section title="Physical">
+          <Field label="Object size" value={work.object_size_cm} />
+          <Field label="Number of copies held" value={work.number_of_copies != null ? String(work.number_of_copies) : null} />
+          <Field label="Binding" value={work.binding} />
+          <Field label="Bound with" value={work.bound_with} />
+        </Section>
 
-          <Section title="Location at the BPH">
-            <Field label="Present location" value={work.present_location} />
-            <Field label="Shelf mark" value={work.shelf_mark} mono />
-            <Field label="State Collection shelf mark" value={work.state_shelf_mark} mono />
-            <Field label="Provenance / collection" value={work.provenance} />
-          </Section>
+        <Section title="Location at the BPH">
+          <Field label="Present location" value={work.present_location} />
+          <Field label="Shelf mark" value={work.shelf_mark} mono />
+          <Field label="State Collection shelf mark" value={work.state_shelf_mark} mono />
+          <Field label="Provenance / collection" value={work.provenance} />
+        </Section>
 
-          <Section title="Notes">
-            <Field label="Bibliography" value={work.bibliography} />
-            <Field label="Remarks" value={work.remarks} />
-          </Section>
+        <Section title="Notes">
+          <Field label="Bibliography" value={work.bibliography} />
+          <Field label="Remarks" value={work.remarks} />
+        </Section>
 
-          <Section title="Identifiers">
-            <Field label="UBN" value={work.ubn} mono />
-            <Field label="USTC" value={work.ustc_sn} mono />
-            {work.ia_identifier && (
-              <FieldRaw label="Internet Archive">
-                <a
-                  href={`https://archive.org/details/${work.ia_identifier}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-accent-rust hover:underline"
-                >
-                  {work.ia_identifier}
-                  <ExternalLink className="w-3 h-3" />
-                </a>
-              </FieldRaw>
-            )}
-          </Section>
-        </div>
+        <Section title="Identifiers">
+          <Field label="UBN" value={work.ubn} mono />
+          <Field label="USTC" value={work.ustc_sn} mono />
+          {work.ia_identifier && (
+            <FieldRaw label="Internet Archive">
+              <a
+                href={`https://archive.org/details/${work.ia_identifier}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-accent-rust hover:underline"
+              >
+                {work.ia_identifier}
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            </FieldRaw>
+          )}
+        </Section>
 
-        <p className="text-xs text-muted border-t border-border-light pt-4">
-          Source: Bibliotheca Philosophica Hermetica catalog (UBN {work.ubn}). Any data corrections should be made in the BPH catalog and re-imported.
+        <p className="text-xs text-muted border-t border-border-light pt-4 mt-2">
+          Catalog data sourced from the Bibliotheca Philosophica Hermetica (UBN {work.ubn}). Corrections should be made in the BPH catalog and re-imported.
         </p>
       </div>
     </div>
@@ -226,7 +341,6 @@ export default async function CatalogEntryPage({ params }: Props) {
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  // Hide the section if every Field rendered nothing
   return (
     <section className="mb-6">
       <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-2">{title}</h2>
@@ -235,11 +349,11 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-function Field({ label, value, mono = false }: { label: string; value: string | null; mono?: boolean }) {
+function Field({ label, value, mono = false }: { label: string; value: string | null | undefined; mono?: boolean }) {
   if (!value) return null;
   return (
     <div className="flex flex-col sm:flex-row sm:gap-3 text-sm">
-      <dt className="text-muted shrink-0 sm:w-44">{label}</dt>
+      <dt className="text-muted shrink-0 sm:w-52">{label}</dt>
       <dd className={`text-primary ${mono ? 'font-mono text-xs' : ''}`}>{value}</dd>
     </div>
   );
@@ -248,7 +362,7 @@ function Field({ label, value, mono = false }: { label: string; value: string | 
 function FieldRaw({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col sm:flex-row sm:gap-3 text-sm">
-      <dt className="text-muted shrink-0 sm:w-44">{label}</dt>
+      <dt className="text-muted shrink-0 sm:w-52">{label}</dt>
       <dd className="text-primary">{children}</dd>
     </div>
   );

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -430,7 +430,7 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug,
                     <td className="px-3 py-2 align-top">
                       <div className="font-medium text-primary leading-snug">
                         <a
-                          href={digitized ? tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug) : detailUrl(w.ubn)}
+                          href={detailUrl(w.ubn)}
                           className="hover:text-accent-rust transition-colors"
                         >
                           {displayTitle}


### PR DESCRIPTION
Follow-up to #1618.

- Single-column layout on `/catalog/{ubn}`.
- New "Digital edition on Source Library" section shown whenever the UBN matches a live SL book — surfaces `display_title`, `english_title`, canonical author, original language, page count, translation %, first-English-translation badge, categories, DOI, and the `reading_summary.overview` as a short blurb. Ends with a prominent CTA to read.
- Catalog browser: title now always links to the catalog detail (`/catalog/{ubn}`), and "Read on Source Library" is a distinct link below the title for digitized rows. Previously the title linked to the SL book for digitized rows, which gave no path to the catalog metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)