### PR TITLE
Re-archive IIIF books at full resolution + factor shared helpers

### DIFF
--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -1,0 +1,176 @@
+/**
+ * Shared IIIF / image-archive helpers.
+ *
+ * Used by:
+ *   - scripts/workers/archive-ocr.mjs
+ *   - scripts/maintenance/archive-unarchived-books.ts
+ *   - scripts/workers/backfill-hires-illustrations.mjs
+ *   - scripts/maintenance/rearchive-iiif-fullres.mjs
+ *
+ * `upgradeToFullRes` was inlined in three places before this module
+ * existed. Keep them in lock-step — a regression in one host's URL
+ * pattern would silently degrade re-archive quality across the corpus.
+ *
+ * Per-host rate limits are intentionally conservative: museum and
+ * library IIIF servers throttle aggressively (BNF, Bodleian, BSB),
+ * and we want to be a good citizen.
+ */
+
+// ── Per-domain rate limits (requests per second) ──
+
+export const DOMAIN_LIMITS = {
+  'archive.org': 10,
+  'gallica.bnf.fr': 3,
+  'api.digitale-sammlungen.de': 5,
+  'iiif.wellcomecollection.org': 5,
+  'www.e-rara.ch': 2,
+  'digi.vatlib.it': 3,
+  'iiif.bodleian.ox.ac.uk': 3,
+  'images.lib.cam.ac.uk': 3,
+  'image.digitalcollections.manchester.ac.uk': 3,
+  'images.uba.uva.nl': 3,
+  'cdm21059.contentdm.oclc.org': 3,
+  'dl.ndl.go.jp': 3,
+};
+
+const DEFAULT_LIMIT = 5;
+
+const _domainBuckets = new Map();
+
+export function getDomainLimit(url) {
+  try {
+    const host = new URL(url).hostname;
+    return DOMAIN_LIMITS[host] ?? DEFAULT_LIMIT;
+  } catch {
+    return DEFAULT_LIMIT;
+  }
+}
+
+/**
+ * Fetch a URL respecting per-domain rate limits.
+ * Returns a Buffer on success, throws on HTTP error or timeout.
+ *
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {number} [opts.timeout=30000]
+ * @param {string} [opts.userAgent]
+ * @returns {Promise<Buffer>}
+ */
+export async function rateLimitedFetch(url, opts = {}) {
+  const { timeout = 30000, userAgent = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)' } = opts;
+
+  let host;
+  try { host = new URL(url).hostname; } catch { host = 'unknown'; }
+  const limit = getDomainLimit(url);
+
+  if (!_domainBuckets.has(host)) _domainBuckets.set(host, { last: 0, count: 0 });
+  const bucket = _domainBuckets.get(host);
+
+  const now = Date.now();
+  if (now - bucket.last > 1000) { bucket.count = 0; bucket.last = now; }
+  if (bucket.count >= limit) {
+    const wait = 1000 - (now - bucket.last);
+    if (wait > 0) await new Promise(r => setTimeout(r, wait));
+    bucket.count = 0;
+    bucket.last = Date.now();
+  }
+  bucket.count++;
+
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeout);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': userAgent },
+    });
+    clearTimeout(t);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return Buffer.from(await res.arrayBuffer());
+  } catch (e) {
+    clearTimeout(t);
+    throw e;
+  }
+}
+
+// ── IIIF URL transforms ──
+
+/**
+ * Upgrade a IIIF image URL to request full native resolution.
+ *
+ * Most institutional IIIF servers honour `/full/full/` (request the
+ * image at its native pixel dimensions, subject to the server's
+ * `maxArea`). Some hosts have been observed to require explicit
+ * variants — see the per-host branches.
+ *
+ * If the URL doesn't match a recognised IIIF pattern, returns the
+ * original unchanged.
+ */
+export function upgradeToFullRes(url) {
+  if (!url || typeof url !== 'string') return url;
+  try {
+    if (url.includes('archive.org') && url.includes('/full/pct:')) {
+      return url.replace(/\/full\/pct:\d+\//, '/full/full/');
+    }
+    if (url.includes('digitale-sammlungen') && url.match(/\/full\/\d+,\//)) {
+      return url.replace(/\/full\/\d+,\//, '/full/full/');
+    }
+    if (url.includes('gallica') && url.match(/\/full\/\d+,?\d*\//)) {
+      return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
+    }
+    if (url.includes('digi.vatlib') && url.match(/\/full\/\d+,?\d*\//)) {
+      return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
+    }
+    if (url.match(/\/full\/(?:pct:\d+|\d+,?\d*)\/\d+\/default\./)) {
+      return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, '/full/full/');
+    }
+  } catch {}
+  return url;
+}
+
+/**
+ * Detect whether a URL appears to use a IIIF Image API path.
+ * Used to decide whether the URL is even eligible for full-res upgrade.
+ */
+export function isIiifUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+  return /\/iiif\/|\/full\/(?:pct:\d+|\d+,?\d*|full|max)\//.test(url);
+}
+
+/**
+ * Returns the explicit pixel cap encoded in the IIIF size segment, or
+ * null if the URL requests full native resolution.
+ *
+ *   /full/1000,/0/default.jpg  →  1000
+ *   /full/full/0/default.jpg   →  null  (no cap)
+ *   /full/pct:50/0/default.jpg →  null  (percentage; treat as unsized)
+ */
+export function getIiifSizeCap(url) {
+  if (!url) return null;
+  const m = url.match(/\/full\/(\d+),(?:\d*)?\/\d+\/default\./);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/**
+ * Fetch a IIIF info.json for a given image URL.
+ * Strips the trailing `/full/.../...jpg` segment to derive the base.
+ *
+ * @returns {Promise<{width:number,height:number,sizes?:Array,maxArea?:number}|null>}
+ */
+export async function fetchIiifInfo(url, opts = {}) {
+  if (!isIiifUrl(url)) return null;
+  // /full/SIZE/ROT/QUALITY.FORMAT  →  /info.json
+  const base = url.replace(/\/full\/[^\/]+\/[^\/]+\/[^\/]+$/, '');
+  if (base === url) return null;
+  try {
+    const buf = await rateLimitedFetch(`${base}/info.json`, opts);
+    const json = JSON.parse(buf.toString('utf8'));
+    return {
+      width: json.width,
+      height: json.height,
+      sizes: json.sizes,
+      maxArea: json.profile?.[1]?.maxArea,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/scripts/maintenance/archive-unarchived-books.ts
+++ b/scripts/maintenance/archive-unarchived-books.ts
@@ -17,6 +17,7 @@
 import { MongoClient } from 'mongodb';
 import sharp from 'sharp';
 import { storagePut } from '../../src/lib/storage';
+import { upgradeToFullRes, rateLimitedFetch } from '../lib/iiif-utils.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = (() => {
@@ -36,70 +37,7 @@ const CONCURRENCY = (() => {
   return idx !== -1 ? parseInt(process.argv[idx + 1]) : 10;
 })();
 
-const DOWNLOAD_TIMEOUT = 30000;
 const MAX_RETRIES = 3;
-
-// Rate limiter per domain
-const domainBuckets = new Map();
-const DOMAIN_LIMITS = {
-  'archive.org': 10, 'gallica.bnf.fr': 3, 'api.digitale-sammlungen.de': 5,
-  'iiif.wellcomecollection.org': 5, 'www.e-rara.ch': 2, 'digi.vatlib.it': 3,
-  'iiif.bodleian.ox.ac.uk': 3, 'images.lib.cam.ac.uk': 3, 'image.digitalcollections.manchester.ac.uk': 3,
-  'images.uba.uva.nl': 3, 'cdm21059.contentdm.oclc.org': 3, 'dl.ndl.go.jp': 3,
-};
-
-function getDomainLimit(url) {
-  try { const host = new URL(url).hostname; return DOMAIN_LIMITS[host] || 5; }
-  catch { return 5; }
-}
-
-async function rateLimitedFetch(url) {
-  let host;
-  try { host = new URL(url).hostname; } catch { host = 'unknown'; }
-  const limit = getDomainLimit(url);
-
-  if (!domainBuckets.has(host)) domainBuckets.set(host, { last: 0, count: 0 });
-  const bucket = domainBuckets.get(host);
-
-  const now = Date.now();
-  if (now - bucket.last > 1000) { bucket.count = 0; bucket.last = now; }
-  if (bucket.count >= limit) {
-    const wait = 1000 - (now - bucket.last);
-    if (wait > 0) await new Promise(r => setTimeout(r, wait));
-    bucket.count = 0;
-    bucket.last = Date.now();
-  }
-  bucket.count++;
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT);
-  try {
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: { 'User-Agent': 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)' }
-    });
-    clearTimeout(timeout);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return Buffer.from(await res.arrayBuffer());
-  } catch (e) {
-    clearTimeout(timeout);
-    throw e;
-  }
-}
-
-// Upgrade IIIF URL to full native resolution. Mirrors archive-ocr.mjs:upgradeToFullRes.
-function upgradeToFullRes(url: string): string {
-  try {
-    if (url.includes('archive.org') && url.includes('/full/pct:')) return url.replace(/\/full\/pct:\d+\//, '/full/full/');
-    if (url.includes('digitale-sammlungen') && url.match(/\/full\/\d+,\//)) return url.replace(/\/full\/\d+,\//, '/full/full/');
-    if (url.includes('gallica') && url.match(/\/full\/\d+,?\d*\//)) return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-    if (url.includes('digi.vatlib') && url.match(/\/full\/\d+,?\d*\//)) return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-    if (url.match(/\/full\/(?:pct:\d+|\d+,?\d*)\/\d+\/default\./)) {
-      return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, '/full/full/');
-    }
-  } catch {}
-  return url;
-}
 
 async function archivePage(db, page) {
   const originalUrl = page.photo_original || page.photo;

--- a/scripts/maintenance/rearchive-iiif-fullres.mjs
+++ b/scripts/maintenance/rearchive-iiif-fullres.mjs
@@ -1,0 +1,516 @@
+#!/usr/bin/env node
+/**
+ * Re-archive existing IIIF-sourced book pages at full native resolution.
+ *
+ * Different from `scripts/maintenance/archive-unarchived-books.ts` (which
+ * only archives pages with NO `archived_photo`), this script targets
+ * pages whose `archived_photo` IS set but where the source was imported
+ * at a downsized IIIF resolution (e.g. `/full/1000,/`). It refetches at
+ * `/full/full/` and overwrites the existing R2 archive.
+ *
+ * Three modes:
+ *
+ *   --audit
+ *     Sample one page per book, fetch info.json, report books where
+ *     the source IIIF master is significantly larger than the current
+ *     archive. No writes.
+ *
+ *   --refetch (default)
+ *     For unsplit books, refetch every page at full-res, overwrite the
+ *     same R2 path, update page records with new image_metadata
+ *     (width, height, source). Sets book.image_resolution_upgraded_at.
+ *
+ *   --recover-split
+ *     For books where the splitter has already run on low-res inputs
+ *     (e.g. Hieroglyphica): refetch each unique parent spread URL
+ *     (`page.photo_original`) at full-res, then UNDO the split:
+ *     deletes right-half page records, restores left-halves to the
+ *     original spread state with the new full-res URL, sets
+ *     `pipeline_auto.status='archive_complete'`, `needs_splitting=true`,
+ *     `needs_resplit=true`. The next splitter run produces correct
+ *     ~2000px halves and the OCR/translate cascade re-runs cleanly.
+ *
+ * Selection filters (any combination):
+ *   --book-id <id>
+ *   --provider <name>          e.g. allard_pierson
+ *   --crisis-only              books with spread_translation_crisis: true
+ *
+ * Other:
+ *   --concurrency N            books processed in parallel (default 2)
+ *   --page-concurrency N       pages per book (default 4)
+ *   --limit N                  max books
+ *   --dry-run                  no writes
+ *   --min-upgrade-ratio R      only refetch if maxres/current >= R (default 1.5)
+ *
+ * Examples:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/rearchive-iiif-fullres.mjs --audit --crisis-only
+ *   node scripts/maintenance/rearchive-iiif-fullres.mjs --book-id 69b4cd55d5b6c3815e1a59eb --recover-split --dry-run
+ *   node scripts/maintenance/rearchive-iiif-fullres.mjs --provider allard_pierson --crisis-only --refetch
+ *
+ * Companion to:
+ *   - scripts/lib/iiif-utils.mjs  (URL upgrade + rate limiting)
+ *   - scripts/workers/batch-split-bph.mjs  (the splitter that re-runs after recovery)
+ *   - .claude/docs/spread-translation-crisis-2026-05-06.md  (background)
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+import { upgradeToFullRes, rateLimitedFetch, fetchIiifInfo, isIiifUrl, getIiifSizeCap } from '../lib/iiif-utils.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: resolve(__dirname, '../../.env.production.local') });
+
+// ── Args ──
+
+const ARG = (name, fallback = null) => {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : fallback;
+};
+const FLAG = (name) => process.argv.includes(name);
+
+const MODE = FLAG('--audit') ? 'audit' : FLAG('--recover-split') ? 'recover-split' : 'refetch';
+const DRY_RUN = FLAG('--dry-run');
+const BOOK_ID = ARG('--book-id');
+const PROVIDER = ARG('--provider');
+const CRISIS_ONLY = FLAG('--crisis-only');
+const CONCURRENCY = parseInt(ARG('--concurrency', '2'));
+const PAGE_CONCURRENCY = parseInt(ARG('--page-concurrency', '4'));
+const LIMIT = parseInt(ARG('--limit', '0'));
+const MIN_UPGRADE_RATIO = parseFloat(ARG('--min-upgrade-ratio', '1.5'));
+const SHARP_MAX_WIDTH = parseInt(ARG('--max-width', '6000'));
+const JPEG_QUALITY = parseInt(ARG('--jpeg-quality', '90'));
+
+// ── Setup ──
+
+const mongo = new MongoClient(process.env.MONGODB_URI);
+await mongo.connect();
+const db = mongo.db('bookstore');
+
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+  },
+});
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+async function r2Put(key, buffer, contentType = 'image/jpeg') {
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: contentType,
+    CacheControl: 'public, max-age=86400, s-maxage=86400',
+  }));
+  return `${R2_PUBLIC_URL}/${key}`;
+}
+
+// ── Helpers ──
+
+function buildBookQuery() {
+  if (BOOK_ID) return { id: BOOK_ID };
+  const q = {};
+  if (PROVIDER) q['image_source.provider'] = PROVIDER;
+  if (CRISIS_ONLY) q.spread_translation_crisis = true;
+  return q;
+}
+
+function isAlreadySplit(pages) {
+  return pages.some(p => p.split_side === 'left' || p.split_side === 'right');
+}
+
+async function jpegDims(buf) {
+  try {
+    const meta = await sharp(buf).metadata();
+    return { width: meta.width, height: meta.height };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Process one source URL: upgrade, fetch, resize-cap, return buffer + dims.
+ * Skips if the URL doesn't appear to be IIIF or upgrade is a no-op.
+ */
+async function fetchUpgraded(url) {
+  if (!isIiifUrl(url)) return { skipped: 'not-iiif', url };
+  const upgraded = upgradeToFullRes(url);
+  if (upgraded === url) return { skipped: 'no-upgrade-pattern', url };
+  let raw;
+  try {
+    raw = await rateLimitedFetch(upgraded, { timeout: 60_000 });
+  } catch (e) {
+    return { skipped: 'fetch-fail', url: upgraded, error: e.message };
+  }
+  // Cap at SHARP_MAX_WIDTH
+  let processed;
+  try {
+    processed = await sharp(raw)
+      .resize(SHARP_MAX_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: JPEG_QUALITY, progressive: true })
+      .toBuffer();
+  } catch (e) {
+    return { skipped: 'sharp-fail', url: upgraded, error: e.message };
+  }
+  const dims = await jpegDims(processed);
+  return { upgraded, raw, processed, dims };
+}
+
+// ── Audit mode ──
+
+async function audit() {
+  const books = await db.collection('books').find(buildBookQuery(), {
+    projection: { id: 1, slug: 1, title: 1, 'image_source.provider': 1 },
+  }).limit(LIMIT || 0).toArray();
+
+  console.log(`Auditing ${books.length} books for low-res IIIF source...\n`);
+
+  const results = { highRes: 0, lowRes: 0, nonIiif: 0, noPages: 0, fetchFail: 0 };
+  const lowResBooks = [];
+
+  for (const b of books) {
+    const samplePage = await db.collection('pages').findOne(
+      { book_id: b.id, page_number: { $gte: 3 } },
+      { projection: { photo: 1, photo_original: 1, archived_photo: 1 } },
+      { sort: { page_number: 1 } },
+    );
+    if (!samplePage) { results.noPages++; continue; }
+
+    const sourceUrl = samplePage.photo_original || samplePage.photo;
+    if (!isIiifUrl(sourceUrl)) { results.nonIiif++; continue; }
+
+    const info = await fetchIiifInfo(sourceUrl);
+    if (!info) { results.fetchFail++; continue; }
+
+    const cap = getIiifSizeCap(sourceUrl);
+    const masterWidth = info.width;
+    const ratio = cap ? masterWidth / cap : null;
+
+    const isLowRes = ratio !== null && ratio >= MIN_UPGRADE_RATIO;
+    if (isLowRes) {
+      results.lowRes++;
+      lowResBooks.push({
+        id: b.id,
+        slug: b.slug,
+        title: b.title,
+        provider: b.image_source?.provider,
+        currentCap: cap,
+        masterWidth,
+        masterHeight: info.height,
+        upgradeRatio: ratio.toFixed(1) + 'x',
+      });
+      console.log(`  LOW-RES  ${cap}px → ${masterWidth}px (${ratio.toFixed(1)}x)  ${(b.title || '').substring(0, 50)} [${b.image_source?.provider}]`);
+    } else {
+      results.highRes++;
+    }
+  }
+
+  console.log(`\nAudit summary:`);
+  console.log(`  Hi-res or already at master: ${results.highRes}`);
+  console.log(`  Low-res (refetch candidates): ${results.lowRes}`);
+  console.log(`  Non-IIIF source: ${results.nonIiif}`);
+  console.log(`  No pages: ${results.noPages}`);
+  console.log(`  Fetch failed: ${results.fetchFail}`);
+
+  if (lowResBooks.length) {
+    console.log(`\nSample of low-res candidates (top 10 by upgrade ratio):`);
+    lowResBooks.sort((a, b) => parseFloat(b.upgradeRatio) - parseFloat(a.upgradeRatio));
+    for (const x of lowResBooks.slice(0, 10)) {
+      console.log(`  ${x.upgradeRatio.padEnd(6)}  ${x.currentCap}→${x.masterWidth}px  ${(x.title || '').substring(0, 55)}  id=${x.id}`);
+    }
+  }
+}
+
+// ── Refetch mode (un-split books) ──
+
+async function refetchOne(book) {
+  const pages = await db.collection('pages').find(
+    { book_id: book.id },
+    { projection: { id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, split_side: 1 } },
+  ).sort({ page_number: 1 }).toArray();
+
+  if (!pages.length) return { skipped: 'no-pages' };
+  if (isAlreadySplit(pages)) return { skipped: 'already-split (use --recover-split)' };
+
+  // Decide once based on first IIIF page
+  const sample = pages.find(p => isIiifUrl(p.photo_original || p.photo));
+  if (!sample) return { skipped: 'no-iiif-source' };
+  const sourceUrl = sample.photo_original || sample.photo;
+  const info = await fetchIiifInfo(sourceUrl);
+  if (!info) return { skipped: 'info-json-fail' };
+  const cap = getIiifSizeCap(sourceUrl);
+  if (!cap || info.width / cap < MIN_UPGRADE_RATIO) {
+    return { skipped: `not-low-res (cap=${cap || 'full'}, master=${info.width})` };
+  }
+
+  console.log(`  ${(book.title || '').substring(0, 55)} — upgrading ${cap}→${info.width}px (${pages.length} pages)`);
+
+  let updated = 0, skipped = 0, failed = 0;
+  await parallelMap(pages, async (page) => {
+    const url = page.photo_original || page.photo;
+    if (!isIiifUrl(url)) { skipped++; return; }
+    const result = await fetchUpgraded(url);
+    if (result.skipped) { skipped++; return; }
+
+    const key = `archived/${book.id}/${page.page_number}.jpg`;
+    if (DRY_RUN) {
+      updated++;
+      return;
+    }
+    try {
+      const newUrl = await r2Put(key, result.processed);
+      await db.collection('pages').updateOne(
+        { _id: page._id || new ObjectId(page.id) },
+        { $set: {
+          archived_photo: newUrl,
+          photo: newUrl,
+          'image_metadata.width': result.dims?.width,
+          'image_metadata.height': result.dims?.height,
+          'image_metadata.source_max_width': info.width,
+          'image_metadata.upgraded_at': new Date(),
+          updated_at: new Date(),
+        } },
+      );
+      updated++;
+    } catch (e) {
+      console.error(`    page ${page.page_number} fail: ${e.message?.substring(0, 80)}`);
+      failed++;
+    }
+  }, PAGE_CONCURRENCY);
+
+  if (!DRY_RUN && updated > 0) {
+    await db.collection('books').updateOne(
+      { id: book.id },
+      { $set: {
+        'image_resolution_upgraded_at': new Date(),
+        'image_resolution_upgrade_source': info.width,
+        updated_at: new Date(),
+      } },
+    );
+  }
+
+  return { updated, skipped, failed };
+}
+
+// ── Recovery mode (already-split books) ──
+
+async function recoverOne(book) {
+  const pages = await db.collection('pages').find(
+    { book_id: book.id },
+    { projection: { id: 1, _id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, split_side: 1, split_from: 1 } },
+  ).sort({ page_number: 1 }).toArray();
+
+  if (!pages.length) return { skipped: 'no-pages' };
+  if (!isAlreadySplit(pages)) return { skipped: 'not-split (use --refetch)' };
+
+  // Group by photo_original to identify parent spreads. Each parent
+  // produced one or two children (single, or left+right halves).
+  const groups = new Map();  // photo_original -> [pages]
+  for (const p of pages) {
+    const k = p.photo_original || p.photo;
+    if (!k) continue;
+    if (!groups.has(k)) groups.set(k, []);
+    groups.get(k).push(p);
+  }
+
+  // Sample one IIIF source to confirm low-res
+  const sampleUrl = [...groups.keys()].find(u => isIiifUrl(u));
+  if (!sampleUrl) return { skipped: 'no-iiif-source' };
+  const info = await fetchIiifInfo(sampleUrl);
+  if (!info) return { skipped: 'info-json-fail' };
+  const cap = getIiifSizeCap(sampleUrl);
+  if (!cap || info.width / cap < MIN_UPGRADE_RATIO) {
+    return { skipped: `not-low-res (cap=${cap || 'full'}, master=${info.width})` };
+  }
+
+  console.log(`  ${(book.title || '').substring(0, 55)} — recovering ${groups.size} parent spreads at ${info.width}px (${pages.length} child pages)`);
+
+  // Build the new (pre-split) page set: one record per unique parent.
+  // Number them in original sequence (extracted from the page_number on
+  // any child — left halves keep the original number; right halves get
+  // a +0.5 offset). We pick the LOWEST page_number in each group.
+  const newPages = [];  // { originalPageNumber, sourceUrl, children, isSplit }
+  for (const [src, children] of groups) {
+    children.sort((a, b) => a.page_number - b.page_number);
+    const firstChild = children[0];
+    // For renumbered books, the original page_number can be reconstructed
+    // from the split_from chain. Simpler heuristic: lowest child.page_number
+    // is monotone with the original parent's position.
+    newPages.push({
+      sourceUrl: src,
+      children,
+      seq: firstChild.page_number,
+      isSplit: children.length > 1,
+    });
+  }
+  // Order by seq to assign new page numbers 1..N
+  newPages.sort((a, b) => a.seq - b.seq);
+
+  let refetched = 0, fetchFailed = 0;
+  const refetchedUrls = new Map();  // sourceUrl -> { key, dims }
+
+  // Step A: refetch every unique parent at full-res, upload to canonical R2 path.
+  await parallelMap(newPages, async (entry, idx) => {
+    const newPageNum = idx + 1;
+    const result = await fetchUpgraded(entry.sourceUrl);
+    if (result.skipped) {
+      fetchFailed++;
+      console.error(`    ${entry.sourceUrl.substring(0, 80)}: ${result.skipped} ${result.error || ''}`);
+      return;
+    }
+    const key = `archived/${book.id}/${newPageNum}.jpg`;
+    if (DRY_RUN) {
+      refetchedUrls.set(entry.sourceUrl, { key, dims: result.dims, newPageNum });
+      refetched++;
+      return;
+    }
+    try {
+      const newUrl = await r2Put(key, result.processed);
+      refetchedUrls.set(entry.sourceUrl, { key, dims: result.dims, newPageNum, url: newUrl });
+      refetched++;
+    } catch (e) {
+      fetchFailed++;
+      console.error(`    upload p${newPageNum} fail: ${e.message?.substring(0, 80)}`);
+    }
+  }, PAGE_CONCURRENCY);
+
+  if (DRY_RUN) {
+    return { refetched, fetchFailed, would_replace_pages: pages.length, with_pages: newPages.length };
+  }
+
+  // Step B: undo the split. Delete all child pages, recreate one record per parent.
+  const session = mongo.startSession();
+  try {
+    await session.withTransaction(async () => {
+      // Delete every child page (we'll create fresh records below)
+      await db.collection('pages').deleteMany({ book_id: book.id }, { session });
+
+      // Create new pre-split page records
+      const docs = newPages.map((entry, idx) => {
+        const newPageNum = idx + 1;
+        const r = refetchedUrls.get(entry.sourceUrl);
+        if (!r) return null;
+        const newId = new ObjectId();
+        return {
+          _id: newId,
+          id: newId.toHexString(),
+          tenant_id: 'default',
+          book_id: book.id,
+          page_number: newPageNum,
+          photo: r.url,
+          photo_original: entry.sourceUrl,
+          archived_photo: r.url,
+          image_metadata: {
+            width: r.dims?.width,
+            height: r.dims?.height,
+            source_max_width: info.width,
+            upgraded_at: new Date(),
+            recovered_from_low_res_split: true,
+          },
+          created_at: new Date(),
+          updated_at: new Date(),
+        };
+      }).filter(Boolean);
+
+      if (docs.length) {
+        await db.collection('pages').insertMany(docs, { session });
+      }
+
+      // Reset book to pre-split state, ready for splitter
+      await db.collection('books').updateOne(
+        { id: book.id },
+        { $set: {
+          pages_count: docs.length,
+          pages_ocr: 0,
+          pages_translated: 0,
+          needs_splitting: true,
+          needs_resplit: true,
+          'pipeline_auto.status': 'archive_complete',
+          'pipeline_auto.split_checked': false,
+          'pipeline_auto.last_updated': new Date(),
+          'image_resolution_upgraded_at': new Date(),
+          'image_resolution_upgrade_source': info.width,
+          updated_at: new Date(),
+        }, $unset: {
+          spread_translation_crisis: '',
+          translation_stale_reason: '',
+        } },
+        { session },
+      );
+    });
+  } finally {
+    await session.endSession();
+  }
+
+  return { refetched, fetchFailed, replaced_child_pages: pages.length, new_parent_pages: newPages.length };
+}
+
+// ── Concurrency helper ──
+
+async function parallelMap(items, fn, concurrency) {
+  const results = [];
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      results[idx] = await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}
+
+// ── Main ──
+
+async function main() {
+  console.log(`Mode: ${MODE.toUpperCase()}${DRY_RUN ? ' (DRY RUN)' : ''}`);
+  console.log(`Filters: ${BOOK_ID ? `book-id=${BOOK_ID}` : ''}${PROVIDER ? ` provider=${PROVIDER}` : ''}${CRISIS_ONLY ? ' crisis-only' : ''}`);
+  console.log(`Concurrency: ${CONCURRENCY} books × ${PAGE_CONCURRENCY} pages | min-upgrade-ratio=${MIN_UPGRADE_RATIO} | max-width=${SHARP_MAX_WIDTH}px | jpeg-q=${JPEG_QUALITY}\n`);
+
+  if (MODE === 'audit') {
+    await audit();
+    return;
+  }
+
+  const books = await db.collection('books').find(buildBookQuery(), {
+    projection: { id: 1, slug: 1, title: 1, 'image_source.provider': 1 },
+  }).limit(LIMIT || 0).toArray();
+  console.log(`Found ${books.length} books to process\n`);
+
+  let processed = 0, skipped = 0, failed = 0;
+  const startTime = Date.now();
+  const queue = [...books];
+
+  await parallelMap(queue, async (book) => {
+    try {
+      const result = (MODE === 'recover-split') ? await recoverOne(book) : await refetchOne(book);
+      if (result.skipped) {
+        skipped++;
+        console.log(`  skip: ${(book.title || '').substring(0, 55)} — ${result.skipped}`);
+      } else {
+        processed++;
+      }
+    } catch (e) {
+      failed++;
+      console.error(`  FAIL ${(book.title || '').substring(0, 50)}: ${e.message?.substring(0, 100)}`);
+    }
+  }, CONCURRENCY);
+
+  const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(1);
+  console.log(`\nDone in ${elapsed} min. Processed: ${processed}, Skipped: ${skipped}, Failed: ${failed}`);
+}
+
+try {
+  await main();
+} finally {
+  await mongo.close();
+}

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -14,6 +14,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { upgradeToFullRes } from '../lib/iiif-utils.mjs';
 
 const MAX_PAGES = 10_000;
 const MAX_PAGES_PER_DOMAIN = 5000;  // Prevent one domain from crowding out others
@@ -138,36 +139,7 @@ async function uploadToR2(key, buffer, contentType) {
   return `${R2_PUBLIC_URL}/${key}`;
 }
 
-/**
- * Upgrade a IIIF image URL to full resolution.
- * Most sources store photo URLs at reduced resolution (pct:50, 1000px, etc.).
- * For archival, we want the highest resolution available.
- */
-function upgradeToFullRes(url) {
-  try {
-    // Internet Archive IIIF: .../full/pct:50/0/default.jpg -> .../full/full/0/default.jpg
-    if (url.includes('archive.org') && url.includes('/full/pct:')) {
-      return url.replace(/\/full\/pct:\d+\//, '/full/full/');
-    }
-    // MDZ (digitale-sammlungen): .../full/1000,/0/default.jpg -> .../full/full/0/default.jpg
-    if (url.includes('digitale-sammlungen') && url.match(/\/full\/\d+,\//)) {
-      return url.replace(/\/full\/\d+,\//, '/full/full/');
-    }
-    // Gallica IIIF: same pattern
-    if (url.includes('gallica') && url.match(/\/full\/\d+,?\d*\//)) {
-      return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-    }
-    // Vatican IIIF
-    if (url.includes('digi.vatlib') && url.match(/\/full\/\d+,?\d*\//)) {
-      return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-    }
-    // e-rara, Bodleian, Cambridge, HAB, Wellcome — all IIIF
-    if (url.match(/\/full\/(?:pct:\d+|\d+,?\d*)\/\d+\/default\./)) {
-      return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, '/full/full/');
-    }
-  } catch {}
-  return url; // Return original if no upgrade pattern matches
-}
+// upgradeToFullRes is imported from ../lib/iiif-utils.mjs
 
 async function archivePage(page, db) {
   const originalUrl = page.photo;

--- a/scripts/workers/backfill-hires-illustrations.mjs
+++ b/scripts/workers/backfill-hires-illustrations.mjs
@@ -23,6 +23,7 @@
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { upgradeToFullRes } from '../lib/iiif-utils.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = (() => { const i = process.argv.indexOf('--limit'); return i !== -1 ? parseInt(process.argv[i+1]) : 0; })();
@@ -64,19 +65,6 @@ async function waitForToken(domain) {
     b.last = Date.now(); b.count = 0;
   }
   b.count++;
-}
-
-function upgradeToFullRes(url) {
-  try {
-    if (url.includes('archive.org') && url.includes('/full/pct:')) return url.replace(/\/full\/pct:\d+\//, '/full/full/');
-    if (url.includes('digitale-sammlungen') && url.match(/\/full\/\d+,\//)) return url.replace(/\/full\/\d+,\//, '/full/full/');
-    if (url.includes('gallica') && url.match(/\/full\/\d+,?\d*\//)) return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-    if (url.includes('digi.vatlib') && url.match(/\/full\/\d+,?\d*\//)) return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-    if (url.match(/\/full\/(?:pct:\d+|\d+,?\d*)\/\d+\/default\./)) {
-      return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, '/full/full/');
-    }
-  } catch {}
-  return url;
 }
 
 async function downloadImage(url, retries = 2) {


### PR DESCRIPTION
Companion to #1655. Addresses the gap that was exposed when running the splitter on Horapollo *Hieroglyphica*: source IIIF was imported at \`/full/1000,/\` (Allard Pierson and Vatican IIIF have masters at 8551×5538 and 4000+ wide), so the splitter halved a 1000×648 spread into 510×648 — too small for OCR or display. The fresh-archive script in #1655 doesn't pick these up because its filter is \`archived_photo: { \$exists: false }\`.

## Changes

**\`scripts/lib/iiif-utils.mjs\`** — new shared module. \`upgradeToFullRes\` was duplicated in three places (archive-ocr.mjs, archive-unarchived-books.ts, backfill-hires-illustrations.mjs); now lives in one place and the three callers import from it. Net -106 / +4 lines on the refactor. Adds \`isIiifUrl\`, \`getIiifSizeCap\`, \`fetchIiifInfo\` helpers.

**\`scripts/maintenance/rearchive-iiif-fullres.mjs\`** — new script with three modes:

- \`--audit\` — samples one page per book, fetches info.json, reports books where the master is significantly larger than the current archive. No writes.
- \`--refetch\` (default) — for unsplit books, refetch every page at \`/full/full/\`, overwrite the existing R2 archive path, store new \`image_metadata\` on each page.
- \`--recover-split\` — for books like Hieroglyphica where the splitter already ran on low-res inputs: refetches each unique parent spread URL at full-res, transactionally deletes split-child page records, recreates one record per parent, resets the book to \`archive_complete\` + \`needs_splitting: true\` + \`needs_resplit: true\` so the splitter re-runs at proper resolution.

Selection: \`--book-id\`, \`--provider\`, \`--crisis-only\` (any combination). Concurrency 2 books × 4 pages by default, sharp cap 6000px, JPEG q90, minimum upgrade ratio 1.5×.

## Test plan

- [x] \`node --check\` passes on iiif-utils.mjs and the new script.
- [x] \`upgradeToFullRes\` smoke test: Allard Pierson, Vatican, archive.org, gallica, mdz patterns all rewrite correctly; non-IIIF URLs pass through unchanged.
- [x] Project tsc check (no new errors introduced by the refactor).
- [ ] On Hetzner: dry-run \`--audit --crisis-only\` against the spread-crisis cohort to confirm count of low-res books matches earlier audit (8 expected: 7 allard_pierson + 1 vatican).
- [ ] On Hetzner: dry-run \`--book-id <Hieroglyphica> --recover-split\` to confirm transaction shape without writes.
- [ ] On Hetzner: live \`--book-id <Hieroglyphica> --recover-split\` end-to-end. Expected: 316 spreads refetched at \`/full/full/\` (~8551px each → resized to 6000px), 630 split children deleted, 316 fresh page records, book reset to \`archive_complete\`.
- [ ] Splitter re-runs on Hieroglyphica via existing \`needs_resplit\` path → produces ~3000px halves (vs the prior 510px).
- [ ] Spot-check OCR cascade picks up the re-split book and re-OCRs cleanly.

## Out of scope (separate)

- Going-forward import scripts that hardcode \`/full/1000,/\` or similar. #1655 noted these as a separate cleanup; should be reviewed with this work in mind.
- Re-archiving non-crisis books with low-res IIIF (the broader corpus). \`--audit\` without \`--crisis-only\` will surface them; remediation is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)