### PR TITLE
BPH catalogue/books views: drop the SL hero (Webflow partners use their own)

### DIFF
--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -143,6 +143,13 @@ export default function SharedLibraryView({
   return (
     <div className="min-h-screen bg-cream">
       {!embed && <ConditionalSiteHeader variant="dark" />}
+      {/* Hero, Illustrations, and Contributing Libraries are suppressed on
+          the dedicated BPH catalogue/books views so the iframe renders just
+          the catalogue. Webflow partners build their own page chrome around
+          the iframe, so the hero is duplicative there. The default landing
+          (no view param) and other tenants still show the full hero. */}
+      {!showUnifiedCatalogue && (
+      <>
       {/* Hero Section */}
       <div className="relative bg-dark overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-b from-black/70 via-black/40 to-transparent" />
@@ -308,6 +315,8 @@ export default function SharedLibraryView({
             </div>
           </div>
         </div>
+      )}
+      </>
       )}
 
       <div className="max-w-7xl mx-auto px-6 py-10">


### PR DESCRIPTION
## Summary

Suppresses the SL hero, Illustrations row, and Contributing Libraries row on \`bph.sourcelibrary.org/catalog\` and \`/catalog?view=books\`. Webflow partners wrap the iframe with their own page chrome, so the SL hero is duplicative there.

The default landing (no \`?view=\`) and all non-BPH tenants still show the full hero.

## Preview links to evaluate

After Vercel finishes the preview build:

- **List mode (Show all):** \`https://<preview>/embed/bph?view=catalog\`
- **Grid mode (Show digitised & translated):** \`https://<preview>/embed/bph?view=books\`
- **Default landing (should still show hero):** \`https://<preview>/embed/bph\`

The Vercel bot will post the preview URL on this PR.

## Test plan

- [ ] On preview \`/embed/bph?view=catalog\`: page starts with "Library Catalogue" heading, no big black hero
- [ ] On preview \`/embed/bph?view=books\`: same — no hero, just the unified shell + grid
- [ ] On preview \`/embed/bph\` (no view): full hero still present, Selected Books row still present
- [ ] On preview \`/embed/internet-archive\` (other tenant): hero still present (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)