### PR TITLE
BPH: cron to sync bph_works.sl_book_id every 6h

### DIFF
--- a/src/app/api/cron/sync-bph-sl-book-ids/route.ts
+++ b/src/app/api/cron/sync-bph-sl-book-ids/route.ts
@@ -1,0 +1,184 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { SUPABASE_URL } from '@/lib/supabase';
+import { verifyCronAuth } from '@/lib/cron-auth';
+
+export const maxDuration = 120;
+export const preferredRegion = 'fra1';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Keep `bph_works.sl_book_id` (+ `sl_book_slug`) in sync with MongoDB.
+ *
+ * Background: the BPH catalogue UI's "Show digitised & translated" filter
+ * relies on `bph_works.sl_book_id IS NOT NULL`. The link from a BPH UBN to a
+ * Source Library book lives in MongoDB (`image_source.provider === 'bph'`
+ * + `dublin_core.dc_identifier` == UBN). New digitised BPH books would
+ * otherwise never appear in the filtered view until someone re-ran the
+ * one-shot backfill script.
+ *
+ * This cron is the recurring half of that pair — see `scripts/backfill-bph-sl-book-ids.mjs`
+ * (PR #1681) for the manual / first-time-backfill version. The logic here is
+ * identical: PATCH bph_works SET sl_book_id=…, sl_book_slug=… WHERE ubn=UBN.
+ * The PATCH is a no-op when the row is already linked correctly, so running
+ * every 6 hours is cheap.
+ *
+ * Out of scope: BPH books imported via IIIF where `dc_identifier` is a manifest
+ * URL rather than a numeric UBN. Those need a separate IIIF-URL → UBN resolver.
+ */
+
+const PARALLEL = 10;
+// Bail out if we're close to the serverless timeout — better to log a partial
+// run than to die mid-batch. The MongoDB read takes a few seconds and each
+// chunk of 10 PATCH calls takes <1s in practice, so 2k books fits easily.
+const TIME_BUDGET_MS = 110_000;
+
+interface LinkableRow {
+  ubn: string;
+  id: string;
+  slug: string;
+}
+
+function extractUbn(dcIdentifier: unknown): string | null {
+  if (typeof dcIdentifier === 'string' && /^\d+$/.test(dcIdentifier)) return dcIdentifier;
+  if (Array.isArray(dcIdentifier)) {
+    for (const v of dcIdentifier) {
+      if (typeof v === 'string' && /^\d+$/.test(v)) return v;
+    }
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const authError = verifyCronAuth(request);
+  if (authError) return authError;
+
+  const startedAt = Date.now();
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseKey) {
+    return NextResponse.json(
+      { error: 'SUPABASE_SERVICE_ROLE_KEY not configured' },
+      { status: 500 },
+    );
+  }
+
+  const headers = {
+    apikey: supabaseKey,
+    Authorization: `Bearer ${supabaseKey}`,
+    'Content-Type': 'application/json',
+    Prefer: 'return=representation',
+  };
+
+  const db = await getDb();
+
+  // Read all BPH books with a dc_identifier and project just the fields we need.
+  const docs = await db
+    .collection('books')
+    .find(
+      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true, $ne: '' } },
+      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 30_000 },
+    )
+    .toArray();
+
+  const linkable: LinkableRow[] = [];
+  let skippedNoUbn = 0;
+  for (const d of docs) {
+    const ubn = extractUbn((d as { dublin_core?: { dc_identifier?: unknown } }).dublin_core?.dc_identifier);
+    if (!ubn) {
+      skippedNoUbn++;
+      continue;
+    }
+    const id = (d as { id?: string; _id?: unknown }).id;
+    if (!id) continue;
+    linkable.push({ ubn, id, slug: ((d as { slug?: string }).slug) || id });
+  }
+
+  let updated = 0;
+  let notFound = 0;
+  let failed = 0;
+  let processed = 0;
+  let timedOut = false;
+  const errors: string[] = [];
+
+  for (let i = 0; i < linkable.length; i += PARALLEL) {
+    if (Date.now() - startedAt > TIME_BUDGET_MS) {
+      timedOut = true;
+      break;
+    }
+
+    const chunk = linkable.slice(i, i + PARALLEL);
+    const results = await Promise.allSettled(
+      chunk.map(async (row) => {
+        const url = `${SUPABASE_URL}/rest/v1/bph_works?ubn=eq.${encodeURIComponent(row.ubn)}`;
+        const res = await fetch(url, {
+          method: 'PATCH',
+          headers,
+          body: JSON.stringify({ sl_book_id: row.id, sl_book_slug: row.slug }),
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (!res.ok) {
+          throw new Error(`${res.status} ${await res.text()}`);
+        }
+        const body = (await res.json()) as unknown;
+        return Array.isArray(body) ? body.length : 0;
+      }),
+    );
+
+    for (let j = 0; j < results.length; j++) {
+      const r = results[j];
+      processed++;
+      if (r.status === 'fulfilled') {
+        if (r.value > 0) updated++;
+        else notFound++;
+      } else {
+        failed++;
+        if (errors.length < 10) {
+          const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+          errors.push(`ubn=${chunk[j].ubn}: ${msg}`);
+        }
+      }
+    }
+  }
+
+  const summary = {
+    ok: true,
+    total_bph_books: docs.length,
+    linkable_count: linkable.length,
+    skipped_no_ubn: skippedNoUbn,
+    processed,
+    updated,
+    not_in_bph_works: notFound,
+    failed,
+    timed_out: timedOut,
+    duration_ms: Date.now() - startedAt,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+
+  // Best-effort logging to cron_runs for dashboard visibility.
+  try {
+    await db.collection('cron_runs').insertOne({
+      cron: 'sync-bph-sl-book-ids',
+      timestamp: new Date(),
+      duration_ms: summary.duration_ms,
+      status: failed > 0 ? 'partial' : 'success',
+      failed: false,
+      actions: {
+        total_bph_books: summary.total_bph_books,
+        linkable: summary.linkable_count,
+        updated,
+        not_in_bph_works: notFound,
+        failed,
+        skipped_no_ubn: skippedNoUbn,
+      },
+      errors: errors.map((e) => ({ message: e })),
+      error_count: errors.length,
+      summary: timedOut
+        ? `timed-out after ${processed}/${linkable.length} (updated=${updated})`
+        : `synced ${linkable.length} BPH books (updated=${updated}, not-in-bph_works=${notFound}, failed=${failed})`,
+    });
+  } catch {
+    // Non-critical — never let logging break the cron response.
+  }
+
+  return NextResponse.json(summary);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -33,6 +33,10 @@
     {
       "path": "/api/cron/collection-health",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/sync-bph-sl-book-ids",
+      "schedule": "0 */6 * * *"
     }
   ]
 }


### PR DESCRIPTION
Closes #1683.

## Summary
- New cron route `/api/cron/sync-bph-sl-book-ids` runs every 6 hours (`0 */6 * * *` in `vercel.json`) to keep `bph_works.sl_book_id` (and `sl_book_slug`) in sync with MongoDB. Without it, newly digitised BPH books never show up under the BPH catalogue's "Show digitised & translated" filter until the manual backfill is re-run.
- The route inlines the same logic as the one-shot `scripts/backfill-bph-sl-book-ids.mjs` from PR #1681: read BPH books from MongoDB (`image_source.provider='bph'` + numeric `dublin_core.dc_identifier`), then `PATCH bph_works SET sl_book_id, sl_book_slug WHERE ubn=<UBN>` for each. The PATCH is a no-op when the row is already linked, so re-running every 6h is cheap (~2k books, ~few seconds in practice).
- Auth via the shared `verifyCronAuth` helper (`Authorization: Bearer ${CRON_SECRET}`). Uses `SUPABASE_SERVICE_ROLE_KEY` from Vercel env for the PATCH calls. Logs a row to `cron_runs` for dashboard visibility.
- Self-bails after ~110s of work to avoid hitting the serverless timeout if the linkable set ever grows enormously.
- The one-shot script in `scripts/` is left untouched so it's still available for manual reruns and dry-runs.

Out of scope (same as #1683): the 104 IIIF-imported BPH books whose `dc_identifier` is a manifest URL instead of a numeric UBN — those need a separate IIIF→UBN resolver.

## Test plan
- [ ] Verify the cron appears in the Vercel project's Cron Jobs UI after the next production deploy.
- [ ] After the first scheduled run, check `cron_runs` for a `sync-bph-sl-book-ids` entry and that `summary` matches the expected count (~2k linkable today, `updated` should be 0 for steady-state runs).
- [ ] Import a new BPH book and confirm its `bph_works` row gets `sl_book_id` set within 6 hours without anyone having to run the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)