### PR TITLE
BPH catalogue: fix Show all toggle being a no-op

### DIFF
--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -6,14 +6,17 @@
  *   FILTER (view)        Show all (catalog)  vs  Show digitised & translated (books)
  *   DISPLAY (display)    List  vs  Grid
  *
- * The segmented toggle changes FILTER only — preserving the user's display
- * choice. The list/grid icons change DISPLAY only — preserving the filter.
+ * The segmented toggle changes FILTER. "Show digitised" preserves the
+ * user's display choice; "Show all" forces list because grid can't actually
+ * represent the full catalogue (thumbnails only exist for the digitised
+ * subset). The list/grid icons change DISPLAY only — preserving the filter.
  *
  * Render matrix:
  *   filter=all     + display=list  → BphCatalogBrowser (full 27,706 works)
  *   filter=all     + display=grid  → covers grid (renders below; only the
  *                                    digitised subset has thumbnails, so
- *                                    a small note explains the gap)
+ *                                    a small note explains the gap — reached
+ *                                    via the grid icon, not the filter toggle)
  *   filter=digitised + display=grid  → covers grid (digitised subset)
  *   filter=digitised + display=list  → BphCatalogBrowser locked to digitised='sl'
  *
@@ -65,8 +68,13 @@ export default function BphUnifiedCatalogue({
 }: Props) {
   const embedHref = useEmbedHref();
 
-  // Filter toggle preserves the current display; view toggle preserves the current filter.
-  const allHref = embedHref(makeHref(basePath, 'catalog', display));
+  // "Show all" forces list display: grid only renders books with thumbnails
+  // (the digitised subset), so preserving grid here would make the toggle a
+  // visual no-op — the very bug a user reported as "Show all doesn't show
+  // all". List is the only display that can faithfully show the full 27,706
+  // works. "Show digitised" preserves display since both modes work for that
+  // subset. View-icons toggle still preserves the current filter.
+  const allHref = embedHref(makeHref(basePath, 'catalog', 'list'));
   const digitizedHref = embedHref(makeHref(basePath, 'books', display));
   const listHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'list'));
   const gridHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'grid'));
@@ -109,6 +117,12 @@ export default function BphUnifiedCatalogue({
         // mockup row grouping. When mode='digitized', lock the underlying
         // browser to digitized='sl' so the table reflects the chosen filter.
         <BphCatalogBrowser
+          // Remount when the filter toggles. BphCatalogBrowser seeds its
+          // `adv.digitized` state from `lockDigitized` once in `useState`,
+          // and has no effect to reset it when the prop flips — so without a
+          // key the table keeps the previous filter and "Show all" appears
+          // not to work.
+          key={`bph-cat-${mode}`}
           basePath={basePath}
           digitizedUbns={digitizedUbns}
           tenantSlug={tenantSlug}


### PR DESCRIPTION
## Summary
Partner reported: "Show all button doesn't do anything / doesn't show all."

Two bugs combined since the list/grid decoupling in #1673:

- **Grid mode**: clicking Show all preserved `display=grid`, but the covers grid only renders books with thumbnails (the digitised subset). Toggle highlight flipped, content was identical. Now Show all forces `display=list` — the only display that can actually show all 27,706 works.
- **List mode**: `BphCatalogBrowser` seeded `adv.digitized` from `lockDigitized` in `useState` once and never reset it when the prop flipped. Switching from Show digitised to Show all left the `'sl'` filter stuck in state. Added `key={mode}` so the browser remounts on filter toggle.

## Test plan
- [ ] On bph.sourcelibrary.org/: click Show all → lands on list view with all 27,706 works (not just the digitised subset).
- [ ] On bph.sourcelibrary.org/catalog?view=books (digitised list): click Show all → table refreshes to show all works, digitised filter cleared.
- [ ] Show digitised still preserves the user's list/grid choice.
- [ ] Grid icon still works from any filter and stays in grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)