### PR TITLE
BPH unified catalogue: one page, two modes (iframe-ready)

### DIFF
--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -105,9 +105,22 @@ interface Props {
   tenantSlug?: string;
   /** When true, defaults to advanced search expanded */
   defaultAdvanced?: boolean;
+  /** Fires whenever the filtered result count updates so a parent shell
+      (the unified catalogue header) can show "X of 27,706 works". */
+  onTotalChange?: (total: number) => void;
+  /** When true, hide the inline "{total} works" label on the simple-search
+      row — the parent shell shows the count instead. */
+  hideInlineCount?: boolean;
 }
 
-export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug, defaultAdvanced = false }: Props) {
+export default function BphCatalogBrowser({
+  basePath,
+  digitizedUbns,
+  tenantSlug,
+  defaultAdvanced = false,
+  onTotalChange,
+  hideInlineCount = false,
+}: Props) {
   const searchParams = useSearchParams();
 
   const initialQ = searchParams.get('cq') || '';
@@ -174,14 +187,16 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug,
       const data = await res.json();
       setWorks(data.works || []);
       setTotal(data.total || 0);
+      onTotalChange?.(data.total || 0);
     } catch (err) {
       if ((err as Error).name === 'AbortError') return; // superseded by a newer query
       setWorks([]);
       setTotal(0);
+      onTotalChange?.(0);
     } finally {
       if (!controller.signal.aborted) setLoading(false);
     }
-  }, [buildParams]);
+  }, [buildParams, onTotalChange]);
 
   // Sync URL params (using c-prefixed keys so they don't collide with parent page params).
   // Uses window.history.replaceState rather than router.replace + basePath so the
@@ -355,9 +370,11 @@ export default function BphCatalogBrowser({ basePath, digitizedUbns, tenantSlug,
           )}
         </button>
 
