### PR TITLE
Imports: request native IIIF resolution instead of fixed downscales

### DIFF
--- a/scripts/import/batch-import-istc-bsb.mjs
+++ b/scripts/import/batch-import-istc-bsb.mjs
@@ -108,7 +108,7 @@ function extractPages(manifest) {
     let imageUrl = imageResource?.['@id'] || '';
     const imageService = imageResource?.service?.['@id'];
     if (imageService) {
-      imageUrl = `${imageService}/full/2000,/0/default.jpg`;
+      imageUrl = `${imageService}/full/full/0/default.jpg`;
     }
     let thumbnail = imageUrl;
     if (imageService) {

--- a/scripts/import/import-thirukkural.ts
+++ b/scripts/import/import-thirukkural.ts
@@ -134,7 +134,7 @@ async function importBook(client: MongoClient, book: BookImport) {
   const now = new Date();
 
   const getPageImageUrl = (n: number) =>
-    `https://archive.org/download/${book.ia_identifier}/page/n${n}/full/pct:50/0/default.jpg`;
+    `https://archive.org/download/${book.ia_identifier}/page/n${n}/full/full/0/default.jpg`;
   const getThumbnailUrl = (n: number) =>
     `https://archive.org/download/${book.ia_identifier}/page/n${n}/full/pct:15/0/default.jpg`;
 

--- a/scripts/import/ndl-daoist-import.mjs
+++ b/scripts/import/ndl-daoist-import.mjs
@@ -236,7 +236,7 @@ async function main() {
       const imageService = imageResource?.service?.['@id'];
 
       if (imageService) {
-        imageUrl = `${imageService}/full/1000,/0/default.jpg`;
+        imageUrl = `${imageService}/full/full/0/default.jpg`;
       }
 
       let thumbnailUrl = imageUrl;

--- a/src/app/api/books/[id]/reimport/route.ts
+++ b/src/app/api/books/[id]/reimport/route.ts
@@ -149,7 +149,7 @@ export const POST = withAuth(async (request, session, context) => {
 
       // Create fresh pages
       const getPageImageUrl = (pageNum: number) =>
-        `https://archive.org/download/${identifier}/page/n${pageNum}/full/pct:50/0/default.jpg`;
+        `https://archive.org/download/${identifier}/page/n${pageNum}/full/full/0/default.jpg`;
 
       const getThumbnailUrl = (pageNum: number) =>
         `https://archive.org/download/${identifier}/page/n${pageNum}/full/pct:15/0/default.jpg`;

--- a/src/app/api/import/e-rara/route.ts
+++ b/src/app/api/import/e-rara/route.ts
@@ -207,12 +207,12 @@ export const POST = withCuratorAuth(async (request, session) => {
       const canvas = canvases[index];
       const serviceId = canvas?.images?.[0]?.resource?.service?.['@id'];
       if (serviceId) {
-        return `${serviceId}/full/2000,/0/default.jpg`;
+        return `${serviceId}/full/full/0/default.jpg`;
       }
-      // Fallback to webcache
+      // Fallback to webcache (max-res variant)
       const canvasId = canvas?.['@id']?.split('/').pop();
       if (canvasId) {
-        return `https://www.e-rara.ch/download/webcache/2000/${canvasId}`;
+        return `https://www.e-rara.ch/download/webcache/0/${canvasId}`;
       }
       return null;
     };

--- a/src/app/api/import/gallica/route.ts
+++ b/src/app/api/import/gallica/route.ts
@@ -125,11 +125,10 @@ export const POST = withCuratorAuth(async (request, session) => {
     const bookId = new ObjectId();
     const bookIdStr = bookId.toHexString();
 
-    // Gallica IIIF image URL pattern
-    // Full quality: /full/full/0/default.jpg (native resolution, typically 3000-5000px)
-    // Display: /full/2000,/0/default.jpg (capped at 2000px wide for reasonable file sizes)
+    // Gallica IIIF image URL pattern — native resolution (typically 3000-5000px).
+    // Archive script downscales for display; we want the full source for posterity.
     const getPageImageUrl = (pageNum: number) =>
-      `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/f${pageNum + 1}/full/2000,/0/default.jpg`;
+      `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/f${pageNum + 1}/full/full/0/default.jpg`;
 
     const getThumbnailUrl = (pageNum: number) =>
       `https://gallica.bnf.fr/iiif/ark:/12148/${ark}/f${pageNum + 1}/full/200,/0/default.jpg`;

--- a/src/app/api/import/google-books/route.ts
+++ b/src/app/api/import/google-books/route.ts
@@ -151,7 +151,7 @@ export const POST = withCuratorAuth(async (request, session) => {
     const bookIdStr = bookId.toHexString();
 
     const getPageImageUrl = (pageNum: number) =>
-      `https://archive.org/download/${ia_identifier}/page/n${pageNum}/full/pct:50/0/default.jpg`;
+      `https://archive.org/download/${ia_identifier}/page/n${pageNum}/full/full/0/default.jpg`;
     const getThumbnailUrl = (pageNum: number) =>
       `https://archive.org/download/${ia_identifier}/page/n${pageNum}/full/pct:15/0/default.jpg`;
 

--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -174,7 +174,7 @@ export const POST = withCuratorAuth(async (request, session) => {
 
     // IA image URL pattern
     const getPageImageUrl = (pageNum: number) =>
-      `https://archive.org/download/${ia_identifier}/page/n${pageNum}/full/pct:50/0/default.jpg`;
+      `https://archive.org/download/${ia_identifier}/page/n${pageNum}/full/full/0/default.jpg`;
 
     const getThumbnailUrl = (pageNum: number) =>
       `https://archive.org/download/${ia_identifier}/page/n${pageNum}/full/pct:15/0/default.jpg`;

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -316,7 +316,7 @@ export const POST = withCuratorAuth(async (request, session) => {
         const imageService = service?.id || service?.['@id'];
 
         if (imageService) {
-          imageUrl = `${imageService}/full/2000,/0/default.jpg`;
+          imageUrl = `${imageService}/full/full/0/default.jpg`;
         }
 
         let thumbnailUrl = canvas.thumbnail?.[0]?.id || '';
@@ -337,7 +337,7 @@ export const POST = withCuratorAuth(async (request, session) => {
         const imageService = imageResource?.service?.['@id'];
 
         if (imageService) {
-          imageUrl = `${imageService}/full/2000,/0/default.jpg`;
+          imageUrl = `${imageService}/full/full/0/default.jpg`;
         }
 
         let thumbnailUrl = imageUrl;

--- a/src/app/api/import/loc/route.ts
+++ b/src/app/api/import/loc/route.ts
@@ -80,7 +80,7 @@ function pickBestImage(variants: LOCFileVariant[]): { photo: string; thumbnail: 
   if (jp2?.info) {
     // IIIF Image API — construct from info endpoint base
     const iiifBase = jp2.info.replace(/\/info\.json$/, '');
-    photo = `${iiifBase}/full/2000,/0/default.jpg`;
+    photo = `${iiifBase}/full/full/0/default.jpg`;
     thumbnail = `${iiifBase}/full/200,/0/default.jpg`;
   }
 

--- a/src/app/api/import/mdz/route.ts
+++ b/src/app/api/import/mdz/route.ts
@@ -156,7 +156,7 @@ export const POST = withCuratorAuth(async (request, session) => {
     // Format: bsb_id_pagenum (padded to 5 digits)
     const getPageImageUrl = (pageNum: number) => {
       const paddedPage = String(pageNum + 1).padStart(5, '0');
-      return `https://api.digitale-sammlungen.de/iiif/image/v2/${normalizedId}_${paddedPage}/full/2000,/0/default.jpg`;
+      return `https://api.digitale-sammlungen.de/iiif/image/v2/${normalizedId}_${paddedPage}/full/full/0/default.jpg`;
     };
 
     const getThumbnailUrl = (pageNum: number) => {

--- a/src/app/api/import/wellcome/route.ts
+++ b/src/app/api/import/wellcome/route.ts
@@ -197,8 +197,8 @@ export const POST = withCuratorAuth(async (request, session) => {
       const imageUrl = canvas?.images?.[0]?.resource?.service?.['@id'] ||
                        canvas?.images?.[0]?.resource?.['@id'];
       if (imageUrl) {
-        // Use IIIF Image API for consistent sizing
-        return `${imageUrl}/full/2000,/0/default.jpg`;
+        // Use IIIF Image API at native resolution
+        return `${imageUrl}/full/full/0/default.jpg`;
       }
       return null;
     };

--- a/src/lib/import-utils.ts
+++ b/src/lib/import-utils.ts
@@ -201,7 +201,7 @@ export function extractCanvasImage(canvas: IIIFCanvas): { photo: string; thumbna
 
     if (serviceId) {
       return {
-        photo: `${serviceId}/full/1000,/0/default.jpg`,
+        photo: `${serviceId}/full/full/0/default.jpg`,
         thumbnail: `${serviceId}/full/200,/0/default.jpg`,
       };
     }
@@ -214,7 +214,7 @@ export function extractCanvasImage(canvas: IIIFCanvas): { photo: string; thumbna
     const serviceId = body.service?.[0]?.id || body.service?.[0]?.['@id'];
     if (serviceId) {
       return {
-        photo: `${serviceId}/full/1000,/0/default.jpg`,
+        photo: `${serviceId}/full/full/0/default.jpg`,
         thumbnail: `${serviceId}/full/200,/0/default.jpg`,
       };
     }


### PR DESCRIPTION
## Summary

Flips all import-time IIIF URL construction from \`/full/1000,/\` (and \`/full/2000,/\`, \`/full/pct:50/\`) to \`/full/full/0/default.jpg\` — native source resolution.

## Why

Closing the gap that the hires-illustrations backfill (PR #1655) just plugged. Every new book imported via Wellcome / MDZ / Gallica / e-rara / IA / LoC / etc. was previously stamping its \`photo\` URL with a hardcoded downscale parameter. When R2 archived that URL it stored the already-downscaled image. The backfill worker had to re-derive the full-res URL after the fact.

This fix makes the initial import pick up the native-res image, so archived_photo is correct from day one and no future backfill pass will be needed.

Thumbnail URLs stay at small fixed sizes (200px) — those are display-only and should not balloon.

## Touched

- \`src/lib/import-utils.ts\` — the shared IIIF canvas helper used by every flow
- \`src/app/api/import/{e-rara,iiif,loc,wellcome,mdz,gallica,ia,google-books}/route.ts\` — provider-specific importers
- \`src/app/api/books/[id]/reimport/route.ts\` — re-import endpoint
- \`scripts/import/{batch-import-istc-bsb,ndl-daoist-import,import-thirukkural}\`

## Out of scope (left alone)

- \`src/app/api/gallery/image/[id]/route.ts\` and \`/hires/route.ts\` — these do on-the-fly derivative resizing; the size param there is correct behavior.
- \`/full/200,/\`, \`pct:15\` — thumbnails stay small intentionally.
- \`direct-import-cosmogony.ts\` already used \`pct:100\` (= full).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Run a small import via one of the API routes on the preview deploy and confirm the resulting page docs have \`photo\` ending in \`/full/full/\`
- [ ] Confirm a subsequent archive-ocr.mjs run on that book picks up the native-res image (size should match what the source IIIF server actually has, not a 2000px cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)