### PR TITLE
Fix wrong <title> on every embed (tenant subdomain) book page

### DIFF
--- a/src/app/embed/[tenant]/book/[slug]/page.tsx
+++ b/src/app/embed/[tenant]/book/[slug]/page.tsx
@@ -1,8 +1,18 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getReadDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
-import BookDetailPage from '@/app/[tenant]/book/[id]/page';
-export { generateMetadata } from '@/app/[tenant]/book/[id]/page';
+import BookDetailPage, { generateMetadata as parentGenerateMetadata } from '@/app/[tenant]/book/[id]/page';
+
+// The parent generateMetadata expects params.id; this route's param is named
+// `slug`. Forward it as id so the lookup actually has a value — otherwise
+// findBookByIdOrSlug builds {$or: [{slug: undefined}, {id: undefined}]},
+// which Mongo collapses to {$or: [{}, {}]} and returns the first book in
+// the tenant, breaking <title> tags on every embed book page.
+export async function generateMetadata({ params }: { params: Promise<{ tenant: string; slug: string }> }): Promise<Metadata> {
+  const { tenant, slug } = await params;
+  return parentGenerateMetadata({ params: Promise.resolve({ tenant, id: slug }) });
+}
 
 export const revalidate = 86400;
 export const preferredRegion = 'fra1';


### PR DESCRIPTION
## Summary
- Every BPH (and any tenant-subdomain) book page rendered the same wrong `<title>` ("Amphitheatrum sapientiae aeternae - Source Library") regardless of which book you opened. Body content was correct; only `<title>` was wrong.
- Cause: `src/app/embed/[tenant]/book/[slug]/page.tsx` re-exported `generateMetadata` from `[tenant]/book/[id]`. The parent destructures `params.id`, but the embed route's param is named `slug` — so `id` was always undefined.
- Downstream that became `findBookByIdOrSlug(db, undefined, ..., tenantId)` → Mongo drops undefined fields → `\$or: [{}, {}]` → returned the first book in the tenant. React `cache()` memoized that single book and reused it for every embed page.
- Fix: wrap the parent `generateMetadata` to forward `slug` as `id`.

## Test plan
- [ ] Hit several BPH book pages on `bph.sourcelibrary.org/book/{slug}` and confirm the browser tab `<title>` matches the book (not "Amphitheatrum sapientiae aeternae")
- [ ] Confirm OG/Twitter card meta tags are correct (these come from the same `generateMetadata`)
- [ ] Sanity-check the non-embed `/book/[id]` route still renders correct titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)