### PR TITLE
Provenance: mirror prompt_id/hash/name to Supabase pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,10 @@
       "Bash(open \"/Users/dereklomas/Downloads/the-magic-in-the-machine.pdf\")",
       "mcp__claude_ai_Gmail__search_threads",
       "mcp__claude_ai_Gmail__get_thread",
-      "mcp__claude_ai_Source_Library__get_book"
+      "mcp__claude_ai_Source_Library__get_book",
+      "Bash(cp /Users/dereklomas/sourcelibrary/.claude/handoffs/2026-05-06-bph-language-pair-eval.md .claude/handoffs/)",
+      "Bash(git add *)",
+      "Bash(git -c user.email=j.d.lomas@tudelft.nl -c user.name=JDerekLomas commit -s -m ' *)"
     ]
   }
 }

--- a/scripts/migration/add-pages-prompt-provenance.sql
+++ b/scripts/migration/add-pages-prompt-provenance.sql
@@ -1,0 +1,30 @@
+-- Add prompt provenance columns to the Supabase pages mirror.
+-- MongoDB pages already carry these (PR #1627 + #1632); the Hetzner
+-- supabase-page-writer dual-write was silently dropping them because
+-- the columns didn't exist.
+--
+-- Each prompt has four fields, all stored together on every overwrite:
+--   prompt_version  — version number/string from the DB prompts collection
+--   prompt_id       — ObjectId of the prompts row, or 'hardcoded' / 'custom'
+--   prompt_hash     — md5(prompt content); cryptographic verifier
+--   prompt_name     — human-readable name (e.g. "Standard Translation")
+--
+-- ocr_prompt_version already exists from an earlier migration.
+-- This adds the three missing fields for both ocr_* and translation_*.
+--
+-- Safe to run repeatedly; column adds are idempotent.
+
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS ocr_prompt_id   TEXT;
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS ocr_prompt_hash TEXT;
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS ocr_prompt_name TEXT;
+
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS translation_prompt_id   TEXT;
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS translation_prompt_hash TEXT;
+ALTER TABLE pages ADD COLUMN IF NOT EXISTS translation_prompt_name TEXT;
+
+COMMENT ON COLUMN pages.ocr_prompt_id   IS 'ObjectId-string of the prompts row used for this OCR write, or "hardcoded" / "custom"';
+COMMENT ON COLUMN pages.ocr_prompt_hash IS 'md5 of the OCR prompt content at write time (cryptographic integrity check)';
+COMMENT ON COLUMN pages.ocr_prompt_name IS 'Human-readable prompt name, e.g. "Standard OCR" or "Latin OCR (Neo-Latin)"';
+COMMENT ON COLUMN pages.translation_prompt_id   IS 'ObjectId-string of the prompts row used for this translation write';
+COMMENT ON COLUMN pages.translation_prompt_hash IS 'md5 of the translation prompt content at write time';
+COMMENT ON COLUMN pages.translation_prompt_name IS 'Human-readable prompt name, e.g. "Standard Translation"';

--- a/scripts/workers/lib/supabase-page-writer.mjs
+++ b/scripts/workers/lib/supabase-page-writer.mjs
@@ -17,14 +17,18 @@ if (!SUPABASE_SERVICE_KEY) {
 const FIELD_MAP = {
   // OCR fields (dot-notation and subdoc)
   'ocr.data': 'ocr_data', 'ocr.updated_at': 'ocr_updated_at', 'ocr.model': 'ocr_model',
-  'ocr.language': 'ocr_language', 'ocr.source': 'ocr_source', 'ocr.prompt_version': 'ocr_prompt_version',
+  'ocr.language': 'ocr_language', 'ocr.source': 'ocr_source',
+  'ocr.prompt_version': 'ocr_prompt_version',
+  'ocr.prompt_id': 'ocr_prompt_id', 'ocr.prompt_hash': 'ocr_prompt_hash', 'ocr.prompt_name': 'ocr_prompt_name',
   'ocr.batch_job_id': 'ocr_batch_job_id', 'ocr.input_tokens': 'ocr_input_tokens', 'ocr.output_tokens': 'ocr_output_tokens',
   // Translation fields (dot-notation and subdoc)
   'translation.data': 'translation_data', 'translation.updated_at': 'translation_updated_at',
   'translation.model': 'translation_model', 'translation.language': 'translation_language',
   'translation.source_language': 'translation_source_language', 'translation.source': 'translation_source',
   'translation.target_language': null, // not in Supabase schema
-  'translation.prompt_version': 'translation_prompt_version', 'translation.batch_job_id': 'translation_batch_job_id',
+  'translation.prompt_version': 'translation_prompt_version',
+  'translation.prompt_id': 'translation_prompt_id', 'translation.prompt_hash': 'translation_prompt_hash', 'translation.prompt_name': 'translation_prompt_name',
+  'translation.batch_job_id': 'translation_batch_job_id',
   'translation.input_tokens': 'translation_input_tokens', 'translation.output_tokens': 'translation_output_tokens',
   'translation.recitation_blocked': 'translation_recitation_blocked',
   'translation.safety_blocked': 'translation_safety_blocked', 'translation.safety_reason': 'translation_safety_reason',


### PR DESCRIPTION
## Summary
Final piece of the data provenance audit. PR #1627 + #1632 stamped all four prompt fields (id, hash, name, version) on MongoDB pages, but the Hetzner dual-write helper at \`scripts/workers/lib/supabase-page-writer.mjs\` was silently dropping three of them — Supabase columns didn't exist, and the FIELD_MAP only listed prompt_version.

## Changes
1. **SQL migration** (\`scripts/migration/add-pages-prompt-provenance.sql\`) adds 6 columns: \`ocr_prompt_id/hash/name\` and \`translation_prompt_id/hash/name\`. Already applied to prod via Hetzner pg client.
2. **FIELD_MAP** updated — three new keys per side so the dual-write carries the fields through.

After this PR, MongoDB and Supabase store identical provenance on every page. Forensic queries against either store can reconstruct the exact prompt content via prompt_hash → prompts collection lookup.

## Also done in this session (not in this PR but related)
- Backfilled \`content_hash\` on the 12 prompt docs that lacked it (52 of 52 now hashed).
- Added \`TRIGGER_SOURCE=worker\` to Hetzner \`.env.production.local\` so all gemini_usage rows from cron-launched workers are correctly attributed (was defaulting to 'unknown').

## Test plan
- [x] Migration applied on prod Supabase
- [ ] Merge → Hetzner auto-pulls
- [ ] Restart workers so they reload supabase-page-writer
- [ ] Sample a fresh page: confirm both MongoDB and Supabase have all 4 prompt fields
- [ ] Sample a fresh gemini_usage row from worker: confirm \`triggered_by: 'worker'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)