### PR TITLE
Use 'Digitized copy' label instead of 'Read on Source Library'

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -196,7 +196,7 @@ export default async function CatalogEntryPage({ params }: Props) {
           <section className="mb-8 p-5 rounded-lg border border-accent-rust/30 bg-white">
             <div className="flex items-center gap-2 mb-3">
               <BookMarked className="w-4 h-4 text-accent-rust" />
-              <h2 className="text-sm font-medium text-accent-rust uppercase tracking-wide">Digital edition on Source Library</h2>
+              <h2 className="text-sm font-medium text-accent-rust uppercase tracking-wide">Digitized copy</h2>
             </div>
 
             {slBook.display_title && slBook.display_title !== work.title && (
@@ -259,7 +259,7 @@ export default async function CatalogEntryPage({ params }: Props) {
               className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 transition-colors"
             >
               <BookOpen className="w-4 h-4" />
-              Read full text on Source Library
+              Read the digitized copy
             </a>
           </section>
         )}

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -442,7 +442,7 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug,
                           className="inline-flex items-center gap-1 mt-1 text-xs text-accent-rust hover:underline"
                         >
                           <BookMarked className="w-3 h-3" />
-                          Read on Source Library
+                          Digitized copy
                         </a>
                       )}
                       {/* Mobile: show author + place inline */}


### PR DESCRIPTION
Per Derek — 'Digitized copy' reads more naturally in the catalog context. Updates the inline badge in BphCatalogBrowser, the section heading on the detail page, and the primary CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)