### PR TITLE
BPH catalogue: reconcile digitised count between grid and list

### DIFF
--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -106,8 +106,12 @@ interface Props {
   /** When true, defaults to advanced search expanded */
   defaultAdvanced?: boolean;
   /** Fires whenever the filtered result count updates so a parent shell
-      (the unified catalogue header) can show "X of 27,706 works". */
-  onTotalChange?: (total: number) => void;
+      (the unified catalogue header) can show "X of 27,706 works".
+      `isFiltered` is true when the user has typed a search or applied an
+      advanced filter (not counting parent-locked filters like `lockDigitized`),
+      letting the parent decide whether to show the baseline count or the
+      live filtered count. */
+  onTotalChange?: (total: number, isFiltered: boolean) => void;
   /** When true, hide the inline "{total} works" label on the simple-search
       row — the parent shell shows the count instead. */
   hideInlineCount?: boolean;
@@ -209,6 +213,16 @@ export default function BphCatalogBrowser({
     const controller = new AbortController();
     abortRef.current = controller;
 
+    // A filter is "user-applied" if it's a real search, the keyword chip, or
+    // any advanced field set — but NOT the digitised filter when it was
+    // forced by the parent's lockDigitized toggle. Used by the parent shell
+    // to decide whether to show the baseline count or the filtered count
+    // (e.g. the BPH digitised baseline lives upstream in MongoDB, not in the
+    // Supabase query result this component sees).
+    const isFiltered = !!q || !!kw || Object.entries(a).some(
+      ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
+    );
+
     setLoading(true);
     try {
       const params = buildParams(q, s, kw, off, a);
@@ -216,16 +230,16 @@ export default function BphCatalogBrowser({
       const data = await res.json();
       setWorks(data.works || []);
       setTotal(data.total || 0);
-      onTotalChange?.(data.total || 0);
+      onTotalChange?.(data.total || 0, isFiltered);
     } catch (err) {
       if ((err as Error).name === 'AbortError') return; // superseded by a newer query
       setWorks([]);
       setTotal(0);
-      onTotalChange?.(0);
+      onTotalChange?.(0, isFiltered);
     } finally {
       if (!controller.signal.aborted) setLoading(false);
     }
-  }, [buildParams, onTotalChange]);
+  }, [buildParams, onTotalChange, lockDigitized]);
 
   // Sync URL params (using c-prefixed keys so they don't collide with parent page params).
   // Uses window.history.replaceState rather than router.replace + basePath so the

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -82,9 +82,27 @@ export default function BphUnifiedCatalogue({
   // For display='list' the catalogue table owns its own filtered count
   // (the count drops as the user types in search). Hoist it up via a
   // callback so the unified header can show "X of 27,706 works".
+  // `isFiltered` distinguishes "user has searched/filtered" from "baseline,
+  // showing everything". When mode='digitized' and the user hasn't filtered,
+  // we prefer the MongoDB-derived digitizedTotal (2,280) over the Supabase
+  // count (1,989) — the gap is books whose UBN isn't in bph_works. Showing
+  // the MongoDB total makes the digitised count consistent with the grid
+  // view's count (#1689).
   const [filteredTotal, setFilteredTotal] = useState<number | null>(null);
-  const visibleTotal =
-    display === 'list' ? (filteredTotal ?? catalogTotal) : digitizedTotal;
+  const [isFiltered, setIsFiltered] = useState(false);
+  const handleTotalChange = (total: number, filtered: boolean) => {
+    setFilteredTotal(total);
+    setIsFiltered(filtered);
+  };
+
+  let visibleTotal: number;
+  if (display !== 'list') {
+    visibleTotal = digitizedTotal;
+  } else if (mode === 'digitized' && !isFiltered) {
+    visibleTotal = digitizedTotal;
+  } else {
+    visibleTotal = filteredTotal ?? catalogTotal;
+  }
 
   const toggleNode = (
     <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
@@ -126,7 +144,7 @@ export default function BphUnifiedCatalogue({
           basePath={basePath}
           digitizedUbns={digitizedUbns}
           tenantSlug={tenantSlug}
-          onTotalChange={setFilteredTotal}
+          onTotalChange={handleTotalChange}
           hideInlineCount
           searchRowSlot={toggleNode}
           resultsHeaderSlot={viewIconsNode}


### PR DESCRIPTION
## Summary
Partner-reported (Chiara, BPH): \"Show digitised & translated\" displayed **2,280** in the grid but **1,989** in the list — same toggle, two different numbers. The 291 gap is books in MongoDB whose UBN isn't (yet) in the printed BPH catalogue (\`bph_works\` in Supabase):

- 104 IIIF-only imports (\`dc_identifier=[\"IIIF:https://…\"]\`)
- 136 with no \`dc_identifier\` at all (older imports)
- ~51 stragglers (book has UBN but no matching \`bph_works\` row)

## Fix
UI-side reconciliation. MongoDB is the canonical \"digitised\" count (2,280). When \`mode='digitized'\` and the user hasn't applied a search/filter, the list view's counter now shows \`digitizedTotal\` (2,280) to match the grid. When the user types into the search box or sets an advanced filter, the live filtered count from Supabase takes over (so searching \"tarot\" still reads \"6 of 27,706\" — accurate to the table).

\`BphCatalogBrowser\` now reports whether a user filter is applied alongside the total. The unified header uses that flag to decide which number to display.

## What this does NOT do
Close the underlying data gap. Doing that requires either re-importing a current BPH catalogue dump to add the missing UBNs, or building an IIIF-URL → UBN resolver for the 104 IIIF-only books. Tracked at #1689 for the data side. This PR makes the UI internally consistent so the partner stops seeing two different numbers for the same toggle.

## Test plan
- [ ] Visit bph.sourcelibrary.org/, click \"Show digitised & translated\" → grid counter reads \"2,280 of 27,706 works\".
- [ ] Switch to list view (same filter) → counter still reads \"2,280 of 27,706 works\" (was 1,989 before).
- [ ] Type \"tarot\" in the search box → counter switches to the actual filtered count (\"6 of 27,706\").
- [ ] Clear search → counter returns to 2,280.
- [ ] \"Show all\" + list view unchanged (counter still reflects search-filtered Supabase total).

Closes #1689 (UI portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)