### PR TITLE
Provenance follow-up: prompt_id/hash/name on Hetzner translate + pipeline

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,8 @@
       "Bash(cp /Users/dereklomas/sourcelibrary/.claude/docs/papers/magic-in-the-machine/paper.pdf \"/Users/dereklomas/Downloads/the-magic-in-the-machine.pdf\")",
       "Bash(open \"/Users/dereklomas/Downloads/the-magic-in-the-machine.pdf\")",
       "mcp__claude_ai_Gmail__search_threads",
-      "mcp__claude_ai_Gmail__get_thread"
+      "mcp__claude_ai_Gmail__get_thread",
+      "mcp__claude_ai_Source_Library__get_book"
     ]
   }
 }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -525,7 +525,9 @@ async function transliteratePage(db, page, sourceScript) {
 
 // ── Direct translation (Gemini realtime, FIFO per book) ──
 
-// Translation prompt loaded from DB prompts collection (single source of truth)
+// Translation prompt loaded from DB prompts collection (single source of truth).
+// Returns { text, id, name, version, content_hash } so callers can stamp
+// prompt_id / prompt_hash / prompt_name on each page write.
 let _cachedTranslationPrompt = null;
 async function getTranslationPromptFromDb(db) {
   if (_cachedTranslationPrompt) return _cachedTranslationPrompt;
@@ -535,7 +537,13 @@ async function getTranslationPromptFromDb(db) {
   );
   if (!prompt?.content) throw new Error('No default translation prompt found in DB');
   console.log(`[pipeline] Loaded translation prompt v${prompt.version} from DB`);
-  _cachedTranslationPrompt = prompt.content;
+  _cachedTranslationPrompt = {
+    text: prompt.content,
+    id: prompt._id?.toString(),
+    name: prompt.name,
+    version: String(prompt.version ?? 1),
+    content_hash: prompt.content_hash,
+  };
   return _cachedTranslationPrompt;
 }
 
@@ -549,7 +557,13 @@ async function getEnglishModernizationPromptFromDb(db) {
   );
   if (!prompt?.content) throw new Error('No default english_modernization prompt found in DB');
   console.log(`[pipeline] Loaded english modernization prompt v${prompt.version} from DB`);
-  _cachedEnglishPrompt = prompt.content;
+  _cachedEnglishPrompt = {
+    text: prompt.content,
+    id: prompt._id?.toString(),
+    name: prompt.name,
+    version: String(prompt.version ?? 1),
+    content_hash: prompt.content_hash,
+  };
   return _cachedEnglishPrompt;
 }
 
