### PR TITLE
BPH lockdown — guarantee zero non-BPH content on bph.sourcelibrary.org (#1617)

### DIFF
--- a/.github/workflows/bph-lockdown-audit.yml
+++ b/.github/workflows/bph-lockdown-audit.yml
@@ -1,0 +1,82 @@
+name: BPH lockdown audit
+
+# Crawls the BPH tenant subdomain and asserts no anchor or one-hop redirect
+# escapes off-host. Runs on PRs that touch the routing/URL-building surface
+# (proxy, embed routes, tenant routes, link-emitting libs) and nightly against
+# production.
+#
+# Why these paths: the lockdown invariant is enforced at the proxy + URL
+# generation layer. A change anywhere else is unlikely to leak; a change in
+# any of these files might.
+
+on:
+  pull_request:
+    paths:
+      - 'src/proxy.ts'
+      - 'src/app/embed/**'
+      - 'src/app/[tenant]/**'
+      - 'src/lib/shortlinks.ts'
+      - 'src/lib/embed-ui-policy.ts'
+      - 'src/lib/slugify.ts'
+      - 'src/components/book/Related*.tsx'
+      - 'src/components/book/AuthorCrossReference.tsx'
+      - 'scripts/audit-bph-leaks.mjs'
+  schedule:
+    # 14:00 UTC daily — production sanity check
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Tenant subdomain URL to audit'
+        required: false
+        default: 'https://bph.sourcelibrary.org'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve target URL
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # On PRs, audit the Vercel preview deploy. Falls back to prod if the
+            # preview URL secret isn't wired up — that still catches anchor leaks
+            # on the live site for any PR that ships before this guard does.
+            URL="${{ secrets.VERCEL_PREVIEW_BPH_URL }}"
+            if [ -z "$URL" ]; then URL="https://bph.sourcelibrary.org"; fi
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            URL="${{ github.event.inputs.target }}"
+          else
+            URL="https://bph.sourcelibrary.org"
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Auditing: $URL"
+
+      - name: Wait for Vercel preview (PRs only)
+        if: github.event_name == 'pull_request'
+        # Vercel comments on the PR with the preview URL once the build is done.
+        # 90s is enough for most builds to finish; the audit will retry below if
+        # the URL isn't reachable yet.
+        run: sleep 90
+
+      - name: Run BPH leak audit
+        env:
+          BPH_AUDIT_DEPTH: '3'
+          BPH_AUDIT_MAX: '80'
+        run: |
+          # Up to 3 attempts — preview URLs sometimes 404 right after deploy.
+          for attempt in 1 2 3; do
+            if node scripts/audit-bph-leaks.mjs "${{ steps.target.outputs.url }}"; then
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 30s"
+            sleep 30
+          done
+          echo "BPH lockdown audit failed after 3 attempts"
+          exit 1

--- a/.github/workflows/bph-lockdown-audit.yml
+++ b/.github/workflows/bph-lockdown-audit.yml
@@ -1,26 +1,17 @@
 name: BPH lockdown audit
 
-# Crawls the BPH tenant subdomain and asserts no anchor or one-hop redirect
-# escapes off-host. Runs on PRs that touch the routing/URL-building surface
-# (proxy, embed routes, tenant routes, link-emitting libs) and nightly against
-# production.
+# Crawls the live BPH tenant subdomain and asserts no anchor or one-hop
+# redirect escapes off-host. Runs nightly against production and on demand.
 #
-# Why these paths: the lockdown invariant is enforced at the proxy + URL
-# generation layer. A change anywhere else is unlikely to leak; a change in
-# any of these files might.
+# Not a PR check: the audit asserts an end-to-end property of the deployed
+# bph.sourcelibrary.org host. Vercel preview deploys don't carry the `bph.`
+# subdomain that proxy.ts keys on, so PR-time runs would either test prod
+# (the wrong target — by definition prod still has any pre-merge leaks) or
+# silently skip. The nightly run is the meaningful guard, and developers
+# touching routing/URL surfaces should `gh workflow run "BPH lockdown audit"`
+# before merging.
 
 on:
-  pull_request:
-    paths:
-      - 'src/proxy.ts'
-      - 'src/app/embed/**'
-      - 'src/app/[tenant]/**'
-      - 'src/lib/shortlinks.ts'
-      - 'src/lib/embed-ui-policy.ts'
-      - 'src/lib/slugify.ts'
-      - 'src/components/book/Related*.tsx'
-      - 'src/components/book/AuthorCrossReference.tsx'
-      - 'scripts/audit-bph-leaks.mjs'
   schedule:
     # 14:00 UTC daily — production sanity check
     - cron: '0 14 * * *'
@@ -44,13 +35,7 @@ jobs:
       - name: Resolve target URL
         id: target
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # On PRs, audit the Vercel preview deploy. Falls back to prod if the
-            # preview URL secret isn't wired up — that still catches anchor leaks
-            # on the live site for any PR that ships before this guard does.
-            URL="${{ secrets.VERCEL_PREVIEW_BPH_URL }}"
-            if [ -z "$URL" ]; then URL="https://bph.sourcelibrary.org"; fi
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             URL="${{ github.event.inputs.target }}"
           else
             URL="https://bph.sourcelibrary.org"
@@ -58,25 +43,8 @@ jobs:
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Auditing: $URL"
 
-      - name: Wait for Vercel preview (PRs only)
-        if: github.event_name == 'pull_request'
-        # Vercel comments on the PR with the preview URL once the build is done.
-        # 90s is enough for most builds to finish; the audit will retry below if
-        # the URL isn't reachable yet.
-        run: sleep 90
-
       - name: Run BPH leak audit
         env:
           BPH_AUDIT_DEPTH: '3'
           BPH_AUDIT_MAX: '80'
-        run: |
-          # Up to 3 attempts — preview URLs sometimes 404 right after deploy.
-          for attempt in 1 2 3; do
-            if node scripts/audit-bph-leaks.mjs "${{ steps.target.outputs.url }}"; then
-              exit 0
-            fi
-            echo "Attempt $attempt failed; retrying in 30s"
-            sleep 30
-          done
-          echo "BPH lockdown audit failed after 3 attempts"
-          exit 1
+        run: node scripts/audit-bph-leaks.mjs "${{ steps.target.outputs.url }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,21 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 - **NEVER** embed secrets in code — use `process.env.VAR` with no fallback
 - Review scripts for hardcoded credentials before committing
 
+## Tenant Subdomain Lockdown — CRITICAL
+Tenant subdomains (e.g. `bph.sourcelibrary.org`) MUST be a closed system. Visitors must never be able to land on, follow a link to, or be redirected to non-tenant content. EFM and other partners use these subdomains as their public face — leaks break the trust model.
+
+**Invariants** — verify every change against these:
+
+1. **No proxy redirect off the tenant subdomain.** `src/proxy.ts` rewrites every BPH path to `/embed/bph/...`. Never add a branch that issues a redirect to `sourcelibrary.org/...` (the original `/gallery` redirect was the canonical bug). Rewrites stay on-host; redirects must too.
+2. **Every server query touching a tenant page filters by tenant.** When rendered under `/embed/[tenant]/*` or `/[tenant]/*` with a tenant subdomain host, all data fetches must include the tenant constraint. The default for `held_by` / `image_source.provider` (Supabase) and `tenantId` (Atlas) is GLOBAL — explicit filtering is required. This applies to: book listings, related-books, related-editions, gallery images, collection highlights, exhibition books, mentioned books.
+3. **Pre-computed cross-references are not safe in embed mode.** `book.related_books`, `book.author_cross_ref`, and similar fields are computed across the whole library. Gate them behind `embedPolicy.show*` flags (defined in `src/lib/embed-ui-policy.ts`) — they must be `false` when `isEmbedded`.
+4. **Share/quote URLs use the request host.** `getShortUrl()` and the `/api/[tenant]/books/[id]/quote` route accept a `baseUrl` derived from the request via `getRequestBaseUrl(headers)`. Don't hardcode `https://sourcelibrary.org` in user-facing URLs returned from the API.
+5. **Internal anchor links are relative, not absolute.** `/book/...`, `/collections/...`, `/gallery/...` resolve against the tenant subdomain via `proxy.ts` rewrites. Any `https://sourcelibrary.org/...` href in component output is a leak.
+
+**Verifying the invariant**
+
+`node scripts/audit-bph-leaks.mjs` crawls the BPH subdomain, follows internal links to a configurable depth, and exits non-zero if any anchor or one-hop redirect resolves off-subdomain. Run it after touching anything in `src/proxy.ts`, `src/app/embed/**`, `src/app/[tenant]/**`, or any component that builds URLs.
+
 ## Stack
 - Next.js 16, MongoDB Atlas, Gemini AI, Vercel deployment
 - Production database: `bookstore` (~17K live books, ~24.5K warehouse), NOT `sourcelibrary_research`

--- a/scripts/audit-bph-leaks.mjs
+++ b/scripts/audit-bph-leaks.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * BPH lockdown audit — crawls a tenant subdomain and reports any link
+ * that escapes back to the main sourcelibrary.org site.
+ *
+ * Usage:
+ *   node scripts/audit-bph-leaks.mjs                          # crawls https://bph.sourcelibrary.org
+ *   node scripts/audit-bph-leaks.mjs https://bph.sourcelibrary.org
+ *   BPH_AUDIT_DEPTH=3 BPH_AUDIT_MAX=100 node scripts/audit-bph-leaks.mjs
+ *
+ * Exits 0 when no leaks are found; non-zero when leaks are detected. Wire
+ * into CI to keep the BPH subdomain pure.
+ *
+ * What "leak" means here:
+ *   - An <a href> that resolves to sourcelibrary.org (or any apex/www host
+ *     other than the tenant subdomain) is flagged. Visitors on the BPH
+ *     subdomain must never have a one-click escape into the wider library.
+ *   - An HTTP redirect (302/301) to a non-tenant host on the first hop is
+ *     flagged. The /gallery → sourcelibrary.org bug we shipped early on
+ *     was exactly this.
+ *
+ * Out of scope (manual audit needed): verifying that every book.id rendered
+ * on a page belongs to the tenant. Doable by parsing /book/<id> links and
+ * checking each book's tenantId via the API; not implemented here to keep
+ * the script offline-friendly.
+ */
+
+const TARGET = (process.argv[2] || 'https://bph.sourcelibrary.org').replace(/\/+$/, '');
+const MAX_DEPTH = Number(process.env.BPH_AUDIT_DEPTH || 2);
+const MAX_PAGES = Number(process.env.BPH_AUDIT_MAX || 60);
+
+const targetUrl = new URL(TARGET);
+const TENANT_HOST = targetUrl.host.toLowerCase();
+
+// Hosts that are explicitly OK to link to from the tenant subdomain.
+// Image CDNs, third-party DOI/IIIF endpoints, etc. live here.
+const ALLOWED_EXTERNAL = new Set([
+  'images.sourcelibrary.org',
+  'doi.org',
+  'creativecommons.org',
+  'iconclass.org',
+  'chineseiconography.org',
+  'github.com',
+  'twitter.com',
+  'x.com',
+  'mail.google.com',
+]);
+
+// Hosts that explicitly count as a leak — links here from a tenant subdomain
+// dump the visitor out of the tenant context.
+const LEAK_HOSTS = new Set([
+  'sourcelibrary.org',
+  'www.sourcelibrary.org',
+]);
+
+function classifyHref(href, fromUrl) {
+  if (!href) return null;
+  if (href.startsWith('javascript:') || href.startsWith('mailto:') || href.startsWith('tel:') || href.startsWith('#')) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(href, fromUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  const host = url.host.toLowerCase();
+  if (host === TENANT_HOST) return { url, kind: 'same-origin' };
+  if (LEAK_HOSTS.has(host)) return { url, kind: 'leak' };
+  if (ALLOWED_EXTERNAL.has(host)) return { url, kind: 'allowed-external' };
+  return { url, kind: 'external' };
+}
+
+const ANCHOR_RE = /<a\b[^>]*\bhref\s*=\s*("([^"]*)"|'([^']*)')/gi;
+
+function extractHrefs(html) {
+  const out = [];
+  let m;
+  while ((m = ANCHOR_RE.exec(html)) !== null) {
+    out.push(m[2] ?? m[3] ?? '');
+  }
+  return out;
+}
+
+const visited = new Set();
+const queue = [];
+const leaks = [];        // { fromUrl, href, resolved }
+const redirectLeaks = []; // { fromUrl, redirectedTo }
+let pagesFetched = 0;
+
+// Seed paths to probe explicitly. The BPH UI doesn't render anchors for some
+// of these (e.g. /gallery), so a pure link-crawler would miss the redirect bug.
+// Visitors reach them by typing them, following SEO-indexed external links, or
+// via legacy share URLs. If proxy.ts ever regresses to redirecting one of these
+// off-subdomain, the audit fires.
+const SEED_PATHS = [
+  '/',
+  '/gallery',
+  '/gallery/image/anything',
+  '/search',
+  '/catalog',
+  '/collections',
+  '/browse',
+  '/explore',
+  '/artwork',
+];
+for (const p of SEED_PATHS) queue.push({ url: TARGET + p, depth: 0 });
+
+async function fetchPage(url) {
+  // manual: catch one-hop redirects to off-domain hosts (the gallery bug)
+  const res = await fetch(url, { redirect: 'manual', headers: { 'User-Agent': 'BPH-Lockdown-Audit/1.0' } });
+  if (res.status >= 300 && res.status < 400) {
+    const loc = res.headers.get('location');
+    if (loc) {
+      const classification = classifyHref(loc, url);
+      if (classification?.kind === 'leak') {
+        // Record and STOP — following the redirect would count every link on
+        // the off-subdomain page as a fresh leak, drowning the real signal.
+        redirectLeaks.push({ fromUrl: url, redirectedTo: classification.url.toString() });
+        return { html: '', finalUrl: url, skipped: true };
+      }
+      // Same-origin or allowed-external redirect — follow once and crawl normally
+      const followed = await fetch(classification?.url?.toString() || loc, {
+        redirect: 'follow',
+        headers: { 'User-Agent': 'BPH-Lockdown-Audit/1.0' },
+      });
+      return { html: await followed.text(), finalUrl: followed.url };
+    }
+  }
+  return { html: await res.text(), finalUrl: res.url };
+}
+
+while (queue.length > 0 && pagesFetched < MAX_PAGES) {
+  const { url, depth } = queue.shift();
+  if (visited.has(url)) continue;
+  visited.add(url);
+  pagesFetched++;
+
+  let page;
+  try {
+    page = await fetchPage(url);
+  } catch (err) {
+    process.stderr.write(`fetch failed: ${url} — ${err?.message || err}\n`);
+    continue;
+  }
+
+  const hrefs = extractHrefs(page.html);
+  for (const href of hrefs) {
+    const classified = classifyHref(href, page.finalUrl);
+    if (!classified) continue;
+    if (classified.kind === 'leak') {
+      leaks.push({ fromUrl: url, href, resolved: classified.url.toString() });
+    } else if (classified.kind === 'same-origin' && depth < MAX_DEPTH) {
+      const next = classified.url.toString().split('#')[0];
+      if (!visited.has(next)) queue.push({ url: next, depth: depth + 1 });
+    }
+  }
+}
+
+const totalLeaks = leaks.length + redirectLeaks.length;
+process.stdout.write(`\nBPH lockdown audit\n`);
+process.stdout.write(`  base:    ${TARGET}\n`);
+process.stdout.write(`  pages:   ${pagesFetched} (visited)\n`);
+process.stdout.write(`  depth:   ${MAX_DEPTH}\n`);
+process.stdout.write(`  leaks:   ${totalLeaks}\n`);
+
+if (redirectLeaks.length > 0) {
+  process.stdout.write(`\nRedirect leaks (${redirectLeaks.length}):\n`);
+  for (const r of redirectLeaks.slice(0, 50)) {
+    process.stdout.write(`  ${r.fromUrl}\n    → ${r.redirectedTo}\n`);
+  }
+}
+
+if (leaks.length > 0) {
+  // Group by resolved host to make the report scannable
+  const byHost = new Map();
+  for (const l of leaks) {
+    const host = new URL(l.resolved).host;
+    if (!byHost.has(host)) byHost.set(host, []);
+    byHost.get(host).push(l);
+  }
+  process.stdout.write(`\nAnchor leaks (${leaks.length}):\n`);
+  for (const [host, group] of byHost) {
+    process.stdout.write(`  ${host}: ${group.length} link(s)\n`);
+    for (const l of group.slice(0, 5)) {
+      process.stdout.write(`    href="${l.href}"   from ${l.fromUrl}\n`);
+    }
+    if (group.length > 5) process.stdout.write(`    … and ${group.length - 5} more\n`);
+  }
+}
+
+if (totalLeaks === 0) {
+  process.stdout.write(`\nNo leaks detected. The BPH subdomain stays inside ${TENANT_HOST}.\n`);
+  process.exit(0);
+} else {
+  process.stdout.write(`\nLeaks detected. Patch each one before shipping.\n`);
+  process.exit(1);
+}

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -512,6 +512,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
         book={book}
         collections={bookCollections}
         relatedBooks={relatedBooksByAuthor}
+        isEmbedded={!embedPolicy.showAuthorCrossReference}
       />
     );
   }
