### PR TITLE
Add BPH search page + tenant-scoped hero search box

### DIFF
--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { useSearchParams, useRouter, useParams } from 'next/navigation';
 import SiteHeader from '@/components/layout/SiteHeader';
+import { useEmbed } from '@/lib/EmbedContext';
 import { useDebouncedCallback } from 'use-debounce';
 import { reportError } from '@/components/providers/ErrorReporter';
 import {
@@ -54,10 +55,12 @@ interface CategoryOption { value: string; label: string; icon?: string; }
 
 type ViewMode = 'unified' | 'books' | 'index' | 'images';
 
-export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string } = {}) {
+export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { defaultLibrary?: string; forceEmbedded?: boolean } = {}) {
   const router = useRouter();
   const { tenant } = useParams<{ tenant: string }>();
   const searchParams = useSearchParams();
+  const embedFromContext = useEmbed();
+  const embed = forceEmbedded || embedFromContext;
 
   const initialMode = (searchParams.get('mode') as ViewMode) || 'unified';
   const [query, setQuery] = useState(searchParams.get('q') || '');
@@ -725,7 +728,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
 
   return (
     <div className="bg-cream">
-      <SiteHeader variant="dark" />
+      {!embed && <SiteHeader variant="dark" />}
 
       {/* Search Bar */}
       <div className="bg-white border-b border-border-light sticky top-0 z-10">
@@ -896,7 +899,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
                       ))}
                     </select>
                   </div>
