### PR TITLE
BPH catalogue: title-prefix relevance bump for search

### DIFF
--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -178,8 +178,38 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: result.error.message }, { status: 500 });
   }
 
+  let works = result.data || [];
+
+  // Title-prefix relevance bump (issue #1690).
+  //
+  // When the user has a simple search query (`q`), rows whose title *starts*
+  // with the query should appear before rows where the query merely appears
+  // somewhere else in the record. The underlying ordering (default: title A-Z)
+  // is preserved within each group.
+  //
+  // Implementation: we re-sort the current page in JS using a stable sort that
+  // keeps title-prefix matches first and falls back to the order Postgres
+  // already returned. This avoids any Supabase schema changes (no view, no RPC).
+  //
+  // Limitation: this only re-orders the page that was fetched. If a perfect
+  // prefix match sits on page 2 alphabetically, it will not be promoted to
+  // page 1 — that would require a server-side computed-column sort or an RPC.
+  // For BPH (a few thousand rows) the first page is what users see, so this
+  // fix satisfies the partner complaint without infra changes.
+  if (q.length >= 2 && works.length > 1) {
+    const needle = q.toLocaleLowerCase();
+    // Decorate-sort-undecorate to keep the comparator stable.
+    const decorated = works.map((row, idx) => {
+      const title = (row as { title?: string | null }).title || '';
+      const prefixMatch = title.toLocaleLowerCase().startsWith(needle) ? 0 : 1;
+      return { row, idx, prefixMatch };
+    });
+    decorated.sort((a, b) => a.prefixMatch - b.prefixMatch || a.idx - b.idx);
+    works = decorated.map((d) => d.row);
+  }
+
   return NextResponse.json({
-    works: result.data || [],
+    works,
     total: result.count || 0,
     offset,
     limit,


### PR DESCRIPTION
Closes #1690.

## Problem
When a BPH visitor types a title into the simple-search box (e.g. `tarot`), the matching book often does not appear first. The default sort is already `title` A-Z, so a row whose title merely *contains* the query but starts with an earlier letter (e.g. "Clef absolue...") wins over the row whose title actually *starts with* the query ("The tarot of the Bohemians").

## Approach
In `src/app/api/catalog/bph/route.ts`, after fetching the page from Supabase, stably re-sort the returned rows so that titles starting with the query come first, and the existing A-Z order is preserved within each group.

- Only applies when `q.length >= 2` (matches the existing search threshold).
- Case-insensitive via `toLocaleLowerCase()`.
- No diacritic normalisation — that is #1680 and lands separately.
- The user-visible sort label stays "Title A-Z"; advanced filters, `digitized=sl`, year range, etc. are untouched.

## Why not server-side ORDER BY?
The Supabase JS client doesn't expose computed-expression sorting, and the cleaner options (Postgres view, generated column, or RPC) all require a schema change. Re-sorting the returned page in JS keeps the fix to a single file with zero infra impact.

## Limitation (documented in code)
This only reorders the page that was fetched. If a perfect prefix match would alphabetically sit on page 2, it will not be promoted to page 1. For the BPH catalogue (a few thousand rows, partner traffic concentrated on the first page) this satisfies the partner complaint; a full fix would need an RPC or computed column and can be a follow-up.

## Test plan
- [ ] On `bph.sourcelibrary.org`, search `tarot` with the default sort — confirm "The tarot of the Bohemians..." now appears before "Clef absolue...".
- [ ] Search `tarot` with `digitized=sl` filter — same ordering, no broken filter.
- [ ] Empty `q` — list order is unchanged from current behaviour.
- [ ] Advanced filters (author/title/year range) still work and respect the bump when `q` is also set.