### PR TITLE
Fix api-client treating /book, /gallery, etc. as tenant slugs

### DIFF
--- a/src/lib/api-client/analytics.ts
+++ b/src/lib/api-client/analytics.ts
@@ -1,4 +1,4 @@
-import { apiClient } from './client';
+import { apiClient, getTenantSlug } from './client';
 import type {
   AnalyticsStats,
   TrackEventRequest,
@@ -11,21 +11,6 @@ import type {
   TrafficData,
   CanonData,
 } from './types/analytics';
-
-function getTenantSlug(): string {
-  if (typeof window === 'undefined') return '';
-  const parts = window.location.pathname.split('/').filter(Boolean);
-  
-  // Handle embed routes: /embed/[tenant]/... -> extract [tenant]
-  if (parts[0] === 'embed' && parts.length > 1) {
-    const tenant = parts[1];
-    return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-  }
-  
-  // Handle regular routes: /[tenant]/... -> extract [tenant]
-  const tenant = parts[0] || '';
-  return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-}
 
 /**
  * Analytics API client

--- a/src/lib/api-client/books.ts
+++ b/src/lib/api-client/books.ts
@@ -1,4 +1,4 @@
-import { apiClient, streamRequest } from './client';
+import { apiClient, getTenantSlug, streamRequest } from './client';
 import { upload } from './upload';
 
 import type { Book } from '@/lib/types';
@@ -25,24 +25,6 @@ import type {
   BookDownloadFormats,
   RoadmapResponse,
 } from './types/books';
-
-/**
- * Get the tenant slug from the current page URL
- */
-function getTenantSlug(): string {
-  if (typeof window === 'undefined') return '';
-  const parts = window.location.pathname.split('/').filter(Boolean);
-  
-  // Handle embed routes: /embed/[tenant]/... -> extract [tenant]
-  if (parts[0] === 'embed' && parts.length > 1) {
-    const tenant = parts[1];
-    return tenant && /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-  }
-  
-  // Handle regular routes: /[tenant]/... -> extract [tenant]
-  const tenant = parts[0] || '';
-  return tenant && /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-}
 
 /**
  * Construct a book API URL, tenant-scoped when available

--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -14,7 +14,7 @@ const NON_TENANT_SEGMENTS = new Set([
   'identify', 'for-researchers', 'admin',
 ]);
 
-function getTenantSlugFromPathname(pathname: string): string | null {
+export function getTenantSlugFromPathname(pathname: string): string | null {
   const segments = pathname.split('/').filter(Boolean);
   // Handle /embed/{tenant}/... paths (tenant subdomains rewrite to /embed/bph/...)
   if (segments[0] === 'embed' && segments[1]) {
@@ -29,6 +29,14 @@ function getTenantSlugFromPathname(pathname: string): string | null {
   if (!/^[a-z0-9-]+$/.test(slug)) return null;
   if (NON_TENANT_SEGMENTS.has(slug)) return null;
   return slug;
+}
+
+// Browser-only wrapper. Returns the tenant slug for the current page, or ''
+// for SSR or non-tenant root routes (`/book/...`, `/gallery/...`, etc).
+// Used by sibling api-client modules to build tenant-scoped URLs.
+export function getTenantSlug(): string {
+  if (typeof window === 'undefined') return '';
+  return getTenantSlugFromPathname(window.location.pathname) ?? '';
 }
 
 // Create axios instance with defaults

--- a/src/lib/api-client/likes.ts
+++ b/src/lib/api-client/likes.ts
@@ -1,20 +1,5 @@
-import { apiClient } from './client';
+import { apiClient, getTenantSlug } from './client';
 import type { LikeTargetType } from '@/lib/types';
-
-function getTenantSlug(): string {
-  if (typeof window === 'undefined') return '';
-  const parts = window.location.pathname.split('/').filter(Boolean);
-  
-  // Handle embed routes: /embed/[tenant]/... -> extract [tenant]
-  if (parts[0] === 'embed' && parts.length > 1) {
-    const tenant = parts[1];
-    return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-  }
-  
-  // Handle regular routes: /[tenant]/... -> extract [tenant]
-  const tenant = parts[0] || '';
-  return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-}
 
 /**
  * Likes API client

--- a/src/lib/api-client/pages.ts
+++ b/src/lib/api-client/pages.ts
@@ -1,4 +1,4 @@
-import { apiClient } from './client';
+import { apiClient, getTenantSlug } from './client';
 import type { Page } from '@/lib/types';
 import type {
   PageOcrRequest,
@@ -13,24 +13,6 @@ import type {
   PageAskRequest,
   PageAskResponse
 } from './types/pages';
-
-/**
- * Get current tenant slug from URL
- */
-function getTenantSlug(): string {
-  if (typeof window === 'undefined') return '';
-  const parts = window.location.pathname.split('/').filter(Boolean);
-  
-  // Handle embed routes: /embed/[tenant]/... -> extract [tenant]
-  if (parts[0] === 'embed' && parts.length > 1) {
-    const tenant = parts[1];
-    return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-  }
-  
-  // Handle regular routes: /[tenant]/... -> extract [tenant]
-  const tenant = parts[0] || '';
-  return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-}
 
 /**
  * Pages API client

--- a/src/lib/api-client/reading-history.ts
+++ b/src/lib/api-client/reading-history.ts
@@ -1,19 +1,4 @@
-import { apiClient } from './client';
-
-function getTenantSlug(): string {
-  if (typeof window === 'undefined') return '';
-  const parts = window.location.pathname.split('/').filter(Boolean);
-  
-  // Handle embed routes: /embed/[tenant]/... -> extract [tenant]
-  if (parts[0] === 'embed' && parts.length > 1) {
-    const tenant = parts[1];
-    return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-  }
-  
-  // Handle regular routes: /[tenant]/... -> extract [tenant]
-  const tenant = parts[0] || '';
-  return /^[a-z0-9-]+$/.test(tenant) ? tenant : '';
-}
+import { apiClient, getTenantSlug } from './client';
 
 export interface ReadingHistoryEntry {
   book_id: string;


### PR DESCRIPTION
## Summary

- BookHistory on `sourcelibrary.org/book/<slug>` reported "Failed to load history: Book not found" for every book.
- Root cause: five sibling `api-client/*.ts` modules each carried their own copy of `getTenantSlug()` that returned `parts[0]` whenever it matched `/^[a-z0-9-]+$/`, without excluding global root segments. On `/book/<slug>`, that returned `"book"`, so the client called `/api/book/books/<id>/history`. That URL matches the `[tenant]/books/[id]/history` route with `tenant="book"`, `resolveTenantId("book")` returns null, and the route 404s with `Book not found`.
- `client.ts` already had the correct version (`getTenantSlugFromPathname`) which checks `NON_TENANT_SEGMENTS`. Export a thin browser wrapper from there and replace the broken locals in `books.ts`, `pages.ts`, `analytics.ts`, `likes.ts`, and `reading-history.ts`. Behavior on real tenant paths (`/efm/...`, `/embed/bph/...`) is unchanged.

## Test plan

- [ ] Visit `https://sourcelibrary.org/book/greek-enchiridion-hephaestion` signed in as inner_circle and confirm Book History expands without the "Book not found" error.
- [ ] Confirm the network request goes to `/api/books/<id>/history` (not `/api/book/books/<id>/history`).
- [ ] Spot-check tenant-prefixed routes (`/embed/bph/...`) still send the tenant header / use `/api/bph/...`.
- [ ] `npx tsc --noEmit` passes (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)