-                  {!defaultLibrary && (
+                  {!defaultLibrary && !embed && (
                     <div>
                       <label className="block text-sm text-secondary mb-1">Library</label>
                       <select value={library} onChange={(e) => setLibrary(e.target.value)}
@@ -969,7 +972,7 @@ export default function SearchPage({ defaultLibrary }: { defaultLibrary?: string
                       ))}
                     </select>
                   </div>
-                  {!defaultLibrary && (
+                  {!defaultLibrary && !embed && (
                     <div>
                       <label className="block text-sm text-secondary mb-1">Library</label>
                       <select value={library} onChange={(e) => setLibrary(e.target.value)}

--- a/src/app/api/search/visual/route.ts
+++ b/src/app/api/search/visual/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabase';
+import { getReadDb } from '@/lib/mongodb';
+import { getTenantContextFromRequest } from '@/lib/tenant-context';
 
 export const maxDuration = 15;
 
@@ -25,6 +27,13 @@ export async function GET(request: NextRequest) {
 
   if (!query || query.length < 2) {
     return NextResponse.json({ results: [], query: '', total: 0 });
+  }
+
+  // Tenant context — when present, only return images whose book is in this
+  // tenant. Required for tenant subdomain lockdown (e.g. bph.sourcelibrary.org).
+  const { slug: tenantSlug, id: tenantId } = getTenantContextFromRequest(request.headers);
+  if (tenantSlug && !tenantId) {
+    return NextResponse.json({ results: [], query, total: 0 });
   }
 
   try {
@@ -78,9 +87,25 @@ export async function GET(request: NextRequest) {
       similarity: number;
     }>;
 
+    // Tenant filter: keep only matches whose book is in this tenant.
+    let scoped = matches;
+    if (tenantId) {
+      const bookIds = Array.from(new Set(matches.map(m => m.book_id).filter(Boolean)));
+      if (bookIds.length === 0) {
+        scoped = [];
+      } else {
+        const db = await getReadDb();
+        const allowedDocs = await db.collection('books')
+          .find({ id: { $in: bookIds }, tenantId }, { projection: { id: 1 } })
+          .toArray();
+        const allowed = new Set(allowedDocs.map(d => d.id as string));
+        scoped = matches.filter(m => allowed.has(m.book_id));
+      }
+    }
+
     // Deduplicate by book — max 3 per book for diversity
     const byBook = new Map<string, number>();
-    const deduped = matches.filter(m => {
+    const deduped = scoped.filter(m => {
       const count = byBook.get(m.book_id) || 0;
       if (count >= 3) return false;
       byBook.set(m.book_id, count + 1);

--- a/src/app/embed/[tenant]/search/layout.tsx
+++ b/src/app/embed/[tenant]/search/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from '@/app/[tenant]/search/layout';

--- a/src/app/embed/[tenant]/search/page.tsx
+++ b/src/app/embed/[tenant]/search/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+// Tenant subdomains route /search here (see src/proxy.ts).
+// usePathname() on the client returns the original URL (the proxy rewrite is
+// invisible), so useEmbed() can't auto-detect embed mode. Pass forceEmbedded
+// explicitly so the page hides global chrome (SiteHeader) and cross-tenant
+// filters (Library partner selector).
+import SearchPage from '@/app/[tenant]/search/page';
+
+export default function EmbedTenantSearchPage() {
+  return <SearchPage forceEmbedded />;
+}

--- a/src/app/embed/[tenant]/search/visual/page.tsx
+++ b/src/app/embed/[tenant]/search/visual/page.tsx
@@ -1,0 +1,4 @@
+// Tenant subdomain entry for /search/visual (see src/proxy.ts).
+// The visual search API filters by tenant via x-tenant-id header set by proxy.ts,
+// so this re-export needs no extra plumbing.
+export { default } from '@/app/[tenant]/search/visual/page';

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -8,7 +8,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { BookOpen, ExternalLink, Images, Library } from 'lucide-react';
+import { BookOpen, ExternalLink, Images, Library, Search } from 'lucide-react';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
 import CollectionBookCard from '@/components/CollectionBookCard';
 import CollectionFilters from '@/components/collections/CollectionFilters';
@@ -17,6 +17,7 @@ import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { getEmbedUiPolicy } from '@/lib/embed-ui-policy';
 import { useEmbed, useEmbedHref } from '@/lib/EmbedContext';
+import UnifiedSearch from '@/components/search/UnifiedSearch';
 
 export const PER_PAGE = 60;
 
@@ -153,6 +154,22 @@ export default function SharedLibraryView({
           <p className="text-lg text-white/70 max-w-3xl leading-relaxed mb-4">
             {partner.description}
           </p>
+
+          {/* On a tenant subdomain, `/search` is rewritten by proxy.ts to keep the
+              URL clean. On a tenant URL prefix, link with the prefix so navigation
+              stays scoped (the global /search route is not tenant-aware here). */}
+          {tenantSlug && (
+            <div className="max-w-2xl mb-5">
+              <UnifiedSearch />
+              <Link
+                href={forceEmbedded ? '/search' : `${basePath}/search`}
+                className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors mt-3"
+              >
+                <Search className="w-3.5 h-3.5" />
+                Open the full search page
+              </Link>
+            </div>
+          )}
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
             <span>{total.toLocaleString()} translated books</span>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -335,8 +335,11 @@ export async function proxy(request: NextRequest) {
   if (tenant && !pathname.startsWith('/embed/') && !pathname.startsWith('/_next/') && !pathname.startsWith('/api/')) {
     const url = request.nextUrl.clone();
     // Map common paths to embed equivalents
-    if (pathname === '/' || pathname === '/search') {
+    if (pathname === '/') {
       url.pathname = `/embed/${tenant}`;
+    } else if (pathname === '/search' || pathname.startsWith('/search/')) {
+      // Dedicated search results page — keep traffic in embed namespace.
+      url.pathname = `/embed/${tenant}${pathname}`;
     } else if (pathname.startsWith('/book/') && (pathname.includes('/page/') || pathname.includes('/page-number/'))) {
       // Page reader + page-number: keep traffic in embed namespace
       url.pathname = `/embed/${tenant}${pathname}`;
@@ -563,16 +566,30 @@ export async function proxy(request: NextRequest) {
   }
 
   // Root /api/* calls from tenant pages do not include the tenant segment in the pathname.
-  // Infer tenant from referer so legacy root APIs remain tenant-safe during migration.
+  // Infer tenant from host (subdomain), then path, then referer so legacy root
+  // APIs remain tenant-safe.
   if (!tenantId && pathname.startsWith('/api/')) {
-    const [, apiPrefix, apiTenantSegment] = pathname.split('/');
+    // Tenant subdomain (e.g. bph.sourcelibrary.org/api/search) — map host to
+    // tenant. Without this, client-side fetches from tenant subdomains would
+    // hit global APIs unfiltered and leak cross-tenant content.
+    if (tenant) {
+      const subdomainTenant = await resolveTenantByExactSlug(tenant);
+      if (subdomainTenant?.id) {
+        tenantId = subdomainTenant.id;
+        tenantSlug = tenant;
+      }
+    }
 
-    // If the API path is /api/{tenant}/..., prefer explicit tenant segment.
-    if (apiPrefix === 'api' && apiTenantSegment) {
-      const pathTenant = await resolveActiveTenant(apiTenantSegment);
-      if (pathTenant) {
-        tenantId = pathTenant.id;
-        tenantSlug = pathTenant.slug;
+    if (!tenantId) {
+      const [, apiPrefix, apiTenantSegment] = pathname.split('/');
+
+      // If the API path is /api/{tenant}/..., prefer explicit tenant segment.
+      if (apiPrefix === 'api' && apiTenantSegment) {
+        const pathTenant = await resolveActiveTenant(apiTenantSegment);
+        if (pathTenant) {
+          tenantId = pathTenant.id;
+          tenantSlug = pathTenant.slug;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Tenant subdomains (e.g. `bph.sourcelibrary.org`) had no dedicated search results page — `/search` was being rewritten to the embed root. This PR adds the missing route, wires an autocomplete search box into the tenant landing hero, and closes a lockdown gap where client-side `/api/*` fetches from a tenant subdomain were not getting tenant headers.

## Changes

- **`src/proxy.ts`** — route `/search` (and subpaths) on a tenant subdomain to `/embed/{tenant}/search`; propagate host-resolved tenant id onto `/api/*` requests.
- **`src/app/embed/[tenant]/search/{layout,page,visual/page}.tsx`** — re-export the tenant search page with `forceEmbedded` so `SiteHeader` and the cross-tenant Library filter are hidden.
- **`src/app/[tenant]/search/page.tsx`** — accept `forceEmbedded` prop; gate `SiteHeader` and Library partner filter on `embed`.
- **`src/app/api/search/visual/route.ts`** — when tenant headers are present, post-filter CLIP visual matches against the tenant's books (Supabase RPC has no tenant column).
- **`src/components/libraries/SharedLibraryView.tsx`** — add `UnifiedSearch` + "Open the full search page" link to the hero on tenant landing pages.

## BPH lockdown invariants

- ✅ `/search` on `bph.sourcelibrary.org` rewrites internally (no off-host redirect)
- ✅ `/api/search`, `/api/search/visual`, `/api/search/unified` now receive `x-tenant-id` header on every request from a tenant subdomain (host-derived)
- ✅ Visual search post-filtered by tenant (was a known gap)
- ✅ Library partner filter hidden in embed mode (no escape into other partners' books)

## Test plan

- [ ] Visit https://bph.sourcelibrary.org/search on the preview — see the search results page render with no SiteHeader/global chrome
- [ ] Type a query in the BPH home hero search box — autocomplete shows BPH-only results
- [ ] Press Enter on a query — lands on `bph.sourcelibrary.org/search?q=...`
- [ ] Click "Open the full search page" — lands on the search page (no query)
- [ ] Run `node scripts/audit-bph-leaks.mjs` against the preview URL — exit 0
- [ ] Spot-check a result with intentionally cross-tenant text (e.g. a Greek concept also in non-BPH books) — only BPH books appear
- [ ] On `sourcelibrary.org/bhutan` (URL-prefix tenant): hero search box appears, Enter goes to `/bhutan/search?q=...`
- [ ] On `sourcelibrary.org/libraries/{slug}` (non-tenant page): no hero search box (tenantSlug not passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)