### PR TITLE
Fix reader double-crop on split-from-spread pages

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -545,7 +545,13 @@ export default function TranslationEditor({
     if (tier === 'display') return getPageDisplayUrl(p) || '';
 
     // Full tier: for magnifier/fullscreen — want the highest resolution
-    // Split pages with crop use proxy for server-side crop
+    // split_from_spread pages have a pre-cropped half at archived_photo. The legacy
+    // `crop` coordinates on these pages are relative to the original spread — applying
+    // them to archived_photo would double-crop (quarter-width tall-and-narrow image).
+    if (p.split_from_spread && isUsableImageUrl(p.archived_photo)) {
+      return p.archived_photo!;
+    }
+    // Legacy split pages without pre-cropped variants: server-side crop of the original
     if (p.crop?.xStart !== undefined && p.crop?.xEnd !== undefined) {
       const baseUrl = p.archived_photo || p.photo_original || p.photo;
       if (!baseUrl) return '';


### PR DESCRIPTION
## Summary
- Reader's source-image panel was swapping in a quarter-width "tall and narrow" image after the thumbnail decoded
- Root cause: split-from-spread pages have a pre-cropped half stored at `archived_photo`, but the splitter also keeps legacy `crop` coords (relative to the original spread). The `'full'` tier of `TranslationEditor.getImageUrl` was sending both to the image proxy → proxy applied the crop again
- Empirically verified: `archived_photo` raw = 2000×2460 (aspect 0.813), proxied with `cx=0&cw=510` = 1020×2460 (aspect 0.415)
- Fix: mirror the `split_from_spread` fast-path that already exists in `lib/utils.ts` `getPageDisplayUrl` / `getPageThumbUrl` — when `archived_photo` is a usable pre-cropped half, return it directly and skip the crop+proxy branch

## Why thumbnail looked right and main image didn't
`getPageDisplayUrl` (used for `pageDisplayUrl` / thumbnail prop) checks `split_from_spread` first and returns `page.photo` directly. `getImageUrl(_, 'full')` (used for `pageFullUrl` / src prop) skipped that guard and went straight to the crop branch.

## Test plan
- [ ] Open a freshly resplit BPH book in the reader (e.g. one of the 215 books in the spread-translation-crisis cohort that's been re-split). Source panel image should match the thumbnail proportions, not be tall-and-narrow.
- [ ] Open a legacy split book that has `crop` coords but NO pre-cropped `archived_photo` (older splitter output). Should still proxy with crop.
- [ ] Open a non-split page. Unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)