### PR TITLE
Add Node cover-write helper; route maintenance scripts through it

### DIFF
--- a/scripts/lib/cover-write.mjs
+++ b/scripts/lib/cover-write.mjs
@@ -1,0 +1,100 @@
+/**
+ * Node-side mirror of `src/lib/cover-fields.ts`.
+ *
+ * Used by:
+ *   - pipeline-orchestrator.mjs (Phase 3 + Phase 8.9, after migration)
+ *   - smart-cover-selection.mjs
+ *   - batch-cover-selection.mjs (vision)
+ *   - one-shot scripts in scripts/_archived/2026-05-cover-fixes/
+ *
+ * Produces the same update shape as `buildCoverUpdate()` in TS so that
+ * the BPH embed API reads (image_thumb || image_display || …) and the
+ * `getBookThumbnailUrl()` reader path always agree, regardless of which
+ * writer ran.
+ *
+ * Keep this in lock-step with src/lib/cover-fields.ts. The unit tests
+ * in tests/unit/cover-fields.test.ts pin the TS shape; if you change
+ * field semantics there, mirror it here.
+ */
+
+/** The four canonical write keys + provenance. */
+export const COVER_WRITE_FIELDS = [
+  'image_display',
+  'image_thumb',
+  'image_full',
+  'image_source_url',
+  'thumbnail',
+  'thumbnail_blob',
+  'thumbnail_source',
+  'cover_page',
+  'cover_selected_at',
+];
+
+/**
+ * Resolve the best image URL for a page, suitable for use as a cover.
+ * Mirrors `pageImageUrl()` from src/lib/types/page.ts.
+ *
+ * Returns DIRECT URLs only — never `/api/image?url=` wrappers.
+ */
+export function resolvePageCoverUrl(page) {
+  // Split pages: use `photo` directly (the cropped half).
+  // The legacy fallback would point at the full spread via archived_photo.
+  if (page.split_from_spread || page.crop) {
+    const url = page.photo;
+    return url && url.startsWith('http') ? url : null;
+  }
+
+  const url = page.enhanced_photo
+    || page.cropped_photo
+    || page.archived_photo
+    || page.photo_original
+    || page.photo
+    || '';
+  return url && url.startsWith('http') ? url : null;
+}
+
+/**
+ * Build a cover-update payload from a chosen page.
+ *
+ * @param {Object} page                Page document (must include the URL fields)
+ * @param {Object} opts
+ * @param {string} opts.source         e.g. 'manual' | 'smart_ocr' | 'vision' | 'pipeline-auto'
+ * @param {string} [opts.method]       Provenance method label (e.g. 'cover-picker-ui')
+ * @param {number} [opts.confidence]   0..1 confidence
+ * @param {string} [opts.detail]       Free-form provenance detail
+ * @param {string} [opts.actor]        'pipeline' | 'admin' | 'script'
+ * @returns {Object|null}              Update doc to pass to `$set`, or null if page has no usable image
+ */
+export function buildCoverUpdate(page, opts) {
+  const url = resolvePageCoverUrl(page);
+  if (!url) return null;
+
+  const thumbUrl = page.image_thumb || page.thumbnail_blob || url;
+
+  const update = {
+    image_display: url,
+    image_thumb: thumbUrl,
+    thumbnail: url,
+    thumbnail_blob: thumbUrl,
+    thumbnail_source: opts.source,
+  };
+
+  if (page.page_number !== undefined) {
+    update.cover_page = page.page_number;
+    update.cover_selected_at = new Date();
+  }
+
+  if (opts.method) {
+    update.field_provenance = {
+      thumbnail: {
+        source: opts.actor || 'script',
+        method: opts.method,
+        confidence: opts.confidence ?? 1,
+        date: new Date(),
+        detail: opts.detail,
+      },
+    };
+  }
+
+  return update;
+}

--- a/scripts/maintenance/backfill-cover-selection.mjs
+++ b/scripts/maintenance/backfill-cover-selection.mjs
@@ -9,6 +9,8 @@
  */
 
 import { MongoClient } from 'mongodb';
