### PR TITLE
BPH catalogue: don't auto-open Advanced when filter is locked

### DIFF
--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -162,7 +162,14 @@ export default function BphCatalogBrowser({
     yearTo: searchParams.get('cyto') || '',
     digitized: lockDigitized ? 'sl' : ((searchParams.get('cdig') || '') as AdvancedFilters['digitized']),
   };
-  const hasAnyAdv = Object.values(initialAdv).some(v => v !== '');
+  // "Has a user-applied advanced filter?" — drives whether the Advanced
+  // panel is open on mount. Exclude the digitised filter when it's forced
+  // by `lockDigitized` (the parent's "Show digitised & translated" toggle)
+  // so the panel doesn't auto-open just because the user picked a top-level
+  // view. Same exclusion rule as `advCount` below.
+  const hasAnyAdv = Object.entries(initialAdv).some(
+    ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
+  );
 
   const [works, setWorks] = useState<BphWork[]>([]);
   const [total, setTotal] = useState(0);


### PR DESCRIPTION
## Summary
Partner-reported (Chiara, BPH): switching to list view opened the Advanced search section automatically, when it should stay collapsed until the user clicks the Advanced button.

The Advanced panel uses \`hasAnyAdv\` as its open-on-mount signal — true if any advanced filter value is non-empty. But the "Show digitised & translated" toggle forces \`adv.digitized='sl'\` via the parent's \`lockDigitized\` prop, and that non-empty value was counted as a user-applied filter, opening the panel.

Fix: apply the same exclusion rule we already use for the \`advCount\` badge — a filter locked by the parent view doesn't count as a user-applied filter.

## Test plan
- [ ] Visit bph.sourcelibrary.org/, toggle to "Show digitised & translated", switch to list view → Advanced section is collapsed (button visible, panel hidden).
- [ ] Click Advanced → panel opens. Enter an author. Reload → panel stays open (because there's a real applied filter now).
- [ ] Toggle to "Show all" → panel stays collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)