### PR TITLE
BPH: surface editor when author is "Unknown" (magazines, anthologies)

### DIFF
--- a/scripts/backfill-bph-editor-from-catalogue.mjs
+++ b/scripts/backfill-bph-editor-from-catalogue.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Backfill MongoDB books.editor (and fix books.author='Unknown') from the
+ * BPH Supabase catalogue.
+ *
+ * Context: 124 BPH-provider books in MongoDB are stored with the literal
+ * string author='Unknown'. The BPH catalogue (Supabase bph_works) often has
+ * the responsible party for these — usually an editor (Waite, Thomasius,
+ * Prszybram, …) but occasionally an author whose name wasn't captured at
+ * import time. The book detail page renders "Unknown" because that's what's
+ * in the data; partner-reported as confusing (Chiara, BPH).
+ *
+ * For each book with author='Unknown' that has a numeric UBN matching a row
+ * in bph_works:
+ *   - If bph_works.author is set: overwrite book.author with the catalogue
+ *     value (the import lost it; this restores it).
+ *   - Else if bph_works.editor is set: set book.editor (book.author stays
+ *     'Unknown' — UI fallback renders the editor instead).
+ *   - Else (catalogue also has neither): leave the record alone.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   SUPABASE_SERVICE_KEY=$(grep SUPABASE_SERVICE_ROLE_KEY ~/vibecodingevents/.env.local | cut -d= -f2)
+ *   node scripts/backfill-bph-editor-from-catalogue.mjs --dry-run
+ *   node scripts/backfill-bph-editor-from-catalogue.mjs
+ *
+ * Idempotent — safe to re-run. Doesn't touch records whose author is already
+ * a real name.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const SUPABASE_URL = 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (!SUPABASE_KEY) {
+  console.error('SUPABASE_SERVICE_KEY required');
+  process.exit(1);
+}
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI required');
+  process.exit(1);
+}
+
+function extractUbn(dcIdentifier) {
+  if (typeof dcIdentifier === 'string' && /^\d+$/.test(dcIdentifier)) return dcIdentifier;
+  if (Array.isArray(dcIdentifier)) {
+    for (const v of dcIdentifier) {
+      if (typeof v === 'string' && /^\d+$/.test(v)) return v;
+    }
+  }
+  return null;
+}
+
+async function lookupCatalogue(ubns) {
+  const out = new Map();
+  // Chunk to keep URL safe.
+  const CHUNK = 200;
+  for (let i = 0; i < ubns.length; i += CHUNK) {
+    const chunk = ubns.slice(i, i + CHUNK);
+    const inList = chunk.map((u) => `"${u}"`).join(',');
+    const url = `${SUPABASE_URL}/rest/v1/bph_works?ubn=in.(${encodeURIComponent(inList).replace(/%2C/g, ',').replace(/%22/g, '"')})&select=ubn,author,editor,variant_author,pseudonym`;
+    const res = await fetch(url, {
+      headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+    });
+    if (!res.ok) throw new Error(`Supabase ${res.status}: ${await res.text()}`);
+    const rows = await res.json();
+    for (const r of rows) out.set(r.ubn, r);
+  }
+  return out;
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI, { socketTimeoutMS: 120_000 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  console.log('Loading BPH books with author="Unknown"…');
+  const docs = await db
+    .collection('books')
+    .find(
+      { 'image_source.provider': 'bph', author: 'Unknown' },
+      { projection: { id: 1, slug: 1, title: 1, 'dublin_core.dc_identifier': 1, editor: 1 } }
+    )
+    .toArray();
+
+  const linkable = [];
+  let skippedNoUbn = 0;
+  for (const d of docs) {
+    const ubn = extractUbn(d.dublin_core?.dc_identifier);
+    if (!ubn) {
+      skippedNoUbn++;
+      continue;
+    }
+    linkable.push({ id: d.id, slug: d.slug, title: d.title, ubn, currentEditor: d.editor });
+  }
+  console.log(`  ${docs.length} unknown-author BPH books`);
+  console.log(`  ${linkable.length} with usable UBN`);
+  console.log(`  ${skippedNoUbn} skipped (no numeric UBN — likely IIIF imports)`);
+
+  const ubns = linkable.map((l) => l.ubn);
+  console.log('\nLooking up bph_works rows…');
+  const cat = await lookupCatalogue(ubns);
+  console.log(`  ${cat.size} catalogue rows fetched`);
+
+  const updates = [];
+  let neither = 0;
+  for (const row of linkable) {
+    const r = cat.get(row.ubn);
+    if (!r) {
+      neither++;
+      continue;
+    }
+    const author = (r.author || r.variant_author || r.pseudonym || '').trim();
+    const editor = (r.editor || '').trim();
+    if (author) {
+      updates.push({ id: row.id, set: { author }, kind: 'author', ubn: row.ubn, title: row.title });
+    } else if (editor) {
+      updates.push({ id: row.id, set: { editor }, kind: 'editor', ubn: row.ubn, title: row.title });
+    } else {
+      neither++;
+    }
+  }
+
+  console.log(`\n  ${updates.filter((u) => u.kind === 'author').length} books → restore author from catalogue`);
+  console.log(`  ${updates.filter((u) => u.kind === 'editor').length} books → set editor from catalogue (author stays "Unknown")`);
+  console.log(`  ${neither} books → catalogue has neither author nor editor; leaving as-is`);
+
+  if (DRY_RUN) {
+    console.log('\nDRY RUN — first 5 author restorations:');
+    for (const u of updates.filter((x) => x.kind === 'author').slice(0, 5)) {
+      console.log(`  ${u.id} ubn=${u.ubn}  author ← "${u.set.author}"  (${u.title?.slice(0, 60)})`);
+    }
+    console.log('\nDRY RUN — first 5 editor assignments:');
+    for (const u of updates.filter((x) => x.kind === 'editor').slice(0, 5)) {
+      console.log(`  ${u.id} ubn=${u.ubn}  editor ← "${u.set.editor}"  (${u.title?.slice(0, 60)})`);
+    }
+    await client.close();
+    return;
+  }
+
+  console.log('\nApplying updates…');
+  let applied = 0;
+  for (const u of updates) {
+    const res = await db.collection('books').updateOne({ id: u.id }, { $set: u.set });
+    if (res.modifiedCount > 0) applied++;
+  }
+  console.log(`  ${applied} books updated`);
+
+  await client.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/backfill-bph-sl-book-ids.mjs
+++ b/scripts/backfill-bph-sl-book-ids.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Backfill bph_works.sl_book_id (and sl_book_slug) from MongoDB.
+ *
+ * Why: the BPH catalogue UI uses `digitized=sl` to filter to BPH works that
+ * have an SL book. The API query is `WHERE sl_book_id IS NOT NULL`, but that
+ * column was never populated — the digitised set lives in MongoDB
+ * (image_source.provider='bph' with dublin_core.dc_identifier == UBN).
+ * Without this backfill, "Show digitised & translated" in the list view is
+ * empty for every search.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   SUPABASE_SERVICE_KEY=$(grep SUPABASE_SERVICE_ROLE_KEY ~/vibecodingevents/.env.local | cut -d= -f2)
+ *   node scripts/backfill-bph-sl-book-ids.mjs --dry-run
+ *   node scripts/backfill-bph-sl-book-ids.mjs
+ *
+ * Idempotent: runs PATCH … WHERE ubn = UBN. Re-running just refreshes slug
+ * values for any books that were renamed since the last run.
+ *
+ * Scope:
+ *   - Only books where image_source.provider='bph' AND dublin_core.dc_identifier
+ *     is a plain numeric string (the BPH catalogue UBN format).
+ *   - Books imported via IIIF where dc_identifier is `["IIIF:https://…"]` are
+ *     not linkable to a UBN by this script (104 books at last count). They
+ *     need a separate IIIF-URL → UBN resolution step, out of scope here.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const SUPABASE_URL = 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DRY_RUN = process.argv.includes('--dry-run');
+const PARALLEL = 10;
+
+if (!SUPABASE_KEY) {
+  console.error('SUPABASE_SERVICE_KEY env var required (use Supabase service-role key)');
+  process.exit(1);
+}
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI env var required');
+  process.exit(1);
+}
+
+const headers = {
+  apikey: SUPABASE_KEY,
+  Authorization: `Bearer ${SUPABASE_KEY}`,
+  'Content-Type': 'application/json',
+  Prefer: 'return=minimal',
+};
+
+function extractUbn(dcIdentifier) {
+  // UBN format observed in BPH catalogue: short numeric string (4-6 digits).
+  if (typeof dcIdentifier === 'string' && /^\d+$/.test(dcIdentifier)) return dcIdentifier;
+  if (Array.isArray(dcIdentifier)) {
+    for (const v of dcIdentifier) {
+      if (typeof v === 'string' && /^\d+$/.test(v)) return v;
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI, {
+    socketTimeoutMS: 120_000,
+    serverSelectionTimeoutMS: 30_000,
+  });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  console.log('Loading BPH books with dc_identifier from MongoDB…');
+  const docs = await db
+    .collection('books')
+    .find(
+      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true, $ne: '' } },
+      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 } }
+    )
+    .toArray();
+
+  const linkable = [];
+  let skippedNoUbn = 0;
+  for (const d of docs) {
+    const ubn = extractUbn(d.dublin_core?.dc_identifier);
+    if (!ubn) {
+      skippedNoUbn++;
+      continue;
+    }
+    linkable.push({ ubn, id: d.id, slug: d.slug || d.id });
+  }
+  console.log(`  ${docs.length} BPH books in MongoDB`);
+  console.log(`  ${linkable.length} linkable via numeric UBN`);
+  console.log(`  ${skippedNoUbn} skipped (non-UBN dc_identifier — typically IIIF-import books)`);
+  console.log('');
+
+  if (DRY_RUN) {
+    console.log('DRY RUN — first 5 updates that would be issued:');
+    for (const x of linkable.slice(0, 5)) {
+      console.log(`  ubn=${x.ubn} → sl_book_id=${x.id} sl_book_slug=${x.slug}`);
+    }
+    await client.close();
+    return;
+  }
+
+  let updated = 0;
+  let notFound = 0;
+  let failed = 0;
+  const errors = [];
+
+  for (let i = 0; i < linkable.length; i += PARALLEL) {
+    const chunk = linkable.slice(i, i + PARALLEL);
+    const results = await Promise.allSettled(
+      chunk.map(async (row) => {
+        const url = `${SUPABASE_URL}/rest/v1/bph_works?ubn=eq.${encodeURIComponent(row.ubn)}`;
+        const res = await fetch(url, {
+          method: 'PATCH',
+          headers: { ...headers, Prefer: 'return=representation' },
+          body: JSON.stringify({ sl_book_id: row.id, sl_book_slug: row.slug }),
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (!res.ok) {
+          throw new Error(`${res.status} ${await res.text()}`);
+        }
+        const body = await res.json();
+        return Array.isArray(body) ? body.length : 0;
+      })
+    );
+
+    for (let j = 0; j < results.length; j++) {
+      const r = results[j];
+      if (r.status === 'fulfilled') {
+        if (r.value > 0) updated++;
+        else notFound++;
+      } else {
+        failed++;
+        if (errors.length < 10) errors.push(`ubn=${chunk[j].ubn}: ${r.reason.message}`);
+      }
+    }
+
+    if ((i + PARALLEL) % 200 === 0 || i + PARALLEL >= linkable.length) {
+      process.stdout.write(
+        `\r  progress: ${Math.min(i + PARALLEL, linkable.length)} / ${linkable.length}  (updated=${updated} not-in-bph_works=${notFound} failed=${failed})`
+      );
+    }
+  }
+  console.log('\n');
+  console.log(`Done. updated=${updated}, not-in-bph_works=${notFound}, failed=${failed}`);
+  if (errors.length > 0) {
+    console.log('\nFirst errors:');
+    for (const e of errors) console.log('  ' + e);
+  }
+
+  await client.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -607,13 +607,32 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
               {book.display_title && book.title !== book.display_title && (
                 <p className="text-stone-400 mt-1 italic text-sm sm:text-base">{book.title}</p>
               )}
-              <p className="text-lg sm:text-xl text-stone-300 mt-2">
-                {embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
-                  <Link href={authorUrl(book.author)!} className="hover:text-white transition-colors">
-                    <AuthorName author={book.author} />
-                  </Link>
-                ) : <AuthorName author={book.author} />}
-              </p>
+              {/* Byline: prefer author; fall back to "edited by {editor}" for
+                  magazines / edited volumes / anthologies where the catalogue
+                  has no single author. When both fields are present, show
+                  author with the editor as a secondary credit. The literal
+                  string "Unknown" is the BPH import's placeholder, not a real
+                  attribution — treat it as missing. */}
+              {(() => {
+                const editor = ((book as { editor?: string }).editor || '').trim();
+                const hasRealAuthor = !!book.author && !/^unknown$/i.test(book.author.trim());
+                return (
+                  <p className="text-lg sm:text-xl text-stone-300 mt-2">
+                    {hasRealAuthor ? (
+                      embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
+                        <Link href={authorUrl(book.author)!} className="hover:text-white transition-colors">
+                          <AuthorName author={book.author} />
+                        </Link>
+                      ) : <AuthorName author={book.author} />
+                    ) : editor ? (
+                      <span>edited by <AuthorName author={editor} /></span>
+                    ) : <AuthorName author={book.author} />}
+                    {hasRealAuthor && editor && (
+                      <span className="text-stone-400 text-base"> · edited by <AuthorName author={editor} /></span>
+                    )}
+                  </p>
+                );
+              })()}
 
               {/* DOI badge */}
               {book.doi && (


### PR DESCRIPTION
## Summary
Partner-reported (Chiara, BPH): UBN 14998 \"The unknown world…\" shows \"Author: Unknown\" on the book detail page even though the BPH catalogue lists Waite, Arthur Edward as editor. Same pattern affects every magazine, festschrift, and edited volume imported from BPH.

Two parts:

**Data backfill** (already run in production): \`scripts/backfill-bph-editor-from-catalogue.mjs\` reconciles MongoDB book records against the Supabase \`bph_works\` catalogue. For the 124 BPH books with \`author='Unknown'\` (the import's placeholder), looked up the matching catalogue row and either restored the catalogue's author (5 books) or set a new \`editor\` field (46 books). 51 books were left as-is because the catalogue itself has no responsible party. 22 IIIF-only imports without a numeric UBN are out of scope.

**UI** (this PR): book detail hero now treats \`author='Unknown'\` as missing and, when an editor exists, renders \"edited by X\" instead. When both are present, the editor appears as a secondary credit.

## Test plan
- [ ] Visit /book/the-unknown-world-a-magazine-devoted-to-the-occult-sciences → byline reads \"edited by Waite, Arthur Edward\" (not \"Unknown\").
- [ ] Visit /book/al-coranus-s-lex-islamitica-muhammedis (UBN 223) → byline reads \"edited by Hinckelmann, Abraham\".
- [ ] Visit a regular BPH book with a real author → byline unchanged.
- [ ] Visit a book with neither author nor editor (51 left in this state) → still says \"Unknown\" since we have no better signal; this is honest and matches the catalogue.

## Out of scope (follow-up issue #1682)
- Book cards / search results — still display \"Unknown\" for these records. Same byline-fallback logic should move into \`CollectionBookCard\` and search result cards.
- Citation builder + JSON-LD (\`citation_author\`) — currently emits \"Unknown\"; should follow the same fallback.
- 22 IIIF-only BPH books with non-numeric \`dc_identifier\` — need a separate IIIF→UBN resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)