### PR TITLE
BPH search: hide Collections lane (cross-tenant leak)

### DIFF
--- a/e2e/bph-iframe.spec.ts
+++ b/e2e/bph-iframe.spec.ts
@@ -155,6 +155,24 @@ test.describe('BPH iframe — search (/embed/bph/search)', () => {
     );
     expect(leaks, `Found ${leaks.length} hardcoded sourcelibrary.org links: ${leaks.slice(0, 3).join(', ')}`).toHaveLength(0);
   });
+
+  test('no Collection cards leak through search (cross-tenant guard)', async ({ page }) => {
+    // Collections are SL-global content (Depth Psychology, Hermetica, etc.).
+    // Showing them on bph.sourcelibrary.org/search is a cross-tenant leak.
+    // The Hartmann query specifically surfaces "Depth Psychology" — easy
+    // regression marker. Guard added in feedback round 2 (image #8).
+    await page.goto('/embed/bph/search?q=Hartmann');
+    await expect(page.locator('text=/CATALOG MATCHES/i').first()).toBeVisible({ timeout: SEARCH_TIMEOUT });
+
+    // Search-result collection cards are <a href="/collections/{slug}"> with
+    // a "{N} books" label. Anchors with that pattern indicate the lane is on.
+    const collectionAnchors = page.locator('a[href^="/collections/"]');
+    expect(await collectionAnchors.count()).toBe(0);
+
+    // Also no "Depth Psychology" label anywhere (it's an SL-only collection).
+    const dp = page.locator('text=/Depth Psychology/i');
+    expect(await dp.count()).toBe(0);
+  });
 });
 
 test.describe('BPH iframe — orphan param strip', () => {

--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -1125,8 +1125,10 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
         {/* Browse mode — shown when no query + books tab */}
         {isBrowseMode && viewMode !== 'images' && (
           <div>
-            {/* Collection pills — truncated on mobile */}
-            {collectionsList.length > 0 && (() => {
+            {/* Collection pills — truncated on mobile.
+                Collections are SL-global content; hidden in embed mode to
+                avoid cross-tenant leak on bph.sourcelibrary.org etc. */}
+            {!embed && collectionsList.length > 0 && (() => {
               const visibleCollections = showAllCollections
                 ? collectionsList
                 : collectionsList.slice(0, MOBILE_COLLECTION_LIMIT);
@@ -1438,7 +1440,9 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             </>
           );
 
-          const collectionCards = collectionResults.length > 0 && (
+          // Collections are SL-global (cross-tenant) content. In embed mode
+          // (BPH iframe etc.) they would be a cross-tenant leak — hide.
+          const collectionCards = !embed && collectionResults.length > 0 && (
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {collectionResults.map(col => (
                 <SearchCollectionCard key={col.slug} col={col} />


### PR DESCRIPTION
## Summary

Searching \"Hartmann\" on bph.sourcelibrary.org/search surfaced a \"Depth Psychology\" collection card (image #8 in partner feedback). Collections are an SL-global editorial concept — they shouldn't appear inside the BPH iframe per the lockdown invariants.

Gates two render sites in \`src/app/[tenant]/search/page.tsx\`:
- The \"all\" tab's collection-cards block at the top of results
- The browse-mode collection-pills filter row

Both now skip when \`embed\` is true.

Adds an e2e regression test in \`bph-iframe.spec.ts\`:
- No \`<a href=\"/collections/...\">\` on \`/embed/bph/search?q=Hartmann\`
- No \"Depth Psychology\" text (the SL-only collection that triggered this report)

## Test plan

- [ ] Preview: \`/embed/bph/search?q=Hartmann\` — no \"Depth Psychology\" card, no \"All books · Depth Psychology · …\" pill row
- [ ] Preview: \`/embed/internet-archive/search?q=poetry\` — no collections (regression check on other tenant)
- [ ] Preview (non-embed): \`/search?q=Hartmann\` on \`*.vercel.app\` (no embed context) — collections still visible (no regression on main site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)