### PR TITLE
BPH catalogue: diacritic-insensitive search (Boehme → Böhme)

### DIFF
--- a/scripts/migration/add-bph-diacritic-normalization.sql
+++ b/scripts/migration/add-bph-diacritic-normalization.sql
@@ -1,0 +1,107 @@
+-- Diacritic-insensitive search for bph_works (issue #1680).
+--
+-- Goal: searching "Boehme" finds "Böhme", "Goerlitz" finds "Görlitz", "Mueller"
+-- finds "Müller". Postgres `unaccent` handles the accent stripping; on top we
+-- collapse the standard German digraphs so the convention "ö ↔ oe" matches
+-- symmetrically. The normalisation runs on both stored values (generated
+-- columns) and the user query (in `src/lib/text-normalize.ts` — keep these
+-- in sync).
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/add-bph-diacritic-normalization.sql
+--
+-- Idempotent. CREATE INDEX without CONCURRENTLY because the script is meant to
+-- be run during a window where bph_works writes are paused (BPH catalogue is
+-- a slow-trickle import, so blocking writes for index build is fine).
+
+CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- IMMUTABLE wrapper. Extension's unaccent() is declared STABLE — generated
+-- columns and expression indexes require IMMUTABLE.
+CREATE OR REPLACE FUNCTION public.immutable_unaccent(text)
+RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+AS $$ SELECT public.unaccent('public.unaccent', $1) $$;
+
+-- normalize_bph_text:
+--   1. lowercase
+--   2. unaccent (strips diacritics: Böhme → Bohme)
+--   3. collapse German digraphs (oe→o, ue→u, ae→a, ss→s)
+--
+-- Order matters. Unaccent first means "Böhme" → "bohme" (no digraph), then the
+-- digraph rules are a no-op on it. "Boehme" → "boehme" → "bohme" via oe→o.
+-- Both forms converge on "bohme" — that's the property we need.
+CREATE OR REPLACE FUNCTION public.normalize_bph_text(t text)
+RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+AS $$
+  SELECT regexp_replace(
+    regexp_replace(
+      regexp_replace(
+        regexp_replace(
+          public.immutable_unaccent(lower(coalesce(t, ''))),
+          'oe', 'o', 'g'
+        ),
+        'ue', 'u', 'g'
+      ),
+      'ae', 'a', 'g'
+    ),
+    'ss', 's', 'g'
+  )
+$$;
+
+-- Generated columns. Each one folds the standard field together with its
+-- variants so a per-field filter (Advanced > Author, etc.) finds variant
+-- spellings without separate ilike calls.
+ALTER TABLE bph_works
+  ADD COLUMN IF NOT EXISTS title_norm      text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ', title, parallel_title, uniform_title))
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS author_norm     text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ', author, variant_author, pseudonym))
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS editor_norm     text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ', editor, variant_editor))
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS place_norm      text GENERATED ALWAYS AS (
+    public.normalize_bph_text(place)
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS printer_norm    text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ', printer, variant_printer))
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS publisher_norm  text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ', publisher, variant_publisher))
+  ) STORED,
+  ADD COLUMN IF NOT EXISTS shelf_mark_norm text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ', shelf_mark, state_shelf_mark))
+  ) STORED,
+  -- Combined column for the general search box (`q` parameter).
+  ADD COLUMN IF NOT EXISTS search_norm     text GENERATED ALWAYS AS (
+    public.normalize_bph_text(concat_ws(' ',
+      title, parallel_title, uniform_title,
+      author, variant_author, pseudonym,
+      editor, variant_editor,
+      place, printer, publisher, variant_printer, variant_publisher,
+      shelf_mark, state_shelf_mark,
+      keywords, language, series_title, volume_title
+    ))
+  ) STORED;
+
+-- Trigram indexes for fast substring search (ILIKE '%pattern%').
+CREATE INDEX IF NOT EXISTS idx_bph_search_norm_trgm
+  ON bph_works USING gin (search_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_title_norm_trgm
+  ON bph_works USING gin (title_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_author_norm_trgm
+  ON bph_works USING gin (author_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_editor_norm_trgm
+  ON bph_works USING gin (editor_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_place_norm_trgm
+  ON bph_works USING gin (place_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_printer_norm_trgm
+  ON bph_works USING gin (printer_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_publisher_norm_trgm
+  ON bph_works USING gin (publisher_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_bph_shelf_mark_norm_trgm
+  ON bph_works USING gin (shelf_mark_norm gin_trgm_ops);

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabase, sanitizeFilterValue } from '@/lib/supabase';
+import { normalizeBphSearchText } from '@/lib/text-normalize';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,6 +30,11 @@ const FIELDS_LEGACY = 'ubn, title, author, year, shelf_mark, keywords, ia_identi
 
 // Cache the schema mode for the lifetime of the runtime.
 let schemaMode: 'new' | 'legacy' | null = null;
+// Tracks whether the `*_norm` diacritic-insensitive columns from
+// add-bph-diacritic-normalization.sql have been applied. Auto-detected on
+// the first query that uses them; falls back to plain ilike on the original
+// columns if they don't exist yet.
+let hasNormalizedColumns: boolean | null = null;
 
 function isMissingColumnError(err: { message?: string; code?: string }): boolean {
   if (!err) return false;
@@ -74,13 +80,21 @@ export async function GET(req: NextRequest) {
     const fields = mode === 'new' ? FIELDS_NEW : FIELDS_LEGACY;
     let query = supabase.from('bph_works').select(fields, { count: 'exact' });
 
-    // Simple search.
+    // Simple search. When the diacritic-normalised `search_norm` column
+    // exists (after applying add-bph-diacritic-normalization.sql), query
+    // against it with the normalised user input so "Boehme" finds "Böhme".
+    // Falls back to the original tsvector / per-field ilike on first miss.
     if (q.length >= 2) {
-      const safe = sanitizeFilterValue(q);
-      if (mode === 'new') {
-        // Full-text across all fields.
+      if (mode === 'new' && hasNormalizedColumns !== false) {
+        const normQ = sanitizeFilterValue(normalizeBphSearchText(q));
+        if (normQ.length > 0) {
+          query = query.ilike('search_norm', `%${normQ}%`);
+        }
+      } else if (mode === 'new') {
+        const safe = sanitizeFilterValue(q);
         query = query.textSearch('search_tsv', safe, { type: 'websearch', config: 'simple' });
       } else {
+        const safe = sanitizeFilterValue(q);
         query = query.or(`title.ilike.%${safe}%,author.ilike.%${safe}%,shelf_mark.ilike.%${safe}%`);
       }
     }
@@ -88,7 +102,18 @@ export async function GET(req: NextRequest) {
     const ilikeFilter = (col: string, val: string) => {
       if (!val) return;
       const safe = sanitizeFilterValue(val);
+      const normVal = sanitizeFilterValue(normalizeBphSearchText(val));
+      const useNorm = mode === 'new' && hasNormalizedColumns !== false && normVal.length > 0;
+
       if (mode === 'new') {
+        // Per-field `*_norm` columns roll up the standard field with its
+        // variants (e.g. author_norm covers author + variant_author +
+        // pseudonym), so one ilike replaces the previous .or() chain.
+        if (useNorm) {
+          const normCol = col === 'shelf_mark' ? 'shelf_mark_norm' : `${col}_norm`;
+          query = query.ilike(normCol, `%${normVal}%`);
+          return;
+        }
         if (col === 'author') {
           query = query.or(`author.ilike.%${safe}%,variant_author.ilike.%${safe}%,pseudonym.ilike.%${safe}%`);
         } else if (col === 'title') {
@@ -165,13 +190,27 @@ export async function GET(req: NextRequest) {
     return await query.range(offset, offset + limit - 1);
   }
 
-  // Try the cached mode; on missing-column error, retry in legacy and remember.
+  // Try the cached mode; on missing-column error, retry — first by
+  // disabling the diacritic-norm columns (the most recent addition), then
+  // by falling back to the legacy schema.
   let result = await runQuery(schemaMode || 'new');
+  if (
+    result.error &&
+    isMissingColumnError(result.error) &&
+    (schemaMode || 'new') === 'new' &&
+    hasNormalizedColumns !== false
+  ) {
+    // Missing column with new schema — likely the *_norm columns aren't
+    // applied yet. Retry without them.
+    hasNormalizedColumns = false;
+    result = await runQuery('new');
+  }
   if (result.error && isMissingColumnError(result.error) && (schemaMode || 'new') === 'new') {
     schemaMode = 'legacy';
     result = await runQuery('legacy');
   } else if (!result.error && schemaMode === null) {
     schemaMode = 'new';
+    if (hasNormalizedColumns === null) hasNormalizedColumns = true;
   }
 
   if (result.error) {

--- a/src/lib/text-normalize.ts
+++ b/src/lib/text-normalize.ts
@@ -1,0 +1,37 @@
+/**
+ * Diacritic + German digraph normalisation for BPH catalogue search.
+ *
+ * MUST match the Postgres `public.normalize_bph_text()` function (see
+ * `scripts/migration/add-bph-diacritic-normalization.sql`) byte-for-byte.
+ * If they diverge, query-side and stored-side disagree and search appears
+ * to silently miss results.
+ *
+ * Pipeline:
+ *   1. Lowercase
+ *   2. NFD-decompose + strip combining diacritics (Böhme → bohme)
+ *   3. Explicit ß → ss (NFD doesn't decompose ß; Postgres `unaccent`
+ *      handles it via its rules file, so the JS side must too)
+ *   4. Collapse German digraphs: oe→o, ue→u, ae→a, ss→s
+ *
+ * Examples:
+ *   "Böhme"    → "bohme"
+ *   "Boehme"   → "bohme"   (matches Böhme — symmetric)
+ *   "Müller"   → "muller"
+ *   "Mueller"  → "muller"  (matches Müller)
+ *   "Goerlitz" → "gorlitz" (matches "Görlitz" → "gorlitz")
+ *   "Straße"   → "strase"  (matches "Strasse" → "strase")
+ *
+ * Issue: #1680.
+ */
+export function normalizeBphSearchText(value: string | null | undefined): string {
+  if (!value) return '';
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/ß/g, 'ss')
+    .replace(/oe/g, 'o')
+    .replace(/ue/g, 'u')
+    .replace(/ae/g, 'a')
+    .replace(/ss/g, 's');
+}


### PR DESCRIPTION
## Summary
Partner-reported (#1680): a user typing "Boehme" finds nothing because works by Jakob Böhme are indexed under the umlauted form. Same for Dürer/Durer, Müller/Mueller, Görlitz/Goerlitz. German-language collection means this is the single biggest unforced error in BPH search relevance.

## What's in this PR

**1. SQL migration** — \`scripts/migration/add-bph-diacritic-normalization.sql\`. NOT auto-applied; needs to be run via the Supabase SQL editor or psql:
\`\`\`
psql "\$DATABASE_URL" -f scripts/migration/add-bph-diacritic-normalization.sql
\`\`\`
Enables \`unaccent\` + \`pg_trgm\`; adds an IMMUTABLE \`normalize_bph_text\` function (unaccent + lower + German digraph collapse oe/ue/ae→o/u/a, ß/ss→s); adds generated \`*_norm\` columns for title/author/editor/place/printer/publisher/shelf_mark — each folding the standard field with its variants — plus a combined \`search_norm\` for the simple-search box; adds GIN trigram indexes on each.

**2. JS-side normaliser** — \`src/lib/text-normalize.ts\`. Mirrors the SQL function byte-for-byte. The query side and stored side must agree or search silently misses results.

**3. API update** — \`/api/catalog/bph\` uses the \`*_norm\` columns when they exist (one ilike per field, replacing the \`.or()\` variant chain). Auto-detects on first PostgREST missing-column error and degrades to the original behaviour (same fallback pattern as the existing \`schemaMode\` legacy detection), so **this change is safe to ship before the migration is applied** — search works as today until the SQL runs, then automatically picks up the new behaviour.

## Symmetric matching the user gets after the migration

| Input | Stored | Match? |
|---|---|---|
| Boehme | Böhme | ✓ |
| Müller | Mueller | ✓ |
| Goerlitz | Görlitz | ✓ |
| Straße | Strasse | ✓ |

## Out of scope
Variant alias search (Behmen, Behmius, Jacob/Jakob) — handled by the entity normalisation system from the 2026-04-02 handoff. BPH books need to be entity-linked first.

## Test plan
- [ ] Deploy this PR. Search behaviour unchanged until the migration runs.
- [ ] Run migration. Confirm \`bph_works.search_norm\` exists.
- [ ] /api/catalog/bph?q=boehme → returns Böhme works.
- [ ] /api/catalog/bph?q=Böhme → returns same set.
- [ ] /api/catalog/bph?author=Mueller → returns Müller works.
- [ ] Existing searches still work (regression check on a few queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)