### PR TITLE
Tenant subdomain: detect in useEmbedContext to stop SL header leak

### DIFF
--- a/src/components/tenant/TenantLayoutWrapper.tsx
+++ b/src/components/tenant/TenantLayoutWrapper.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { EmbedContext } from '@/lib/EmbedContext';
-import { usePathname } from 'next/navigation';
+import { useEmbedContext } from '@/hooks/useEmbedContext';
 
 export function TenantLayoutWrapper({ children }: { children: React.ReactNode }) {
-    const pathname = usePathname();
-    const onEmbedRoute = pathname?.startsWith('/embed/') ?? false;
-    const inIframe = typeof window !== 'undefined' && window.self !== window.top;
-    const embed = onEmbedRoute || inIframe;
+    // Reuse the central detection — pathname + iframe + tenant subdomain.
+    // Previously this wrapper only checked pathname/iframe, so on tenant
+    // subdomains (bph.sourcelibrary.org) the EmbedContext value was wrong
+    // and the SL header leaked through anywhere consumers gated on it.
+    const { isEmbedded } = useEmbedContext();
 
     return (
-        <EmbedContext.Provider value={embed}>
+        <EmbedContext.Provider value={isEmbedded}>
             {children}
         </EmbedContext.Provider>
     );

--- a/src/hooks/useEmbedContext.ts
+++ b/src/hooks/useEmbedContext.ts
@@ -1,18 +1,49 @@
 /**
- * Hook to detect if the current page is embedded in an iframe
- * and should use embed-specific styling/layout.
+ * Hook to detect if the current page is embedded in an iframe, served
+ * from a tenant subdomain, or rendered under an /embed/ route — any of
+ * which should suppress global Source Library chrome (header, footer,
+ * cross-site links).
  */
 
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+/**
+ * Matches tenant subdomain hosts like `bph.sourcelibrary.org`. Excludes
+ * `www.` and the bare apex — those are the canonical global site.
+ */
+function isTenantSubdomain(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h.startsWith('www.')) return false;
+  if (!/\.sourcelibrary\.(org|com|net)$/.test(h)) return false;
+  return h.split('.').length >= 3;
+}
 
 export function useEmbedContext() {
   const pathname = usePathname();
-
   const onEmbedRoute = pathname?.startsWith('/embed/') ?? false;
-  const inIframe = typeof window !== 'undefined' && window.self !== window.top;
-  const isEmbedded = onEmbedRoute || inIframe;
+
+  // Browser-only signals. SSR and the first client render both compute
+  // these as false (deterministic match → no hydration warning); a
+  // post-mount effect upgrades the state, which is what fixes the
+  // tenant-subdomain leak that was rendering the global SL header on
+  // pages like bph.sourcelibrary.org/collections/foo.
+  const [browserSignals, setBrowserSignals] = useState({
+    inIframe: false,
+    onTenantSubdomain: false,
+  });
+
+  useEffect(() => {
+    setBrowserSignals({
+      inIframe: window.self !== window.top,
+      onTenantSubdomain: isTenantSubdomain(window.location.host),
+    });
+  }, []);
+
+  const isEmbedded =
+    onEmbedRoute || browserSignals.inIframe || browserSignals.onTenantSubdomain;
 
   return { isEmbedded, isLoading: false };
 }


### PR DESCRIPTION
## Summary
Partner-reported (Chiara, BPH): the Source Library Beta header sometimes appeared on bph.sourcelibrary.org when navigating between pages. Hard tenant-lockdown violation.

Root cause: \`useEmbedContext\` only checked \`pathname.startsWith('/embed/')\` and the iframe flag. On a tenant subdomain the proxy rewrites the request internally (e.g. \`/collections/foo\` → \`/embed/bph/collections/foo\`) but the browser URL — and therefore \`usePathname()\` — keeps the original clean path. So \`isEmbedded=false\` on tenant subdomain pages whose underlying components render \`<ConditionalSiteHeader>\` unconditionally (catalog detail, collections detail, etc).

Add a third signal: detect tenant subdomain via \`window.location.host\`. A post-mount effect populates the state so SSR and the first client render still agree — both compute false; the upgrade happens after hydration.

**Trade-off**: a brief flash of header during initial paint before the effect runs. The proper fix (server-side detection via \`x-tenant-slug\` header) needs converting \`ConditionalSiteHeader\` to an async server component, which breaks its import from the client \`SharedLibraryView\`. Tracked as follow-up — this PR is the persistent-leak stopper.

Also updates \`TenantLayoutWrapper\` to reuse the central hook instead of reimplementing the same broken check — the \`EmbedContext\` value was wrong on tenant subdomains for the same reason and propagated to every downstream consumer.

## Test plan
- [ ] bph.sourcelibrary.org/ → no SL header (already worked via forceEmbedded).
- [ ] bph.sourcelibrary.org/collections/{slug} → no SL header (previously leaked).
- [ ] bph.sourcelibrary.org/catalog/{ubn} → no SL header (previously leaked).
- [ ] Back/forward navigation between these pages → no SL header at any step.
- [ ] sourcelibrary.org/ → SL header still renders.
- [ ] sourcelibrary.org/{tenant} (global domain, tenant path) → SL header still renders.
- [ ] Iframe contexts unchanged.

## Follow-up
Server-side detection to eliminate the hydration flash: convert \`ConditionalSiteHeader\` and \`ConditionalFooter\` to async server components reading \`x-tenant-slug\`. Requires also moving the conditional-render decision out of \`SharedLibraryView\` (client) up to its parent server routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)