### PR TITLE
Public-API auth gate (log-only) + per-user attribution

### DIFF
--- a/src/app/api/books/[id]/quote/route.ts
+++ b/src/app/api/books/[id]/quote/route.ts
@@ -4,6 +4,7 @@ import { Book, Page, TranslationEdition } from '@/lib/types';
 import { getShortUrl, getRequestBaseUrl } from '@/lib/shortlinks';
 import { markForExport } from '@/lib/provenance';
 import { isBot, isTrustedBot, botMaxPage } from '@/lib/bot-gate';
+import { withApiAuth } from '@/lib/api-auth';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
@@ -130,7 +131,7 @@ function generateCitations(
 }
 
 // GET /api/books/[id]/quote?page=N - Get a quote from a specific page
-export async function GET(request: NextRequest, context: RouteContext) {
+export const GET = withApiAuth(async (request: NextRequest, context: RouteContext) => {
   try {
     const { id: bookId } = await context.params;
     const { searchParams } = new URL(request.url);
@@ -242,4 +243,4 @@ export async function GET(request: NextRequest, context: RouteContext) {
     console.error('Error getting quote:', error);
     return NextResponse.json({ error: 'Failed to get quote' }, { status: 500 });
   }
-}
+}, { route: 'books.quote' });

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -5,6 +5,7 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { ObjectId } from 'mongodb';
 import { logAuditEvent } from '@/lib/audit-logger';
 import { withAdminAuth, withCuratorAuth } from '@/lib/auth-helpers';
+import { withApiAuth } from '@/lib/api-auth';
 import { logMetadataChange, diffBookFields } from '@/lib/book-changelog';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { mirrorBookToCatalog } from '@/lib/books-catalog';
@@ -12,10 +13,10 @@ import { COVER_WRITE_FIELDS } from '@/lib/cover-fields';
 
 export const preferredRegion = 'fra1';
 
-export async function GET(
+export const GET = withApiAuth(async (
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-) {
+) => {
   try {
     const { id } = await params;
     const { searchParams } = new URL(request.url);
@@ -104,7 +105,7 @@ export async function GET(
     console.error('Error fetching book:', error);
     return NextResponse.json({ error: 'Failed to fetch book' }, { status: 500 });
   }
-}
+}, { route: 'books.get' });
 
 export const DELETE = withAdminAuth(async (request, session, context) => {
   try {

--- a/src/app/api/books/[id]/text/route.ts
+++ b/src/app/api/books/[id]/text/route.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/lib/mongodb';
 import { ObjectId } from 'mongodb';
 import { isBot, isTrustedBot, botMaxPage, botGateResponse } from '@/lib/bot-gate';
 import { getChapterTexts } from '@/lib/chapter-text';
+import { withApiAuth } from '@/lib/api-auth';
 
 export const maxDuration = 30;
 
@@ -20,10 +21,10 @@ export const maxDuration = 30;
  *   format=json|plain (default: json)
  *   include_metadata=true — include page-level OCR/translation metadata
  */
-export async function GET(
+export const GET = withApiAuth(async (
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-) {
+) => {
   try {
     const { id: bookId } = await params;
     const { searchParams } = new URL(request.url);
@@ -313,4 +314,4 @@ export async function GET(
     console.error('Bulk text error:', error);
     return NextResponse.json({ error: 'Failed to fetch text' }, { status: 500 });
   }
-}
+}, { route: 'books.text' });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,4 +1,6 @@
+import type { NextRequest } from 'next/server';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { withApiAuth } from '@/lib/api-auth';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -463,7 +465,7 @@ export async function GET() {
   });
 }
 
-export async function POST(req: Request) {
+export const POST = withApiAuth(async (req: NextRequest) => {
   try {
     const body = await req.json();
 
@@ -495,7 +497,7 @@ export async function POST(req: Request) {
       headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
     });
   }
-}
+}, { route: 'mcp' });
 
 export async function DELETE() {
   // Stateless — no sessions to delete

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -6,6 +6,7 @@ import { buildPageSearchStage } from '@/lib/atlas-search';
 import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-search';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
+import { withApiAuth } from '@/lib/api-auth';
 
 export const preferredRegion = 'fra1';
 
@@ -42,7 +43,7 @@ function extractSnippet(text: string, query: string, contextChars = 150): string
 }
 
 // GET /api/search - Search across books and translations
-export async function GET(request: NextRequest) {
+export const GET = withApiAuth(async (request: NextRequest) => {
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') || '';
@@ -677,4 +678,4 @@ export async function GET(request: NextRequest) {
       },
     });
   }
-}
+}, { route: 'search' });

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -17,16 +17,16 @@ export default function DevelopersPage() {
       header={
         <ContentHeader
           title="For Developers & AI"
-          subtitle="Search, read, and cite rare historical texts via MCP, CLI, or REST. No API key needed."
+          subtitle="Search, read, and cite rare historical texts via MCP, CLI, or REST. Sign in for a free API key — generous limits and attributed usage."
         />
       }
     >
-      {/* Request API Key */}
+      {/* Get an API Key */}
       <section className="mb-16">
         <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
-          <h2 className="text-lg font-semibold text-primary mb-2">Request an API Key</h2>
+          <h2 className="text-lg font-semibold text-primary mb-2">Get an API Key</h2>
           <p className="text-secondary mb-6">
-            For bulk access to OCR text, translations, and page-level data. Keys are reviewed within 24 hours.
+            Free for individual use. Higher limits for signed-in callers and partner-tier access available on request.
           </p>
           <ApiKeyRequestForm />
         </div>

--- a/src/components/developers/ApiKeyRequestForm.tsx
+++ b/src/components/developers/ApiKeyRequestForm.tsx
@@ -136,8 +136,14 @@ export default function ApiKeyRequestForm() {
                 {copied ? <Check className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4 text-green-700" />}
               </button>
             </div>
+            <div className="mt-4">
+              <p className="text-xs text-green-700 mb-1.5 font-medium">Install MCP with this key</p>
+              <code className="block px-3 py-2 bg-stone-900 text-stone-100 rounded-lg text-xs font-mono break-all">
+                claude mcp add source-library https://sourcelibrary.org/api/mcp -H &quot;Authorization: Bearer {newKey}&quot;
+              </code>
+            </div>
             <p className="text-xs text-green-600 mt-3">
-              Explorer tier: 10 requests/min, 100 pages/day. Use header <code className="text-green-700">Authorization: Bearer YOUR_KEY</code>
+              Or use it directly: <code className="text-green-700">Authorization: Bearer YOUR_KEY</code>
             </p>
           </div>
         )}
@@ -215,11 +221,23 @@ export default function ApiKeyRequestForm() {
   }
 
   return (
-    <div>
-      <p className="text-sm text-secondary mb-4">
-        <Link href="/auth/signin" className="text-accent-rust font-medium hover:underline">Sign in</Link> to generate an API key instantly, or fill out the form below for review.
-      </p>
-      <form onSubmit={handleSubmit} className="space-y-4">
+    <div className="space-y-6">
+      <div className="bg-stone-50 border border-stone-200 rounded-xl p-5 text-center">
+        <p className="text-sm text-stone-700 mb-4">
+          Sign in (free) to generate an API key instantly. We use it to track per-user usage and offer higher limits to signed-in callers.
+        </p>
+        <Link
+          href="/auth/signin?callbackUrl=/developers"
+          className="inline-block px-5 py-2.5 bg-stone-800 text-white rounded-lg hover:bg-stone-700 transition-colors text-sm font-medium"
+        >
+          Sign in to get a key
+        </Link>
+      </div>
+      <details className="group">
+        <summary className="cursor-pointer text-xs text-muted hover:text-stone-700 select-none">
+          Or request a partner key by email →
+        </summary>
+        <form onSubmit={handleSubmit} className="space-y-4 mt-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label htmlFor="name" className="block text-sm font-medium text-stone-700 mb-1">Name *</label>
@@ -281,7 +299,8 @@ export default function ApiKeyRequestForm() {
         >
           {formStatus === 'submitting' ? 'Submitting...' : 'Request API Key'}
         </button>
-      </form>
+        </form>
+      </details>
     </div>
   );
 }

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,0 +1,214 @@
+/**
+ * Public-API auth gate. Three identities:
+ *
+ *   1. session   — NextAuth cookie (signed-in user, generous tier)
+ *   2. apikey    — Bearer sl_data_... (existing dataset keys, tier-based)
+ *   3. anon      — per-IP token bucket (drives signups via 401)
+ *
+ * Plus a verified-bot exemption (Googlebot/Bingbot UA + same-origin web traffic),
+ * so SEO indexing and the React frontend are never blocked.
+ *
+ * Soft-launch contract: enforcement is OFF unless API_AUTH_ENFORCE=1. In log-only
+ * mode every call is logged with `would_block: true|false` so we can size the
+ * anonymous tier from real traffic before turning on the gate.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { validateApiKey } from '@/lib/dataset/api-keys';
+import { checkRateLimit, getClientIp } from '@/lib/rate-limit';
+import { logApiUsage } from '@/lib/api-usage';
+import type { ApiKeyDoc } from '@/lib/dataset/types';
+
+export type ApiIdentityKind = 'session' | 'apikey' | 'bot' | 'anon';
+
+export interface ApiIdentity {
+  kind: ApiIdentityKind;
+  userId?: string;
+  apiKeyId?: string;
+  apiKeyTier?: string;
+  bot?: string;
+}
+
+export interface ApiAuthDecision {
+  allowed: boolean;
+  identity: ApiIdentity;
+  status: number;       // 200, 401, or 429
+  retryAfter?: number;  // seconds, when 429
+  reason?: string;      // why blocked (for logging + error body)
+}
+
+// Tier limits applied per IP / user / key per window.
+// Tuned to be generous for signed-in users and just-tight-enough for anon
+// to make signing in worth it for anyone reading more than a couple of books.
+const ANON_LIMIT_PER_HOUR = Number(process.env.API_ANON_LIMIT_PER_HOUR || 60);
+const SESSION_LIMIT_PER_HOUR = Number(process.env.API_SESSION_LIMIT_PER_HOUR || 5000);
+
+// User-Agent substrings that get the verified-bot bypass. Reverse-DNS verification
+// would be the gold standard; for now we rely on UA strings since the only cost
+// of a false positive is one extra unauthenticated call slipping through.
+const VERIFIED_BOT_UAS = [
+  'googlebot', 'google-extended', 'bingbot', 'msnbot',
+  'duckduckbot', 'applebot', 'mojeekbot',
+];
+
+function detectVerifiedBot(ua: string): string | null {
+  const lower = ua.toLowerCase();
+  for (const sig of VERIFIED_BOT_UAS) if (lower.includes(sig)) return sig;
+  return null;
+}
+
+function sameOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  try {
+    const o = new URL(origin).hostname.toLowerCase();
+    return o === 'sourcelibrary.org' || o.endsWith('.sourcelibrary.org');
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the request's identity and decide whether it gets through the gate. */
+export async function requireApiAccess(request: NextRequest): Promise<ApiAuthDecision> {
+  // 1) NextAuth session cookie — best identity, generous limit.
+  try {
+    const session = await auth();
+    if (session?.user?.id) {
+      const ip = getClientIp(request);
+      const rl = checkRateLimit(
+        { name: 'api:session', limit: SESSION_LIMIT_PER_HOUR, windowSeconds: 3600 },
+        `${session.user.id}:${ip}`,
+      );
+      if (!rl.allowed) {
+        return {
+          allowed: false,
+          status: 429,
+          retryAfter: rl.retryAfter,
+          identity: { kind: 'session', userId: session.user.id },
+          reason: 'session_rate_limit',
+        };
+      }
+      return { allowed: true, status: 200, identity: { kind: 'session', userId: session.user.id } };
+    }
+  } catch {
+    // auth() can throw in edge contexts — fall through, treat as anonymous.
+  }
+
+  // 2) Bearer API key. validateApiKey already updates last_used_at atomically.
+  const authHeader = request.headers.get('authorization');
+  if (authHeader) {
+    const keyDoc = await validateApiKey(authHeader);
+    if (keyDoc) {
+      return {
+        allowed: true,
+        status: 200,
+        identity: {
+          kind: 'apikey',
+          apiKeyId: String((keyDoc as ApiKeyDoc)._id),
+          userId: keyDoc.user_id,
+          apiKeyTier: keyDoc.tier,
+        },
+      };
+    }
+  }
+
+  // 3) Verified bot or same-origin web traffic — exempt from the gate.
+  // Same-origin covers the React frontend's own /api/books/[id] calls during
+  // server/client renders. Spoofable, but the worst case is the scraper
+  // gets the same access as a logged-out human, which is what they get today.
+  const ua = request.headers.get('user-agent') || '';
+  const bot = detectVerifiedBot(ua);
+  if (bot) {
+    return { allowed: true, status: 200, identity: { kind: 'bot', bot } };
+  }
+  if (sameOrigin(request)) {
+    return { allowed: true, status: 200, identity: { kind: 'anon' } };
+  }
+
+  // 4) Anonymous — token bucket per IP. Past the limit, return 401 with a
+  // signup CTA in the body so MCP/SDK clients surface the message verbatim.
+  const ip = getClientIp(request);
+  const rl = checkRateLimit(
+    { name: 'api:anon', limit: ANON_LIMIT_PER_HOUR, windowSeconds: 3600 },
+    ip,
+  );
+  if (!rl.allowed) {
+    return {
+      allowed: false,
+      status: 401,
+      retryAfter: rl.retryAfter,
+      identity: { kind: 'anon' },
+      reason: 'anon_rate_limit',
+    };
+  }
+  return { allowed: true, status: 200, identity: { kind: 'anon' } };
+}
+
+/** Body returned to anonymous callers who blew the rate limit. */
+function buildSignupCta(retryAfter?: number) {
+  return {
+    error: 'Anonymous rate limit exceeded.',
+    message:
+      'Sign in (free) for 5,000 calls/hour, or generate an API key for unlimited use.',
+    signin_url: 'https://sourcelibrary.org/auth/signin',
+    get_key_url: 'https://sourcelibrary.org/developers',
+    retry_after_seconds: retryAfter,
+  };
+}
+
+type RouteHandler<C = unknown> = (
+  request: NextRequest,
+  ctx: C,
+  identity: ApiIdentity,
+) => Promise<Response> | Response;
+
+export interface WithApiAuthOptions {
+  /** Logical name of the route, recorded in api_usage for grouping. */
+  route: string;
+}
+
+/**
+ * Wrap an API route with the public-API gate. Honours API_AUTH_ENFORCE: when
+ * unset (or 0), every call goes through with `would_block` flagged in the log
+ * so you can size the anon tier from real traffic before flipping the switch.
+ */
+export function withApiAuth<C = unknown>(
+  handler: RouteHandler<C>,
+  opts: WithApiAuthOptions,
+) {
+  const enforce = process.env.API_AUTH_ENFORCE === '1';
+
+  return async (request: NextRequest, ctx: C): Promise<Response> => {
+    const start = Date.now();
+    const decision = await requireApiAccess(request);
+
+    if (!decision.allowed && enforce) {
+      const body =
+        decision.status === 401 ? buildSignupCta(decision.retryAfter)
+        : { error: 'Rate limit exceeded', retry_after_seconds: decision.retryAfter };
+
+      const headers: Record<string, string> = {};
+      if (decision.retryAfter) headers['Retry-After'] = String(decision.retryAfter);
+
+      logApiUsage({
+        request, identity: decision.identity, route: opts.route,
+        status: decision.status, ms: Date.now() - start,
+        wouldBlock: true, blocked: true, reason: decision.reason,
+      });
+
+      return NextResponse.json(body, { status: decision.status, headers });
+    }
+
+    const response = await handler(request, ctx, decision.identity);
+
+    logApiUsage({
+      request, identity: decision.identity, route: opts.route,
+      status: response.status, ms: Date.now() - start,
+      wouldBlock: !decision.allowed,
+      blocked: false,
+      reason: decision.reason,
+    });
+
+    return response;
+  };
+}

--- a/src/lib/api-usage.ts
+++ b/src/lib/api-usage.ts
@@ -1,0 +1,83 @@
+/**
+ * Append-only usage log for the public-API gate. One doc per gated call.
+ *
+ * Indexes (created lazily on first write — idempotent, MongoDB no-ops if present):
+ *   - { ts: 1 } TTL 90 days for raw events
+ *   - { user_id: 1, ts: -1 } for "what did this user do" views
+ *   - { api_key_id: 1, ts: -1 } for "what is this key being used for"
+ *   - { route: 1, ts: -1 } for hot-route analysis
+ *
+ * Writes are fire-and-forget; logging failures never affect the response.
+ * IPs are hashed (SHA-256, 16 hex chars) so the collection isn't a PII liability
+ * but we can still de-dupe by source.
+ */
+import { createHash } from 'crypto';
+import { NextRequest } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { getClientIp } from '@/lib/rate-limit';
+import type { ApiIdentity } from '@/lib/api-auth';
+
+const COLLECTION = 'api_usage';
+
+let indexesEnsured = false;
+async function ensureIndexes() {
+  if (indexesEnsured) return;
+  indexesEnsured = true;
+  try {
+    const db = await getDb();
+    const col = db.collection(COLLECTION);
+    await Promise.all([
+      col.createIndex({ ts: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 90 }),
+      col.createIndex({ user_id: 1, ts: -1 }),
+      col.createIndex({ api_key_id: 1, ts: -1 }),
+      col.createIndex({ route: 1, ts: -1 }),
+    ]);
+  } catch {
+    indexesEnsured = false;
+  }
+}
+
+function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+export interface LogApiUsageInput {
+  request: NextRequest;
+  identity: ApiIdentity;
+  route: string;
+  status: number;
+  ms: number;
+  wouldBlock: boolean;     // would the gate have blocked this call?
+  blocked: boolean;        // did the gate actually block it (enforce mode)?
+  reason?: string;
+}
+
+export function logApiUsage(input: LogApiUsageInput): void {
+  // Fire-and-forget; never await.
+  void writeLogEntry(input).catch(() => {});
+}
+
+async function writeLogEntry(input: LogApiUsageInput) {
+  await ensureIndexes();
+  const db = await getDb();
+  const ip = getClientIp(input.request);
+
+  await db.collection(COLLECTION).insertOne({
+    ts: new Date(),
+    identity_kind: input.identity.kind,
+    user_id: input.identity.userId || null,
+    api_key_id: input.identity.apiKeyId || null,
+    api_key_tier: input.identity.apiKeyTier || null,
+    bot: input.identity.bot || null,
+    route: input.route,
+    method: input.request.method,
+    path: input.request.nextUrl.pathname,
+    status: input.status,
+    ms: input.ms,
+    ip_hash: hashIp(ip),
+    user_agent: (input.request.headers.get('user-agent') || '').slice(0, 200),
+    would_block: input.wouldBlock,
+    blocked: input.blocked,
+    reason: input.reason || null,
+  });
+}


### PR DESCRIPTION
## Summary

Adds a unified auth gate to the public API surface so we can (a) drive signups and (b) attribute usage per user. Lands in **log-only mode** — nothing breaks on merge. Enforcement flips on by setting `API_AUTH_ENFORCE=1`.

### What's wrapped
- `/api/books/[id]` (book metadata)
- `/api/books/[id]/text` (bulk text)
- `/api/books/[id]/quote` (citation API)
- `/api/search`
- `/api/mcp` (POST)

Admin / pipeline / cron / health / track routes are untouched.

### Identity resolution
`withApiAuth` resolves each request in priority order:
1. **NextAuth session cookie** → identity = user, generous tier (5,000/hr)
2. **Bearer API key** → existing `validateApiKey` (already updates `last_used_at`)
3. **Verified bot UA** (Googlebot, Bingbot, etc.) → exempt — preserves SEO
4. **Same-origin** (sourcelibrary.org / tenant subdomains) → exempt — preserves the React frontend's own fetches
5. **Anonymous** → per-IP token bucket (default 60/hr, tunable via `API_ANON_LIMIT_PER_HOUR`)

When enforcement is on, anon rate-limit failures return `401` with a JSON body containing `signin_url` and `get_key_url` so MCP/SDK clients surface the signup CTA verbatim.

### Attribution: `api_usage` collection
One append-only doc per gated call: `{ ts, identity_kind, user_id, api_key_id, route, method, path, status, ms, ip_hash, user_agent, would_block, blocked }`. TTL 90d on raw, indexes on `user_id`, `api_key_id`, `route`. IPs are hashed (SHA-256, 16 hex chars) so it isn't a PII liability.

### UI changes (`/developers`)
- Subtitle no longer contradicts itself ("No API key needed" is gone).
- Anonymous path leads with **Sign in to get a key** as the primary CTA. The partner-by-email request form is preserved but moved behind a disclosure.
- After key generation, the success card shows a copy-pasteable MCP install line with the key already embedded.

### Rollout
1. **Merge** — gate runs in log-only mode immediately. Watch `api_usage` for a week to see real identity mix and would-block rate.
2. **Tune** the anon limit via `API_ANON_LIMIT_PER_HOUR` env var based on what shows up.
3. **Flip on** with `API_AUTH_ENFORCE=1` once the limit's right.
4. Email known anon high-volume IPs ("you're using our API — sign in for a free key") if any look identifiable.

## Test plan
- [ ] After deploy, hit `/api/books/{id}` anonymously and confirm 200 + a row in `api_usage` with `identity_kind: 'anon'`, `would_block: false`
- [ ] Hit `/api/books/{id}` with `Authorization: Bearer sl_data_...` and confirm `identity_kind: 'apikey'`
- [ ] Sign in via Google, hit `/api/search?q=test` from the website, confirm `identity_kind: 'session'` and `user_id` populated
- [ ] Hit any wrapped route with `User-Agent: Googlebot/2.1` and confirm `identity_kind: 'bot'`
- [ ] Visit `/developers` signed-out — see "Sign in to get a key" as primary; partner form behind disclosure
- [ ] Sign in, click "Generate API Key" — see new key + MCP install line
- [ ] In a staging env, set `API_AUTH_ENFORCE=1` + `API_ANON_LIMIT_PER_HOUR=2`, exceed the limit, confirm 401 with signup CTA body

🤖 Generated with [Claude Code](https://claude.com/claude-code)