### PR TITLE
api-auth: tune limits from log-only data + flag npm MCP as legacy

### DIFF
--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -72,8 +72,11 @@ export default function DevelopersPage() {
 
         <div className="space-y-4 mb-8">
           <div className="bg-white rounded-xl border border-border-light overflow-hidden">
-            <div className="bg-stone-100 px-4 py-2 border-b border-border-light">
+            <div className="bg-stone-100 px-4 py-2 border-b border-border-light flex items-center justify-between">
               <span className="text-sm font-medium text-stone-700">Claude Code (remote &mdash; no install)</span>
+              <span className="text-xs text-muted">
+                Add <code className="text-stone-700">-H &quot;Authorization: Bearer YOUR_KEY&quot;</code> for higher limits
+              </span>
             </div>
             <pre className="p-4 text-sm overflow-x-auto bg-stone-900 text-stone-100">
 {`claude mcp add source-library https://sourcelibrary.org/api/mcp`}
@@ -81,8 +84,9 @@ export default function DevelopersPage() {
           </div>
 
           <div className="bg-white rounded-xl border border-border-light overflow-hidden">
-            <div className="bg-stone-100 px-4 py-2 border-b border-border-light">
+            <div className="bg-stone-100 px-4 py-2 border-b border-border-light flex items-center justify-between">
               <span className="text-sm font-medium text-stone-700">Claude Code (local via npm)</span>
+              <span className="text-xs text-muted">Legacy &mdash; prefer remote above</span>
             </div>
             <pre className="p-4 text-sm overflow-x-auto bg-stone-900 text-stone-100">
 {`claude mcp add source-library -- npx -y @source-library/mcp-server`}

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -38,10 +38,12 @@ export interface ApiAuthDecision {
 }
 
 // Tier limits applied per IP / user / key per window.
-// Tuned to be generous for signed-in users and just-tight-enough for anon
-// to make signing in worth it for anyone reading more than a couple of books.
+// Anon 60/hr — calibrated to flag bursty scrapers without bothering casual
+// browsing. Session 1,000/hr — generous for any human research session;
+// dropped from 5,000 after 16h of data showed the heaviest signed-in user
+// did 13 hits in 16h. Anyone hitting 1,000/hr is using a key anyway.
 const ANON_LIMIT_PER_HOUR = Number(process.env.API_ANON_LIMIT_PER_HOUR || 60);
-const SESSION_LIMIT_PER_HOUR = Number(process.env.API_SESSION_LIMIT_PER_HOUR || 5000);
+const SESSION_LIMIT_PER_HOUR = Number(process.env.API_SESSION_LIMIT_PER_HOUR || 1000);
 
 // User-Agent substrings that get the verified-bot bypass. Reverse-DNS verification
 // would be the gold standard; for now we rely on UA strings since the only cost

--- a/src/lib/api-budget.ts
+++ b/src/lib/api-budget.ts
@@ -27,8 +27,14 @@ export interface BudgetCheck {
   tier: 'apikey' | 'session' | 'anon';
 }
 
-const ANON_DAILY_PAGES = Number(process.env.API_ANON_PAGES_PER_DAY || 50);
-const SESSION_DAILY_PAGES = Number(process.env.API_SESSION_PAGES_PER_DAY || 500);
+// Tuned 2026-05-11 from 16h of log-only data: only one caller exceeded 50/day
+// (philosophers-corpus, an AI research agent at 65 pages). Bumping anon to 100
+// gives borderline cases room while still flagging real scrapers. Session was
+// wildly oversized — heaviest signed-in user did 13 hits in 16h, zero close
+// to 500 pages — but a research session reading parallel translations could
+// plausibly need 200.
+const ANON_DAILY_PAGES = Number(process.env.API_ANON_PAGES_PER_DAY || 100);
+const SESSION_DAILY_PAGES = Number(process.env.API_SESSION_PAGES_PER_DAY || 200);
 
 function pickLimit(identity: ApiIdentity): { limit: number; tier: BudgetCheck['tier'] } {
   if (identity.kind === 'apikey' || identity.kind === 'bot') {


### PR DESCRIPTION
## What

After 16 hours of log-only data from the auth gate (PRs #1660/#1663/#1665), adjust the default limits to match actual production traffic, and mark the npm MCP install as legacy.

### Limit tuning

| Limit | Before | After | Reason |
|---|---:|---:|---|
| Anon hits/hr | 60 | **60** (unchanged) | The one would-block burst (philosophers-corpus, 31 search calls in <1min) is exactly what this is meant to flag |
| Anon pages/day | 50 | **100** | One agent (philosophers-corpus) hit 65 — borderline-honest. 100 gives similar cases room before blocking |
| Session hits/hr | 5,000 | **1,000** | Heaviest signed-in user did 13 hits in 16h. 5K was wildly oversized; anyone real won't notice the change |
| Session pages/day | 500 | **200** | No signed-in user came near 50/day; 200 is still > any human research session |

All env-tunable via `API_ANON_LIMIT_PER_HOUR`, `API_ANON_PAGES_PER_DAY`, `API_SESSION_LIMIT_PER_HOUR`, `API_SESSION_PAGES_PER_DAY`.

### npm MCP install marked "Legacy"

`@source-library/mcp-server` (the npm package) calls our public REST API unauthenticated. Once `API_AUTH_ENFORCE=1` flips on, npm-MCP users will hit the gate. The remote MCP install (`claude mcp add source-library https://sourcelibrary.org/api/mcp -H "Authorization: Bearer ..."`) supports passing a key at install time and is now the supported path.

The /developers page now:
- Labels the npm install block "Legacy — prefer remote above"
- Hints next to the remote install that adding `-H "Authorization: Bearer YOUR_KEY"` unlocks higher limits

Still **log-only** — `API_AUTH_ENFORCE` remains unset. Once a week or so of /text traffic accumulates and we've reviewed the budget data, flip enforcement on in Vercel env.

## Test plan
- [ ] After deploy, hit `/api/search?q=test` 61 times anonymously and confirm the 61st triggers `would_block: true` with reason `anon_rate_limit` in `api_usage` (gate still in log-only)
- [ ] Visit `/developers`: confirm npm block has "Legacy" badge and remote block shows the `-H Authorization` hint
- [ ] Visit /developers signed-in, generate a key, confirm the MCP install line in the success card matches the new remote-with-key format

🤖 Generated with [Claude Code](https://claude.com/claude-code)