### PR TITLE
search_images: surface 23k standalone artworks via source param

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -348,6 +348,126 @@ export async function getQuote(args: {
   };
 }
 
+type ImageSource = "gallery" | "artworks" | "all";
+
+interface NormalizedImage {
+  source: "gallery" | "artwork";
+  type?: string | null;
+  description?: string | null;
+  title?: string | null;
+  author?: string | null;
+  year?: number | string | null;
+  page?: number | null;
+  quality?: number | null;
+  similarity?: number | null;
+  subjects?: string[];
+  figures?: string[];
+  symbols?: string[];
+  period?: string | null;
+  culture?: string | null;
+  genre?: string | null;
+  technique?: string | null;
+  medium?: string | null;
+  current_location?: string | null;
+  image_url: string | null;
+  url: string;
+  book_url?: string | null;
+}
+
+async function fetchGallery(args: {
+  query?: string; type?: string; subject?: string; figure?: string; symbol?: string;
+  year_from?: number; year_to?: number; book_id?: string; min_quality?: number; limit: number;
+}): Promise<NormalizedImage[]> {
+  const params = new URLSearchParams();
+  if (args.query) params.set("q", args.query);
+  if (args.type) params.set("type", args.type);
+  if (args.subject) params.set("subject", args.subject);
+  if (args.figure) params.set("figure", args.figure);
+  if (args.symbol) params.set("symbol", args.symbol);
+  if (args.year_from) params.set("yearStart", String(args.year_from));
+  if (args.year_to) params.set("yearEnd", String(args.year_to));
+  if (args.book_id) params.set("bookId", args.book_id);
+  if (args.min_quality !== undefined) params.set("minQuality", String(args.min_quality));
+  params.set("limit", String(args.limit));
+
+  const result = await apiGet("/gallery", params) as Record<string, unknown>;
+  const items = (result.items as Array<{
+    pageId: string; detectionIndex: number; description: string; type?: string;
+    galleryQuality?: number; bookTitle: string; bookId?: string; author?: string;
+    year?: number; pageNumber: number;
+    metadata?: { subjects?: string[]; figures?: string[]; symbols?: string[] };
+    imageUrl: string; visualSimilarity?: number;
+  }>) ?? [];
+
+  return items.map(item => ({
+    source: "gallery" as const,
+    type: item.type ?? null,
+    description: item.description,
+    title: item.bookTitle,
+    author: item.author ?? null,
+    year: item.year ?? null,
+    page: item.pageNumber,
+    quality: item.galleryQuality ?? null,
+    similarity: item.visualSimilarity ?? null,
+    subjects: item.metadata?.subjects,
+    figures: item.metadata?.figures,
+    symbols: item.metadata?.symbols,
+    image_url: item.imageUrl,
+    url: `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
+    book_url: item.bookId ? `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}` : null,
+  }));
+}
+
+async function fetchArtworks(args: {
+  query?: string; type?: string; subject?: string; figure?: string; symbol?: string;
+  year_from?: number; year_to?: number; book_id?: string; limit: number;
+}): Promise<NormalizedImage[]> {
+  const params = new URLSearchParams();
+  if (args.query) params.set("q", args.query);
+  if (args.type) params.set("type", args.type);
+  if (args.subject) params.set("subject", args.subject);
+  if (args.figure) params.set("figure", args.figure);
+  if (args.symbol) params.set("symbol", args.symbol);
+  if (args.year_from) params.set("year_from", String(args.year_from));
+  if (args.year_to) params.set("year_to", String(args.year_to));
+  if (args.book_id) params.set("book_id", args.book_id);
+  params.set("limit", String(args.limit));
+
+  const result = await apiGet("/artwork/search", params) as Record<string, unknown>;
+  const items = (result.items as Array<{
+    id: string; title: string; author: string | null; year: number | null;
+    published: string | null; type: string | null; medium: string | null;
+    description: string | null; image_url: string | null; thumbnail_url: string | null;
+    url: string; period?: string | null; culture?: string | null; genre?: string | null;
+    technique?: string | null; subjects?: string[]; figures?: string[]; symbols?: string[];
+    similarity?: number; current_location?: string | null;
+  }>) ?? [];
+
+  return items.map(item => ({
+    source: "artwork" as const,
+    type: item.type ?? null,
+    description: item.description,
+    title: item.title,
+    author: item.author,
+    year: item.year ?? item.published ?? null,
+    page: null,
+    quality: null,
+    similarity: item.similarity ?? null,
+    subjects: item.subjects,
+    figures: item.figures,
+    symbols: item.symbols,
+    period: item.period ?? null,
+    culture: item.culture ?? null,
+    genre: item.genre ?? null,
+    technique: item.technique ?? null,
+    medium: item.medium ?? null,
+    current_location: item.current_location ?? null,
+    image_url: item.image_url ?? item.thumbnail_url ?? null,
+    url: item.url,
+    book_url: null,
+  }));
+}
+
 export async function searchImages(args: {
   query?: string;
   type?: string;
@@ -359,52 +479,52 @@ export async function searchImages(args: {
   book_id?: string;
   min_quality?: number;
   limit?: number;
+  source?: ImageSource;
 }) {
-  const params = new URLSearchParams();
-  if (args.query) params.set("q", args.query);
-  if (args.type) params.set("type", args.type);
-  if (args.subject) params.set("subject", args.subject);
-  if (args.figure) params.set("figure", args.figure);
-  if (args.symbol) params.set("symbol", args.symbol);
-  if (args.year_from) params.set("yearStart", String(args.year_from));
-  if (args.year_to) params.set("yearEnd", String(args.year_to));
-  if (args.book_id) params.set("bookId", args.book_id);
-  if (args.min_quality !== undefined) params.set("minQuality", String(args.min_quality));
-  params.set("limit", String(Math.min(args.limit || 20, 50)));
+  const limit = Math.min(args.limit || 20, 50);
+  const source: ImageSource = args.source || "all";
+  const baseArgs = {
+    query: args.query, type: args.type, subject: args.subject,
+    figure: args.figure, symbol: args.symbol,
+    year_from: args.year_from, year_to: args.year_to,
+    book_id: args.book_id,
+  };
 
-  const result = await apiGet("/gallery", params) as Record<string, unknown>;
+  // For 'all', request both halves at full limit, then interleave so the
+  // caller never sees a single source dominate just because it returns first.
+  const wantGallery = source === "all" || source === "gallery";
+  const wantArtworks = source === "all" || source === "artworks";
+
+  const [galleryItems, artworkItems] = await Promise.all([
+    wantGallery
+      ? fetchGallery({ ...baseArgs, min_quality: args.min_quality, limit }).catch(() => [] as NormalizedImage[])
+      : Promise.resolve([] as NormalizedImage[]),
+    wantArtworks
+      ? fetchArtworks({ ...baseArgs, limit }).catch(() => [] as NormalizedImage[])
+      : Promise.resolve([] as NormalizedImage[]),
+  ]);
+
+  let images: NormalizedImage[];
+  if (source === "gallery") {
+    images = galleryItems;
+  } else if (source === "artworks") {
+    images = artworkItems;
+  } else {
+    // Interleave: artwork, gallery, artwork, gallery, ... so both surface in top results
+    images = [];
+    const max = Math.max(galleryItems.length, artworkItems.length);
+    for (let i = 0; i < max; i++) {
+      if (i < artworkItems.length) images.push(artworkItems[i]);
+      if (i < galleryItems.length) images.push(galleryItems[i]);
+    }
+    images = images.slice(0, limit);
+  }
 
   return {
-    total: result.total,
-    showing: (result.items as unknown[])?.length || 0,
-    images: (
-      result.items as Array<{
-        pageId: string;
-        detectionIndex: number;
-        description: string;
-        type?: string;
-        galleryQuality?: number;
-        bookTitle: string;
-        bookId?: string;
-        author?: string;
-        year?: number;
-        pageNumber: number;
-        metadata?: { subjects?: string[]; figures?: string[]; symbols?: string[] };
-        imageUrl: string;
-      }>
-    )?.map((item) => ({
-      description: item.description,
-      type: item.type,
-      quality: item.galleryQuality,
-      book: { title: item.bookTitle, author: item.author, year: item.year },
-      page: item.pageNumber,
-      subjects: item.metadata?.subjects,
-      figures: item.metadata?.figures,
-      symbols: item.metadata?.symbols,
-      image_url: item.imageUrl,
-      url: `https://sourcelibrary.org/gallery/image/${item.pageId}-${item.detectionIndex}`,
-      book_url: item.bookId ? `https://sourcelibrary.org/book/${item.bookId}?page=${item.pageNumber}` : undefined,
-    })),
-    available_filters: result.filters,
+    total: images.length,
+    showing: images.length,
+    source,
+    counts: { gallery: galleryItems.length, artworks: artworkItems.length },
+    images,
   };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -252,17 +252,22 @@ const TOOLS: Tool[] = [
   {
     name: "search_images",
     description:
-      "Search 50,000+ historical illustrations, emblems, engravings, and diagrams. Filter by type, subject, figure, symbol, year range, book, or text query. Returns image metadata with gallery and book citation URLs.",
+      "Search the visual collection: 50,000+ illustrations extracted from book pages PLUS 23,000+ standalone artworks (paintings, frescoes, prints, sculptures from Met, Rijksmuseum, Wikimedia, NGA). Filter by type, subject, figure, symbol, year, book, or text query. Each result has a `source` field — `gallery` (illustration in a book) or `artwork` (standalone museum work). Use `type=painting` or `type=fresco` to find standalone works; `type=woodcut`, `type=engraving`, `type=emblem` etc. surface mostly book illustrations. The `source` parameter narrows the search: 'all' (default), 'gallery' (illustrations only), or 'artworks' (standalone works only).",
     inputSchema: {
       type: "object" as const,
       properties: {
         query: {
           type: "string",
-          description: "Text search for image descriptions (e.g., 'ouroboros', 'tree of life', 'alchemical laboratory')",
+          description: "Text search across descriptions, subjects, figures, titles, and artists (e.g., 'ouroboros', 'Raphael fresco', 'Botticelli')",
+        },
+        source: {
+          type: "string",
+          enum: ["all", "gallery", "artworks"],
+          description: "Which collection to search. 'all' (default) returns both illustrations and standalone artworks, interleaved. 'gallery' = book illustrations only. 'artworks' = standalone paintings/prints/sculptures only.",
         },
         type: {
           type: "string",
-          description: "Image type (woodcut, engraving, emblem, diagram, frontispiece, etc.)",
+          description: "Image type. For book illustrations: woodcut, engraving, emblem, diagram, frontispiece, portrait, illustration, map, chart, decorative, musical_score, symbol. For standalone artworks: painting, drawing, print, fresco, engraving, woodcut, emblem, map, tablet, object.",
         },
         subject: {
           type: "string",
@@ -278,19 +283,19 @@ const TOOLS: Tool[] = [
         },
         year_from: {
           type: "number",
-          description: "Filter by source book publication year (start)",
+          description: "Filter by publication year (start)",
         },
         year_to: {
           type: "number",
-          description: "Filter by source book publication year (end)",
+          description: "Filter by publication year (end)",
         },
         book_id: {
           type: "string",
-          description: "Only images from a specific book",
+          description: "Only return images from a specific book or artwork id",
         },
         min_quality: {
           type: "number",
-          description: "Minimum gallery quality score 0-1 (default 0.5)",
+          description: "Minimum gallery quality score 0-1 (default 0.5). Applies to gallery illustrations only.",
         },
         limit: {
           type: "number",

--- a/src/app/api/artwork/search/route.ts
+++ b/src/app/api/artwork/search/route.ts
@@ -1,60 +1,261 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getReadDb } from '@/lib/mongodb';
+import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-context';
+import { semanticArtworkSearch } from '@/lib/semantic-search';
+
+export const maxDuration = 30;
+
+const VISUAL_RESOURCE_TYPES = ['painting', 'drawing', 'print', 'fresco', 'engraving', 'woodcut', 'emblem', 'map', 'tablet', 'object'];
 
 /**
- * GET /api/artwork/search?q=...&limit=...
+ * GET /api/artwork/search
  *
- * Search artwork items (paintings, prints, sculptures) stored in the books collection.
- * These are distinct from gallery_images (extracted illustrations from book pages).
- * Artworks are identified by having R2 artwork/ thumbnail URLs.
+ * Search standalone artworks (paintings, frescoes, prints, sculptures, manuscripts) —
+ * the museum-tier layer imported from Met, Rijksmuseum, Wikimedia, NGA, AIC.
+ * Distinct from /api/gallery, which searches illustrations extracted from book pages.
+ *
+ * Query params:
+ *   q          — semantic + regex search across title/author/medium/description
+ *   type       — resource_type filter (painting, drawing, print, fresco, engraving, woodcut, emblem, map)
+ *   subject    — post-filter on semantic result subjects (only applied when q is set)
+ *   figure     — post-filter on semantic result figures (only applied when q is set)
+ *   symbol     — post-filter on semantic result symbols (only applied when q is set)
+ *   period     — period filter (e.g. "Baroque", "Renaissance") — passed to semanticArtworkSearch
+ *   culture    — culture filter (e.g. "Italian", "Dutch") — passed to semanticArtworkSearch
+ *   genre      — genre filter (e.g. "religious", "mythological") — passed to semanticArtworkSearch
+ *   year_from  — published year >= (string-compared, since published is stored as string)
+ *   year_to    — published year <=
+ *   book_id    — return a specific artwork
+ *   limit      — max results (default 20, max 50)
+ *   offset     — pagination offset (default 0)
  */
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const query = searchParams.get('q');
-  const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 50);
+  try {
+    const { searchParams } = new URL(request.url);
+    const tenantCtx = getTenantContextFromRequest(request);
+    let tenantId = tenantCtx.id;
+    if (!tenantId && tenantCtx.slug) {
+      tenantId = await resolveTenantId(tenantCtx.slug);
+    }
 
-  if (!query) {
-    return NextResponse.json({ error: 'q parameter required' }, { status: 400 });
-  }
+    const q = searchParams.get('q');
+    const typeFilter = searchParams.get('type');
+    const subjectFilter = searchParams.get('subject');
+    const figureFilter = searchParams.get('figure');
+    const symbolFilter = searchParams.get('symbol');
+    const period = searchParams.get('period');
+    const culture = searchParams.get('culture');
+    const genre = searchParams.get('genre');
+    const yearStart = searchParams.get('year_from') || searchParams.get('yearStart');
+    const yearEnd = searchParams.get('year_to') || searchParams.get('yearEnd');
+    const bookId = searchParams.get('book_id') || searchParams.get('bookId');
+    const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 50);
+    const offset = parseInt(searchParams.get('offset') || '0');
 
-  const db = await getReadDb();
-  const pattern = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const db = await getReadDb();
+    const tenantScope = tenantId ? { tenantId } : {};
 
-  const artworks = await db.collection('books')
-    .find({
-      thumbnail: { $regex: /^https:\/\/images\.sourcelibrary\.org\/artwork\// },
+    // ── Path A: book_id direct lookup ─────────────────────────────────
+    if (bookId) {
+      const artwork = await db.collection('books').findOne({
+        id: bookId,
+        ...tenantScope,
+        resource_type: { $in: VISUAL_RESOURCE_TYPES },
+        visible: true,
+      });
+      const items = artwork ? [shapeArtworkRow(artwork)] : [];
+      return NextResponse.json({ total: items.length, showing: items.length, items });
+    }
+
+    // ── Path B: semantic + post-filter (when q present) ───────────────
+    if (q) {
+      const semanticLimit = Math.min(limit + offset + 30, 120);
+      const semanticResults = await semanticArtworkSearch(q, semanticLimit, {
+        period: period ?? undefined,
+        culture: culture ?? undefined,
+        genre: genre ?? undefined,
+        threshold: 0.25,
+      });
+
+      // Resolve full Mongo docs for slug, image URLs, year, tenant scope
+      let docs: Array<Record<string, unknown>> = [];
+      if (semanticResults.length > 0) {
+        const ids = semanticResults.map(r => r.book_id);
+        docs = await db.collection('books').find({
+          id: { $in: ids },
+          ...tenantScope,
+          visible: true,
+          resource_type: { $in: VISUAL_RESOURCE_TYPES },
+        }).toArray();
+      }
+      const docMap = new Map(docs.map(d => [d.id as string, d]));
+
+      let merged = semanticResults
+        .map(r => {
+          const doc = docMap.get(r.book_id);
+          if (!doc) return null;
+          return shapeArtworkRow(doc, r);
+        })
+        .filter((row): row is ArtworkRow => row !== null);
+
+      // Apply post-filters that the RPC doesn't support
+      if (typeFilter) merged = merged.filter(r => r.type === typeFilter);
+      if (subjectFilter) merged = merged.filter(r => (r.subjects ?? []).some(s => matchesIgnoreCase(s, subjectFilter)));
+      if (figureFilter) merged = merged.filter(r => (r.figures ?? []).some(f => matchesIgnoreCase(f, figureFilter)));
+      if (symbolFilter) merged = merged.filter(r => (r.symbols ?? []).some(s => matchesIgnoreCase(s, symbolFilter)));
+      if (yearStart) merged = merged.filter(r => !r.published || r.published >= yearStart);
+      if (yearEnd) merged = merged.filter(r => !r.published || r.published <= yearEnd);
+
+      // Fallback: if semantic returned nothing usable, do a regex fallback
+      if (merged.length === 0) {
+        const pattern = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regexFilter: Record<string, unknown> = {
+          ...tenantScope,
+          visible: true,
+          resource_type: typeFilter
+            ? typeFilter
+            : { $in: VISUAL_RESOURCE_TYPES },
+          $or: [
+            { title: { $regex: pattern, $options: 'i' } },
+            { display_title: { $regex: pattern, $options: 'i' } },
+            { author: { $regex: pattern, $options: 'i' } },
+            { medium: { $regex: pattern, $options: 'i' } },
+          ],
+        };
+        const regexDocs = await db.collection('books')
+          .find(regexFilter)
+          .limit(limit + offset + 1)
+          .toArray();
+        merged = regexDocs.map(d => shapeArtworkRow(d));
+      }
+
+      const page = merged.slice(offset, offset + limit);
+      return NextResponse.json({
+        total: merged.length,
+        showing: page.length,
+        items: page,
+      });
+    }
+
+    // ── Path C: browse (no q) — Mongo direct ──────────────────────────
+    const filter: Record<string, unknown> = {
+      ...tenantScope,
       visible: true,
-      $or: [
-        { title: { $regex: pattern, $options: 'i' } },
-        { artist: { $regex: pattern, $options: 'i' } },
-        { author: { $regex: pattern, $options: 'i' } },
-      ],
+      resource_type: typeFilter
+        ? typeFilter
+        : { $in: VISUAL_RESOURCE_TYPES },
+    };
+    if (yearStart || yearEnd) {
+      const yf: Record<string, string> = {};
+      if (yearStart) yf.$gte = yearStart;
+      if (yearEnd) yf.$lte = yearEnd;
+      filter.published = yf;
+    }
+
+    const docs = await db.collection('books')
+      .find(filter, { projection: artworkProjection })
+      .sort({ published: 1, title: 1 })
+      .skip(offset)
+      .limit(limit + 1)
+      .toArray();
+
+    const hasMore = docs.length > limit;
+    if (hasMore) docs.splice(limit);
+
+    const items = docs.map(d => shapeArtworkRow(d));
+    return NextResponse.json({
+      total: hasMore ? offset + items.length + 1 : offset + items.length,
+      showing: items.length,
+      items,
     }, {
-      projection: {
-        _id: 0, id: 1, title: 1, artist: 1, author: 1, year: 1,
-        thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, slug: 1, medium: 1,
-        collections: 1,
-      },
-    })
-    .limit(limit)
-    .toArray();
+      headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },
+    });
+  } catch (error) {
+    console.error('Artwork search error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to search artworks' },
+      { status: 500 }
+    );
+  }
+}
 
-  const items = artworks.map(art => ({
-    id: art.id,
-    title: art.title,
-    artist: art.artist || art.author,
-    year: art.year,
-    medium: art.medium,
-    image_url: art.thumbnail_blob || art.thumbnail,
-    thumbnail_url: art.thumbnail,
-    url: `https://sourcelibrary.org/book/${art.slug || art.id}`,
-    collections: art.collections,
-  }));
+const artworkProjection = {
+  _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
+  published: 1, year: 1, resource_type: 1, medium: 1,
+  thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1,
+  image_full: 1, summary: 1, current_location: 1, collections: 1,
+};
 
-  return NextResponse.json({
-    total: items.length,
-    items,
-  }, {
-    headers: { 'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600' },
-  });
+interface ArtworkRow {
+  id: string;
+  source: 'artwork';
+  title: string;
+  author: string | null;
+  published: string | null;
+  year: number | null;
+  type: string | null;
+  medium: string | null;
+  description: string | null;
+  image_url: string | null;
+  thumbnail_url: string | null;
+  url: string;
+  collections: string[];
+  current_location?: string | null;
+  period?: string | null;
+  culture?: string | null;
+  genre?: string | null;
+  technique?: string | null;
+  subjects?: string[];
+  figures?: string[];
+  symbols?: string[];
+  similarity?: number;
+}
+
+function shapeArtworkRow(
+  doc: Record<string, unknown>,
+  semantic?: {
+    period: string | null; culture: string | null; genre: string | null;
+    technique: string | null; subjects: string[]; figures: string[];
+    symbols: string[]; similarity: number; summary_text: string | null;
+  }
+): ArtworkRow {
+  const slug = (doc.slug as string) || (doc.id as string);
+  const title = (doc.display_title as string) || (doc.title as string);
+  const description = semantic?.summary_text
+    || (typeof doc.summary === 'string' ? (doc.summary as string) : null);
+  const thumbnail = (doc.image_thumb as string) || (doc.thumbnail_blob as string)
+    || (doc.thumbnail as string) || null;
+  const image = (doc.image_display as string) || (doc.image_full as string)
+    || (doc.thumbnail as string) || thumbnail;
+
+  return {
+    id: doc.id as string,
+    source: 'artwork',
+    title,
+    author: (doc.author as string) ?? null,
+    published: (doc.published as string) ?? null,
+    year: (doc.year as number) ?? null,
+    type: (doc.resource_type as string) ?? null,
+    medium: (doc.medium as string) ?? null,
+    description: description ? description.slice(0, 500) : null,
+    image_url: image,
+    thumbnail_url: thumbnail,
+    url: `https://sourcelibrary.org/book/${slug}`,
+    collections: (doc.collections as string[]) ?? [],
+    current_location: (doc.current_location as string) ?? null,
+    ...(semantic ? {
+      period: semantic.period,
+      culture: semantic.culture,
+      genre: semantic.genre,
+      technique: semantic.technique,
+      subjects: semantic.subjects,
+      figures: semantic.figures,
+      symbols: semantic.symbols,
+      similarity: Math.round(semantic.similarity * 1000) / 1000,
+    } : {}),
+  };
+}
+
+function matchesIgnoreCase(value: string, query: string): boolean {
+  return value.toLowerCase().includes(query.toLowerCase());
 }


### PR DESCRIPTION
Closes #1646.

## Summary
- `search_images` now reaches the museum-tier layer (~23k paintings, frescoes, prints from Met / Rijksmuseum / Wikimedia / NGA), not just the 50k illustrations extracted from book pages.
- New `source` parameter: `'all'` (default), `'gallery'`, or `'artworks'`.
- Each result row carries a `source` field so callers can render them differently.
- Tool description updated to advertise the union type vocabulary (painting, fresco, drawing, print alongside woodcut, engraving, emblem, etc.).

## What changed
- **`src/app/api/artwork/search/route.ts`** — rewritten as a real search endpoint. Was 60 lines of regex on `thumbnail` URLs; now accepts `q`, `type` (mapped to `resource_type`), `subject`/`figure`/`symbol` (post-filters when `q` is set), `year_from`/`year_to`, `period`, `culture`, `genre`, `book_id`, `limit`, `offset`. Uses `semanticArtworkSearch` for `q` queries (with regex fallback), Mongo direct query for browse. Tenant-scoped via `getTenantContextFromRequest` + `tenantId`.
- **`mcp-server/src/api.ts`** — `searchImages` fans out to `/api/gallery` and `/api/artwork/search` in parallel, normalizes both into one shape with `source: 'gallery' | 'artwork'`, and interleaves them when `source='all'` so both halves surface in the top results.
- **`mcp-server/src/index.ts`** — tool description rewritten; `source` parameter added to schema; `type` description lists both vocabularies.

## CLIP visual search
`/api/gallery?visual=true` already passes both `source_type` values through (gallery/route.ts L902–944), so no change needed there. The `clipTextSearch` boost helper is gallery-only by design — it's a boost on the gallery path, not the unified path.

## Tenant scoping
Both halves filter by `tenantId` when a tenant subdomain is in play. Verified the artwork endpoint pulls `tenantId` from `getTenantContextFromRequest` / `resolveTenantId` and applies it to every `books` query.

## Test plan
- [ ] `search_images({ type: 'painting' })` returns standalone paintings (was 0)
- [ ] `search_images({ query: 'Raphael fresco' })` surfaces Met/Rijksmuseum frescoes alongside book engravings
- [ ] `search_images({ source: 'artworks' })` returns artworks only
- [ ] `search_images({ source: 'gallery' })` matches the old behavior
- [ ] Each row has a `source` field
- [ ] BPH preview deploy: artwork results respect tenant scoping (no cross-tenant leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)