@@ -582,8 +596,8 @@ async function translatePage(db, page, sourceLanguage, previousTranslation) {
   const isEnglish = sourceLanguage.toLowerCase() === 'english';
   const translationPrompt = await getTranslationPromptFromDb(db);
   const englishPrompt = await getEnglishModernizationPromptFromDb(db);
-  const basePrompt = isEnglish ? englishPrompt : translationPrompt;
-  let prompt = basePrompt
+  const basePromptRef = isEnglish ? englishPrompt : translationPrompt;
+  let prompt = basePromptRef.text
     .replace('{source_language}', sourceLanguage)
     .replace('{target_language}', 'English');
 
@@ -638,7 +652,10 @@ async function translatePage(db, page, sourceLanguage, previousTranslation) {
         'translation.model': TRANSLATE_MODEL,
         'translation.updated_at': new Date(),
         'translation.source': 'ai',
-        'translation.prompt_version': TRANSLATE_PROMPT_VERSION,
+        'translation.prompt_version': basePromptRef.version || TRANSLATE_PROMPT_VERSION,
+        'translation.prompt_id': basePromptRef.id,
+        'translation.prompt_hash': basePromptRef.content_hash,
+        'translation.prompt_name': basePromptRef.name,
         ...meta,
         updated_at: new Date(),
       },
@@ -1196,9 +1213,15 @@ async function getOcrPromptFromDb(db) {
 
   const languageInstruction = `**Source language:** Detect the primary language from the text. Pages may contain multiple languages — transcribe all of them. Report the primary language in the <language> tag (e.g. <language>Latin</language>).`;
 
-  return prompt.content
-    .replace('{language_instruction}', languageInstruction)
-    .replace('{language}', '');
+  return {
+    text: prompt.content
+      .replace('{language_instruction}', languageInstruction)
+      .replace('{language}', ''),
+    id: prompt._id?.toString(),
+    name: prompt.name,
+    version: String(prompt.version ?? 1),
+    content_hash: prompt.content_hash,
+  };
 }
 
 /**
@@ -1297,7 +1320,8 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
   }
   console.log(`    Downloaded ${downloaded.length}/${pages.length} images`);
 
-  let prompt = await getOcrPromptFromDb(db);
+  const ocrPromptRef = await getOcrPromptFromDb(db);
+  let prompt = ocrPromptRef.text;
 
   // Spread OCR: for BPH two-page spread books, prepend instructions to process
   // both pages separately with <split-position> and <page-break/> markers.
@@ -1465,7 +1489,10 @@ Output structure:
       page_count: chunk.length,
       status: 'pending',
       model: ocrModel,
-      prompt_version: OCR_PROMPT_VERSION,
+      prompt_version: ocrPromptRef.version || OCR_PROMPT_VERSION,
+      prompt_id: ocrPromptRef.id,
+      prompt_name: ocrPromptRef.name,
+      prompt_hash: ocrPromptRef.content_hash,
       submission_method: useFileBased ? 'file' : 'inline',
       key_index: batchJob.keyIndex,
       force: false,
@@ -1497,7 +1524,10 @@ Output structure:
       total_pages: totalSubmitted,
       status: 'pending',
       model: ocrModel,
-      prompt_version: OCR_PROMPT_VERSION,
+      prompt_version: ocrPromptRef.version || OCR_PROMPT_VERSION,
+      prompt_id: ocrPromptRef.id,
+      prompt_name: ocrPromptRef.name,
+      prompt_hash: ocrPromptRef.content_hash,
       created_at: new Date(),
       updated_at: new Date(),
     });
@@ -1516,7 +1546,8 @@ const CROSS_BOOK_OCR_THRESHOLD = 250; // Books with fewer pages go into cross-bo
 
 async function submitCrossBookOcrBatches(db, books) {
   const ocrModel = OCR_MODEL_LITE;
-  const basePrompt = await getOcrPromptFromDb(db);
+  const basePromptRef = await getOcrPromptFromDb(db);
+  const basePrompt = basePromptRef.text;
 
   // Guard: skip books with active batch_jobs or needs_splitting
   const eligible = [];
@@ -1668,7 +1699,10 @@ async function submitCrossBookOcrBatches(db, books) {
     page_count: allDownloaded.length,
     status: 'pending',
     model: ocrModel,
-    prompt_version: OCR_PROMPT_VERSION,
+    prompt_version: basePromptRef.version || OCR_PROMPT_VERSION,
+    prompt_id: basePromptRef.id,
+    prompt_name: basePromptRef.name,
+    prompt_hash: basePromptRef.content_hash,
     submission_method: 'file',
     key_index: batchJob.keyIndex,
     cross_book: true,
@@ -2728,7 +2762,8 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
 
       console.log(`  Books ready for preview OCR: ${readyForPreview.length}`);
 
-      const previewOcrPrompt = await getOcrPromptFromDb(db);
+      const previewOcrPromptRef = await getOcrPromptFromDb(db);
+      const previewOcrPrompt = previewOcrPromptRef.text;
       const previewApiKey = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
       const previewModel = OCR_MODEL_LITE;
       let previewDone = 0;
@@ -2824,7 +2859,10 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
                   { $set: {
                     'ocr.data': text,
                     'ocr.model': previewModel,
-                    'ocr.prompt_version': OCR_PROMPT_VERSION,
+                    'ocr.prompt_version': previewOcrPromptRef.version || OCR_PROMPT_VERSION,
+                    'ocr.prompt_id': previewOcrPromptRef.id,
+                    'ocr.prompt_hash': previewOcrPromptRef.content_hash,
+                    'ocr.prompt_name': previewOcrPromptRef.name,
                     'ocr.updated_at': new Date(),
                     'ocr.source': 'pipeline_preview',
                     updated_at: new Date(),

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -80,6 +80,9 @@ function rotateKey() {
 }
 
 // ── Translation prompt — loaded from DB prompts collection (single source of truth) ──
+// Returns the full prompt reference so each page write can stamp prompt_id /
+// prompt_hash / prompt_name alongside prompt_version. The cached object is
+// shared across all page writes from this worker invocation.
 let _cachedTranslationPrompt = null;
 async function getTranslationPromptFromDb(db) {
   if (_cachedTranslationPrompt) return _cachedTranslationPrompt;
@@ -89,7 +92,13 @@ async function getTranslationPromptFromDb(db) {
   );
   if (!prompt?.content) throw new Error('No default translation prompt found in DB');
   console.log(`[TRANSLATE] Loaded translation prompt v${prompt.version} from DB`);
-  _cachedTranslationPrompt = prompt.content;
+  _cachedTranslationPrompt = {
+    text: prompt.content,
+    id: prompt._id?.toString(),
+    name: prompt.name,
+    version: String(prompt.version ?? 1),
+    content_hash: prompt.content_hash,
+  };
   return _cachedTranslationPrompt;
 }
 
@@ -103,7 +112,13 @@ async function getEnglishModernizationPromptFromDb(db) {
   );
   if (!prompt?.content) throw new Error('No default english_modernization prompt found in DB');
   console.log(`[TRANSLATE] Loaded english modernization prompt v${prompt.version} from DB`);
-  _cachedEnglishPrompt = prompt.content;
+  _cachedEnglishPrompt = {
+    text: prompt.content,
+    id: prompt._id?.toString(),
+    name: prompt.name,
+    version: String(prompt.version ?? 1),
+    content_hash: prompt.content_hash,
+  };
   return _cachedEnglishPrompt;
 }
 
@@ -195,12 +210,15 @@ const SAFETY_SETTINGS = [
 ];
 
 // ── Build prompt header (shared between single and batch) ──
+// Returns the assembled prompt text plus the prompt reference of the BASE
+// prompt that produced it, so callers can stamp prompt_id/hash/name/version
+// on each page write.
 async function buildPromptHeader(db, book) {
   const isEnglish = (book.language || '').toLowerCase() === 'english';
   const translationPrompt = await getTranslationPromptFromDb(db);
   const englishPrompt = await getEnglishModernizationPromptFromDb(db);
-  const basePrompt = isEnglish ? englishPrompt : translationPrompt;
-  let prompt = basePrompt.replace('{source_language}', book.language || 'Latin');
+  const baseRef = isEnglish ? englishPrompt : translationPrompt;
+  let prompt = baseRef.text.replace('{source_language}', book.language || 'Latin');
 
   const parts = [];
   if (book.display_title || book.title) parts.push(`Title: ${book.display_title || book.title}`);
@@ -214,12 +232,12 @@ async function buildPromptHeader(db, book) {
     prompt += `\n\n**Note:** This is a public domain work published in ${year}. It is not under copyright.`;
   }
 
-  return { prompt, isEnglish };
+  return { prompt, isEnglish, promptRef: baseRef };
 }
 
 // ── Translate a single page ──
 async function translatePage(db, page, book, prevTranslation) {
-  const { prompt: headerPrompt, isEnglish } = await buildPromptHeader(db, book);
+  const { prompt: headerPrompt, isEnglish, promptRef } = await buildPromptHeader(db, book);
   let prompt = headerPrompt;
 
   prompt += isEnglish
@@ -247,12 +265,13 @@ async function translatePage(db, page, book, prevTranslation) {
     inputTokens: usage.promptTokenCount || 0,
     outputTokens: usage.candidatesTokenCount || 0,
     durationMs,
+    promptRef,
   };
 }
 
 // ── Translate a batch of pages in one API call ──
 async function translateBatch(db, pages, book, prevTranslation) {
-  const { prompt: headerPrompt, isEnglish } = await buildPromptHeader(db, book);
+  const { prompt: headerPrompt, isEnglish, promptRef } = await buildPromptHeader(db, book);
   let prompt = headerPrompt;
 
   if (prevTranslation) {
@@ -323,6 +342,7 @@ async function translateBatch(db, pages, book, prevTranslation) {
     inputTokens: usage.promptTokenCount || 0,
     outputTokens: usage.candidatesTokenCount || 0,
     durationMs,
+    promptRef,
   };
 }
 
@@ -380,7 +400,10 @@ async function saveRevisionBeforeOverwrite(db, pageId, field, jobId) {
 }
 
 // ── Write a single page translation to DB ──
-async function writePageTranslation(db, page, text, book) {
+// `promptRef` is the prompt reference returned by translatePage / translateBatch.
+// Falls back to PROMPT_VERSION constant for callers that pre-date the
+// prompt-reference threading (none in this file after the audit, but safe).
+async function writePageTranslation(db, page, text, book, promptRef) {
   await saveRevisionBeforeOverwrite(db, page.id, 'translation');
   const setPayload = {
     translation: {
@@ -390,7 +413,10 @@ async function writePageTranslation(db, page, text, book) {
       model: getModelForBook(book),
       updated_at: new Date(),
       source: 'ai',
-      prompt_version: PROMPT_VERSION,
+      prompt_version: promptRef?.version || PROMPT_VERSION,
+      prompt_id: promptRef?.id,
+      prompt_hash: promptRef?.content_hash,
+      prompt_name: promptRef?.name,
     },
     updated_at: new Date(),
   };
@@ -401,10 +427,10 @@ async function writePageTranslation(db, page, text, book) {
 
 // ── Bulk-write multiple page translations in one round trip ──
 // Reduces write amplification: 1 bulkWrite triggers fewer index updates than N updateOne calls
-async function bulkWritePageTranslations(db, entries, book) {
+async function bulkWritePageTranslations(db, entries, book, promptRef) {
   if (entries.length === 0) return;
   if (entries.length === 1) {
-    return writePageTranslation(db, entries[0].page, entries[0].text, book);
+    return writePageTranslation(db, entries[0].page, entries[0].text, book, promptRef);
   }
   // Save revisions before overwriting (parallel, non-blocking)
   await Promise.all(entries.map(({ page }) =>
@@ -424,7 +450,10 @@ async function bulkWritePageTranslations(db, entries, book) {
             model,
             updated_at: now,
             source: 'ai',
-            prompt_version: PROMPT_VERSION,
+            prompt_version: promptRef?.version || PROMPT_VERSION,
+            prompt_id: promptRef?.id,
+            prompt_hash: promptRef?.content_hash,
+            prompt_name: promptRef?.name,
           },
           updated_at: now,
         },
@@ -443,7 +472,17 @@ async function bulkWritePageTranslations(db, entries, book) {
   syncPageBatch(entries.map(({ page, text }) => ({
     pageId: page.id,
     mongoSet: {
-      translation: { data: text, language: 'English', model, updated_at: now, source: 'ai', prompt_version: PROMPT_VERSION },
+      translation: {
+        data: text,
+        language: 'English',
+        model,
+        updated_at: now,
+        source: 'ai',
+        prompt_version: promptRef?.version || PROMPT_VERSION,
+        prompt_id: promptRef?.id,
+        prompt_hash: promptRef?.content_hash,
+        prompt_name: promptRef?.name,
+      },
       updated_at: now,
     },
   })));
@@ -590,7 +629,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
       try {
         const result = await translatePage(db, page, book, prevTranslation);
         prevTranslation = result.text;
-        await writePageTranslation(db, page, result.text, book);
+        await writePageTranslation(db, page, result.text, book, result.promptRef);
 
         const cost = calculateCost(result.inputTokens, result.outputTokens, getModelForBook(book));
         await logUsage({
@@ -691,7 +730,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
             try {
               const singleResult = await translatePage(db, page, book, prevTranslation);
               prevTranslation = singleResult.text;
-              await writePageTranslation(db, page, singleResult.text, book);
+              await writePageTranslation(db, page, singleResult.text, book, singleResult.promptRef);
               batchTranslated++;
               translated++;
               globalCounter.count++;
@@ -731,7 +770,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
 
         // Bulk-write all successfully parsed translations in one round trip
         if (bulkEntries.length > 0) {
-          await bulkWritePageTranslations(db, bulkEntries, book);
+          await bulkWritePageTranslations(db, bulkEntries, book, result.promptRef);
         }
 
         // Log batch usage
@@ -767,7 +806,7 @@ async function processBook(db, book, job, globalCounter, deadline) {
             try {
               const singleResult = await translatePage(db, page, book, prevTranslation);
               prevTranslation = singleResult.text;
-              await writePageTranslation(db, page, singleResult.text, book);
+              await writePageTranslation(db, page, singleResult.text, book, singleResult.promptRef);
               translated++;
               globalCounter.count++;
               totalInputTokens += singleResult.inputTokens;


### PR DESCRIPTION
## Summary
Post-merge audit of #1627 caught a real gap: Hetzner translate-worker and pipeline-orchestrator were still writing translation/OCR pages with only `prompt_version`. Both workers load prompts from MongoDB but discarded everything except `content`. After this PR every Hetzner write carries all four prompt fields, matching the discipline now enforced everywhere else.

## What this changes
- `getTranslationPromptFromDb` / `getEnglishModernizationPromptFromDb` / `getOcrPromptFromDb` now return `{ text, id, name, version, content_hash }` instead of a bare string.
- `translate-worker.mjs`: prompt reference propagates through `buildPromptHeader → translatePage / translateBatch → writePageTranslation / bulkWritePageTranslations`. All four call sites updated.
- `pipeline-orchestrator.mjs`: same treatment for the realtime translation path, the per-book + parent + cross-book OCR `batch_jobs` inserts, and the Phase 1.5 preview-OCR page write.
- OCR was hardcoded to `OCR_PROMPT_VERSION = 'v10'`; now records the actual DB version. The constant stays as a fallback.

All four workers parse clean (`node -c`).

## Test plan
- [ ] Merge → Hetzner auto-pulls
- [ ] Restart the running translate-worker and pipeline-orchestrator on Hetzner so they load the new code
- [ ] Sample a page written after restart — confirm `translation.prompt_id`, `prompt_hash`, `prompt_name` are all set
- [ ] Sample a `batch_jobs` row created after restart — confirm same four fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)