+import { scorePageForCover } from '../lib/cover-scoring.mjs';
+import { buildCoverUpdate } from '../lib/cover-write.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = (() => {
@@ -16,8 +18,6 @@ const LIMIT = (() => {
   return idx !== -1 ? parseInt(process.argv[idx + 1]) : 0;
 })();
 
-// Import scoring from pipeline-orchestrator dynamically
-// The functions aren't exported, so we inline the core logic
 const client = new MongoClient(process.env.MONGODB_URI, {
   serverSelectionTimeoutMS: 30000,
   socketTimeoutMS: 120000,
@@ -50,41 +50,50 @@ for (let i = 0; i < books.length; i++) {
       { book_id: book.id, page_number: { $lte: 20 } },
       { projection: {
         page_number: 1, page_type: 1, hidden: 1,
-        cropped_photo: 1, archived_photo: 1, photo: 1,
-        'ocr.data': 1, detected_images: 1,
+        cropped_photo: 1, archived_photo: 1, photo: 1, enhanced_photo: 1,
+        photo_original: 1, split_from_spread: 1, crop: 1,
+        image_thumb: 1, thumbnail_blob: 1,
+        'ocr.data': 1,
       }}
     ).sort({ page_number: 1 }).maxTimeMS(10000).toArray();
 
     if (!pages.length) { skipped++; continue; }
 
-    // Score each page (same logic as pipeline-orchestrator scorePageForCover)
-    const scored = pages.map(p => ({ page: p, ...scorePageForCover(p) }))
+    // Score each page using the shared scorer (same logic as pipeline + smart-cover-selection)
+    const scored = pages.map(p => ({ page: p, ...scorePageForCover(p, { bookTitle: book.title }) }))
       .sort((a, b) => b.score - a.score);
 
     const best = scored[0];
     if (best.score < 30) { skipped++; continue; }
 
-    const url = best.page.cropped_photo || best.page.archived_photo || best.page.photo;
-    if (!url || !url.startsWith('http')) { skipped++; continue; }
+    const update = buildCoverUpdate(best.page, {
+      source: 'smart_ocr',
+      actor: 'script',
+      method: 'backfill-cover-selection',
+      confidence: Math.min(best.score / 100, 1),
+      detail: `${best.reason} (score: ${best.score})`,
+    });
+    if (!update) { skipped++; continue; }
 
     if (!DRY_RUN) {
-      const updates = {
-        cover_page: best.page.page_number,
-        thumbnail: url,
-        updated_at: new Date(),
-        'field_provenance.thumbnail': {
-          source: 'backfill-cover-selection',
-          method: 'score-based',
-          confidence: Math.min(best.score / 100, 1),
-          date: new Date(),
-        },
-      };
-      // Skip thumbnail update if current thumbnail is already on R2
-      if (book.thumbnail?.startsWith('https://images.sourcelibrary.org')) {
-        delete updates.thumbnail;
-        delete updates['field_provenance.thumbnail'];
+      // If the book already has an R2-hosted thumbnail and the new one would
+      // come from a different host, leave the URL fields alone but still
+      // record cover_page + provenance.
+      if (book.thumbnail?.startsWith('https://images.sourcelibrary.org')
+          && !update.image_display.startsWith('https://images.sourcelibrary.org')) {
+        const partial = {
+          cover_page: update.cover_page,
+          cover_selected_at: update.cover_selected_at,
+          field_provenance: update.field_provenance,
+          updated_at: new Date(),
+        };
+        await db.collection('books').updateOne({ id: book.id }, { $set: partial });
+      } else {
+        await db.collection('books').updateOne(
+          { id: book.id },
+          { $set: { ...update, updated_at: new Date() } },
+        );
       }
-      await db.collection('books').updateOne({ id: book.id }, { $set: updates });
     }
 
     updated++;
@@ -105,104 +114,3 @@ console.log(`Skipped (no good cover): ${skipped}`);
 console.log(`Failed: ${failed}`);
 
 await client.close();
-
-// --- Scoring function (copied from pipeline-orchestrator.mjs) ---
-
-function scorePageForCover(page) {
-  const ocr = (page.ocr?.data || '').substring(0, 800).toLowerCase();
-  const pageType = page.page_type;
-  const pageNum = page.page_number;
-  let score = 0;
-  let reason = pageType || 'unknown';
-
-  if (page.hidden) return { score: -200, reason: 'hidden' };
-  if (pageType === 'blank') return { score: -100, reason: 'blank' };
-  if (pageType === 'digitizer-notice') return { score: -90, reason: 'digitizer-notice' };
-
-  if (ocr.includes('front cover') || (ocr.includes('external') && ocr.includes('cover')) ||
-      (ocr.includes('binding') && ocr.includes('spine')) || ocr.includes('fore-edge') ||
-      ocr.includes('closed book') || ocr.includes('book block') ||
-      ocr.includes('leather-bound') || ocr.includes('leather bound') ||
-      ((ocr.includes('blind-stamp') || ocr.includes('blind stamp')) && ocr.includes('cover'))) {
-    return { score: -80, reason: 'physical book photo' };
-  }
-
-  if (ocr.includes('digitized by') || (ocr.includes('google') && ocr.includes('logo')) ||
-      (ocr.includes('internet archive') && ocr.includes('logo')) ||
-      ocr.includes('proquest') || ocr.includes('early european books') ||
-      ocr.includes('hathitrust') || ocr.includes('scan sheet') ||
-      ocr.includes('e-rara.ch') || ocr.includes('www.e-rara') ||
-      ocr.includes('gallica.bnf') || ocr.includes('mdz-nbn') ||
-      ocr.includes('digital.staatsbibliothek') || ocr.includes('daten.digitale-sammlungen')) {
-    return { score: -70, reason: 'digitizer insert' };
-  }
-
-  const isBphBookplate = (ocr.includes('pelican') && (ocr.includes('piety') || ocr.includes('nest') || ocr.includes('young') || ocr.includes('hermetica'))) ||
-      ocr.includes('philosophia hermetica') || ocr.includes('philosophica hermetica');
-  if (isBphBookplate && pageType !== 'title-page') {
-    return { score: -65, reason: 'BPH pelican bookplate' };
-  }
-
-  const hasExLibris = ocr.includes('ex-libris') || ocr.includes('exlibris') || ocr.includes('ex libris') ||
-      ocr.includes('bookplate') || (ocr.includes('ownership') && ocr.includes('stamp')) ||
-      ocr.includes('library stamp') || ocr.includes('library sticker');
-  if (hasExLibris && pageType !== 'title-page') {
-    return { score: -60, reason: 'ex-libris/bookplate' };
-  }
-
-  if (ocr.includes('bleed-through') || ocr.includes('ghosting') || ocr.includes('mirrored impression')) {
-    return { score: -50, reason: 'bleed-through' };
-  }
-
-  if (pageType === 'toc' || pageType === 'index') return { score: -20, reason: pageType };
-  if (pageType === 'colophon') return { score: -10, reason: 'colophon' };
-
-  const hasHeadings = (ocr.match(/^#+ .+/gm) || []).length;
-  const isTitlePage = pageType === 'title-page';
-  const looksLikeTitlePage = !pageType && hasHeadings >= 3;
-
-  if (isTitlePage) { score += 80; reason = 'title-page'; }
-  else if (looksLikeTitlePage) { score += 70; reason = 'likely title-page'; }
-
-  if (isTitlePage || looksLikeTitlePage) {
-    if (ocr.includes('excudebat') || ocr.includes('typis') || ocr.includes('apud') ||
-        ocr.includes('impensis') || ocr.includes('sumptibus') || ocr.includes('officina') ||
-        ocr.includes('printed by') || ocr.includes('published by') || ocr.includes('printed for')) {
-      score += 15;
-      reason = (isTitlePage ? 'title-page' : 'likely title-page') + ' with imprint';
-    }
-    if (ocr.includes('decorative') || ocr.includes('ornamental') || ocr.includes('border') ||
-        ocr.includes('frame') || ocr.includes('vignette') || ocr.includes('woodcut') ||
-        ocr.includes('architectural') || ocr.includes("printer's mark") ||
-        ocr.includes("printer's device")) {
-      score += 20;
-      reason = 'decorated title-page';
-    }
-  }
-
-  if (pageType === 'frontispiece') {
-    if (ocr.includes('cover') && (ocr.includes('leather') || ocr.includes('binding') || ocr.includes('marbled'))) {
-      return { score: -80, reason: 'binding photo (mislabeled frontispiece)' };
-    }
-    score += 90; reason = 'frontispiece';
-    if (ocr.includes('engrav') || ocr.includes('allegor') || ocr.includes('portrait') ||
-        ocr.includes('emblem') || ocr.includes('woodcut')) {
-      score += 15; reason = 'frontispiece with engraving';
-    }
-  }
-
-  if (pageType === 'illustration') {
-    if (ocr.includes('photograph') && (ocr.includes('fore-edge') || (ocr.includes('book') && ocr.includes('closed')))) {
-      return { score: -80, reason: 'physical book photo' };
-    }
-    score += 60; reason = 'illustration';
-  }
-
-  if (pageType === 'dedication') { score += 15; reason = 'dedication'; }
-  if (pageType === 'text' && score === 0) { score += 5; reason = 'text'; }
-
-  if (pageNum <= 5) score += 5;
-  else if (pageNum <= 10) score += 3;
-
-  return { score, reason };
-}

--- a/scripts/maintenance/batch-cover-selection.mjs
+++ b/scripts/maintenance/batch-cover-selection.mjs
@@ -18,6 +18,7 @@
 
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import { buildCoverUpdate } from '../lib/cover-write.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const SKIP_MANUAL = process.argv.includes('--skip-manual');
@@ -111,7 +112,7 @@ async function fetchImageBase64(url, retries = 2) {
 
 async function selectCover(genModel, book, pages) {
   const imageParts = [];
-  const pageMap = new Map();
+  const pageMap = new Map(); // 1-based index → full page object
 
   for (const page of pages) {
     const url = getPageImageUrl(page);
@@ -121,7 +122,7 @@ async function selectCover(genModel, book, pages) {
     if (!img) continue;
 
     imageParts.push({ inlineData: { mimeType: img.mimeType, data: img.base64 } });
-    pageMap.set(imageParts.length, { pageNumber: page.page_number, url });
+    pageMap.set(imageParts.length, page);
   }
 
   if (imageParts.length === 0) return null;
@@ -129,24 +130,34 @@ async function selectCover(genModel, book, pages) {
   const result = await genModel.generateContent({
     contents: [{ role: 'user', parts: [{ text: PROMPT }, ...imageParts] }],
     safetySettings: SAFETY_SETTINGS,
-    generationConfig: { temperature: 0.1, maxOutputTokens: 500, responseMimeType: 'application/json' },
+    generationConfig: { temperature: 0.1, maxOutputTokens: 1500, responseMimeType: 'application/json' },
   });
 
   const text = result.response.text().trim();
-  const parsed = JSON.parse(text);
+  const parsed = parseJsonLenient(text);
+  if (!parsed) return null;
   const usage = result.response.usageMetadata;
 
-  const selected = pageMap.get(parsed.selected_page_number);
-  if (!selected) return null;
+  const selectedPage = pageMap.get(parsed.selected_page_number);
+  if (!selectedPage) return null;
 
   return {
-    url: selected.url,
-    pageNumber: selected.pageNumber,
+    page: selectedPage,
     rationale: parsed.rationale,
     confidence: parsed.confidence,
     inputTokens: usage?.promptTokenCount || 0,
     outputTokens: usage?.candidatesTokenCount || 0,
   };
+}
+
+function parseJsonLenient(text) {
+  if (!text) return null;
+  let t = text.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
+  try { return JSON.parse(t); } catch {}
+  const m = t.match(/\{[\s\S]*\}/);
+  if (m) { try { return JSON.parse(m[0]); } catch {} }
+  try { return JSON.parse(t.replace(/,(\s*[}\]])/g, '$1')); } catch {}
+  return null;
 }
 
 // --- Main ---
@@ -191,7 +202,11 @@ async function processBook(book) {
   try {
     const pages = await db.collection('pages')
       .find({ book_id: book.id }, {
-        projection: { page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, _id: 0 }
+        projection: {
+          page_number: 1, photo: 1, photo_original: 1, archived_photo: 1,
+          cropped_photo: 1, enhanced_photo: 1, split_from_spread: 1, crop: 1,
+          image_thumb: 1, thumbnail_blob: 1, _id: 0,
+        }
       })
       .sort({ page_number: 1 })
       .limit(MAX_PAGES)
@@ -205,11 +220,17 @@ async function processBook(book) {
     totalInputTokens += result.inputTokens;
     totalOutputTokens += result.outputTokens;
 
-    // Check if it picked a different page than current cover
-    const currentThumb = book.thumbnail || '';
-    const isSame = currentThumb === result.url;
+    const update = buildCoverUpdate(result.page, {
+      source: 'vision',
+      actor: 'script',
+      method: 'batch-cover-selection',
+      confidence: result.confidence === 'high' ? 0.95 : result.confidence === 'medium' ? 0.7 : 0.4,
+      detail: `${result.confidence}: ${result.rationale}`,
+    });
+    if (!update) { skipped++; return; }
 
-    if (isSame) {
+    // Skip if it picked the same URL as the current cover
+    if ((book.thumbnail || '') === update.image_display) {
       skipped++;
       return;
     }
@@ -217,18 +238,16 @@ async function processBook(book) {
     upgraded++;
     const shortTitle = (book.title || '').substring(0, 55);
     console.log(`  ${shortTitle}`);
-    console.log(`    → page ${result.pageNumber} (${result.confidence}) | ${result.rationale}`);
+    console.log(`    → page ${update.cover_page} (${result.confidence}) | ${result.rationale}`);
 
     if (!DRY_RUN) {
       await db.collection('books').updateOne(
         { id: book.id },
         { $set: {
-          thumbnail: result.url,
-          thumbnail_source: 'ai_vision',
+          ...update,
           cover_updated_at: new Date(),
           cover_rationale: result.rationale,
           cover_confidence: result.confidence,
-          cover_page_number: result.pageNumber,
         }}
       );
     }


### PR DESCRIPTION
## Summary

Companion to #1628 on the Node side. Two tracked maintenance scripts had cover-write bugs:

- \`backfill-cover-selection.mjs\` was inlining a ~95%-match copy of \`scorePageForCover\` that had drifted from the canonical scorer (no title-match bonus, smaller OCR window, missing decorative checks).
- \`batch-cover-selection.mjs\` (Gemini Vision) was writing only the legacy \`thumbnail\` field, leaving canonical \`image_display\` / \`image_thumb\` stale — same bug class as the Cover Picker bug from #1626.

This PR adds \`scripts/lib/cover-write.mjs\` (mirror of the TS \`buildCoverUpdate\`) and threads both scripts through it. After this lands, every tracked cover writer — UI, API, pipeline, maintenance — goes through one helper.

## Files
- \`scripts/lib/cover-write.mjs\` — new. \`buildCoverUpdate(page, opts)\` + \`resolvePageCoverUrl()\` + \`COVER_WRITE_FIELDS\`. Lock-step warning in the header.
- \`scripts/maintenance/backfill-cover-selection.mjs\` — drops 110 lines of inlined scorer; imports from \`scripts/lib/cover-scoring.mjs\` and \`scripts/lib/cover-write.mjs\`.
- \`scripts/maintenance/batch-cover-selection.mjs\` — passes the chosen page through \`buildCoverUpdate\` so all four canonical fields move together. Adds lenient JSON parser for Gemini's markdown-wrapped responses.

## Test plan
- [ ] \`node --check\` passes on both modified scripts.
- [ ] Dry-run \`backfill-cover-selection.mjs --dry-run --limit 5\` produces same picks as before (scorer is identical, just deduplicated).
- [ ] Dry-run \`batch-cover-selection.mjs --dry-run --limit 3\` returns Gemini picks and resolves all four fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)