### PR TITLE
BPH catalog: derive bibliographic format from size, with field provenance

### DIFF
--- a/scripts/migration/add-bph-format-and-provenance.sql
+++ b/scripts/migration/add-bph-format-and-provenance.sql
@@ -1,0 +1,23 @@
+-- Add bibliographic format + per-field provenance to bph_works.
+--
+-- `bibliographic_format` is the cataloger's "what fold of sheet is this" answer
+-- (folio / quarto / octavo / duodecimo / sextodecimo / smaller). Vitec Memorix
+-- export doesn't include it; we derive from `object_size_cm` height where
+-- possible, and leave NULL when there's no signal.
+--
+-- `field_provenance` is a JSONB map keyed by field name. Each entry records
+-- `source` (e.g. "import", "derived_from_size", "manual"), `evidence` (free
+-- text — what we used to decide), and `derived_at` (ISO timestamp). This lets
+-- Paul's team distinguish authoritative cataloged data from our heuristic
+-- backfill, and gives librarians a clear path to override (set the field by
+-- hand, write `source: "manual"`).
+--
+-- Run via:
+--   psql "$DATABASE_URL" -f scripts/migration/add-bph-format-and-provenance.sql
+
+ALTER TABLE bph_works
+  ADD COLUMN IF NOT EXISTS bibliographic_format TEXT,
+  ADD COLUMN IF NOT EXISTS field_provenance     JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS bph_works_format_idx ON bph_works (bibliographic_format)
+  WHERE bibliographic_format IS NOT NULL;

