### PR TITLE
Search: surface Jung books for 'carl jung' / 'c.g. jung' / 'carl gustav jung'

### DIFF
--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -307,6 +307,19 @@ export async function browseArtists(letter: string): Promise<{ name: string; cou
 const SEARCH_SELECT = `${BOOK_SELECT}, summary_text, doi, work_id`;
 
 /**
+ * Author alias groups. Each group lists name variants that should be treated as
+ * equivalent at search time — querying any member surfaces records whose author
+ * field matches any other member.
+ *
+ * Why: the books_catalog `author` column stores a single display form (e.g.
+ * "C.G. Jung" on one record, "Carl Gustav Jung" on another). Without aliasing,
+ * a search for "carl jung" misses the "C.G. Jung" record entirely.
+ */
+const AUTHOR_ALIAS_GROUPS: string[][] = [
+  ['carl jung', 'carl gustav jung', 'c.g. jung'],
+];
+
+/**
  * Search books by title/author text — returns full metadata for search display.
  *
  * Single Supabase query replaces the old two-hop pattern:
@@ -344,7 +357,22 @@ export async function searchBooksCatalog(
   } else if (words.length >= 2) {
     const titleAnds = words.map(w => `title.ilike.%${w}%`).join(',');
     const displayAnds = words.map(w => `display_title.ilike.%${w}%`).join(',');
-    orFilter += `,and(${titleAnds}),and(${displayAnds})`;
+    const authorAnds = words.map(w => `author.ilike.%${w}%`).join(',');
+    orFilter += `,and(${titleAnds}),and(${displayAnds}),and(${authorAnds})`;
+
+    // Author alias expansion: if the query matches a known alias group, also
+    // search authors using each alternate variant in the group.
+    const lowerSafe = safe.toLowerCase();
+    const aliasGroup = AUTHOR_ALIAS_GROUPS.find(group => group.some(a => lowerSafe.includes(a)));
+    if (aliasGroup) {
+      for (const variant of aliasGroup) {
+        if (lowerSafe.includes(variant)) continue;
+        const variantWords = variant.split(/\s+/).filter(w => w.length >= 2);
+        if (variantWords.length < 2) continue;
+        const variantAnds = variantWords.map(w => `author.ilike.%${w}%`).join(',');
+        orFilter += `,and(${variantAnds})`;
+      }
+    }
 
     // Cross-field AND: author + title words (catches "newton principia")
     if (contentWords.length >= 2 && contentWords.length <= 3) {


### PR DESCRIPTION
## Summary
- Author search was substring-only, so 'carl jung' missed 'Carl Gustav Jung' (words not adjacent). Adds AND-of-words for the author column, matching the existing title/display_title behavior.
- Adds a small alias map so 'carl jung', 'carl gustav jung', and 'c.g. jung' all surface both Jung records — without it each query only finds the record whose author field happens to spell the name that way.

Two pre-1930 Jung works exist in the library — *Wandlungen und Symbole der Libido* (author: 'Carl Gustav Jung') and *Psychology of the Unconscious* (author: 'C.G. Jung') — but production search returned zero books for any common spelling of his name.

## Test plan
- [ ] On the preview URL, search 'carl jung' — both books appear in the Books lane
- [ ] Search 'c.g. jung' — both books appear
- [ ] Search 'carl gustav jung' — both books appear
- [ ] Spot-check an unrelated multi-word query (e.g. 'newton principia') still works
- [ ] No regression in cross-field author+title matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)