### PR TITLE
Likes/favorites: resolve tenant from target when proxy header is missing

### DIFF
--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -11,6 +11,53 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { LikeTargetType } from '@/lib/types';
 
 /**
+ * Resolve the tenantId that a like for this target should be filed under.
+ *
+ * Toggle requests come in from many surfaces: tenant subdomains, /[tenant]/...
+ * paths, and (most often) global URLs like /book/{slug}, /favorites, and
+ * /gallery/image/{id}. The proxy can only attach a tenant header for the first
+ * two. For the rest, we fall back to looking up the target's own tenantId —
+ * books, pages, and gallery images all carry one. This keeps likes correctly
+ * scoped without relying on the request path.
+ */
+async function resolveTargetTenantId(
+  db: Awaited<ReturnType<typeof getDb>>,
+  targetType: LikeTargetType,
+  targetId: string
+): Promise<string | null> {
+  try {
+    if (targetType === 'book') {
+      const book = await db.collection('books').findOne(
+        { $or: [{ id: targetId }, { slug: targetId }] },
+        { projection: { tenantId: 1 } }
+      );
+      return (book?.tenantId as string) || null;
+    }
+    if (targetType === 'page') {
+      const page = await db.collection('pages').findOne(
+        { id: targetId },
+        { projection: { tenantId: 1 } }
+      );
+      return (page?.tenantId as string) || null;
+    }
+    if (targetType === 'image') {
+      // Image targetIds are `{pageId}:{detectionIndex}` — the tenant lives on
+      // the parent page.
+      const pageId = targetId.split(':')[0] || targetId.split('-').slice(0, -1).join('-');
+      if (!pageId) return null;
+      const page = await db.collection('pages').findOne(
+        { id: pageId },
+        { projection: { tenantId: 1 } }
+      );
+      return (page?.tenantId as string) || null;
+    }
+  } catch {
+    // Lookup failures fall through to null — the caller decides what to do.
+  }
+  return null;
+}
+
+/**
  * POST /api/likes
  *
  * Toggle a like for a target. If already liked, removes it. If not, adds it.
@@ -39,15 +86,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { id: tenantId } = getTenantContextFromRequest(request);
+    const db = await getDb();
+
+    // Prefer the tenant header attached by the proxy; fall back to the
+    // target's own tenantId for likes initiated from non-tenant URLs.
+    let tenantId = getTenantContextFromRequest(request).id;
+    if (!tenantId) {
+      tenantId = await resolveTargetTenantId(db, target_type as LikeTargetType, target_id);
+    }
     if (!tenantId) {
       return NextResponse.json(
-        { error: 'Tenant not found' },
-        { status: 400 }
+        { error: 'Target not found' },
+        { status: 404 }
       );
     }
 
-    const db = await getDb();
     const filter = { target_type, target_id, visitor_id, tenantId };
 
     // Atomic toggle: try to delete first — if nothing was deleted, insert
@@ -124,6 +177,12 @@ export async function POST(request: NextRequest) {
  *   - visitor_id: string (optional, to check if liked)
  *
  * Example: /api/likes?targets=[{"type":"image","id":"abc:0"}]&visitor_id=xyz
+ *
+ * Tenant scoping: when the request carries a tenant header (subdomain or
+ * /[tenant]/ route), counts are scoped to that tenant. Without a tenant
+ * header — the common case for likes initiated from /book/{slug},
+ * /favorites, etc. — we count across all tenants. Target IDs are globally
+ * unique so the cross-tenant count is the correct one.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -158,12 +217,7 @@ export async function GET(request: NextRequest) {
     }
 
     const { id: tenantId } = getTenantContextFromRequest(request);
-    if (!tenantId) {
-      return NextResponse.json(
-        { error: 'Tenant not found' },
-        { status: 400 }
-      );
-    }
+    const tenantFilter = tenantId ? { tenantId } : {};
 
     const db = await getDb();
 
@@ -171,7 +225,7 @@ export async function GET(request: NextRequest) {
     const countPipeline = [
       {
         $match: {
-          tenantId,
+          ...tenantFilter,
           $or: targets.map(t => ({
             target_type: t.type,
             target_id: t.id,
@@ -208,7 +262,7 @@ export async function GET(request: NextRequest) {
     // Check if visitor has liked (if visitor_id provided)
     if (visitorId) {
       const visitorLikes = await db.collection('likes').find({
-        tenantId,
+        ...tenantFilter,
         visitor_id: visitorId,
         $or: targets.map(t => ({
           target_type: t.type,


### PR DESCRIPTION
## Summary
Reported: favorites not working for users. Confirmed via API probe — \`POST /api/likes\` and \`GET /api/likes\` return \`{\"error\":\"Tenant not found\"}\` from any non-tenant URL (sourcelibrary.org/, /book/{slug}, /favorites, /collections/{slug}, /gallery/image/{id}). That covers basically every surface where the heart appears for canonical-URL traffic.

Root cause: the tenant-scoping pass in f39f2656 (2026-04-21) made the likes API require a tenant header attached by the proxy. The proxy only attaches one for tenant subdomains (\`bph.sourcelibrary.org\`) and \`/[tenant]/\` paths — never for global URLs. So most clicks have failed silently since April.

## Fix
- **POST**: when no tenant header, look up the target's own \`tenantId\` (books, pages, and pages-by-image-id all carry one). Likes stay correctly scoped to the target's tenant. Returns 404 only if the target genuinely doesn't exist.
- **GET**: drop the tenant requirement entirely. Target IDs are globally unique so the cross-tenant count is the correct one. When the request carries a tenant header (subdomain), we still scope; otherwise we count across tenants.

The proxy-side fallback chain (referer parsing) stays as-is — it helps other APIs that haven't been refactored. The likes API is now resilient on its own.

## Test plan
- [ ] /book/{slug} → click heart → heart fills, count increments. (Reload: state persists.)
- [ ] /book/{slug} → click heart on a page-level item → cascade still sets book like.
- [ ] /favorites → page renders user's likes (via /api/likes/mine, already lenient).
- [ ] bph.sourcelibrary.org/book/{slug} → click heart → scoped to BPH tenant (no leak between tenants).
- [ ] Gallery image → click heart → works.
- [ ] Existing tenant-subdomain behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)