### PR TITLE
Fix broken collection illustrations + librarian page-link mismatch

### DIFF
--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -420,6 +420,7 @@ async function fetchCollectionData(id: string, provider?: string) {
               book_id: { $in: bookIds.slice(0, 200) },
               gallery_quality: { $gte: 0.8 },
               type: { $nin: ['decorative', 'symbol', 'musical_score', 'printer_device', 'printer_mark', 'ornament', 'border'] },
+              archive_status: { $ne: 'source_blocked' },
             }, { maxTimeMS: 3000 })
             .sort({ gallery_quality: -1 })
             .limit(60)
@@ -611,11 +612,15 @@ export default async function CollectionDetailPage({ params, provider }: Props &
   const tier3 = curatedHighlightsData.filter((h: { tier: number }) => h.tier === 3).slice(0, 8);
   const hasCuratedHighlights = curatedHighlightsData.length > 0;
 
-  // Build a diverse pool of ~50 top images (max 2 per book), then randomly pick 9 for display
+  // Build a diverse pool of ~50 top images (max 2 per book), then randomly pick 9 for display.
+  // Only accept records that actually have an extracted/uploaded image — the legacy `image_url`
+  // field can point to an unarchived AIC asset (archive_status: 'source_blocked') whose target
+  // /pages/{book_id}/0000.jpg never got uploaded, producing broken thumbnails on the page.
   const imagePool: typeof galleryImages = [];
   const bookImageCounts = new Map<string, number>();
   for (const img of galleryImages) {
-    const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
+    if (img.archive_status === 'source_blocked') continue;
+    const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl;
     if (!thumb) continue;
     const bid = img.book_id || img.bookId;
     const count = bookImageCounts.get(bid) || 0;
@@ -704,8 +709,8 @@ export default async function CollectionDetailPage({ params, provider }: Props &
               heroImages.length <= 4 ? 'grid-cols-2 sm:grid-cols-4' :
                 'grid-cols-3 sm:grid-cols-6'
             }`}>
-            {heroImages.map((img: { pageId?: string; page_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string }) => {
-              const src = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl || img.imageUrl || img.image_url;
+            {heroImages.map((img: { pageId?: string; page_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string }) => {
+              const src = img.thumbnail_url || img.thumbnailUrl || img.extracted_url || img.extractedUrl;
               const key = `${img.pageId || img.page_id}-${img.detectionIndex ?? img.detection_index}`;
               if (!src) return null;
               return (
@@ -849,8 +854,8 @@ export default async function CollectionDetailPage({ params, provider }: Props &
               </Link>
             </div>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4 mt-5">
-              {diverseGalleryImages.map((img: { pageId?: string; page_id?: string; bookId?: string; book_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; imageUrl?: string; image_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
-                const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl || img.imageUrl || img.image_url;
+              {diverseGalleryImages.map((img: { pageId?: string; page_id?: string; bookId?: string; book_id?: string; detectionIndex?: number; detection_index?: number; thumbnailUrl?: string; thumbnail_url?: string; extractedUrl?: string; extracted_url?: string; museumDescription?: string; museum_description?: string; description?: string; bookTitle?: string; book_title?: string; type?: string }) => {
+                const thumb = img.extracted_url || img.extractedUrl || img.thumbnail_url || img.thumbnailUrl;
                 const pageId = img.pageId || img.page_id;
                 const bookId = img.bookId || img.book_id;
                 const detIdx = img.detectionIndex ?? img.detection_index;

--- a/src/app/librarian/thread/[id]/page.tsx
+++ b/src/app/librarian/thread/[id]/page.tsx
@@ -334,39 +334,70 @@ function SourceCards({ threadId }: { threadId: string }) {
       {expanded && (
         <div className="mt-3 grid gap-3">
           {bookList.map(([bookId, book]) => {
-            const bookUrl = `https://sourcelibrary.org/book/${book.slug || bookId}`;
+            const bookSlug = book.slug || bookId;
+            const sortedPages = [...book.pages].sort((a, b) => a - b);
+            // Single-cited-page: card click jumps straight to that page. Multi-page:
+            // each page number is its own link so the visible "Page N" label and the
+            // destination always match (was a bug where card → /book/{slug} only).
+            const cardHref = sortedPages.length === 1
+              ? `https://sourcelibrary.org/book/${bookSlug}/page-number/${sortedPages[0]}`
+              : `https://sourcelibrary.org/book/${bookSlug}`;
             const thumbUrl = `https://sourcelibrary.org/api/image?url=https://images.sourcelibrary.org/covers/${bookId}.jpg&w=120&q=75`;
             return (
-              <a
+              <div
                 key={bookId}
-                href={bookUrl}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="flex gap-3 p-3 bg-white rounded-lg border border-[#e8e4dc] hover:border-[#c9a86c] transition-colors group"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={thumbUrl}
-                  alt=""
-                  className="w-14 h-20 object-cover rounded flex-shrink-0 bg-[#f0ece4]"
-                  loading="lazy"
-                  onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                />
+                <a href={cardHref} target="_blank" rel="noopener noreferrer" className="flex-shrink-0">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={thumbUrl}
+                    alt=""
+                    className="w-14 h-20 object-cover rounded bg-[#f0ece4]"
+                    loading="lazy"
+                    onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  />
+                </a>
                 <div className="min-w-0 flex-1">
-                  <p className="text-[13px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors" style={{ fontWeight: 400 }}>
-                    {book.title}
-                  </p>
-                  <p className="text-[11px] text-[#8a8480] font-sans mt-0.5">
-                    {book.author}
-                  </p>
-                  <p className="text-[11px] text-[#9e4a3a] font-sans mt-1">
-                    {book.pages.length === 1
-                      ? `Page ${book.pages[0]}`
-                      : `Pages ${book.pages.sort((a, b) => a - b).join(', ')}`
-                    }
+                  <a href={cardHref} target="_blank" rel="noopener noreferrer" className="block">
+                    <p className="text-[13px] font-serif text-[#1a1612] leading-snug group-hover:text-[#9e4a3a] transition-colors" style={{ fontWeight: 400 }}>
+                      {book.title}
+                    </p>
+                    <p className="text-[11px] text-[#8a8480] font-sans mt-0.5">
+                      {book.author}
+                    </p>
+                  </a>
+                  <p className="text-[11px] font-sans mt-1">
+                    {sortedPages.length === 1 ? (
+                      <a
+                        href={`https://sourcelibrary.org/book/${bookSlug}/page-number/${sortedPages[0]}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[#9e4a3a] hover:underline"
+                      >
+                        Page {sortedPages[0]}
+                      </a>
+                    ) : (
+                      <>
+                        <span className="text-[#8a8480]">Pages </span>
+                        {sortedPages.map((p, i) => (
+                          <span key={p}>
+                            <a
+                              href={`https://sourcelibrary.org/book/${bookSlug}/page-number/${p}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-[#9e4a3a] hover:underline"
+                            >
+                              {p}
+                            </a>
+                            {i < sortedPages.length - 1 ? <span className="text-[#8a8480]">, </span> : null}
+                          </span>
+                        ))}
+                      </>
+                    )}
                   </p>
                 </div>
-              </a>
+              </div>
             );
           })}
 