-        <span className="text-sm text-muted ml-auto">
-          {total.toLocaleString()} works
-        </span>
+        {!hideInlineCount && (
+          <span className="text-sm text-muted ml-auto">
+            {total.toLocaleString()} works
+          </span>
+        )}
       </div>
 
       {/* Advanced search panel */}

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+/**
+ * Unified BPH catalogue. The partner mockup folds the previous
+ * /catalog (table of all 27,706 works) and /catalog?view=books (grid of
+ * 2,280 digitised+translated covers) into a single page with a
+ * segmented toggle:
+ *
+ *   Show all                       → list view, full bph_works table
+ *   Show digitised & translated    → grid view, MongoDB books with covers
+ *
+ * The toggle and the list/grid icons drive the same state — they are
+ * two ways to express the same mode. Switching modes navigates so each
+ * mode keeps its own URL params (so the URL bar reflects what's actually
+ * filtered, matching the rule established in #1640).
+ *
+ * The component renders the shell (heading, toggle, counter, view icons)
+ * and the catalogue table when mode='all'. When mode='digitized' it
+ * only renders the shell; SharedLibraryView renders the books grid
+ * underneath because that grid is fed by server-side data.
+ */
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { LayoutGrid, List } from 'lucide-react';
+import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
+import { useEmbedHref } from '@/lib/EmbedContext';
+
+export type CatalogueMode = 'all' | 'digitized';
+
+interface Props {
+  /** "all" → list view, catalogue table. "digitized" → grid view, books with covers. */
+  mode: CatalogueMode;
+  /** Total works in bph_works (denominator for the counter, regardless of mode). */
+  catalogTotal: number;
+  /** When mode='digitized', the count of digitised+translated SL books (server-fetched).
+      When mode='all', this is ignored — the catalogue table reports its own filtered count. */
+  digitizedTotal: number;
+  /** basePath for embed/link construction (e.g. "/embed/bph"). */
+  basePath: string;
+  /** UBN → {id, slug} map for the catalogue browser's "digitised copy" hyperlinks. */
+  digitizedUbns: Record<string, { id: string; slug: string }>;
+  /** Tenant slug for nested book URLs. */
+  tenantSlug?: string;
+}
+
+export default function BphUnifiedCatalogue({
+  mode,
+  catalogTotal,
+  digitizedTotal,
+  basePath,
+  digitizedUbns,
+  tenantSlug,
+}: Props) {
+  const embedHref = useEmbedHref();
+
+  // Each mode keeps its own URL params; switching modes drops the other set.
+  const allHref = embedHref(`${basePath}?view=catalog`);
+  const digitizedHref = embedHref(`${basePath}?view=books`);
+
+  // For mode='all' the catalogue table owns its own filtered count
+  // (the count drops as the user types in search). Hoist it up via a
+  // callback so the unified header can show "X of 27,706 works".
+  const [filteredTotal, setFilteredTotal] = useState<number | null>(null);
+  const visibleTotal =
+    mode === 'all' ? (filteredTotal ?? catalogTotal) : digitizedTotal;
+
+  return (
+    <>
+      <div className="mb-6">
+        <h2 className="text-2xl sm:text-3xl text-primary font-display">
+          Library Catalogue
+        </h2>
+        <p className="text-sm text-muted mt-1">
+          Complete catalogue of the Bibliotheca Philosophica Hermetica.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+
+        <div className="flex items-center ml-auto gap-3">
+          <span className="text-sm text-muted">
+            <span className="font-medium text-primary">{visibleTotal.toLocaleString()}</span>{' '}
+            of {catalogTotal.toLocaleString()} works
+          </span>
+          <ViewIcons mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+        </div>
+      </div>
+
+      {mode === 'all' && (
+        <BphCatalogBrowser
+          basePath={basePath}
+          digitizedUbns={digitizedUbns}
+          tenantSlug={tenantSlug}
+          onTotalChange={setFilteredTotal}
+          hideInlineCount
+        />
+      )}
+      {/* mode='digitized': SharedLibraryView renders the books grid below us. */}
+    </>
+  );
+}
+
+function SegmentedToggle({
+  mode,
+  allHref,
+  digitizedHref,
+}: {
+  mode: CatalogueMode;
+  allHref: string;
+  digitizedHref: string;
+}) {
+  const base =
+    'px-4 py-2 text-sm font-medium transition-colors';
+  const active = 'bg-primary text-white';
+  const inactive = 'bg-white text-secondary hover:bg-warm';
+  return (
+    <div className="inline-flex border border-border-light rounded-md overflow-hidden">
+      <Link href={allHref} className={`${base} ${mode === 'all' ? active : inactive}`}>
+        Show all
+      </Link>
+      <Link
+        href={digitizedHref}
+        className={`${base} -ml-px ${mode === 'digitized' ? active : inactive}`}
+      >
+        Show digitised &amp; translated
+      </Link>
+    </div>
+  );
+}
+
+function ViewIcons({
+  mode,
+  allHref,
+  digitizedHref,
+}: {
+  mode: CatalogueMode;
+  allHref: string;
+  digitizedHref: string;
+}) {
+  const base =
+    'inline-flex items-center justify-center w-9 h-9 transition-colors border border-border-light';
+  const active = 'bg-primary text-white border-primary';
+  const inactive = 'bg-white text-muted hover:text-primary hover:bg-warm';
+  return (
+    <div className="inline-flex">
+      <Link
+        href={allHref}
+        title="List view (all 27,706 works)"
+        aria-label="List view"
+        className={`${base} rounded-l-md ${mode === 'all' ? active : inactive}`}
+      >
+        <List className="w-4 h-4" />
+      </Link>
+      <Link
+        href={digitizedHref}
+        title="Grid view (digitised & translated)"
+        aria-label="Grid view"
+        className={`${base} rounded-r-md -ml-px ${mode === 'digitized' ? active : inactive}`}
+      >
+        <LayoutGrid className="w-4 h-4" />
+      </Link>
+    </div>
+  );
+}

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -14,6 +14,7 @@ import CollectionBookCard from '@/components/CollectionBookCard';
 import CollectionFilters from '@/components/collections/CollectionFilters';
 import { bookTitle } from '@/lib/collections-utils';
 import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
