### PR TITLE
Splitter: prefer R2-hosted URL when setting book thumbnail

### DIFF
--- a/scripts/workers/batch-split-bph.mjs
+++ b/scripts/workers/batch-split-bph.mjs
@@ -363,15 +363,26 @@ async function processBook(r2, db, book) {
     'translation.data': { $exists: true, $ne: '' },
   });
 
-  // Set thumbnail to first page
+  // Set thumbnail to first page. Prefer R2-hosted URLs over the page's
+  // original `photo` field, which for IIIF imports points at the source
+  // library's image server (e.g. images.uba.uva.nl) — that violates the
+  // R2-only policy. archived_photo is set during the archive phase to a
+  // canonical /archived/{id}/{n}.jpg URL on R2.
   const firstPage = allPages[0];
+  const isR2 = (u) => u && u.includes('images.sourcelibrary.org');
+  const thumbnailUrl =
+    (isR2(firstPage?.archived_photo) ? firstPage.archived_photo : null)
+    || (isR2(firstPage?.photo) ? firstPage.photo : null)
+    || firstPage?.archived_photo
+    || firstPage?.photo
+    || firstPage?.cropped_photo;
 
   const setDoc = {
     pages_count: allPages.length,
     pages_ocr: ocrCount,
     pages_translated: translateCount,
     needs_splitting: false,
-    thumbnail: firstPage?.photo || firstPage?.cropped_photo,
+    thumbnail: thumbnailUrl,
     'pipeline_auto.split_checked': true,
     'pipeline_auto.last_updated': new Date(),
     updated_at: new Date(),


### PR DESCRIPTION
Caught when end-to-end testing PR #1650 (resplit cohort patch) on Horapollo *Hieroglyphica*. Page 1 was a \`split_side: single\` page (flyleaf) — its \`photo\` field was the original IIIF source URL (\`images.uba.uva.nl/iiif/...\`) while \`archived_photo\` correctly held the canonical R2 URL (\`/archived/{id}/1.jpg\`). The splitter copied \`photo\` directly into \`book.thumbnail\`, leaking an external IIIF URL into the BPH listing in violation of the R2-only image policy.

Newly-split pages aren't affected (both fields point at fresh R2 uploads). Only \`split_side: single\` pages — flyleaves and other untouched single-page scans — hit this.

Fix: prefer the page's \`archived_photo\` when it's on R2, then \`photo\` when it's on R2, then fall back. Same path for both fresh-import and resplit-cohort books, gated on the URL host check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)