### PR TITLE
BPH cleanup: cross-tenant nav, duplicate-card distinguishability, embed white space

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -595,7 +595,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 <p className="text-stone-400 mt-1 italic text-sm sm:text-base">{book.title}</p>
               )}
               <p className="text-lg sm:text-xl text-stone-300 mt-2">
-                {authorUrl(book.author) ? (
+                {embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
                   <Link href={authorUrl(book.author)!} className="hover:text-white transition-colors">
                     <AuthorName author={book.author} />
                   </Link>
@@ -965,31 +965,21 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
               </div>
             )}
 
-            {/* Collections */}
+            {/* Collections — hidden in embed/tenant views since these would jump to the full Source Library */}
             {embedPolicy.enableBookCollectionNavigation && bookCollections.length > 0 && (
               <div>
                 <h3 className="text-sm font-medium mb-3" style={{ color: 'var(--text-secondary)' }}>Collections</h3>
                 <div className="flex flex-wrap gap-2">
-                  {bookCollections.map(col =>
-                    embedPolicy.enableBookCollectionNavigation ? (
-                      <Link
-                        key={col.slug}
-                        href={`/collections/${col.slug}`}
-                        className="text-xs px-2.5 py-1 rounded-full transition-colors"
-                        style={{ color: 'var(--text-secondary)', backgroundColor: 'var(--bg-tertiary)' }}
-                      >
-                        {col.name}
-                      </Link>
-                    ) : (
-                      <span
-                        key={col.slug}
-                        className="text-xs px-2.5 py-1 rounded-full"
-                        style={{ color: 'var(--text-secondary)', backgroundColor: 'var(--bg-tertiary)' }}
-                      >
-                        {col.name}
-                      </span>
-                    )
-                  )}
+                  {bookCollections.map(col => (
+                    <Link
+                      key={col.slug}
+                      href={`/collections/${col.slug}`}
+                      className="text-xs px-2.5 py-1 rounded-full transition-colors"
+                      style={{ color: 'var(--text-secondary)', backgroundColor: 'var(--bg-tertiary)' }}
+                    >
+                      {col.name}
+                    </Link>
+                  ))}
                 </div>
               </div>
             )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -644,6 +644,3 @@ body:has(.embed-mode) [data-site-mode-indicator] {
 body:has(.embed-mode) {
   background: #fafaf8;
 }
-body:has(.embed-mode) #main-content {
-  min-height: 100vh;
-}

--- a/src/components/AuthorName.tsx
+++ b/src/components/AuthorName.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { formatAuthor } from '@/lib/utils';
 
 interface AuthorNameProps {
@@ -10,18 +11,30 @@ interface AuthorNameProps {
  * Renders an author name, handling bibliographic bracket conventions.
  * Authors in [brackets] are displayed as "attr. Name" in italics,
  * indicating attributed (uncertain) authorship.
+ * Multiple authors separated by "|" are rendered with " · " between them.
  */
 export default function AuthorName({ author, className, fallback }: AuthorNameProps) {
-  const { name, attributed } = formatAuthor(author);
-  if (!name) return fallback ? <span className={className}>{fallback}</span> : null;
+  if (!author) return fallback ? <span className={className}>{fallback}</span> : null;
 
-  if (attributed) {
-    return (
-      <span className={className}>
-        <span className="italic" title="Attributed author (uncertain)">attr. {name}</span>
-      </span>
-    );
-  }
+  const parts = author
+    .split('|')
+    .map(p => formatAuthor(p))
+    .filter(p => p.name);
 
-  return <span className={className}>{name}</span>;
+  if (parts.length === 0) return fallback ? <span className={className}>{fallback}</span> : null;
+
+  return (
+    <span className={className}>
+      {parts.map((p, i) => (
+        <Fragment key={i}>
+          {i > 0 && <span className="opacity-50"> · </span>}
+          {p.attributed ? (
+            <span className="italic" title="Attributed author (uncertain)">attr. {p.name}</span>
+          ) : (
+            p.name
+          )}
+        </Fragment>
+      ))}
+    </span>
+  );
 }

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -135,6 +135,13 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
                     {book.year}
                   </span>
                 );
+              } else if (book.published) {
+                chips.push(
+                  <span key="year" className="flex items-center gap-1">
+                    <Calendar className="w-3 h-3" />
+                    {book.published}
+                  </span>
+                );
               }
               if (isArtwork) {
                 if (book.resource_type) {


### PR DESCRIPTION
## Summary
- **Book page (BPH/embed):** Author name no longer links to `/author/...` (was jumping out of BPH catalog into the full Source Library). Collections section hidden entirely instead of showing non-clickable badges with the \"Collections\" header.
- **AuthorName:** Splits multi-author strings on \`|\` and renders with \` · \` separator. Fixes \"Ulstad, Philip|Ficino, Marsilio\" being smushed together.
- **CollectionBookCard:** Falls back to \`book.published\` when \`book.year\` is 0/missing — gives more cards a date chip so duplicate-titled editions are distinguishable.
- **Embed CSS:** Removed \`min-height: 100vh\` on \`#main-content\` so the page sizes to content. Was creating a \"weird white area\" below short search results.

## Test plan
- [ ] Visit a BPH book page (e.g. https://sourcelibrary-v2-git-worktree-bph-cleanup-….vercel.app/embed/bph/book/<slug>): confirm author is plain text, Collections section is gone, multi-author shows separator.
- [ ] Visit BPH home, search to narrow results: page no longer extends with white space below.
- [ ] Visit a non-embed book page (sourcelibrary.org/book/<slug>): author is still a link, Collections still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)