### PR TITLE
Fix RevisionHistory silently 403'ing on the default tenant

### DIFF
--- a/src/components/reader/RevisionHistory.tsx
+++ b/src/components/reader/RevisionHistory.tsx
@@ -49,12 +49,6 @@ function SourceBadge({ source }: { source: string }) {
   );
 }
 
-function getTenantSlug(): string {
-  if (typeof window === 'undefined') return '';
-  const slug = window.location.pathname.split('/')[1] || '';
-  return /^[a-z0-9-]+$/.test(slug) ? slug : '';
-}
-
 export default function RevisionHistory({ pageId, field, currentSource, editedBy, editedAt, model }: RevisionHistoryProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [revisions, setRevisions] = useState<PageRevision[]>([]);
@@ -67,8 +61,7 @@ export default function RevisionHistory({ pageId, field, currentSource, editedBy
   useEffect(() => {
     if (!isOpen) return;
     setLoading(true);
-    const tenant = getTenantSlug();
-    fetch(`/api/${tenant}/pages/${pageId}/revisions?field=${field}&limit=20`)
+    fetch(`/api/pages/${pageId}/revisions?field=${field}&limit=20`)
       .then(r => r.json())
       .then(data => {
         setRevisions(data.revisions || []);
@@ -93,8 +86,7 @@ export default function RevisionHistory({ pageId, field, currentSource, editedBy
   async function handleRestore(revisionId: string) {
     setRestoring(revisionId);
     try {
-      const tenant = getTenantSlug();
-      const res = await fetch(`/api/${tenant}/pages/${pageId}/revisions/${revisionId}/restore`, {
+      const res = await fetch(`/api/pages/${pageId}/revisions/${revisionId}/restore`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ restoredBy: 'User' }),


### PR DESCRIPTION
## Summary

- `RevisionHistory` inferred the tenant from `window.location.pathname.split('/')[1]`. On `sourcelibrary.org/book/<id>` that returned `'book'`, which fails `resolveTenantId()` and the `/api/[tenant]/pages/[id]/revisions` route returns 403. The component caught the error and set `revisions = []`, so the dropdown always showed **"No previous versions"** on the entire default tenant — every reader page on the main domain — regardless of actual revision history.
- Restore was also silently broken: there is no `/api/[tenant]/pages/[id]/revisions/[revisionId]/restore` route at all (only the non-tenant version exists), so the restore button POST'd to a 404.
- Switched both fetches to the non-tenant routes. `getRevisions()` doesn't filter by tenant anyway, and the data is keyed on `page_id`, so there's no security loss.

## Diagnosis trail

I noticed this while landing a manual translation of Pico's *Oratio* and finding the dropdown showed "No previous versions" even though I'd written 14 revisions to `page_revisions`. Verified the API directly:

```
$ curl /api/pages/<id>/revisions?field=translation
{"revisions":[{...the saved Gemini translation...}], "total":1}

$ curl /api/book/pages/<id>/revisions?field=translation
{"error":"Unauthorized"}
```

## Test plan

- [ ] Open any book on sourcelibrary.org/book/<id>, click the translation provenance pill, confirm "Translation History" panel renders prior versions if any exist
- [ ] Verify the restore button on a previous revision actually restores (POSTs to `/api/pages/<id>/revisions/<rev>/restore`)
- [ ] Tenant subdomains (e.g. bph.sourcelibrary.org) — confirm history still loads on rewritten `/embed/<tenant>/...` paths

## Notes

- One unrelated cleanup that fell out of this: the now-unused `getTenantSlug()` function was removed from the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)