### PR TITLE
Add /admin/r2-coverage to surface R2 archive gaps

### DIFF
--- a/scripts/workers/r2-coverage-snapshot.mjs
+++ b/scripts/workers/r2-coverage-snapshot.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * R2 Coverage Snapshot Worker
+ *
+ * Aggregates per-book R2 archive state across the pages collection and writes
+ * the result to system_config._id: 'r2_coverage_snapshot'. The /admin/r2-coverage
+ * page reads this doc instead of running 5M-row regex aggregations on every load.
+ *
+ * Run on demand or via Hetzner cron (every 6h is plenty — coverage changes slowly).
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/workers/r2-coverage-snapshot.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const R2_HOST_REGEX = /^https:\/\/images\.sourcelibrary\.org/;
+const ARCHIVE_FAILED_REGEX = /^failed:/;
+
+async function run() {
+  const client = new MongoClient(MONGODB_URI, { socketTimeoutMS: 1800000 });
+  await client.connect();
+  const db = client.db('bookstore');
+  const start = Date.now();
+
+  console.log(`[r2-coverage-snapshot] Starting at ${new Date().toISOString()}`);
+
+  // Single aggregation: per-book R2 state across the whole pages collection.
+  // $regexMatch is acceptable here because it's run once per book per snapshot,
+  // not on every admin page load.
+  console.log('  aggregating pages by book_id (this can take 10-20 min on Atlas)...');
+  const perBook = await db.collection('pages').aggregate([
+    { $group: {
+      _id: '$book_id',
+      total: { $sum: 1 },
+      r2: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: R2_HOST_REGEX } }, 1, 0] } },
+      failed: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: ARCHIVE_FAILED_REGEX } }, 1, 0] } },
+    }},
+  ], { allowDiskUse: true, maxTimeMS: 1800000 }).toArray();
+
+  console.log(`  per-book aggregation done: ${perBook.length} books with pages, ${((Date.now() - start)/60000).toFixed(1)} min`);
+
+  const statsByBook = new Map(perBook.map(s => [s._id, s]));
+
+  // Pull book metadata in one pass — only what we need
+  const books = await db.collection('books').find(
+    { status: { $ne: 'deleted' }, pages_count: { $gt: 0 } },
+    { projection: { id: 1, title: 1, language: 1, 'image_source.provider': 1, 'pipeline_auto.status': 1, 'pipeline_auto.error': 1 } }
+  ).toArray();
+
+  // Bucket books by R2 coverage
+  const buckets = { full: 0, partial_high: 0, partial_med: 0, partial_low: 0, none: 0 };
+  let totalPages = 0;
+  let totalR2 = 0;
+  let totalFailed = 0;
+  const byProvider = {};
+  const byProviderUnarchived = {};
+  const partialBooks = []; // books with some-but-not-all R2 coverage
+  const noR2Books = [];    // books with zero R2 coverage but >0 pages
+
+  for (const b of books) {
+    const s = statsByBook.get(b.id) || { total: 0, r2: 0, failed: 0 };
+    if (s.total === 0) continue; // no pages doc — skip
+    const provider = b.image_source?.provider || 'unknown';
+    const unarchived = Math.max(0, s.total - s.r2 - s.failed);
+    const ratio = s.r2 / s.total;
+
+    totalPages += s.total;
+    totalR2 += s.r2;
+    totalFailed += s.failed;
+
+    if (!byProvider[provider]) byProvider[provider] = { books: 0, pages: 0, r2: 0, failed: 0 };
+    byProvider[provider].books += 1;
+    byProvider[provider].pages += s.total;
+    byProvider[provider].r2 += s.r2;
+    byProvider[provider].failed += s.failed;
+    byProviderUnarchived[provider] = (byProviderUnarchived[provider] || 0) + unarchived;
+
+    if (ratio >= 0.99) buckets.full += 1;
+    else if (ratio >= 0.5) buckets.partial_high += 1;
+    else if (ratio >= 0.1) buckets.partial_med += 1;
+    else if (ratio > 0) buckets.partial_low += 1;
+    else buckets.none += 1;
+
+    if (ratio > 0 && ratio < 0.99) {
+      partialBooks.push({
+        id: b.id,
+        title: b.title,
+        language: b.language,
+        provider,
+        status: b.pipeline_auto?.status || null,
+        error: b.pipeline_auto?.error?.slice(0, 80) || null,
+        pages: s.total,
+        r2: s.r2,
+        failed: s.failed,
+        unarchived,
+        pct: Math.round(ratio * 1000) / 10,
+      });
+    } else if (ratio === 0 && s.total > 0) {
+      noR2Books.push({
+        id: b.id,
+        title: b.title,
+        language: b.language,
+        provider,
+        status: b.pipeline_auto?.status || null,
+        pages: s.total,
+      });
+    }
+  }
+
+  partialBooks.sort((a, b) => b.unarchived - a.unarchived);
+  noR2Books.sort((a, b) => b.pages - a.pages);
+
+  const snapshot = {
+    _id: 'r2_coverage_snapshot',
+    computed_at: new Date(),
+    computation_ms: Date.now() - start,
+    library: {
+      books_with_pages: buckets.full + buckets.partial_high + buckets.partial_med + buckets.partial_low + buckets.none,
+      total_pages: totalPages,
+      r2_pages: totalR2,
+      failed_pages: totalFailed,
+      unarchived_pages: totalPages - totalR2 - totalFailed,
+      r2_pct: totalPages > 0 ? Math.round((totalR2 / totalPages) * 1000) / 10 : 0,
+    },
+    coverage_buckets: buckets,
+    by_provider: byProvider,
+    partial_books_top200: partialBooks.slice(0, 200),
+    no_r2_books_top200: noR2Books.slice(0, 200),
+    partial_books_count: partialBooks.length,
+    no_r2_books_count: noR2Books.length,
+  };
+
+  await db.collection('system_config').replaceOne(
+    { _id: 'r2_coverage_snapshot' },
+    snapshot,
+    { upsert: true },
+  );
+
+  const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+  console.log(`[r2-coverage-snapshot] Done in ${elapsed}s`);
+  console.log(`  Library: ${snapshot.library.r2_pct}% R2 (${totalR2.toLocaleString()}/${totalPages.toLocaleString()} pages)`);
+  console.log(`  Buckets: full=${buckets.full}, partial_high=${buckets.partial_high}, partial_med=${buckets.partial_med}, partial_low=${buckets.partial_low}, none=${buckets.none}`);
+  console.log(`  Partial books: ${partialBooks.length} | No-R2 books: ${noR2Books.length}`);
+
+  await client.close();
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/[tenant]/admin/AdminNav.tsx
+++ b/src/app/[tenant]/admin/AdminNav.tsx
@@ -19,6 +19,7 @@ const adminLinks: NavItem[] = [
   { href: '/admin/collections', label: 'Collections' },
   { href: '/admin/duplicates', label: 'Duplicates' },
   { href: '/admin/catalog-coverage', label: 'Catalog' },
+  { href: '/admin/r2-coverage', label: 'R2 Storage' },
   {
     href: '/admin/outreach',
     label: 'Outreach',

--- a/src/app/[tenant]/admin/r2-coverage/page.tsx
+++ b/src/app/[tenant]/admin/r2-coverage/page.tsx
@@ -18,20 +18,58 @@ interface StuckBook {
   error?: string;
 }
 
+interface PartialBook {
+  id: string;
+  title: string;
+  language: string;
+  provider: string;
+  status: string | null;
+  error: string | null;
+  pages: number;
+  r2: number;
+  failed: number;
+  unarchived: number;
+  pct: number;
+}
+
+interface NoR2Book {
+  id: string;
+  title: string;
+  language: string;
+  provider: string;
+  status: string | null;
+  pages: number;
+}
+
+interface SnapshotData {
+  computed_at: string;
+  computation_ms: number;
+  library: { books_with_pages: number; total_pages: number; r2_pages: number; failed_pages: number; unarchived_pages: number; r2_pct: number };
+  coverage_buckets: { full: number; partial_high: number; partial_med: number; partial_low: number; none: number };
+  by_provider: Record<string, { books: number; pages: number; r2: number; failed: number }>;
+  partial_books_count: number;
+  no_r2_books_count: number;
+  partial_books_top200: PartialBook[];
+  no_r2_books_top200: NoR2Book[];
+}
+
 interface Coverage {
   generated_at: string;
+  snapshot: SnapshotData | null;
   stuck: {
     summary: { books: number; pages_total: number; pages_r2: number; pages_unarchived: number; pages_failed: number };
     by_provider: Record<string, { books: number; pages_unarchived: number }>;
     books: StuckBook[];
   };
-  library_by_provider: { provider: string; books: number; pages: number }[];
 }
+
+type Tab = 'stuck' | 'partial' | 'no_r2';
 
 export default function R2CoveragePage() {
   const [data, setData] = useState<Coverage | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('stuck');
   const [filter, setFilter] = useState('');
 
   useEffect(() => {
@@ -45,102 +83,234 @@ export default function R2CoveragePage() {
   }, []);
 
   const stuck = data?.stuck;
-  const filtered = stuck?.books.filter(b =>
-    !filter ||
-    b.title.toLowerCase().includes(filter.toLowerCase()) ||
-    (b.author || '').toLowerCase().includes(filter.toLowerCase()) ||
-    (b.provider || '').toLowerCase().includes(filter.toLowerCase())
-  ) || [];
+  const snap = data?.snapshot;
+
+  const filterBook = (s: string, ...fields: (string | undefined | null)[]) =>
+    !s || fields.some(f => (f || '').toLowerCase().includes(s.toLowerCase()));
+
+  const filteredStuck = stuck?.books.filter(b => filterBook(filter, b.title, b.author, b.provider)) || [];
+  const filteredPartial = snap?.partial_books_top200.filter(b => filterBook(filter, b.title, b.provider)) || [];
+  const filteredNoR2 = snap?.no_r2_books_top200.filter(b => filterBook(filter, b.title, b.provider)) || [];
 
   return (
     <div style={{ padding: 24, color: '#c9d1d9', background: '#0d1117', minHeight: '100vh', fontFamily: 'system-ui, sans-serif' }}>
       <h1 style={{ marginTop: 0, fontSize: 24 }}>R2 Image Archive Coverage</h1>
       <p style={{ color: '#8b949e', marginTop: 4, marginBottom: 16, fontSize: 14 }}>
-        Source-of-truth image storage. Pages on R2 are durable; pages on source URLs are vulnerable to upstream throttling/404s (this is what blocks OCR for the books below).
+        Source-of-truth image storage. Pages on R2 are durable; pages on source URLs are vulnerable to upstream throttling/404s.
       </p>
 
       {loading && <p>Loading…</p>}
       {error && <p style={{ color: '#f85149' }}>Error: {error}</p>}
 
-      {data && stuck && (
+      {data && (
         <>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, marginBottom: 24 }}>
-            <Card label="Stuck books" value={stuck.summary.books.toLocaleString()} hint="needs_attention with image-download failures" />
-            <Card label="Pages on R2" value={stuck.summary.pages_r2.toLocaleString()} hint={`of ${stuck.summary.pages_total.toLocaleString()} (${stuck.summary.pages_total > 0 ? Math.round(stuck.summary.pages_r2 / stuck.summary.pages_total * 100) : 0}%)`} />
-            <Card label="Pages to archive" value={stuck.summary.pages_unarchived.toLocaleString()} hint="re-archive these to clear the queue" warn />
-            <Card label="Pages permanently failed" value={stuck.summary.pages_failed.toLocaleString()} hint="archived_photo: 'failed:...'" />
-          </div>
-
-          <h2 style={{ fontSize: 18, marginTop: 24 }}>Stuck by provider</h2>
-          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 24 }}>
-            {Object.entries(stuck.by_provider).sort((a, b) => b[1].books - a[1].books).map(([provider, s]) => (
-              <div key={provider} style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '10px 14px', minWidth: 160 }}>
-                <div style={{ fontSize: 12, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{provider}</div>
-                <div style={{ fontSize: 18, marginTop: 2 }}>{s.books.toLocaleString()} books</div>
-                <div style={{ fontSize: 12, color: '#8b949e', marginTop: 2 }}>{s.pages_unarchived.toLocaleString()} pages to archive</div>
+          {snap ? (
+            <>
+              <h2 style={{ fontSize: 16, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 24, marginBottom: 8 }}>Library-wide</h2>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12, marginBottom: 8 }}>
+                <Card label="R2 coverage" value={`${snap.library.r2_pct}%`} hint={`${snap.library.r2_pages.toLocaleString()} of ${snap.library.total_pages.toLocaleString()} pages`} />
+                <Card label="Books fully on R2" value={snap.coverage_buckets.full.toLocaleString()} hint="≥99% archived" good />
+                <Card label="Books partially on R2" value={(snap.coverage_buckets.partial_high + snap.coverage_buckets.partial_med + snap.coverage_buckets.partial_low).toLocaleString()} hint={`high ${snap.coverage_buckets.partial_high}, med ${snap.coverage_buckets.partial_med}, low ${snap.coverage_buckets.partial_low}`} warn />
+                <Card label="Books with zero R2" value={snap.coverage_buckets.none.toLocaleString()} hint="have pages but never archived" warn />
+                <Card label="Pages to archive" value={snap.library.unarchived_pages.toLocaleString()} hint={`${snap.library.failed_pages.toLocaleString()} permanently failed`} warn />
               </div>
-            ))}
+              <p style={{ fontSize: 11, color: '#8b949e', marginTop: 0, marginBottom: 24 }}>
+                Snapshot computed {new Date(snap.computed_at).toLocaleString()} in {(snap.computation_ms / 1000).toFixed(1)}s. Refresh: <code style={{ background: '#161b22', padding: '1px 5px', borderRadius: 3 }}>node scripts/workers/r2-coverage-snapshot.mjs</code>
+              </p>
+            </>
+          ) : (
+            <div style={{ background: '#1c2128', border: '1px solid #9e6a03', borderRadius: 8, padding: 12, marginBottom: 16, fontSize: 13 }}>
+              <strong style={{ color: '#e3b341' }}>No library snapshot yet.</strong> Run <code style={{ background: '#0d1117', padding: '1px 5px', borderRadius: 3 }}>node scripts/workers/r2-coverage-snapshot.mjs</code> to populate (~10–20 min on Atlas). Until then this page only shows the explicitly-stuck set below.
+            </div>
+          )}
+
+          {snap && (
+            <>
+              <h2 style={{ fontSize: 16, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 24, marginBottom: 8 }}>By provider</h2>
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 24 }}>
+                {Object.entries(snap.by_provider).sort((a, b) => b[1].pages - a[1].pages).map(([provider, p]) => {
+                  const pct = p.pages > 0 ? Math.round((p.r2 / p.pages) * 100) : 0;
+                  return (
+                    <div key={provider} style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '10px 14px', minWidth: 180 }}>
+                      <div style={{ fontSize: 12, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{provider}</div>
+                      <div style={{ fontSize: 16, marginTop: 2 }}>{p.books.toLocaleString()} books · {pct}% R2</div>
+                      <div style={{ fontSize: 11, color: '#8b949e', marginTop: 2 }}>{(p.pages - p.r2 - p.failed).toLocaleString()} pages to archive</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          <div style={{ borderBottom: '1px solid #30363d', marginBottom: 12, marginTop: 24 }}>
+            <TabBtn active={tab === 'stuck'} onClick={() => setTab('stuck')}>Stuck (errored) · {stuck?.summary.books ?? 0}</TabBtn>
+            <TabBtn active={tab === 'partial'} onClick={() => setTab('partial')}>Partial R2 · {snap?.partial_books_count ?? 0}</TabBtn>
+            <TabBtn active={tab === 'no_r2'} onClick={() => setTab('no_r2')}>Zero R2 · {snap?.no_r2_books_count ?? 0}</TabBtn>
           </div>
 
-          <h2 style={{ fontSize: 18, marginTop: 24, marginBottom: 8 }}>Stuck books ({filtered.length}{filter ? ` of ${stuck.books.length}` : ''})</h2>
           <input
             type="search"
-            placeholder="Filter by title, author, or provider…"
+            placeholder="Filter by title or provider…"
             value={filter}
             onChange={e => setFilter(e.target.value)}
             style={{ width: '100%', maxWidth: 480, padding: '6px 10px', marginBottom: 12, background: '#0d1117', color: '#c9d1d9', border: '1px solid #30363d', borderRadius: 6, fontSize: 13 }}
           />
-          <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
-              <thead>
-                <tr style={{ background: '#1c2128', color: '#8b949e' }}>
-                  <Th>Q</Th>
-                  <Th>Book</Th>
-                  <Th>Lang</Th>
-                  <Th>Provider</Th>
-                  <Th align="right">R2 / Total</Th>
-                  <Th align="right">Unarchived</Th>
-                  <Th align="right">R2%</Th>
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map(b => (
-                  <tr key={b.id} style={{ borderTop: '1px solid #30363d' }}>
-                    <Td>{b.quality_score ?? '—'}</Td>
-                    <Td>
-                      <Link href={`/book/${b.id}`} target="_blank" style={{ color: '#58a6ff', textDecoration: 'none' }}>
-                        {b.title?.slice(0, 80)}
-                      </Link>
-                      <div style={{ color: '#8b949e', fontSize: 11, marginTop: 2 }}>{b.author?.slice(0, 60)}</div>
-                    </Td>
-                    <Td>{b.language}</Td>
-                    <Td>{b.provider}</Td>
-                    <Td align="right">{b.pages_r2.toLocaleString()} / {b.pages_total.toLocaleString()}</Td>
-                    <Td align="right" warn={b.pages_unarchived > 0}>{b.pages_unarchived.toLocaleString()}</Td>
-                    <Td align="right">
-                      <Bar pct={b.r2_pct} />
-                    </Td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
 
-          <p style={{ marginTop: 16, fontSize: 12, color: '#8b949e' }}>
-            Generated {new Date(data.generated_at).toLocaleString()}.
-            Re-archive script: <code style={{ background: '#161b22', padding: '2px 6px', borderRadius: 4 }}>scripts/_tmp-archive-needs-attention.ts</code>
-          </p>
+          {tab === 'stuck' && stuck && <StuckTable rows={filteredStuck} />}
+          {tab === 'partial' && snap && <PartialTable rows={filteredPartial} totalAvailable={snap.partial_books_count} showing={snap.partial_books_top200.length} />}
+          {tab === 'no_r2' && snap && <NoR2Table rows={filteredNoR2} totalAvailable={snap.no_r2_books_count} showing={snap.no_r2_books_top200.length} />}
         </>
       )}
     </div>
   );
 }
 
-function Card({ label, value, hint, warn }: { label: string; value: string; hint?: string; warn?: boolean }) {
+function TabBtn({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
   return (
-    <div style={{ background: '#161b22', border: `1px solid ${warn ? '#9e6a03' : '#30363d'}`, borderRadius: 8, padding: '12px 16px' }}>
+    <button
+      onClick={onClick}
+      style={{
+        padding: '8px 14px',
+        background: 'transparent',
+        color: active ? '#f0f6fc' : '#8b949e',
+        border: 'none',
+        borderBottom: active ? '2px solid #58a6ff' : '2px solid transparent',
+        marginBottom: -1,
+        cursor: 'pointer',
+        font: 'inherit',
+        fontSize: 13,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function StuckTable({ rows }: { rows: StuckBook[] }) {
+  return (
+    <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+        <thead>
+          <tr style={{ background: '#1c2128', color: '#8b949e' }}>
+            <Th>Q</Th>
+            <Th>Book</Th>
+            <Th>Lang</Th>
+            <Th>Provider</Th>
+            <Th align="right">R2 / Total</Th>
+            <Th align="right">Unarchived</Th>
+            <Th align="right">R2%</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(b => (
+            <tr key={b.id} style={{ borderTop: '1px solid #30363d' }}>
+              <Td>{b.quality_score ?? '—'}</Td>
+              <Td>
+                <Link href={`/book/${b.id}`} target="_blank" style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                  {b.title?.slice(0, 80)}
+                </Link>
+                <div style={{ color: '#8b949e', fontSize: 11, marginTop: 2 }}>{b.author?.slice(0, 60)}</div>
+              </Td>
+              <Td>{b.language}</Td>
+              <Td>{b.provider}</Td>
+              <Td align="right">{b.pages_r2.toLocaleString()} / {b.pages_total.toLocaleString()}</Td>
+              <Td align="right" warn={b.pages_unarchived > 0}>{b.pages_unarchived.toLocaleString()}</Td>
+              <Td align="right"><Bar pct={b.r2_pct} /></Td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PartialTable({ rows, totalAvailable, showing }: { rows: PartialBook[]; totalAvailable: number; showing: number }) {
+  return (
+    <>
+      {totalAvailable > showing && (
+        <p style={{ fontSize: 12, color: '#8b949e', margin: '0 0 8px' }}>Showing top {showing} of {totalAvailable.toLocaleString()} partial-R2 books (sorted by unarchived pages).</p>
+      )}
+      <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr style={{ background: '#1c2128', color: '#8b949e' }}>
+              <Th>Book</Th>
+              <Th>Lang</Th>
+              <Th>Provider</Th>
+              <Th>Status</Th>
+              <Th align="right">R2 / Total</Th>
+              <Th align="right">Unarchived</Th>
+              <Th align="right">R2%</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(b => (
+              <tr key={b.id} style={{ borderTop: '1px solid #30363d' }}>
+                <Td>
+                  <Link href={`/book/${b.id}`} target="_blank" style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                    {b.title?.slice(0, 80)}
+                  </Link>
+                </Td>
+                <Td>{b.language}</Td>
+                <Td>{b.provider}</Td>
+                <Td>{b.status || '—'}</Td>
+                <Td align="right">{b.r2.toLocaleString()} / {b.pages.toLocaleString()}</Td>
+                <Td align="right" warn={b.unarchived > 0}>{b.unarchived.toLocaleString()}</Td>
+                <Td align="right"><Bar pct={b.pct} /></Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function NoR2Table({ rows, totalAvailable, showing }: { rows: NoR2Book[]; totalAvailable: number; showing: number }) {
+  return (
+    <>
+      {totalAvailable > showing && (
+        <p style={{ fontSize: 12, color: '#8b949e', margin: '0 0 8px' }}>Showing top {showing} of {totalAvailable.toLocaleString()} zero-R2 books (sorted by pages).</p>
+      )}
+      <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr style={{ background: '#1c2128', color: '#8b949e' }}>
+              <Th>Book</Th>
+              <Th>Lang</Th>
+              <Th>Provider</Th>
+              <Th>Status</Th>
+              <Th align="right">Pages</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(b => (
+              <tr key={b.id} style={{ borderTop: '1px solid #30363d' }}>
+                <Td>
+                  <Link href={`/book/${b.id}`} target="_blank" style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                    {b.title?.slice(0, 80)}
+                  </Link>
+                </Td>
+                <Td>{b.language}</Td>
+                <Td>{b.provider}</Td>
+                <Td>{b.status || '—'}</Td>
+                <Td align="right" warn>{b.pages.toLocaleString()}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function Card({ label, value, hint, warn, good }: { label: string; value: string; hint?: string; warn?: boolean; good?: boolean }) {
+  const borderColor = warn ? '#9e6a03' : good ? '#238636' : '#30363d';
+  const valueColor = warn ? '#e3b341' : good ? '#3fb950' : '#f0f6fc';
+  return (
+    <div style={{ background: '#161b22', border: `1px solid ${borderColor}`, borderRadius: 8, padding: '12px 16px' }}>
       <div style={{ fontSize: 11, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{label}</div>
-      <div style={{ fontSize: 22, marginTop: 4, color: warn ? '#e3b341' : '#f0f6fc' }}>{value}</div>
+      <div style={{ fontSize: 22, marginTop: 4, color: valueColor }}>{value}</div>
       {hint && <div style={{ fontSize: 11, color: '#8b949e', marginTop: 2 }}>{hint}</div>}
     </div>
   );

--- a/src/app/[tenant]/admin/r2-coverage/page.tsx
+++ b/src/app/[tenant]/admin/r2-coverage/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface StuckBook {
+  id: string;
+  title: string;
+  author: string;
+  language: string;
+  provider: string | null;
+  quality_score: number | null;
+  pages_total: number;
+  pages_r2: number;
+  pages_failed: number;
+  pages_unarchived: number;
+  r2_pct: number;
+  error?: string;
+}
+
+interface Coverage {
+  generated_at: string;
+  stuck: {
+    summary: { books: number; pages_total: number; pages_r2: number; pages_unarchived: number; pages_failed: number };
+    by_provider: Record<string, { books: number; pages_unarchived: number }>;
+    books: StuckBook[];
+  };
+  library_by_provider: { provider: string; books: number; pages: number }[];
+}
+
+export default function R2CoveragePage() {
+  const [data, setData] = useState<Coverage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/admin/r2-coverage')
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then(d => { if (!cancelled) setData(d); })
+      .catch(e => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const stuck = data?.stuck;
+  const filtered = stuck?.books.filter(b =>
+    !filter ||
+    b.title.toLowerCase().includes(filter.toLowerCase()) ||
+    (b.author || '').toLowerCase().includes(filter.toLowerCase()) ||
+    (b.provider || '').toLowerCase().includes(filter.toLowerCase())
+  ) || [];
+
+  return (
+    <div style={{ padding: 24, color: '#c9d1d9', background: '#0d1117', minHeight: '100vh', fontFamily: 'system-ui, sans-serif' }}>
+      <h1 style={{ marginTop: 0, fontSize: 24 }}>R2 Image Archive Coverage</h1>
+      <p style={{ color: '#8b949e', marginTop: 4, marginBottom: 16, fontSize: 14 }}>
+        Source-of-truth image storage. Pages on R2 are durable; pages on source URLs are vulnerable to upstream throttling/404s (this is what blocks OCR for the books below).
+      </p>
+
+      {loading && <p>Loading…</p>}
+      {error && <p style={{ color: '#f85149' }}>Error: {error}</p>}
+
+      {data && stuck && (
+        <>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, marginBottom: 24 }}>
+            <Card label="Stuck books" value={stuck.summary.books.toLocaleString()} hint="needs_attention with image-download failures" />
+            <Card label="Pages on R2" value={stuck.summary.pages_r2.toLocaleString()} hint={`of ${stuck.summary.pages_total.toLocaleString()} (${stuck.summary.pages_total > 0 ? Math.round(stuck.summary.pages_r2 / stuck.summary.pages_total * 100) : 0}%)`} />
+            <Card label="Pages to archive" value={stuck.summary.pages_unarchived.toLocaleString()} hint="re-archive these to clear the queue" warn />
+            <Card label="Pages permanently failed" value={stuck.summary.pages_failed.toLocaleString()} hint="archived_photo: 'failed:...'" />
+          </div>
+
+          <h2 style={{ fontSize: 18, marginTop: 24 }}>Stuck by provider</h2>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 24 }}>
+            {Object.entries(stuck.by_provider).sort((a, b) => b[1].books - a[1].books).map(([provider, s]) => (
+              <div key={provider} style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '10px 14px', minWidth: 160 }}>
+                <div style={{ fontSize: 12, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{provider}</div>
+                <div style={{ fontSize: 18, marginTop: 2 }}>{s.books.toLocaleString()} books</div>
+                <div style={{ fontSize: 12, color: '#8b949e', marginTop: 2 }}>{s.pages_unarchived.toLocaleString()} pages to archive</div>
+              </div>
+            ))}
+          </div>
+
+          <h2 style={{ fontSize: 18, marginTop: 24, marginBottom: 8 }}>Stuck books ({filtered.length}{filter ? ` of ${stuck.books.length}` : ''})</h2>
+          <input
+            type="search"
+            placeholder="Filter by title, author, or provider…"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            style={{ width: '100%', maxWidth: 480, padding: '6px 10px', marginBottom: 12, background: '#0d1117', color: '#c9d1d9', border: '1px solid #30363d', borderRadius: 6, fontSize: 13 }}
+          />
+          <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+              <thead>
+                <tr style={{ background: '#1c2128', color: '#8b949e' }}>
+                  <Th>Q</Th>
+                  <Th>Book</Th>
+                  <Th>Lang</Th>
+                  <Th>Provider</Th>
+                  <Th align="right">R2 / Total</Th>
+                  <Th align="right">Unarchived</Th>
+                  <Th align="right">R2%</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(b => (
+                  <tr key={b.id} style={{ borderTop: '1px solid #30363d' }}>
+                    <Td>{b.quality_score ?? '—'}</Td>
+                    <Td>
+                      <Link href={`/book/${b.id}`} target="_blank" style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                        {b.title?.slice(0, 80)}
+                      </Link>
+                      <div style={{ color: '#8b949e', fontSize: 11, marginTop: 2 }}>{b.author?.slice(0, 60)}</div>
+                    </Td>
+                    <Td>{b.language}</Td>
+                    <Td>{b.provider}</Td>
+                    <Td align="right">{b.pages_r2.toLocaleString()} / {b.pages_total.toLocaleString()}</Td>
+                    <Td align="right" warn={b.pages_unarchived > 0}>{b.pages_unarchived.toLocaleString()}</Td>
+                    <Td align="right">
+                      <Bar pct={b.r2_pct} />
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p style={{ marginTop: 16, fontSize: 12, color: '#8b949e' }}>
+            Generated {new Date(data.generated_at).toLocaleString()}.
+            Re-archive script: <code style={{ background: '#161b22', padding: '2px 6px', borderRadius: 4 }}>scripts/_tmp-archive-needs-attention.ts</code>
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Card({ label, value, hint, warn }: { label: string; value: string; hint?: string; warn?: boolean }) {
+  return (
+    <div style={{ background: '#161b22', border: `1px solid ${warn ? '#9e6a03' : '#30363d'}`, borderRadius: 8, padding: '12px 16px' }}>
+      <div style={{ fontSize: 11, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{label}</div>
+      <div style={{ fontSize: 22, marginTop: 4, color: warn ? '#e3b341' : '#f0f6fc' }}>{value}</div>
+      {hint && <div style={{ fontSize: 11, color: '#8b949e', marginTop: 2 }}>{hint}</div>}
+    </div>
+  );
+}
+
+function Th({ children, align = 'left' }: { children: React.ReactNode; align?: 'left' | 'right' }) {
+  return <th style={{ padding: '8px 12px', textAlign: align, fontWeight: 500, fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5 }}>{children}</th>;
+}
+
+function Td({ children, align = 'left', warn }: { children: React.ReactNode; align?: 'left' | 'right'; warn?: boolean }) {
+  return <td style={{ padding: '8px 12px', textAlign: align, color: warn ? '#e3b341' : undefined }}>{children}</td>;
+}
+
+function Bar({ pct }: { pct: number }) {
+  const color = pct >= 95 ? '#3fb950' : pct >= 50 ? '#e3b341' : '#f85149';
+  return (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      <div style={{ width: 60, height: 6, background: '#30363d', borderRadius: 3, overflow: 'hidden' }}>
+        <div style={{ width: `${Math.max(2, pct)}%`, height: '100%', background: color }} />
+      </div>
+      <span style={{ minWidth: 32, textAlign: 'right', color }}>{pct}%</span>
+    </div>
+  );
+}

--- a/src/app/api/admin/r2-coverage/route.ts
+++ b/src/app/api/admin/r2-coverage/route.ts
@@ -5,12 +5,13 @@ import { withAdminAuth } from '@/lib/auth-helpers';
 export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
 
-const R2_HOST_REGEX = /^https:\/\/images\.sourcelibrary\.org/;
-const ARCHIVE_FAILED_REGEX = /^failed:/;
-
 export const GET = withAdminAuth(async () => {
   const db = await getDb();
 
+  // Library-wide snapshot, computed by scripts/workers/r2-coverage-snapshot.mjs
+  const snapshot = await db.collection('system_config').findOne({ _id: 'r2_coverage_snapshot' as unknown as never });
+
+  // Live: stuck books explicitly errored on image downloads (always fresh — narrow query)
   const stuckBooks = await db.collection('books').find({
     'pipeline_auto.status': 'needs_attention',
     status: { $ne: 'deleted' },
@@ -21,7 +22,6 @@ export const GET = withAdminAuth(async () => {
     author: 1,
     language: 1,
     pages_count: 1,
-    pages_ocr: 1,
     quality_score: 1,
     'image_source.provider': 1,
     'pipeline_auto.error': 1,
@@ -33,8 +33,8 @@ export const GET = withAdminAuth(async () => {
     { $group: {
       _id: '$book_id',
       total: { $sum: 1 },
-      r2: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: R2_HOST_REGEX } }, 1, 0] } },
-      failed: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: ARCHIVE_FAILED_REGEX } }, 1, 0] } },
+      r2: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: /^https:\/\/images\.sourcelibrary\.org/ } }, 1, 0] } },
+      failed: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: /^failed:/ } }, 1, 0] } },
     }},
   ]).toArray();
 
@@ -75,23 +75,23 @@ export const GET = withAdminAuth(async () => {
     return acc;
   }, { books: 0, pages_total: 0, pages_r2: 0, pages_unarchived: 0, pages_failed: 0 });
 
-  const bookCoverage = await db.collection('books').aggregate([
-    { $match: { status: { $ne: 'deleted' }, pages_count: { $gt: 0 } } },
-    { $group: {
-      _id: { $ifNull: ['$image_source.provider', 'unknown'] },
-      books: { $sum: 1 },
-      pages: { $sum: '$pages_count' },
-    }},
-    { $sort: { books: -1 } },
-  ]).toArray();
-
   return NextResponse.json({
     generated_at: new Date().toISOString(),
+    snapshot: snapshot ? {
+      computed_at: snapshot.computed_at,
+      computation_ms: snapshot.computation_ms,
+      library: snapshot.library,
+      coverage_buckets: snapshot.coverage_buckets,
+      by_provider: snapshot.by_provider,
+      partial_books_count: snapshot.partial_books_count,
+      no_r2_books_count: snapshot.no_r2_books_count,
+      partial_books_top200: snapshot.partial_books_top200,
+      no_r2_books_top200: snapshot.no_r2_books_top200,
+    } : null,
     stuck: {
       summary: stuckTotals,
       by_provider: stuckByProvider,
       books: stuckRows,
     },
-    library_by_provider: bookCoverage.map(p => ({ provider: p._id, books: p.books, pages: p.pages })),
   });
 });

--- a/src/app/api/admin/r2-coverage/route.ts
+++ b/src/app/api/admin/r2-coverage/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { withAdminAuth } from '@/lib/auth-helpers';
+
+export const maxDuration = 60;
+export const dynamic = 'force-dynamic';
+
+const R2_HOST_REGEX = /^https:\/\/images\.sourcelibrary\.org/;
+const ARCHIVE_FAILED_REGEX = /^failed:/;
+
+export const GET = withAdminAuth(async () => {
+  const db = await getDb();
+
+  const stuckBooks = await db.collection('books').find({
+    'pipeline_auto.status': 'needs_attention',
+    status: { $ne: 'deleted' },
+    'pipeline_auto.error': { $regex: /image downloads failed/i },
+  }).project({
+    id: 1,
+    title: 1,
+    author: 1,
+    language: 1,
+    pages_count: 1,
+    pages_ocr: 1,
+    quality_score: 1,
+    'image_source.provider': 1,
+    'pipeline_auto.error': 1,
+  }).toArray();
+
+  const ids = stuckBooks.map(b => b.id as string);
+  const stuckPageStats = ids.length === 0 ? [] : await db.collection('pages').aggregate([
+    { $match: { book_id: { $in: ids } } },
+    { $group: {
+      _id: '$book_id',
+      total: { $sum: 1 },
+      r2: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: R2_HOST_REGEX } }, 1, 0] } },
+      failed: { $sum: { $cond: [{ $regexMatch: { input: { $ifNull: ['$archived_photo', ''] }, regex: ARCHIVE_FAILED_REGEX } }, 1, 0] } },
+    }},
+  ]).toArray();
+
+  const statsById = new Map(stuckPageStats.map(s => [s._id, s]));
+  const stuckRows = stuckBooks.map(b => {
+    const s = statsById.get(b.id as string) || { total: b.pages_count || 0, r2: 0, failed: 0 };
+    const unarchived = Math.max(0, s.total - s.r2 - s.failed);
+    return {
+      id: b.id,
+      title: b.title,
+      author: b.author,
+      language: b.language,
+      provider: b.image_source?.provider || null,
+      quality_score: b.quality_score ?? null,
+      pages_total: s.total,
+      pages_r2: s.r2,
+      pages_failed: s.failed,
+      pages_unarchived: unarchived,
+      r2_pct: s.total > 0 ? Math.round((s.r2 / s.total) * 100) : 0,
+      error: b.pipeline_auto?.error?.slice(0, 80),
+    };
+  }).sort((a, b) => (b.quality_score ?? 0) - (a.quality_score ?? 0) || b.pages_unarchived - a.pages_unarchived);
+
+  const stuckByProvider: Record<string, { books: number; pages_unarchived: number }> = {};
+  for (const r of stuckRows) {
+    const p = r.provider || 'unknown';
+    if (!stuckByProvider[p]) stuckByProvider[p] = { books: 0, pages_unarchived: 0 };
+    stuckByProvider[p].books += 1;
+    stuckByProvider[p].pages_unarchived += r.pages_unarchived;
+  }
+
+  const stuckTotals = stuckRows.reduce((acc, r) => {
+    acc.books += 1;
+    acc.pages_total += r.pages_total;
+    acc.pages_r2 += r.pages_r2;
+    acc.pages_unarchived += r.pages_unarchived;
+    acc.pages_failed += r.pages_failed;
+    return acc;
+  }, { books: 0, pages_total: 0, pages_r2: 0, pages_unarchived: 0, pages_failed: 0 });
+
+  const bookCoverage = await db.collection('books').aggregate([
+    { $match: { status: { $ne: 'deleted' }, pages_count: { $gt: 0 } } },
+    { $group: {
+      _id: { $ifNull: ['$image_source.provider', 'unknown'] },
+      books: { $sum: 1 },
+      pages: { $sum: '$pages_count' },
+    }},
+    { $sort: { books: -1 } },
+  ]).toArray();
+
+  return NextResponse.json({
+    generated_at: new Date().toISOString(),
+    stuck: {
+      summary: stuckTotals,
+      by_provider: stuckByProvider,
+      books: stuckRows,
+    },
+    library_by_provider: bookCoverage.map(p => ({ provider: p._id, books: p.books, pages: p.pages })),
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/admin/r2-coverage` showing the books stuck on \"image downloads failed\" with their R2 archive %, unarchived count, and provider breakdown
- New API: `GET /api/admin/r2-coverage` aggregates page-level R2 state per book

## Why

741 books are blocked at `needs_attention` because OCR's full pass tries to bulk-fetch images from MDZ / e-rara source URLs (the preview pass already R2-archived the first ~25 pages, but the rest never were) and gets throttled.

R2 is the source of truth (`getPageImageUrl()` in `src/lib/utils.ts:156` prefers `archived_photo` over the source `photo`), but coverage was previously invisible — no admin page surfaced which books were partial.

This page makes the gap obvious. Provider summary shows MDZ (612 stuck) and e-rara (118 stuck) are the worst.

## Test plan

- [ ] Visit `/admin/r2-coverage` on the preview URL
- [ ] Confirm headline cards show stuck count + pages-to-archive
- [ ] Confirm provider table sums to total
- [ ] Filter input narrows the list
- [ ] Book links open in `/book/<id>` tabs
- [ ] Type-check clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)