### PR TITLE
BPH catalogue: surface Advanced filters from grid view

### DIFF
--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -174,6 +174,11 @@ export default function BphCatalogBrowser({
   const hasAnyAdv = Object.entries(initialAdv).some(
     ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
   );
+  // The unified catalogue's grid view links here with `?cadv=1` so the
+  // Advanced panel auto-opens on arrival — partner-requested affordance so
+  // covers-grid users can reach the rich filter UI without first finding
+  // the list/grid icon (issue #1687).
+  const cadvParam = searchParams.get('cadv') === '1';
 
   const [works, setWorks] = useState<BphWork[]>([]);
   const [total, setTotal] = useState(0);
@@ -183,7 +188,7 @@ export default function BphCatalogBrowser({
   const [keyword, setKeyword] = useState(initialKeyword);
   const [offset, setOffset] = useState(initialOffset);
   const [adv, setAdv] = useState<AdvancedFilters>(initialAdv);
-  const [showAdvanced, setShowAdvanced] = useState(defaultAdvanced || hasAnyAdv);
+  const [showAdvanced, setShowAdvanced] = useState(defaultAdvanced || hasAnyAdv || cadvParam);
   const abortRef = useRef<AbortController | null>(null);
 
   const buildParams = useCallback((q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {

--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -26,7 +26,7 @@
  */
 
 import Link from 'next/link';
-import { LayoutGrid, List } from 'lucide-react';
+import { LayoutGrid, List, SlidersHorizontal } from 'lucide-react';
 import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
 import { useEmbedHref } from '@/lib/EmbedContext';
 import { useState } from 'react';
@@ -78,6 +78,14 @@ export default function BphUnifiedCatalogue({
   const digitizedHref = embedHref(makeHref(basePath, 'books', display));
   const listHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'list'));
   const gridHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'grid'));
+  // Grid view doesn't host the Advanced filter panel (those fields query
+  // bph_works in Supabase, which only the list view consumes). When the
+  // user clicks Advanced from the grid we route them to the list view with
+  // `cadv=1` so BphCatalogBrowser auto-opens the panel on arrival. Full
+  // cross-referenced filtering across grid covers is a follow-up (issue
+  // #1687) — this is the minimum-viable affordance.
+  const advancedFromGridHref =
+    embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'list')) + '&cadv=1';
 
   // For display='list' the catalogue table owns its own filtered count
   // (the count drops as the user types in search). Hoist it up via a
@@ -109,6 +117,16 @@ export default function BphUnifiedCatalogue({
   );
   const viewIconsNode = (
     <ViewIcons display={display} listHref={listHref} gridHref={gridHref} />
+  );
+  const advancedButtonNode = (
+    <Link
+      href={advancedFromGridHref}
+      className="inline-flex items-center gap-1.5 text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary hover:bg-warm transition-colors"
+      title="Open advanced filters (switches to list view)"
+    >
+      <SlidersHorizontal className="w-3.5 h-3.5" />
+      Advanced
+    </Link>
   );
   const counterNode = (
     <span className="text-sm text-muted">
@@ -162,6 +180,7 @@ export default function BphUnifiedCatalogue({
         <>
           <div className="flex flex-wrap items-center gap-3 mb-3">
             {toggleNode}
+            {advancedButtonNode}
           </div>
           <div className="flex flex-wrap items-center gap-3 mb-2">
             {counterNode}


### PR DESCRIPTION
## Summary
Partner-reported (Chiara, BPH): the Advanced filter button only existed inside list view, leaving covers-grid users with no way to filter by author / place / printer / year. This PR ships the minimum-viable affordance from issue #1687 — full cross-referenced filtering across grid covers (Supabase bph_works -> UBN -> MongoDB books) is a substantial refactor and remains tracked there.

- Adds an "Advanced" button to the grid-view row chrome in `BphUnifiedCatalogue` (lucide `SlidersHorizontal`, same styling as the existing in-browser Advanced button).
- The button links to the list view with a new `cadv=1` query param.
- `BphCatalogBrowser` now reads `cadv` from `searchParams` and seeds `showAdvanced=true` when present, so the panel auto-opens on arrival.

## URL-param mechanism
Clicking Advanced in grid view sends the user to `?view=...&display=list&cadv=1`. `BphCatalogBrowser` sees `cadv=1` and initialises `showAdvanced = defaultAdvanced || hasAnyAdv || cadvParam`, so the Advanced panel is expanded on the very first render of the list view.

## User flow
1. User on grid view clicks "Advanced".
2. Lands on list view with the Advanced filter panel pre-expanded.
3. Fills filters; results update as they type (existing behaviour).
4. Returns to covers via the grid icon when desired.

## Out of scope (issue #1687 cont.)
- Lifting filter state above both views.
- Cross-referencing `bph_works` filter results to filter the grid covers by UBN.
- Unifying the free-text search between list and grid.

## Test plan
- [ ] On `bph.sourcelibrary.org` grid view, click Advanced -> arrives on list view with Advanced panel open.
- [ ] List-view Advanced button still toggles the panel.
- [ ] Filtering in the panel applies as expected (no regression).
- [ ] Switching back to grid view via the grid icon works.
- [ ] No off-subdomain links introduced (tenant lockdown invariant).

Refs #1687

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)