### PR DESCRIPTION
## Summary

Two user-reported bugs from footer feedback:

- **Collection illustration grid** (`/collections/*`) rendered broken thumbs whenever a `gallery_image` had `archive_status='source_blocked'` — e.g. Art Institute of Chicago entries whose IIIF returns 403. Those records carry an `image_url` pointing at `/pages/{book_id}/0000.jpg`, a target that was never uploaded to R2. Now we filter `source_blocked` at query and render time, and stop falling back to `image_url` — only render thumbs that have a real `extracted_url` or `thumbnail_url`. Reported on `/collections/indic-magic` and `/collections/daoist-alchemy`.
- **Librarian thread "Sources" cards** displayed `Page N` but the card `href` was just `/book/{slug}` — clicking opened the book cover, not the cited page. Now: when a single page is cited the card links straight to `/book/{slug}/page-number/N`; with multiple pages, each page number is its own link so the visible label and click destination always agree.

## Test plan

- [ ] `/collections/indic-magic` and `/collections/daoist-alchemy` no longer show 404 thumbnails in the Illustrations grid.
- [ ] Other collection pages (`/collections/hermetica`, `/collections/secret-societies`) still render their illustrations.
- [ ] In a librarian thread with a single-page citation, clicking the source card opens the cited page.
- [ ] In a librarian thread with multi-page citations, each page number is independently clickable and lands on the correct page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)