### PR TITLE
Move Wikipedia comparison above the fold

### DIFF
--- a/src/app/about/by-the-numbers/page.tsx
+++ b/src/app/about/by-the-numbers/page.tsx
@@ -193,6 +193,31 @@ export default function ByTheNumbersPage() {
           </p>
         </section>
 
+        {/* ───── Scale vs Wikipedia ───── */}
+        <section>
+          <h2 className="font-serif text-3xl text-primary mb-6">3.83 billion words on disk</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-white rounded-2xl border border-border-light p-6">
+              <div className="text-sm uppercase tracking-wider text-secondary font-medium mb-3">Source Library</div>
+              <div className="font-serif text-5xl text-primary tabular-nums leading-none mb-2">3.83B</div>
+              <div className="text-sm text-secondary mb-4">words — original languages + English translation</div>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between"><span className="text-secondary">Original-language OCR</span><span className="tabular-nums text-primary">1.69B</span></div>
+                <div className="flex justify-between"><span className="text-secondary">English translation</span><span className="tabular-nums text-primary">2.14B</span></div>
+              </div>
+            </div>
+            <div className="bg-white rounded-2xl border border-border-light p-6">
+              <div className="text-sm uppercase tracking-wider text-secondary font-medium mb-3">English Wikipedia, for scale</div>
+              <div className="font-serif text-5xl text-primary tabular-nums leading-none mb-2">~4.4B</div>
+              <div className="text-sm text-secondary mb-4">words across ~6.9M articles</div>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between"><span className="text-secondary">Source Library / Wikipedia</span><span className="tabular-nums text-primary">87%</span></div>
+                <div className="flex justify-between"><span className="text-secondary">Translation alone</span><span className="tabular-nums text-primary">49%</span></div>
+              </div>
+            </div>
+          </div>
+        </section>
+
         {/* ───── Reading-readiness ───── */}
         <section>
           <h2 className="font-serif text-3xl text-primary mb-2">From scan to readable text</h2>
@@ -450,41 +475,6 @@ export default function ByTheNumbersPage() {
               <div className="font-serif text-4xl text-primary tabular-nums leading-none mb-2">{fmt(HERO.entityPlaces)}</div>
               <div className="text-sm text-secondary">
                 Cities, monasteries, libraries, regions — geocoded where possible and linked to the books that mention them.
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* ───── Words & corpus scale ───── */}
-        <section>
-          <h2 className="font-serif text-3xl text-primary mb-2">3.8 billion words</h2>
-          <p className="text-secondary mb-8 max-w-2xl">
-            Counted directly from the OCR and translation text on disk: the corpus contains about{' '}
-            <span className="text-primary font-medium">1.69 billion words</span> in original languages and{' '}
-            <span className="text-primary font-medium">2.14 billion words</span> of English translation.
-            For comparison, the entire English Wikipedia is roughly 4.4 billion words —
-            the English translation alone is about half its size.
-          </p>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-white rounded-2xl border border-border-light p-6">
-              <div className="text-sm uppercase tracking-wider text-secondary font-medium mb-3">Source Library, full bilingual corpus</div>
-              <div className="font-serif text-5xl text-primary tabular-nums leading-none mb-2">3.83B</div>
-              <div className="text-sm text-secondary mb-4">words on disk (OCR + English translation)</div>
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between"><span className="text-secondary">Original-language OCR</span><span className="tabular-nums text-primary">1.69B words</span></div>
-                <div className="flex justify-between"><span className="text-secondary">English translation</span><span className="tabular-nums text-primary">2.14B words</span></div>
-                <div className="flex justify-between border-t border-border-light pt-2"><span className="text-secondary">Avg words per page</span><span className="tabular-nums text-primary">448 (OCR) · 594 (English)</span></div>
-              </div>
-            </div>
-            <div className="bg-white rounded-2xl border border-border-light p-6">
-              <div className="text-sm uppercase tracking-wider text-secondary font-medium mb-3">English Wikipedia, for scale</div>
-              <div className="font-serif text-5xl text-primary tabular-nums leading-none mb-2">~4.4B</div>
-              <div className="text-sm text-secondary mb-4">words across ~6.9M articles</div>
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between"><span className="text-secondary">Source Library / Wikipedia</span><span className="tabular-nums text-primary">87%</span></div>
-                <div className="flex justify-between"><span className="text-secondary">English translation alone / Wikipedia</span><span className="tabular-nums text-primary">49%</span></div>
-                <div className="flex justify-between border-t border-border-light pt-2"><span className="text-secondary">Continuous reading at 250 wpm, 8h/day</span><span className="tabular-nums text-primary">~9 years</span></div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Moved the "3.83 billion words" / Wikipedia scale comparison up to sit directly below the hero
- Dropped the explanatory paragraph — the two side-by-side cards carry the comparison on their own
- Net change: -10 lines

## Test plan
- [ ] Preview shows the comparison without scrolling on a 1280px-wide viewport
- [ ] Cards stack on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)