### PR TITLE
e2e: strengthen BPH iframe assertions after negative test

### DIFF
--- a/e2e/bph-iframe.spec.ts
+++ b/e2e/bph-iframe.spec.ts
@@ -26,7 +26,9 @@ test.describe('BPH iframe — digital collection (/embed/bph)', () => {
   test('page renders the unified catalogue with cards', async ({ page }) => {
     await page.goto('/embed/bph');
 
-    await expect(page.locator('h1')).toContainText('Bibliotheca Philosophica Hermetica');
+    // The hero (and its h1) is suppressed in embed mode on the BPH tenant,
+    // so the page begins directly with the "Library Catalogue" h2. Don't
+    // assert the h1 — it's gone deliberately.
     await expect(page.locator('h2', { hasText: BPH_HEADING }).first()).toBeVisible({ timeout: 15_000 });
 
     // Default mode renders the digitised+translated grid → book cards
@@ -94,9 +96,12 @@ test.describe('BPH iframe — search (/embed/bph/search)', () => {
     const searchInput = page.getByPlaceholder(/search/i).first();
     await expect(searchInput).toBeVisible({ timeout: SEARCH_TIMEOUT });
 
-    // SiteHeader's "Sign in" link should NOT be present in embed mode
-    const signInLink = page.getByRole('link', { name: 'Sign in' });
-    await expect(signInLink).toHaveCount(0);
+    // SiteHeader's global nav items (Collections, Gallery, Browse, etc.) must
+    // NOT be present in embed mode. "Sign in" is gated by auth state and isn't
+    // reliable; the nav anchors are. Verified via negative test: visiting
+    // /bph/search renders SiteHeader with these links; /embed/bph/search hides them.
+    const collectionsNav = page.getByRole('navigation').getByRole('link', { name: 'Collections' });
+    await expect(collectionsNav).toHaveCount(0);
 
     await measurePerf(page, 'bph search: embed mode renders');
   });


### PR DESCRIPTION
## Why

After merging #1654, ran a deliberate negative test — pointed the spec at the broken URL pattern (`/bph/search` instead of `/embed/bph/search`) to verify the lockdown assertions actually fail when the regression returns. Two findings:

1. **The "no Sign in link" embed-mode check passed even with SiteHeader clearly visible.** "Sign in" is gated by auth state, so it's not a reliable proxy for embed mode. The negative test caught a weak assertion in the spec.

2. **The h1 assertion was stale.** Recent partner-feedback rounds suppressed the hero in embed mode on BPH; there's no h1 in the SSR'd HTML anymore. The h2 "Library Catalogue" check on the next line is sufficient.

The URL-prefix invariant (the actual fix from #1640) was correctly caught by the negative test on the first try — that assertion is solid.

## What

- Embed-mode check now looks for the global "Collections" nav anchor (only rendered by `SiteHeader`, never in embed mode). Verified via negative test: visiting `/bph/search` correctly fails the assertion; visiting `/embed/bph/search` passes.
- Dropped the h1 assertion in the digital-collection test. Comment explains why.

## Test plan

- [x] `BASE_URL=https://sourcelibrary-v2.vercel.app npx playwright test bph-iframe.spec.ts` — 11/11 passing in ~13s
- [x] Negative test (now deleted, was at `e2e/bph-iframe-negative.spec.ts` during validation) — both assertions correctly failed when pointed at `/bph/search`
- [x] `npx tsc --noEmit` — clean