### PR TITLE
Visual search: oversample CLIP matches under tenant filter

### DIFF
--- a/src/app/api/search/visual/route.ts
+++ b/src/app/api/search/visual/route.ts
@@ -60,11 +60,17 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Search Supabase for visually matching images
+    // Search Supabase for visually matching images. The CLIP RPC has no
+    // tenant column, so when a tenant filter is active we post-filter the
+    // matches in MongoDB below — oversample here so enough survive the
+    // filter (top-N globally would otherwise leave only a handful for niche
+    // tenant queries). Until the RPC gains a tenant column, this is the
+    // pragmatic fix.
+    const baseCount = offset + limit + 10;
     const { data, error } = await supabase.rpc('match_clip_text', {
       query_embedding: embedding,
       match_threshold: threshold,
-      match_count: offset + limit + 10,
+      match_count: tenantId ? Math.min(baseCount * 10, 1000) : baseCount,
     });
 
     if (error) {


### PR DESCRIPTION
## Summary

Follow-up to #1636. After deploying the BPH search page, visual search via `/api/search/visual` returned ~0–1 BPH results for niche queries (e.g. "alchemical": 1 BPH vs 36 global). Cause: the CLIP Supabase RPC has no tenant column, so we post-filter in MongoDB — but the RPC returned only top-40 globally similar images, of which only a handful were BPH.

This oversamples 10× (capped at 1000) when a tenant filter is active so the post-filter has a wider pool. The proper fix is a `filter_tenant_id` param on the `match_clip_text` RPC, which needs a Supabase migration (not this PR).

## Test plan

- [ ] After deploy, `curl 'https://bph.sourcelibrary.org/api/search/visual?q=alchemical&limit=20'` returns >> 1 result
- [ ] Visual search on `https://sourcelibrary.org` (no tenant) is unchanged
- [ ] Latency stays acceptable (Supabase RPC handles match_count up to a few hundred easily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Signed-off-by: JDerekLomas <j.d.lomas@tudelft.nl>