### PR TITLE
Fix BPH search leaks + dropdown overlap

### DIFF
--- a/src/app/api/search/unified/route.ts
+++ b/src/app/api/search/unified/route.ts
@@ -320,16 +320,59 @@ export async function GET(request: NextRequest) {
         }
       } catch { /* non-fatal */ }
     }
-    const filteredArtworks = {
+    let filteredArtworks = {
       results: artworksAboveFloor,
       total: artworksAboveFloor.length,
     };
+
+    // Defense-in-depth tenant filter. When a tenant header is present,
+    // every book-keyed lane is filtered against the tenant's books in
+    // MongoDB. The books lane in particular cannot filter at the source
+    // (Supabase books_catalog has no tenant column — see tenant-browse.ts),
+    // and other lanes have had subtle filter bugs in the past. One MongoDB
+    // round-trip here is a robust safety net.
+    let scopedBooks = booksResult;
+    let scopedIndex = indexResult;
+    let scopedGallery = galleryResult;
+    let scopedSemantic = filteredSemantic;
+    if (tenantContext.id) {
+      const collectIds = [
+        ...booksResult.results.map((r: any) => r.id),
+        ...indexResult.results.map((r: any) => r.book_id),
+        ...galleryResult.results.map((r: any) => r.bookId),
+        ...filteredSemantic.results.map(r => r.book_id),
+        ...filteredArtworks.results.map(r => r.book_id),
+      ].filter(Boolean);
+      const uniqueIds = [...new Set(collectIds)];
+      let allowed: Set<string> = new Set();
+      if (uniqueIds.length > 0) {
+        const docs = await db.collection('books')
+          .find(
+            { id: { $in: uniqueIds }, tenantId: tenantContext.id },
+            { projection: { _id: 0, id: 1 }, maxTimeMS: 3000 },
+          )
+          .toArray();
+        allowed = new Set(docs.map((d: any) => d.id));
+      }
+      const keepById = <T extends Record<string, any>>(arr: T[], idField: string) =>
+        arr.filter(r => allowed.has(r[idField]));
+      scopedBooks = { ...booksResult, results: keepById(booksResult.results, 'id'), total: 0, hasMore: false };
+      scopedBooks.total = scopedBooks.results.length;
+      scopedIndex = { ...indexResult, results: keepById(indexResult.results, 'book_id'), total: 0, hasMore: false };
+      scopedIndex.total = scopedIndex.results.length;
+      scopedGallery = { ...galleryResult, results: keepById(galleryResult.results, 'bookId'), total: 0 };
+      scopedGallery.total = scopedGallery.results.length;
+      scopedSemantic = { ...filteredSemantic, results: keepById(filteredSemantic.results, 'book_id'), total: 0 };
+      scopedSemantic.total = scopedSemantic.results.length;
+      filteredArtworks = { results: keepById(filteredArtworks.results, 'book_id'), total: 0 };
+      filteredArtworks.total = filteredArtworks.results.length;
+    }
 
     // Log search query (fire-and-forget)
     db.collection('analytics_events').insertOne({
       event: 'search_query',
       query,
-      results_count: booksResult.total + indexResult.total + galleryResult.total + filteredVisual.total + filteredSemantic.total + filteredArtworks.total,
+      results_count: scopedBooks.total + scopedIndex.total + scopedGallery.total + filteredVisual.total + scopedSemantic.total + filteredArtworks.total,
       filters: { language, category, library, source: 'unified', tenantId: tenantContext.id || null },
       timestamp: new Date(),
       ip: request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown',
@@ -338,11 +381,11 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       query,
-      books: booksResult,
-      index: indexResult,
-      gallery: galleryResult,
+      books: scopedBooks,
+      index: scopedIndex,
+      gallery: scopedGallery,
       visual: filteredVisual,
-      semantic: filteredSemantic,
+      semantic: scopedSemantic,
       artworks: filteredArtworks,
       collections: collectionsWithTenantSlug,
     }, {

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -160,7 +160,7 @@ export default function SharedLibraryView({
               stays scoped (the global /search route is not tenant-aware here). */}
           {tenantSlug && (
             <div className="max-w-2xl mb-5">
-              <UnifiedSearch />
+              <UnifiedSearch dropdownPosition="bottom" />
               <Link
                 href={forceEmbedded ? '/search' : `${basePath}/search`}
                 className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors mt-3"

--- a/src/components/search/UnifiedSearch.tsx
+++ b/src/components/search/UnifiedSearch.tsx
@@ -75,7 +75,14 @@ function findCompletion(input: string, vocab: string[]): string | null {
   return null;
 }
 
-export default function UnifiedSearch() {
+interface UnifiedSearchProps {
+  /** Where the results dropdown opens. 'top' (default) opens upward — matches
+   *  the global hero where the search sits at the bottom of the viewport.
+   *  'bottom' opens downward — use when the input has content beneath it. */
+  dropdownPosition?: 'top' | 'bottom';
+}
+
+export default function UnifiedSearch({ dropdownPosition = 'top' }: UnifiedSearchProps = {}) {
   const router = useRouter();
   const pathname = usePathname();
   const [query, setQuery] = useState('');
@@ -321,7 +328,7 @@ export default function UnifiedSearch() {
 
       {/* Results Dropdown */}
       {isOpen && (hasResults || noResults) && (
-        <div id="search-results" role="listbox" className="absolute bottom-full mb-2 left-0 right-0 bg-white rounded-xl shadow-xl border border-stone-200 overflow-hidden z-50 max-h-[60vh] overflow-y-auto">
+        <div id="search-results" role="listbox" className={`absolute ${dropdownPosition === 'bottom' ? 'top-full mt-2' : 'bottom-full mb-2'} left-0 right-0 bg-white rounded-xl shadow-xl border border-stone-200 overflow-hidden z-50 max-h-[60vh] overflow-y-auto`}>
           {noResults ? (
             <div className="p-6 text-center">
               <Search className="w-8 h-8 text-stone-300 mx-auto mb-2" />


### PR DESCRIPTION
## Summary

The user reported two bugs after testing the BPH search:

1. **Cross-tenant leak** — searching "bananas" on BPH returned a book from "History of a Voyage to the Falkland Islands" (not in BPH). Searching "rumi" returned 5 Mathnawi editions tagged `tenant_slug=internet-archive`.
2. **Dropdown jumps around** — the typeahead dropdown overlaps the hero description and resizes visibly as results stream in.

### Root cause of the leak

`/api/search/unified` uses Supabase `searchBooksCatalog` for the books lane. The `books_catalog` table has no tenant column (confirmed in `src/lib/tenant-browse.ts:7`), so the books lane returns global books regardless of tenant header. The index lane has its own filter logic but had a similar gap.

### Fix

- **Defense-in-depth post-filter** in `/api/search/unified/route.ts`: when `tenantContext.id` is set, collect all book IDs across books, index, gallery, semantic, artworks lanes, run one MongoDB lookup, and drop any result whose book isn't in the tenant. Visual was already filtered this way; this generalizes the pattern.
- **Dropdown direction prop** on `UnifiedSearch`: `dropdownPosition?: 'top' | 'bottom'` (defaults `'top'`, matching existing global hero). `SharedLibraryView` passes `'bottom'` so the tenant-hero dropdown opens downward into the gallery row instead of overlapping the description.

## Test plan

- [ ] After deploy, `curl https://bph.sourcelibrary.org/api/search/unified?q=bananas` returns `books.total=0, index.total=0, gallery.total=0`
- [ ] `curl https://bph.sourcelibrary.org/api/search/unified?q=rumi` returns 0 books (or only BPH books)
- [ ] BPH home: typing in the hero search box shows the dropdown opening *downward* (not over the description)
- [ ] Global home: dropdown still opens upward (HeroSection unchanged)
- [ ] `node scripts/audit-bph-leaks.mjs https://<preview>` exits 0

Builds on #1636 + #1638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Signed-off-by: JDerekLomas <j.d.lomas@tudelft.nl>