+import BphUnifiedCatalogue from '@/components/libraries/BphUnifiedCatalogue';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { getEmbedUiPolicy } from '@/lib/embed-ui-policy';
 import { useEmbed, useEmbedHref } from '@/lib/EmbedContext';
@@ -131,11 +132,13 @@ export default function SharedLibraryView({
   const embedPolicy = getEmbedUiPolicy(embed);
 
   // BPH layout modes:
-  //   view === 'books'   → full books grid only (digitized SL books)
-  //   view === 'catalog' → catalog browser only (full 27,706-work catalog, no Selected Books)
+  //   view === 'books'   → unified catalogue, "Show digitised & translated" mode (grid)
+  //   view === 'catalog' → unified catalogue, "Show all" mode (catalogue table)
   //   default            → Selected Books + Catalog combo (the main-site landing experience)
   const showBooksGrid = !isBph || view === 'books';
   const showSelectedBooksRow = isBph && view !== 'books' && view !== 'catalog';
+  const showUnifiedCatalogue = isBph && (view === 'books' || view === 'catalog');
+  const catalogueMode = view === 'books' ? 'digitized' : 'all';
 
   return (
     <div className="min-h-screen bg-cream">
@@ -308,28 +311,54 @@ export default function SharedLibraryView({
       )}
 
       <div className="max-w-7xl mx-auto px-6 py-10">
+        {showUnifiedCatalogue && (
+          <BphUnifiedCatalogue
+            mode={catalogueMode}
+            catalogTotal={catalogTotal}
+            digitizedTotal={total}
+            basePath={basePath}
+            digitizedUbns={digitizedUbns}
+            tenantSlug={tenantSlug ?? undefined}
+          />
+        )}
         {showBooksGrid ? (
           <>
-            {/* All Books Header */}
-            <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
-              <div>
-                <h2
-                  className="text-2xl sm:text-3xl text-primary font-display"
-                >
-                  All Books
-                </h2>
-                <p className="text-sm text-muted mt-1">
-                  {total.toLocaleString()} books from {partner.name}
-                </p>
-              </div>
+            {/* All Books Header — only for non-BPH tenants. BPH uses the
+                unified catalogue shell above for both modes. */}
+            {!showUnifiedCatalogue && (
+              <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
+                <div>
+                  <h2
+                    className="text-2xl sm:text-3xl text-primary font-display"
+                  >
+                    All Books
+                  </h2>
+                  <p className="text-sm text-muted mt-1">
+                    {total.toLocaleString()} books from {partner.name}
+                  </p>
+                </div>
 
-              <CollectionFilters
-                collectionId={partner.slug}
-                languages={filteredLanguages}
-                basePath={basePath}
-                showSearch
-              />
-            </div>
+                <CollectionFilters
+                  collectionId={partner.slug}
+                  languages={filteredLanguages}
+                  basePath={basePath}
+                  showSearch
+                />
+              </div>
+            )}
+
+            {/* In BPH unified mode, language/sort filters still belong above
+                the grid — render them in their own row without the heading. */}
+            {showUnifiedCatalogue && (
+              <div className="flex justify-end mb-4">
+                <CollectionFilters
+                  collectionId={partner.slug}
+                  languages={filteredLanguages}
+                  basePath={basePath}
+                  showSearch
+                />
+              </div>
+            )}
 
             {/* Books Grid */}
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
@@ -458,21 +487,30 @@ export default function SharedLibraryView({
               </div>
             )}
 
-            {/* Library Catalogue */}
-            <div className="mb-6">
-              <h2 className="text-2xl sm:text-3xl text-primary font-display">
-                Library Catalogue
-              </h2>
-              <p className="text-sm text-muted mt-1">
-                Complete catalogue of the Bibliotheca Philosophica Hermetica — {catalogTotal.toLocaleString()} works in the collection.
-                Works available on Source Library are marked with a book icon.
-              </p>
-            </div>
-            <BphCatalogBrowser
-              basePath={basePath}
-              digitizedUbns={digitizedUbns}
-              tenantSlug={tenantSlug ?? undefined}
-            />
+            {/* Library Catalogue heading — only on the default landing
+                (showSelectedBooksRow). The /catalog view uses the unified
+                shell rendered above instead. */}
+            {showSelectedBooksRow && (
+              <>
+                <div className="mb-6">
+                  <h2 className="text-2xl sm:text-3xl text-primary font-display">
+                    Library Catalogue
+                  </h2>
+                  <p className="text-sm text-muted mt-1">
+                    Complete catalogue of the Bibliotheca Philosophica Hermetica — {catalogTotal.toLocaleString()} works in the collection.
+                    Works available on Source Library are marked with a book icon.
+                  </p>
+                </div>
+                <BphCatalogBrowser
+                  basePath={basePath}
+                  digitizedUbns={digitizedUbns}
+                  tenantSlug={tenantSlug ?? undefined}
+                />
+              </>
+            )}
+            {/* On the dedicated /catalog view (showUnifiedCatalogue=true,
+                showSelectedBooksRow=false) the BphCatalogBrowser is rendered
+                inside <BphUnifiedCatalogue> above. */}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Implements the partner mockup for the BPH catalogue page (Webflow iframe target).

Folds the previous \`/catalog\` (catalogue table of 27,706 works) and \`/catalog?view=books\` (grid of 2,280 digitised+translated covers) into a single page with a segmented toggle:

- **Show all** → list view, catalogue table (\`bph_works\`)
- **Show digitised & translated** → grid view, MongoDB books with covers

A list/grid icon pair on the right mirrors the toggle. Two ways to express the same state.

Counter format: **\"X of 27,706 works\"**. In Show-all mode, X is the live filtered count from the catalogue API as the user types in search. In Show-digitised mode, X is the server-fetched MongoDB total.

## Scope

- \`/embed/bph?view=catalog\` and \`/embed/bph?view=books\` both render the new unified shell
- The default \`/embed/bph\` landing (Selected Books + brief catalogue) is **unchanged** — partners who land cold there still see the curated combo
- Other tenants (non-BPH) are unchanged

## What \`BphCatalogBrowser\` learnt

- New \`onTotalChange\` callback so the unified shell can show \"X of Y\" using the live filtered count
- New \`hideInlineCount\` so the count isn't duplicated when the shell already shows it

## Held back

- Per-mode sort dropdowns aren't unified yet (catalogue mode uses \`bph_works\` columns, grid mode uses books-catalog sort). Mockup doesn't fully constrain this — flagging for partner if it matters
- The mockup has the sort dropdown in the same row as the view icons. Currently the search/sort row sits below the toggle row. Visual polish pass if the partner wants exact pixel match

## Test plan

- [ ] On bph.sourcelibrary.org/catalog confirm: heading \"Library Catalogue\", subtitle \"Complete catalogue of the Bibliotheca Philosophica Hermetica.\", toggle defaults to \"Show all\", counter reads \"27,706 of 27,706 works\"
- [ ] Type \"Hartmann\" in the search field — counter drops to \"55 of 27,706 works\" and table filters
- [ ] Click \"Show digitised & translated\" — page reloads to /embed/bph?view=books, grid view appears, counter shows \"2,280 of 27,706 works\"
- [ ] Click the list icon (or \"Show all\") — back to catalogue table
- [ ] On bph.sourcelibrary.org root (no \`?view=\`) confirm Selected Books + brief catalogue is unchanged
- [ ] On other tenants (e.g. internet-archive) confirm \"All Books\" header / filters still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)