### PR TITLE
BPH catalogue: row layout match the partner mockup

### DIFF
--- a/e2e/bph-iframe.spec.ts
+++ b/e2e/bph-iframe.spec.ts
@@ -26,7 +26,9 @@ test.describe('BPH iframe — digital collection (/embed/bph)', () => {
   test('page renders the unified catalogue with cards', async ({ page }) => {
     await page.goto('/embed/bph');
 
-    await expect(page.locator('h1')).toContainText('Bibliotheca Philosophica Hermetica');
+    // Hero is suppressed on the unified catalogue views (#1653) so partners
+    // can wrap the iframe with their own page chrome. The "Library Catalogue"
+    // h2 is the top-of-page anchor for both modes.
     await expect(page.locator('h2', { hasText: BPH_HEADING }).first()).toBeVisible({ timeout: 15_000 });
 
     // Default mode renders the digitised+translated grid → book cards

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -111,6 +111,16 @@ interface Props {
   /** When true, hide the inline "{total} works" label on the simple-search
       row — the parent shell shows the count instead. */
   hideInlineCount?: boolean;
+  /** Optional content rendered inline in the search row (between the
+      Subjects dropdown and the Advanced button). The unified catalogue
+      uses this to drop in the "Show all / Show digitised & translated"
+      segmented toggle so it sits alongside the other filter chips. */
+  searchRowSlot?: React.ReactNode;
+  /** Optional content rendered in a results-header row above the table,
+      next to the sort dropdown. The unified catalogue uses this for the
+      list/grid view icons. When provided, the sort dropdown moves out of
+      the search row and into this header row to match the partner mockup. */
+  resultsHeaderSlot?: React.ReactNode;
 }
 
 export default function BphCatalogBrowser({
@@ -120,6 +130,8 @@ export default function BphCatalogBrowser({
   defaultAdvanced = false,
   onTotalChange,
   hideInlineCount = false,
+  searchRowSlot,
+  resultsHeaderSlot,
 }: Props) {
   const searchParams = useSearchParams();
 
@@ -314,9 +326,17 @@ export default function BphCatalogBrowser({
     return `${basePath.replace(/\/$/, '')}/catalog/${encodeURIComponent(ubn)}`;
   };
 
+  // When the parent supplies a results-header slot (the unified shell does
+  // this to host the list/grid view icons), the sort dropdown moves into
+  // that row so it sits next to the icons — matching the partner mockup
+  // (search row stays light filters; sort lives with the count + icons).
+  const sortLivesInHeader = resultsHeaderSlot !== undefined;
+
   return (
     <div>
-      {/* Simple search row */}
+      {/* Search / filter row — search input, subjects dropdown, optional
+          parent-supplied toggle (e.g. Show all / Show digitised & translated),
+          Advanced. Sort moves to the results-header row when sortLivesInHeader. */}
       <div className="flex flex-wrap items-center gap-3 mb-3">
         <div className="relative flex-1 min-w-[14rem] max-w-xl">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
@@ -347,15 +367,19 @@ export default function BphCatalogBrowser({
           ))}
         </select>
 
-        <select
-          value={sort}
-          onChange={(e) => handleSortChange(e.target.value)}
-          className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
-        >
-          {SORT_OPTIONS.map(o => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
+        {searchRowSlot}
+
+        {!sortLivesInHeader && (
+          <select
+            value={sort}
+            onChange={(e) => handleSortChange(e.target.value)}
+            className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
+          >
+            {SORT_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        )}
 
         <button
           onClick={() => setShowAdvanced(s => !s)}
@@ -370,12 +394,41 @@ export default function BphCatalogBrowser({
           )}
         </button>
 
-        {!hideInlineCount && (
+        {!hideInlineCount && !sortLivesInHeader && (
           <span className="text-sm text-muted ml-auto">
             {total.toLocaleString()} works
           </span>
         )}
       </div>
+
+      {/* Results-header row — counter on the left, sort + parent-supplied
+          view icons on the right. Only rendered when the parent passes a
+          slot (the unified shell does so for the BPH iframe). */}
+      {sortLivesInHeader && (
+        <div className="flex flex-wrap items-center gap-3 mb-4">
+          {!hideInlineCount && (
+            <span className="text-sm text-muted">
+              <span className="font-medium text-primary">{total.toLocaleString()}</span>{' '}
+              works
+            </span>
+          )}
+          <div className="flex items-center gap-3 ml-auto">
+            <label className="inline-flex items-center gap-2 text-sm text-muted">
+              <span>Sort by</span>
+              <select
+                value={sort}
+                onChange={(e) => handleSortChange(e.target.value)}
+                className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
+              >
+                {SORT_OPTIONS.map(o => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </label>
+            {resultsHeaderSlot}
+          </div>
+        </div>
+      )}
 
       {/* Advanced search panel */}
       {showAdvanced && (

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -121,6 +121,10 @@ interface Props {
       list/grid view icons. When provided, the sort dropdown moves out of
       the search row and into this header row to match the partner mockup. */
   resultsHeaderSlot?: React.ReactNode;
+  /** When set, the results-header row count reads "{total} of {catalogTotal}
+      works" instead of just "{total} works" — matches the partner mockup
+      framing where the catalogue size is the denominator. */
+  catalogTotal?: number;
 }
 
 export default function BphCatalogBrowser({
@@ -132,6 +136,7 @@ export default function BphCatalogBrowser({
   hideInlineCount = false,
   searchRowSlot,
   resultsHeaderSlot,
+  catalogTotal,
 }: Props) {
   const searchParams = useSearchParams();
 
@@ -403,15 +408,15 @@ export default function BphCatalogBrowser({
 
       {/* Results-header row — counter on the left, sort + parent-supplied
           view icons on the right. Only rendered when the parent passes a
-          slot (the unified shell does so for the BPH iframe). */}
+          slot (the unified shell does so for the BPH iframe). The count
+          renders here regardless of hideInlineCount — that prop only gates
+          the inline count in the search row above. */}
       {sortLivesInHeader && (
         <div className="flex flex-wrap items-center gap-3 mb-4">
-          {!hideInlineCount && (
-            <span className="text-sm text-muted">
-              <span className="font-medium text-primary">{total.toLocaleString()}</span>{' '}
-              works
-            </span>
-          )}
+          <span className="text-sm text-muted">
+            <span className="font-medium text-primary">{total.toLocaleString()}</span>
+            {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString()} works` : ' works'}
+          </span>
           <div className="flex items-center gap-3 ml-auto">
             <label className="inline-flex items-center gap-2 text-sm text-muted">
               <span>Sort by</span>

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -65,6 +65,19 @@ export default function BphUnifiedCatalogue({
   const visibleTotal =
     mode === 'all' ? (filteredTotal ?? catalogTotal) : digitizedTotal;
 
+  const toggleNode = (
+    <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+  );
+  const viewIconsNode = (
+    <ViewIcons mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+  );
+  const counterNode = (
+    <span className="text-sm text-muted">
+      <span className="font-medium text-primary">{visibleTotal.toLocaleString()}</span>{' '}
+      of {catalogTotal.toLocaleString()} works
+    </span>
+  );
+
   return (
     <>
       <div className="mb-6">
@@ -76,28 +89,36 @@ export default function BphUnifiedCatalogue({
         </p>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3 mb-4">
-        <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
-
-        <div className="flex items-center ml-auto gap-3">
-          <span className="text-sm text-muted">
-            <span className="font-medium text-primary">{visibleTotal.toLocaleString()}</span>{' '}
-            of {catalogTotal.toLocaleString()} works
-          </span>
-          <ViewIcons mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
-        </div>
-      </div>
-
-      {mode === 'all' && (
+      {mode === 'all' ? (
+        // BphCatalogBrowser owns the search row and now hosts both the
+        // toggle (inline with filters) and the view icons (in the
+        // results-header row alongside count + sort) — matching the
+        // partner mockup row grouping.
         <BphCatalogBrowser
           basePath={basePath}
           digitizedUbns={digitizedUbns}
           tenantSlug={tenantSlug}
           onTotalChange={setFilteredTotal}
           hideInlineCount
+          searchRowSlot={toggleNode}
+          resultsHeaderSlot={viewIconsNode}
         />
+      ) : (
+        // mode='digitized': no catalogue browser — the books grid lives
+        // in SharedLibraryView. Render the same row chrome ourselves so
+        // the layout matches the mockup. Counter on left, sort + view
+        // icons on right (sort is owned by the books-grid CollectionFilters
+        // component, so we only render the toggle row + counter row here).
+        <>
+          <div className="flex flex-wrap items-center gap-3 mb-3">
+            {toggleNode}
+          </div>
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            {counterNode}
+            <div className="ml-auto">{viewIconsNode}</div>
+          </div>
+        </>
       )}
-      {/* mode='digitized': SharedLibraryView renders the books grid below us. */}
     </>
   );
 }

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -102,6 +102,7 @@ export default function BphUnifiedCatalogue({
           hideInlineCount
           searchRowSlot={toggleNode}
           resultsHeaderSlot={viewIconsNode}
+          catalogTotal={catalogTotal}
         />
       ) : (
         // mode='digitized': no catalogue browser — the books grid lives


### PR DESCRIPTION
## Summary

Rearranges the unified catalogue page rows to match the high-res partner mockups (images 8 and 9):

- **Row 1:** search · subjects · Show all / Show digitised & translated · Advanced
- **Row 2:** counter (left) · Sort by ▾ · list/grid icons (right)

Previously the toggle was on its own row above the search filters and sort sat in the search row.

## Implementation

- BphCatalogBrowser gains \`searchRowSlot\` + \`resultsHeaderSlot\` props
- When \`resultsHeaderSlot\` is supplied, sort moves to a new results-header row alongside count + view icons
- BphUnifiedCatalogue passes the toggle as \`searchRowSlot\` and view icons as \`resultsHeaderSlot\` for mode='all'
- mode='digitized' keeps a simpler shell since the books grid uses CollectionFilters

## Preview links to evaluate

After Vercel finishes the preview build:
- **Default / on load (Show all toggled, list view):** \`<preview>/embed/bph?view=catalog\`
- **Show digitised & translated (grid view):** \`<preview>/embed/bph?view=books\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)