### PR TITLE
Fix Cover Picker: add image_display/image_thumb to PATCH allowedFields

### DIFF
--- a/src/app/api/[tenant]/books/[id]/route.ts
+++ b/src/app/api/[tenant]/books/[id]/route.ts
@@ -251,7 +251,9 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
     // Allowed fields to update
     const allowedFields = [
       'title', 'display_title', 'author', 'language', 'published',
-      'thumbnail', 'thumbnail_blob', 'thumbnail_source', 'categories', 'status', 'summary', 'dublin_core',
+      'thumbnail', 'thumbnail_blob', 'thumbnail_source',
+      'image_display', 'image_thumb', 'image_full', 'image_source_url',
+      'categories', 'status', 'summary', 'dublin_core',
       // USTC catalog fields
       'ustc_id', 'place_published', 'publisher', 'format',
       // Image source and licensing

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -240,7 +240,9 @@ export const PATCH = withCuratorAuth(async (request, session, context) => {
     // Allowed fields to update
     const allowedFields = [
       'title', 'display_title', 'author', 'language', 'published',
-      'thumbnail', 'thumbnail_blob', 'thumbnail_source', 'categories', 'status', 'summary', 'dublin_core',
+      'thumbnail', 'thumbnail_blob', 'thumbnail_source',
+      'image_display', 'image_thumb', 'image_full', 'image_source_url',
+      'categories', 'status', 'summary', 'dublin_core',
       // USTC catalog fields
       'ustc_id', 'place_published', 'publisher', 'format',
       // Image source and licensing


### PR DESCRIPTION
## Summary
- The R2-only migration (#1588) added canonical \`image_display\`, \`image_thumb\`, \`image_full\`, \`image_source_url\` fields and switched \`getBookThumbnailUrl()\` to prefer them. \`CoverImagePicker.tsx\` was updated to dual-write, but the PATCH endpoints' \`allowedFields\` lists were not — so the new keys silently dropped through the filter loop.
- Symptom: "Choose Cover Image spins and then nothing." Picker request returned 200 with only legacy fields persisted; the page rendered from the unchanged canonical \`image_display\` and the cover never visibly updated.
- Adds the four canonical fields to \`allowedFields\` in both \`/api/books/[id]\` and \`/api/[tenant]/books/[id]\` PATCH handlers.

## Context

This was one of three bugs that surfaced today around BPH covers. Full postmortem in \`.claude/handoffs/2026-05-05-bph-cover-pipeline-postmortem.md\` on main. The other two (1,966 BPH books with stale spread URLs in their thumbnail fields, and 85 books that got naive page-2 picks instead of OCR-scored covers) were fixed via one-shot scripts and don't need code changes.

## Test plan
- [ ] On any tenant book detail page (e.g. \`/bph/book/{slug}\`), open Cover Picker, click a different page → modal closes and rendered cover updates immediately.
- [ ] Confirm in MongoDB that the patched book has \`image_display\` and \`image_thumb\` populated to the chosen page's URL (not just legacy \`thumbnail\`).
- [ ] Verify on the bph.sourcelibrary.org listing grid that the new cover propagates after revalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)