@@ -816,15 +817,17 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 showTranslationMethodologyLink={embedPolicy.showTranslationMethodologyLink}
                 showExternalLinks={embedPolicy.showExternalLinks}
               >
-                {(book as unknown as { work_id?: string }).work_id && (
+                {embedPolicy.showRelatedEditions && (book as unknown as { work_id?: string }).work_id && (
                   <Suspense fallback={null}>
                     <RelatedEditions bookId={book.id} workId={(book as unknown as { work_id?: string }).work_id!} />
                   </Suspense>
                 )}
               </BibliographicInfo>
 
-              {/* Cross-reference: artworks by this author (pre-computed) */}
-              {(book as any).author_cross_ref && (
+              {/* Cross-reference: artworks by this author (pre-computed).
+                  Hidden in embed mode — the pre-computed data is not tenant-filtered,
+                  so it can include artworks/books from other tenants. */}
+              {embedPolicy.showAuthorCrossReference && (book as any).author_cross_ref && (
                 <AuthorCrossReference
                   author={book.author}
                   crossRef={(book as any).author_cross_ref}

--- a/src/app/api/[tenant]/books/[id]/quote/route.ts
+++ b/src/app/api/[tenant]/books/[id]/quote/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
-import { getShortUrl } from '@/lib/shortlinks';
+import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -58,6 +58,7 @@ function generateCitations(
   pageNumber: number,
   bookId: string,
   pageId: string,
+  baseUrl: string,
   edition?: TranslationEdition
 ): Citation {
   const year = book.published || 'n.d.';
@@ -106,13 +107,15 @@ function generateCitations(
   // MLA
   const mla = `${authorLastFirst}. ${title}. Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
 
-  // Direct URL to page in Source Library (pinned to edition version)
+  // Direct URL to page in Source Library (pinned to edition version).
+  // baseUrl is the request host so citations rendered on tenant subdomains
+  // (e.g. bph.sourcelibrary.org) link back to the same subdomain.
   const editionVersion = edition?.version;
   const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `https://sourcelibrary.org/book/${bookId}/page/${pageId}${vParam}`;
+  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
 
   // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId);
+  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
 
   return {
     inline,
@@ -206,7 +209,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         published: book.published,
         language: book.language,
       },
-      citation: generateCitations(book, pageNumber, resolvedBookId, page.id, currentEdition),
+      citation: generateCitations(book, pageNumber, resolvedBookId, page.id, getRequestBaseUrl(request.headers), currentEdition),
       license: {
         spdx: 'CC-BY-SA-4.0',
         url: 'https://creativecommons.org/licenses/by-sa/4.0/',

--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
 import { Book, Page, TranslationEdition } from '@/lib/types';
-import { getShortUrl } from '@/lib/shortlinks';
+import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
 
@@ -57,6 +57,7 @@ function generateCitations(
   pageNumber: number,
   bookId: string,
   pageId: string,
+  baseUrl: string,
   edition?: TranslationEdition
 ): Citation {
   const year = book.published || 'n.d.';
@@ -105,13 +106,15 @@ function generateCitations(
   // MLA
   const mla = `${authorLastFirst}. ${title}. Translated by Source Library, ${translationYear}.${doi ? ` DOI: ${doi}.` : ''} Accessed ${accessed}.`;
 
-  // Direct URL to page in Source Library (pinned to edition version)
+  // Direct URL to page in Source Library (pinned to edition version).
+  // baseUrl is derived from the request host so quotes returned from
+  // tenant subdomains link back to the same subdomain.
   const editionVersion = edition?.version;
   const vParam = editionVersion ? `?v=${editionVersion}` : '';
-  const url = `https://sourcelibrary.org/book/${bookId}/page/${pageId}${vParam}`;
+  const url = `${baseUrl}/book/${bookId}/page/${pageId}${vParam}`;
 
   // Short URL for sharing
-  const short_url = getShortUrl(bookId, pageNumber, pageId);
+  const short_url = getShortUrl(bookId, pageNumber, pageId, baseUrl);
 
   return {
     inline,
@@ -199,7 +202,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         published: book.published,
         language: book.language,
       },
-      citation: generateCitations(book, pageNumber, resolvedBookId, page.id, currentEdition),
+      citation: generateCitations(book, pageNumber, resolvedBookId, page.id, getRequestBaseUrl(request.headers), currentEdition),
       license: {
         spdx: 'CC-BY-SA-4.0',
         url: 'https://creativecommons.org/licenses/by-sa/4.0/',

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -225,10 +225,17 @@ async function fetchCollectionData(id: string, provider?: string) {
       ],
     };
   // Provider filter — restrict to a specific library's books.
-  if (provider) {
+  // Used by tenant subdomains (e.g. bph.sourcelibrary.org) to scope every
+  // book listing on the page to that library. The same clause is reused below
+  // for all secondary lookups (highlights, mentions, exhibition, artworks)
+  // so a single page never mixes content from multiple libraries.
+  const providerClause = provider
+    ? { $or: [{ held_by: provider }, { 'image_source.provider': provider }] }
+    : null;
+  if (providerClause) {
     filter.$and = [
       ...(filter.$and as unknown[] || []),
-      { $or: [{ held_by: provider }, { 'image_source.provider': provider }] },
+      providerClause,
     ];
   }
 
@@ -263,7 +270,12 @@ async function fetchCollectionData(id: string, provider?: string) {
     ? withTimeout(
       db.collection('books')
         .find(
-          { collections: id, resource_type: { $exists: true }, hidden: { $ne: true } },
+          {
+            collections: id,
+            resource_type: { $exists: true },
+            hidden: { $ne: true },
+            ...(providerClause ? { $and: [providerClause] } : {}),
+          },
           {
             projection: {
               _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1, published: 1,
@@ -360,7 +372,11 @@ async function fetchCollectionData(id: string, provider?: string) {
       ? withTimeout(
         db.collection('books')
           .find(
-            { id: { $in: curatedBookIds }, visible: true },
+            {
+              id: { $in: curatedBookIds },
+              visible: true,
+              ...(providerClause ? { $and: [providerClause] } : {}),
+            },
             { projection: { ...projection, is_first_translation: 1, 'translation_verification.disposition': 1 } },
           )
           .toArray(),
@@ -389,7 +405,11 @@ async function fetchCollectionData(id: string, provider?: string) {
           // Fallback: dynamic query (before thematic collections are seeded)
           const bookDocs = await db.collection('books')
             .find(
-              { collections: id, visible: true },
+              {
+                collections: id,
+                visible: true,
+                ...(providerClause ? { $and: [providerClause] } : {}),
+              },
               { projection: { id: 1 }, maxTimeMS: 5000 }
             )
             .toArray();
@@ -411,7 +431,11 @@ async function fetchCollectionData(id: string, provider?: string) {
       ? withTimeout(
         db.collection('books')
           .find(
-            { id: { $in: mentionedBookIds }, pages_translated: { $gt: 0 } },
+            {
+              id: { $in: mentionedBookIds },
+              pages_translated: { $gt: 0 },
+              ...(providerClause ? { $and: [providerClause] } : {}),
+            },
             { projection }
           )
           .toArray(),
@@ -518,7 +542,11 @@ async function fetchCollectionData(id: string, provider?: string) {
     if (allBookIds.size > 0) {
       const exBooks = await withTimeout(
         db.collection('books').find(
-          { id: { $in: [...allBookIds] }, visible: true },
+          {
+            id: { $in: [...allBookIds] },
+            visible: true,
+            ...(providerClause ? { $and: [providerClause] } : {}),
+          },
           { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, 'translation_verification.disposition': 1 } },
         ).toArray(),
         8000, [],

--- a/src/app/embed/[tenant]/gallery/image/[id]/page.tsx
+++ b/src/app/embed/[tenant]/gallery/image/[id]/page.tsx
@@ -1,0 +1,4 @@
+// Tenant subdomain entry for /gallery/image/[id] (see src/proxy.ts).
+// The underlying client page is tenant-agnostic — it loads its data via
+// /api/[tenant]/gallery/image/* using the tenant header set by proxy.ts.
+export { default } from '@/app/[tenant]/gallery/image/[id]/page';

--- a/src/app/embed/[tenant]/gallery/layout.tsx
+++ b/src/app/embed/[tenant]/gallery/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from '@/app/[tenant]/gallery/layout';

--- a/src/app/embed/[tenant]/gallery/page.tsx
+++ b/src/app/embed/[tenant]/gallery/page.tsx
@@ -1,0 +1,4 @@
+// Tenant subdomains route /gallery here (see src/proxy.ts).
+// The underlying /[tenant]/gallery page reads x-tenant-id from headers
+// (set by proxy.ts), so it filters to BPH content with no extra plumbing.
+export { default, revalidate } from '@/app/[tenant]/gallery/page';

--- a/src/components/artwork/ArtworkInfo.tsx
+++ b/src/components/artwork/ArtworkInfo.tsx
@@ -65,9 +65,11 @@ interface ArtworkInfoProps {
   prevWork?: ArtworkNavItem | null;
   nextWork?: ArtworkNavItem | null;
   relatedBooks?: RelatedBookPreview[];
+  /** When true, hide cross-tenant widgets (AuthorCrossReference renders unfiltered global data). */
+  isEmbedded?: boolean;
 }
 
-export default function ArtworkInfo({ book, collections, prevWork, nextWork, relatedBooks = [] }: ArtworkInfoProps) {
+export default function ArtworkInfo({ book, collections, prevWork, nextWork, relatedBooks = [], isEmbedded = false }: ArtworkInfoProps) {
   const displayImage = book.thumbnail || (book as any).thumbnail_blob || '';
   const thumbImage = (book as any).thumbnail_blob || '';
   const commonsUrl = (book as any).commons_url || '';
@@ -401,8 +403,9 @@ export default function ArtworkInfo({ book, collections, prevWork, nextWork, rel
           </div>
         )}
 
-        {/* Cross-reference: books by this author (pre-computed) */}
-        {(book as any).author_cross_ref && (
+        {/* Cross-reference: books by this author (pre-computed).
+            Hidden in embed mode — author_cross_ref is computed across all tenants. */}
+        {!isEmbedded && (book as any).author_cross_ref && (
           <AuthorCrossReference
             author={book.author}
             crossRef={(book as any).author_cross_ref}

--- a/src/lib/embed-ui-policy.ts
+++ b/src/lib/embed-ui-policy.ts
@@ -7,6 +7,12 @@ export interface EmbedUiPolicy {
   showTranslationMethodologyLink: boolean;
   showExternalLinks: boolean;
   showGalleryImages: boolean;
+  // BPH lockdown: these widgets render data from across the global library
+  // (RelatedEditions queries every book with the same work_id; AuthorCrossReference
+  // renders pre-computed artwork/book lists that are not tenant-filtered). Hiding
+  // them in embed mode is the simplest way to guarantee no non-tenant content leaks.
+  showRelatedEditions: boolean;
+  showAuthorCrossReference: boolean;
 }
 
 export function getEmbedUiPolicy(isEmbedded: boolean): EmbedUiPolicy {
@@ -20,6 +26,8 @@ export function getEmbedUiPolicy(isEmbedded: boolean): EmbedUiPolicy {
       showTranslationMethodologyLink: true,
       showExternalLinks: true,
       showGalleryImages: true,
+      showRelatedEditions: true,
+      showAuthorCrossReference: true,
     };
   }
 
@@ -32,5 +40,7 @@ export function getEmbedUiPolicy(isEmbedded: boolean): EmbedUiPolicy {
     showTranslationMethodologyLink: false,
     showExternalLinks: false,
     showGalleryImages: false,
+    showRelatedEditions: false,
+    showAuthorCrossReference: false,
   };
 }

--- a/src/lib/shortlinks.ts
+++ b/src/lib/shortlinks.ts
@@ -118,17 +118,34 @@ export function decodeShortlink(code: string): { bookId: string; pageNumber: num
  * @param bookId - Book ID (24-char ObjectId or UUID)
  * @param pageNumber - Page number for shortlink encoding
  * @param pageId - Optional page ID for fallback URL (required for UUID book IDs)
+ * @param baseUrl - Optional base URL (e.g. "https://bph.sourcelibrary.org") used for tenant subdomains.
+ *                  Defaults to https://sourcelibrary.org so existing API consumers are unchanged.
  */
-export function getShortUrl(bookId: string, pageNumber: number, pageId?: string): string {
+export function getShortUrl(bookId: string, pageNumber: number, pageId?: string, baseUrl?: string): string {
+  const base = (baseUrl || 'https://sourcelibrary.org').replace(/\/+$/, '');
   // Only encode shortlinks for 24-char hex ObjectIds
   if (/^[a-f0-9]{24}$/i.test(bookId)) {
     const code = encodeShortlink(bookId, pageNumber);
-    return `https://sourcelibrary.org/q/${code}`;
+    return `${base}/q/${code}`;
   }
   // Fallback to regular URL for UUIDs or other ID formats
   if (pageId) {
-    return `https://sourcelibrary.org/book/${bookId}/page/${pageId}`;
+    return `${base}/book/${bookId}/page/${pageId}`;
   }
   // Last resort: link to book page (user can navigate to specific page)
-  return `https://sourcelibrary.org/book/${bookId}#page-${pageNumber}`;
+  return `${base}/book/${bookId}#page-${pageNumber}`;
+}
+
+/**
+ * Build a tenant-safe base URL from a NextRequest's host header.
+ * Used by the quote API so citations rendered on bph.sourcelibrary.org link
+ * back to bph.sourcelibrary.org rather than the main site.
+ */
+export function getRequestBaseUrl(headers: Headers): string {
+  const host = headers.get('x-forwarded-host') || headers.get('host') || '';
+  if (!host || /[^a-z0-9.\-:]/i.test(host)) {
+    return 'https://sourcelibrary.org';
+  }
+  const proto = headers.get('x-forwarded-proto') || 'https';
+  return `${proto}://${host}`;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -356,16 +356,22 @@ export async function proxy(request: NextRequest) {
       // Catalog entry detail (e.g. /catalog/12345 for UBN-keyed BPH works)
       url.pathname = `/embed/${tenant}${pathname}`;
     } else if (pathname.startsWith('/gallery')) {
-      // Gallery doesn't have tenant-specific embeds — redirect to main site
-      const mainUrl = request.nextUrl.clone();
-      mainUrl.host = 'sourcelibrary.org';
-      mainUrl.port = '';
-      return NextResponse.redirect(mainUrl, 302);
+      // Keep gallery traffic inside the tenant subdomain — never redirect out
+      // to sourcelibrary.org (BPH lockdown invariant).
+      url.pathname = `/embed/${tenant}${pathname}`;
     } else {
       // All other paths on tenant subdomain → embed root (filtered search)
       url.pathname = `/embed/${tenant}`;
     }
-    return NextResponse.rewrite(url);
+    // Resolve and forward the tenant id so embed pages that read tenant context
+    // from headers (e.g. /[tenant]/gallery/page.tsx, re-exported under
+    // /embed/[tenant]/gallery) see the tenant. Pages that already read the
+    // tenant slug from URL params are unaffected.
+    const subdomainTenant = await resolveTenantByExactSlug(tenant);
+    const subdomainHeaders = new Headers(request.headers);
+    subdomainHeaders.set('x-tenant-slug', tenant);
+    if (subdomainTenant?.id) subdomainHeaders.set('x-tenant-id', subdomainTenant.id);
+    return NextResponse.rewrite(url, { request: { headers: subdomainHeaders } });
   }
 
   // --- Canonical book URLs ---


### PR DESCRIPTION
Closes #1617.

## Summary
- Patches every leak point we could verify on `bph.sourcelibrary.org`: `/gallery` redirect to main, RelatedEditions/AuthorCrossReference cross-tenant queries, missing `x-tenant-id` on subdomain rewrites, and quote/shortlink URLs hardcoded to `sourcelibrary.org`.
- Adds `scripts/audit-bph-leaks.mjs` so the invariant is enforceable rather than just documented.
- Documents the lockdown invariant in `CLAUDE.md` so future work doesn't regress it.

## Changes
- **`src/proxy.ts`** — rewrites `/gallery*` on tenant subdomains to `/embed/[tenant]/gallery*` instead of redirecting off-host. Also propagates `x-tenant-id` on the rewrite so embed pages reading the header (gallery) see the tenant.
- **`src/app/embed/[tenant]/gallery/{page,layout}.tsx`** + **`gallery/image/[id]/page.tsx`** — thin re-exports that mount the existing `/[tenant]/gallery` UI under the embed namespace.
- **`src/lib/embed-ui-policy.ts`** — adds `showRelatedEditions` and `showAuthorCrossReference` (false when embedded). Both widgets render pre-computed/global data and previously appeared on BPH book pages.
- **`src/app/[tenant]/book/[id]/page.tsx`** + **`src/components/artwork/ArtworkInfo.tsx`** — gate the two widgets behind the new flags.
- **`src/lib/shortlinks.ts`** — `getShortUrl()` now accepts a `baseUrl`, plus a new `getRequestBaseUrl(headers)` helper.
- **`src/app/api/[tenant]/books/[id]/quote/route.ts`** + **`/api/books/[id]/quote/route.ts`** — both routes derive the base URL from the request host. Quotes returned for bph.sourcelibrary.org now share back to the same subdomain.
- **`src/app/collections/[id]/page.tsx`** — `providerClause` is reused across highlights, mentioned books, exhibition books, the gallery fallback query, and artworks (the main listing was already filtered).
- **`CLAUDE.md`** — documents the five invariants and points at the audit script.

## Audit script
`node scripts/audit-bph-leaks.mjs` crawls https://bph.sourcelibrary.org by default, follows internal links to depth 2, and probes a seed list of risky paths (`/gallery`, `/gallery/image/anything`, `/search`, `/catalog`, …) so visitor-invisible redirect bugs are still caught.

Run against production today (pre-merge):
```
leaks: 2
Redirect leaks (2):
  https://bph.sourcelibrary.org/gallery → https://sourcelibrary.org/gallery
  https://bph.sourcelibrary.org/gallery/image/anything → https://sourcelibrary.org/gallery/image/anything
```

Both are the leaks this PR fixes. No anchor leaks at depth 3 / 80 pages.

## Out of scope
- Verifying every `book.id` rendered on a BPH page belongs to the BPH tenant. The crawler is link-based; deep payload validation would need API access plus tenantId lookup per book. Worth a follow-up if EFM wants belt-and-suspenders.
- Re-keying pre-computed cross-references (`book.related_books`, `book.author_cross_ref`) per tenant. Hidden in embed mode now; recomputing would let us re-enable them on the BPH UI.

## Test plan
- [ ] Vercel preview build passes
- [ ] Visit preview `bph.sourcelibrary.org/gallery` (via preview URL header rewrite or local dev) — renders the BPH gallery, not a redirect
- [ ] Open a BPH book page — RelatedEditions count and AuthorCrossReference panel are no longer rendered
- [ ] Hit `/api/bph/books/{id}/quote?page=N` from the BPH preview host — `citation.url` and `citation.short_url` use the BPH host
- [ ] Run `node scripts/audit-bph-leaks.mjs https://<preview-host>` — exits 0
- [ ] Confirm a non-BPH book viewed via `bph.sourcelibrary.org/book/<slug>` still 404s (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)