--- a/scripts/migration/derive-bph-format-from-size.mjs
+++ b/scripts/migration/derive-bph-format-from-size.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Derive `bibliographic_format` for bph_works rows that have `object_size_cm`
+ * but no format yet. Writes provenance into `field_provenance.bibliographic_format`
+ * so Paul's team can tell a derived value from a librarian-entered one.
+ *
+ * Format buckets (height in cm, the first dimension in the "HxWxD" string):
+ *   folio        ≥35
+ *   quarto       25-34.99
+ *   octavo       20-24.99
+ *   duodecimo    17-19.99
+ *   sextodecimo  15-16.99
+ *   smaller      <15
+ *
+ * These are the standard library-cataloging fall-backs used when the
+ * signature collation isn't known. Real format determination needs the
+ * gathering structure (A-Ff4 etc.), which requires physical inspection;
+ * this is explicitly an estimate, recorded as such in field_provenance.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/derive-bph-format-from-size.mjs [--dry-run] [--limit N]
+ *
+ * Idempotent: only writes rows where bibliographic_format IS NULL or the
+ * existing provenance source is `derived_from_size` (so re-running picks up
+ * the latest threshold tweak without clobbering manual edits).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'util';
+
+const { values: args } = parseArgs({
+  options: {
+    'dry-run': { type: 'boolean', default: false },
+    limit: { type: 'string' },
+  },
+});
+
+const DRY_RUN = args['dry-run'];
+const LIMIT = args.limit ? parseInt(args.limit, 10) : Infinity;
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+function parseHeightCm(raw) {
+  if (!raw) return null;
+  // Vitec format is "HxWxD" with comma decimals: "16,5x11,2x6,2"
+  const norm = String(raw).replace(/,/g, '.');
+  const m = norm.match(/(\d+(?:\.\d+)?)/);
+  if (!m) return null;
+  const h = parseFloat(m[1]);
+  return Number.isFinite(h) && h > 0 ? h : null;
+}
+
+function bucket(heightCm) {
+  if (heightCm >= 35) return 'folio';
+  if (heightCm >= 25) return 'quarto';
+  if (heightCm >= 20) return 'octavo';
+  if (heightCm >= 17) return 'duodecimo';
+  if (heightCm >= 15) return 'sextodecimo';
+  return 'smaller';
+}
+
+async function fetchAllCandidates() {
+  // Only consider rows that lack a format OR whose format is itself derived
+  // (re-deriving lets us refine thresholds without losing manual edits).
+  const all = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('bph_works')
+      .select('ubn, object_size_cm, bibliographic_format, field_provenance')
+      .not('object_size_cm', 'is', null)
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < PAGE) break;
+    if (all.length >= LIMIT) break;
+  }
+  return all.slice(0, LIMIT);
+}
+
+async function main() {
+  console.log('Fetching candidate rows…');
+  const rows = await fetchAllCandidates();
+  console.log(`  ${rows.length} rows have object_size_cm`);
+
+  const now = new Date().toISOString();
+  const updates = [];
+  const dist = { folio: 0, quarto: 0, octavo: 0, duodecimo: 0, sextodecimo: 0, smaller: 0 };
+  let skippedManual = 0;
+  let skippedNoHeight = 0;
+
+  for (const r of rows) {
+    const existingSource = r.field_provenance?.bibliographic_format?.source;
+    if (r.bibliographic_format && existingSource && existingSource !== 'derived_from_size') {
+      skippedManual++;
+      continue;
+    }
+    const h = parseHeightCm(r.object_size_cm);
+    if (h == null) { skippedNoHeight++; continue; }
+
+    const fmt = bucket(h);
+    dist[fmt]++;
+
+    const newProvenance = {
+      ...(r.field_provenance || {}),
+      bibliographic_format: {
+        source: 'derived_from_size',
+        evidence: `height ${h}cm from object_size_cm "${r.object_size_cm}"`,
+        derived_at: now,
+      },
+    };
+
+    updates.push({
+      ubn: r.ubn,
+      bibliographic_format: fmt,
+      field_provenance: newProvenance,
+    });
+  }
+
+  console.log('Distribution:', JSON.stringify(dist, null, 2));
+  console.log(`Skipped: ${skippedManual} manual, ${skippedNoHeight} unparseable height`);
+  console.log(`Will write: ${updates.length} rows`);
+
+  if (DRY_RUN) {
+    console.log('DRY RUN — no writes');
+    if (updates[0]) console.log('Sample update:', JSON.stringify(updates[0], null, 2));
+    return;
+  }
+
+  // Upsert in batches; onConflict on UBN replaces the format + provenance and
+  // leaves every other column untouched (Supabase merges on the columns we
+  // include in the row).
+  const BATCH = 500;
+  let written = 0;
+  for (let i = 0; i < updates.length; i += BATCH) {
+    const slice = updates.slice(i, i + BATCH);
+    const { error } = await supabase
+      .from('bph_works')
+      .upsert(slice, { onConflict: 'ubn' });
+    if (error) {
+      console.error(`Batch ${i / BATCH} failed:`, error.message);
+      process.exit(1);
+    }
+    written += slice.length;
+    if ((i / BATCH) % 4 === 0) console.log(`  ${written}/${updates.length}`);
+  }
+  console.log(`Done — wrote ${written} rows.`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -12,6 +12,12 @@ interface Props {
   params: Promise<{ tenant: string; ubn: string }>;
 }
 
+interface FieldProvenance {
+  source: string;
+  evidence?: string;
+  derived_at?: string;
+}
+
 interface BphWorkRow {
   ubn: string;
   title: string | null;
@@ -39,6 +45,7 @@ interface BphWorkRow {
   remarks: string | null;
   number_of_copies: number | null;
   object_size_cm: string | null;
+  bibliographic_format: string | null;
   binding: string | null;
   bound_with: string | null;
   provenance: string | null;
@@ -46,6 +53,7 @@ interface BphWorkRow {
   ustc_sn: string | null;
   sl_book_id: string | null;
   sl_book_slug: string | null;
+  field_provenance: Record<string, FieldProvenance> | null;
 }
 
 interface SlBook {
@@ -77,8 +85,10 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
       place, printer, publisher, variant_printer, variant_publisher,
       year, shelf_mark, state_shelf_mark, present_location,
       keywords, language, series_title, volume_title,
-      bibliography, remarks, number_of_copies, object_size_cm, binding, bound_with,
-      provenance, ia_identifier, ustc_sn, sl_book_id, sl_book_slug
+      bibliography, remarks, number_of_copies, object_size_cm, bibliographic_format,
+      binding, bound_with,
+      provenance, ia_identifier, ustc_sn, sl_book_id, sl_book_slug,
+      field_provenance
     `)
     .eq('ubn', ubn)
     .maybeSingle();
@@ -297,6 +307,23 @@ export default async function CatalogEntryPage({ params }: Props) {
 
         <Section title="Physical">
           <Field label="Object size" value={work.object_size_cm} />
+          {work.bibliographic_format && (
+            <FieldRaw label="Format">
+              <span className="text-primary capitalize">{work.bibliographic_format}</span>
+              {work.field_provenance?.bibliographic_format?.source === 'derived_from_size' && (
+                <span
+                  className="ml-2 text-xs text-muted italic"
+                  title={
+                    work.field_provenance.bibliographic_format.evidence
+                      ? `Estimated — ${work.field_provenance.bibliographic_format.evidence}. Signature collation needed for an authoritative determination.`
+                      : 'Estimated from object size — signature collation needed for an authoritative determination.'
+                  }
+                >
+                  estimated from size
+                </span>
+              )}
+            </FieldRaw>
+          )}
           <Field label="Number of copies held" value={work.number_of_copies != null ? String(work.number_of_copies) : null} />
           <Field label="Binding" value={work.binding} />
           <Field label="Bound with" value={work.bound_with} />


### PR DESCRIPTION
## Summary

Backfill one of the three Model Catalogus fields the Vitec Memorix export doesn't carry: **bibliographic format** (folio / quarto / octavo / etc.). Derived from `object_size_cm` height using the standard library cataloging fall-back bands. Tracked per-field via a new `field_provenance` JSONB column so EFM librarians can tell hand-authored entries from heuristic backfills, and so we have a place to record future enrichments (original-language pair, etc.) the same way.

## What's in here

- **Schema migration** (`scripts/migration/add-bph-format-and-provenance.sql`) — adds `bibliographic_format TEXT` and `field_provenance JSONB DEFAULT '{}'`.
- **Backfill script** (`scripts/migration/derive-bph-format-from-size.mjs`) — idempotent, skips rows whose provenance source isn't `derived_from_size` (so manual entries survive re-runs). Records `{source, evidence, derived_at}` for every row it touches.
- **UI** — the BPH catalog detail page (`/catalog/<ubn>` on `bph.sourcelibrary.org`) now shows the format in the Physical section. Derived values get an italic "estimated from size" tag with a tooltip explaining that signature collation is needed for an authoritative call.

## Why we don't have the other two fields

| Field | Status |
|---|---|
| Impressum literal (transcribed title-page imprint) | Only practical for the digitized subset (~1k books) via OCR. Rest needs physical inspection. |
| Source/target language pair (e.g. Latin → German) | Feasible via Gemini batch enrichment. Not in this PR — separate effort. |
| Signature collation (e.g. "A-Ff4") | Hands-on physical inspection only. Librarian field. |

## Run after merge

Migration first (no `DATABASE_URL` exposed in `.env.production.local`, so this runs through the Supabase SQL editor):

\`\`\`sql
-- paste contents of scripts/migration/add-bph-format-and-provenance.sql
\`\`\`

Then backfill:

\`\`\`bash
set -a; source .env.production.local; set +a
node scripts/migration/derive-bph-format-from-size.mjs --dry-run   # sanity-check distribution
node scripts/migration/derive-bph-format-from-size.mjs             # ~4,000 rows
\`\`\`

## Test plan

- [ ] Migration applies cleanly in Supabase SQL editor.
- [ ] Dry-run reports the expected ~4k rows and the bucket distribution matches the probe (30/28/23/11/6/2).
- [ ] After backfill, a known-octavo row (e.g. UBN with `object_size_cm` ≈ 21cm) shows "octavo · estimated from size" on its `/catalog/[ubn]` page.
- [ ] A row without `object_size_cm` shows no Format line.
- [ ] Re-running the script touches 0 additional rows (idempotency check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)