### PR TITLE
Hotfix: prod build broken — embed gallery re-exports revalidate

### DIFF
--- a/src/app/embed/[tenant]/gallery/page.tsx
+++ b/src/app/embed/[tenant]/gallery/page.tsx
@@ -1,4 +1,10 @@
 // Tenant subdomains route /gallery here (see src/proxy.ts).
 // The underlying /[tenant]/gallery page reads x-tenant-id from headers
 // (set by proxy.ts), so it filters to BPH content with no extra plumbing.
-export { default, revalidate } from '@/app/[tenant]/gallery/page';
+//
+// Next.js 16 / Turbopack rejects re-exported route segment config —
+// `export { revalidate } from '...'` fails the static-parse check at
+// build time. Declare `revalidate` inline; keep the value in sync with
+// the source page (src/app/[tenant]/gallery/page.tsx).
+export { default } from '@/app/[tenant]/gallery/page';
+export const revalidate = 3600;


### PR DESCRIPTION
## Summary

The lockdown PR (#1623) added \`src/app/embed/[tenant]/gallery/page.tsx\` with a re-export of \`revalidate\`:

\`\`\`ts
export { default, revalidate } from '@/app/[tenant]/gallery/page';
\`\`\`

Next.js 16 / Turbopack rejects this at build time:

> Next.js can't recognize the exported \`revalidate\` field in route. It mustn't be reexported.

That broke the production deploy of \`16480408\` (state \`failure\`), so prod is still serving the **pre-lockdown** bundle — \`bph.sourcelibrary.org/gallery\` continues to 302 to \`sourcelibrary.org/gallery\`. The manually-triggered nightly audit caught it.

## Fix

Re-export \`default\` only and declare \`revalidate = 3600\` inline. Value tracks \`src/app/[tenant]/gallery/page.tsx\` — if that ISR window changes, this needs to follow (called out in the comment).

## Test plan

- [ ] Vercel preview build for this PR succeeds.
- [ ] After merge, prod build succeeds and \`curl -sI https://bph.sourcelibrary.org/gallery\` returns 200, not 302.
- [ ] \`gh workflow run "BPH lockdown audit"\` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)