### PR TITLE
BPH catalogue: decouple list/grid display from filter; fix detail 404

### DIFF
--- a/src/app/[tenant]/page.tsx
+++ b/src/app/[tenant]/page.tsx
@@ -33,6 +33,9 @@ export default async function TenantRoot({ params, searchParams }: Props) {
   const q = typeof sp.q === 'string' ? sp.q : '';
   const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0') || 0;
   const view = typeof sp.view === 'string' ? sp.view : '';
+  const displayParam = typeof sp.display === 'string' ? sp.display : '';
+  const display: 'list' | 'grid' | undefined =
+    displayParam === 'list' || displayParam === 'grid' ? displayParam : undefined;
 
   // Fetch tenant data
   const db = await getDb();
@@ -92,6 +95,7 @@ export default async function TenantRoot({ params, searchParams }: Props) {
     q,
     offset,
     view,
+    display,
     isBph,
     digitizedUbns,
     catalogTotal,

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -44,11 +44,21 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     const q = typeof sp.q === 'string' ? sp.q : '';
     const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0', 10) || 0;
     const view = typeof sp.view === 'string' ? sp.view : 'books';
+    // Display dimension is independent of the view filter. When unset, default
+    // matches what the partner mockup leads with: catalog→list, books→grid.
+    // Once the user picks an icon, their choice persists across filter switches.
+    const displayParam = typeof sp.display === 'string' ? sp.display : '';
+    const display: 'list' | 'grid' = displayParam === 'list' || displayParam === 'grid'
+        ? displayParam
+        : (view === 'catalog' ? 'list' : 'grid');
 
-    // Strip the inactive view's params so a user landing here from a previous
-    // `/catalog` filter (or vice-versa) doesn't see a URL that looks filtered
-    // when nothing is being applied.
-    const stripKeys = view === 'catalog' ? BOOKS_PARAM_KEYS : CATALOG_PARAM_KEYS;
+    // Strip the inactive display's params so a user landing here from a
+    // previous list/grid choice doesn't see a URL that looks filtered when
+    // nothing is being applied. The list view (BphCatalogBrowser) owns the
+    // c-prefixed keys; the grid view (CollectionFilters/books grid) owns
+    // q/sort/language/offset. Stripping is keyed off the active display, not
+    // the view filter, since either filter can be paired with either display.
+    const stripKeys = display === 'list' ? BOOKS_PARAM_KEYS : CATALOG_PARAM_KEYS;
     const orphans = stripKeys.filter(k => typeof sp[k] === 'string' && sp[k] !== '');
     if (orphans.length > 0) {
         const next = new URLSearchParams();
@@ -109,6 +119,7 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         q,
         offset,
         view,
+        display,
         isBph,
         digitizedUbns,
         catalogTotal,

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -125,6 +125,10 @@ interface Props {
       works" instead of just "{total} works" — matches the partner mockup
       framing where the catalogue size is the denominator. */
   catalogTotal?: number;
+  /** When true, lock the digitised filter to "On Source Library" — the user
+      asked for the digitised+translated filter, so all rows must be SL-backed.
+      Hides the digitisation control in Advanced so the user can't override it. */
+  lockDigitized?: boolean;
 }
 
 export default function BphCatalogBrowser({
@@ -137,6 +141,7 @@ export default function BphCatalogBrowser({
   searchRowSlot,
   resultsHeaderSlot,
   catalogTotal,
+  lockDigitized = false,
 }: Props) {
   const searchParams = useSearchParams();
 
@@ -155,7 +160,7 @@ export default function BphCatalogBrowser({
     language: searchParams.get('clang') || '',
     yearFrom: searchParams.get('cyfrom') || '',
     yearTo: searchParams.get('cyto') || '',
-    digitized: (searchParams.get('cdig') || '') as AdvancedFilters['digitized'],
+    digitized: lockDigitized ? 'sl' : ((searchParams.get('cdig') || '') as AdvancedFilters['digitized']),
   };
   const hasAnyAdv = Object.values(initialAdv).some(v => v !== '');
 
@@ -300,15 +305,21 @@ export default function BphCatalogBrowser({
   };
 
   const clearAll = () => {
+    const cleared: AdvancedFilters = lockDigitized ? { ...EMPTY_ADV, digitized: 'sl' } : EMPTY_ADV;
     setSearchQuery('');
     setKeyword('');
-    setAdv(EMPTY_ADV);
+    setAdv(cleared);
     setOffset(0);
-    fetchWorks('', sort, '', 0, EMPTY_ADV);
-    updateUrl('', sort, '', 0, EMPTY_ADV);
+    fetchWorks('', sort, '', 0, cleared);
+    updateUrl('', sort, '', 0, cleared);
   };
 
-  const advCount = useMemo(() => Object.values(adv).filter(v => v !== '').length, [adv]);
+  // When the digitised filter is locked by the parent (Show digitised list view),
+  // don't count it as a user-applied filter — it's part of the view, not a chip.
+  const advCount = useMemo(
+    () => Object.entries(adv).filter(([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')).length,
+    [adv, lockDigitized]
+  );
   const currentPage = Math.floor(offset / PER_PAGE) + 1;
   const totalPages = Math.ceil(total / PER_PAGE);
 
@@ -320,14 +331,14 @@ export default function BphCatalogBrowser({
     return null;
   };
 
-  // Detail-page URL for a catalog entry. On the BPH subdomain this resolves to
-  // /catalog/{ubn} (rewritten to /embed/bph/catalog/{ubn}); on the main site it
-  // resolves to the same path nested under the library page basePath.
+  // Detail-page URL for a catalog entry. Always nest under basePath so the
+  // link works in every host context: bph.sourcelibrary.org (where the proxy
+  // serves /embed/bph/catalog/{ubn} directly), sourcelibrary.org/embed/bph
+  // (the iframe target — must stay inside /embed/bph or it 404s), and
+  // /libraries/{slug}. The bph subdomain proxy doesn't rewrite /embed/...
+  // paths, so the URL bar will read /embed/bph/catalog/{ubn} there — uglier
+  // than the legacy /catalog/{ubn} but functional in every context.
   const detailUrl = (ubn: string) => {
-    // basePath examples: "/embed/bph", "/libraries/bibliotheca-philosophica-hermetica"
-    if (basePath === '/embed/bph' || basePath === '/embed/bph/') {
-      return `/catalog/${encodeURIComponent(ubn)}`;
-    }
     return `${basePath.replace(/\/$/, '')}/catalog/${encodeURIComponent(ubn)}`;
   };
 
@@ -468,19 +479,21 @@ export default function BphCatalogBrowser({
                 />
               </div>
             </div>
-            <div>
-              <label className="block text-xs text-muted mb-1">Digitization</label>
-              <select
-                value={adv.digitized}
-                onChange={(e) => handleAdvChange('digitized', e.target.value)}
-                className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
-              >
-                <option value="">All</option>
-                <option value="sl">On Source Library</option>
-                <option value="true">Digitised anywhere</option>
-                <option value="false">Not digitised</option>
-              </select>
-            </div>
+            {!lockDigitized && (
+              <div>
+                <label className="block text-xs text-muted mb-1">Digitization</label>
+                <select
+                  value={adv.digitized}
+                  onChange={(e) => handleAdvChange('digitized', e.target.value)}
+                  className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
+                >
+                  <option value="">All</option>
+                  <option value="sl">On Source Library</option>
+                  <option value="true">Digitised anywhere</option>
+                  <option value="false">Not digitised</option>
+                </select>
+              </div>
+            )}
           </div>
           <div className="flex items-center gap-2 mt-4">
             <button

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -1,36 +1,41 @@
 'use client';
 
 /**
- * Unified BPH catalogue. The partner mockup folds the previous
- * /catalog (table of all 27,706 works) and /catalog?view=books (grid of
- * 2,280 digitised+translated covers) into a single page with a
- * segmented toggle:
+ * Unified BPH catalogue. Two independent dimensions:
  *
- *   Show all                       → list view, full bph_works table
- *   Show digitised & translated    → grid view, MongoDB books with covers
+ *   FILTER (view)        Show all (catalog)  vs  Show digitised & translated (books)
+ *   DISPLAY (display)    List  vs  Grid
  *
- * The toggle and the list/grid icons drive the same state — they are
- * two ways to express the same mode. Switching modes navigates so each
- * mode keeps its own URL params (so the URL bar reflects what's actually
- * filtered, matching the rule established in #1640).
+ * The segmented toggle changes FILTER only — preserving the user's display
+ * choice. The list/grid icons change DISPLAY only — preserving the filter.
  *
- * The component renders the shell (heading, toggle, counter, view icons)
- * and the catalogue table when mode='all'. When mode='digitized' it
- * only renders the shell; SharedLibraryView renders the books grid
- * underneath because that grid is fed by server-side data.
+ * Render matrix:
+ *   filter=all     + display=list  → BphCatalogBrowser (full 27,706 works)
+ *   filter=all     + display=grid  → covers grid (renders below; only the
+ *                                    digitised subset has thumbnails, so
+ *                                    a small note explains the gap)
+ *   filter=digitised + display=grid  → covers grid (digitised subset)
+ *   filter=digitised + display=list  → BphCatalogBrowser locked to digitised='sl'
+ *
+ * The covers grid (display=grid) is rendered by SharedLibraryView's books
+ * branch — we only render the unified header here. The BphCatalogBrowser
+ * for display=list is rendered inside this component.
  */
 
-import { useState } from 'react';
 import Link from 'next/link';
 import { LayoutGrid, List } from 'lucide-react';
 import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
 import { useEmbedHref } from '@/lib/EmbedContext';
+import { useState } from 'react';
 
 export type CatalogueMode = 'all' | 'digitized';
+export type CatalogueDisplay = 'list' | 'grid';
 
 interface Props {
-  /** "all" → list view, catalogue table. "digitized" → grid view, books with covers. */
+  /** "all" → no filter, full catalogue. "digitized" → SL-digitised subset only. */
   mode: CatalogueMode;
+  /** "list" → catalogue table. "grid" → covers grid. Independent of mode. */
+  display: CatalogueDisplay;
   /** Total works in bph_works (denominator for the counter, regardless of mode). */
   catalogTotal: number;
   /** When mode='digitized', the count of digitised+translated SL books (server-fetched).
@@ -44,8 +49,14 @@ interface Props {
   tenantSlug?: string;
 }
 
+/** Build a `?view=…&display=…` URL preserving the other dimension's value. */
+function makeHref(basePath: string, view: 'catalog' | 'books', display: CatalogueDisplay) {
+  return `${basePath}?view=${view}&display=${display}`;
+}
+
 export default function BphUnifiedCatalogue({
   mode,
+  display,
   catalogTotal,
   digitizedTotal,
   basePath,
@@ -54,22 +65,24 @@ export default function BphUnifiedCatalogue({
 }: Props) {
   const embedHref = useEmbedHref();
 
-  // Each mode keeps its own URL params; switching modes drops the other set.
-  const allHref = embedHref(`${basePath}?view=catalog`);
-  const digitizedHref = embedHref(`${basePath}?view=books`);
+  // Filter toggle preserves the current display; view toggle preserves the current filter.
+  const allHref = embedHref(makeHref(basePath, 'catalog', display));
+  const digitizedHref = embedHref(makeHref(basePath, 'books', display));
+  const listHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'list'));
+  const gridHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'grid'));
 
-  // For mode='all' the catalogue table owns its own filtered count
+  // For display='list' the catalogue table owns its own filtered count
   // (the count drops as the user types in search). Hoist it up via a
   // callback so the unified header can show "X of 27,706 works".
   const [filteredTotal, setFilteredTotal] = useState<number | null>(null);
   const visibleTotal =
-    mode === 'all' ? (filteredTotal ?? catalogTotal) : digitizedTotal;
+    display === 'list' ? (filteredTotal ?? catalogTotal) : digitizedTotal;
 
   const toggleNode = (
     <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
   );
   const viewIconsNode = (
-    <ViewIcons mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+    <ViewIcons display={display} listHref={listHref} gridHref={gridHref} />
   );
   const counterNode = (
     <span className="text-sm text-muted">
@@ -89,11 +102,12 @@ export default function BphUnifiedCatalogue({
         </p>
       </div>
 
-      {mode === 'all' ? (
-        // BphCatalogBrowser owns the search row and now hosts both the
-        // toggle (inline with filters) and the view icons (in the
-        // results-header row alongside count + sort) — matching the
-        // partner mockup row grouping.
+      {display === 'list' ? (
+        // List view: BphCatalogBrowser owns the search row and now hosts both
+        // the toggle (inline with filters) and the view icons (in the
+        // results-header row alongside count + sort) — matching the partner
+        // mockup row grouping. When mode='digitized', lock the underlying
+        // browser to digitized='sl' so the table reflects the chosen filter.
         <BphCatalogBrowser
           basePath={basePath}
           digitizedUbns={digitizedUbns}
@@ -103,21 +117,30 @@ export default function BphUnifiedCatalogue({
           searchRowSlot={toggleNode}
           resultsHeaderSlot={viewIconsNode}
           catalogTotal={catalogTotal}
+          lockDigitized={mode === 'digitized'}
         />
       ) : (
-        // mode='digitized': no catalogue browser — the books grid lives
-        // in SharedLibraryView. Render the same row chrome ourselves so
-        // the layout matches the mockup. Counter on left, sort + view
-        // icons on right (sort is owned by the books-grid CollectionFilters
-        // component, so we only render the toggle row + counter row here).
+        // Grid view: the covers grid lives in SharedLibraryView (fed by
+        // server-side data). Render the same row chrome ourselves so the
+        // layout matches the mockup. Counter on the left, view icons on the
+        // right (sort lives in CollectionFilters above the grid). When
+        // mode='all' the grid still only shows the digitised subset (it's
+        // the only data with thumbnails) — surface that explicitly so the
+        // user understands why the count differs from "27,706 works".
         <>
           <div className="flex flex-wrap items-center gap-3 mb-3">
             {toggleNode}
           </div>
-          <div className="flex flex-wrap items-center gap-3 mb-4">
+          <div className="flex flex-wrap items-center gap-3 mb-2">
             {counterNode}
             <div className="ml-auto">{viewIconsNode}</div>
           </div>
+          {mode === 'all' && (
+            <p className="text-xs text-muted mb-4">
+              Grid view shows the {digitizedTotal.toLocaleString()} books with digitised scans.
+              Switch to list view to browse the full catalogue.
+            </p>
+          )}
         </>
       )}
     </>
@@ -153,13 +176,13 @@ function SegmentedToggle({
 }
 
 function ViewIcons({
-  mode,
-  allHref,
-  digitizedHref,
+  display,
+  listHref,
+  gridHref,
 }: {
-  mode: CatalogueMode;
-  allHref: string;
-  digitizedHref: string;
+  display: CatalogueDisplay;
+  listHref: string;
+  gridHref: string;
 }) {
   const base =
     'inline-flex items-center justify-center w-9 h-9 transition-colors border border-border-light';
@@ -168,18 +191,18 @@ function ViewIcons({
   return (
     <div className="inline-flex">
       <Link
-        href={allHref}
-        title="List view (all 27,706 works)"
+        href={listHref}
+        title="List view"
         aria-label="List view"
-        className={`${base} rounded-l-md ${mode === 'all' ? active : inactive}`}
+        className={`${base} rounded-l-md ${display === 'list' ? active : inactive}`}
       >
         <List className="w-4 h-4" />
       </Link>
       <Link
-        href={digitizedHref}
-        title="Grid view (digitised & translated)"
+        href={gridHref}
+        title="Grid view"
         aria-label="Grid view"
-        className={`${base} rounded-r-md -ml-px ${mode === 'digitized' ? active : inactive}`}
+        className={`${base} rounded-r-md -ml-px ${display === 'grid' ? active : inactive}`}
       >
         <LayoutGrid className="w-4 h-4" />
       </Link>

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -92,6 +92,8 @@ export interface SharedLibraryViewProps {
   q?: string;
   offset: number;
   view: string;
+  /** Display dimension on the BPH unified catalogue. Independent of `view`. */
+  display?: 'list' | 'grid';
   isBph: boolean;
   digitizedUbns?: Record<string, { id: string; slug: string }>;
   catalogTotal?: number;
@@ -115,6 +117,7 @@ export default function SharedLibraryView({
   q,
   offset,
   view,
+  display,
   isBph,
   digitizedUbns = {},
   catalogTotal = 0,
@@ -131,14 +134,20 @@ export default function SharedLibraryView({
   const hasExternalPartnerUrl = /^https?:\/\//i.test(externalPartnerUrl);
   const embedPolicy = getEmbedUiPolicy(embed);
 
-  // BPH layout modes:
-  //   view === 'books'   → unified catalogue, "Show digitised & translated" mode (grid)
-  //   view === 'catalog' → unified catalogue, "Show all" mode (catalogue table)
-  //   default            → Selected Books + Catalog combo (the main-site landing experience)
-  const showBooksGrid = !isBph || view === 'books';
+  // BPH layout: `view` selects the FILTER (catalog = all 27,706, books =
+  // digitised+translated subset). `display` selects the VIEW MODE (list =
+  // BphCatalogBrowser table, grid = book covers grid). The two are independent —
+  // clicking the list/grid icons changes display only; the Show all / Show
+  // digitised toggle changes view only. Default landing (no view) keeps the
+  // legacy Selected Books + Catalog combo.
   const showSelectedBooksRow = isBph && view !== 'books' && view !== 'catalog';
   const showUnifiedCatalogue = isBph && (view === 'books' || view === 'catalog');
   const catalogueMode = view === 'books' ? 'digitized' : 'all';
+  const effectiveDisplay: 'list' | 'grid' =
+    display ?? (catalogueMode === 'digitized' ? 'grid' : 'list');
+  // Render the books grid for non-BPH tenants always; for BPH only when the
+  // unified shell is active AND the user picked grid display.
+  const showBooksGrid = !isBph || (showUnifiedCatalogue && effectiveDisplay === 'grid');
 
   return (
     <div className="min-h-screen bg-cream">
@@ -323,6 +332,7 @@ export default function SharedLibraryView({
         {showUnifiedCatalogue && (
           <BphUnifiedCatalogue
             mode={catalogueMode}
+            display={effectiveDisplay}
             catalogTotal={catalogTotal}
             digitizedTotal={total}
             basePath={basePath}


### PR DESCRIPTION
## Summary

Two related BPH catalogue fixes from partner feedback:

- **Decouple display (list/grid icons) from filter (Show all / Show digitised toggle).** Previously the icons and toggle were aliased — clicking a view icon also flipped the filter. Now they're independent dimensions tracked via separate URL params (`view` for filter, new `display` for list/grid). Default mapping on first arrival is unchanged (catalog→list, books→grid). All four combinations now render reasonably; the new `lockDigitized` prop on `BphCatalogBrowser` enables the previously-missing "digitised + list" combo by pre-applying `digitized='sl'`.
- **Fix 404 on Show-all row click in the iframe-on-sourcelibrary.org context.** `detailUrl` had a special case returning `/catalog/{ubn}` when `basePath === '/embed/bph'` to keep the bph subdomain URL bar pretty (the subdomain proxy rewrites `/catalog/{ubn}` → `/embed/bph/catalog/{ubn}`). But when the iframe loads from `sourcelibrary.org/embed/bph` (no subdomain rewrite), `/catalog/{ubn}` 404s. Always nest under basePath now.

## Test plan
- [ ] On bph.sourcelibrary.org: clicking the list/grid icons keeps the filter (toggle position) unchanged
- [ ] On bph.sourcelibrary.org: clicking the toggle keeps the user's display (list/grid) choice unchanged
- [ ] view=books + display=list shows the BphCatalogBrowser table with only digitised rows; advanced panel hides the Digitisation control
- [ ] view=catalog + display=grid shows the covers grid with the explanatory note about the gap
- [ ] In the EFM iframe (sourcelibrary.org/embed/bph), clicking a Show-all row navigates to the catalogue detail page (no 404)
- [ ] Existing e2e bph-iframe.spec passes (orphan-stripping logic still keys off display=list ≈ legacy view=catalog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)