### PR TITLE
Search AI: scope-aware prompt redirects modern figures to their primary sources

### DIFF
--- a/src/app/api/search/ai-expand/route.ts
+++ b/src/app/api/search/ai-expand/route.ts
@@ -62,7 +62,21 @@ export async function POST(request: NextRequest) {
           contents: [{
             role: 'user',
             parts: [{
-              text: `You are a search guide for Source Library (pre-modern primary sources: 10K+ books, 18K+ artworks).
+              text: `You are a search guide for Source Library (10K+ books, 18K+ artworks).
+
+LIBRARY SCOPE — what's actually here:
+- Texts and artworks from antiquity through ~1850 CE. Sparse coverage 1850–1920; almost nothing after 1920.
+- Core traditions: alchemy (Dorn, Khunrath, Ripley, Maier, Mylius, Trismosin, Flamel), Hermetica (Corpus Hermeticum, Ficino, Bruno, Trismegistus), Kabbalah (Zohar, Luria, Reuchlin, Knorr von Rosenroth), Renaissance natural magic (Agrippa, Della Porta, Dee, Paracelsus), Neoplatonism (Plotinus, Proclus, Iamblichus), Rosicrucian and Masonic texts, gnostic and apocryphal sources, early modern science and medicine, devotional and theological works.
+- Many post-1900 scholars studied this corpus but their OWN works are NOT here. When a visitor searches for one of them, redirect to the primary sources they drew on.
+
+MODERN-FIGURE RULE — if the query names a scholar/author working primarily after ~1900 whose subject IS in the library:
+- C.G. Jung / Carl Jung → alchemy sources he interpreted: Dorn, Khunrath, Ripley, Mylius, Rosarium Philosophorum, Splendor Solis, Aurora Consurgens, Mutus Liber, Atalanta Fugiens
+- Mircea Eliade → primary religious/alchemical texts, gnostic sources, Mithraic and shamanic materials in the library
+- Frances Yates → Bruno, Ficino, Dee, Fludd, Renaissance memory and Hermeticism
+- Gershom Scholem → Zohar, Lurianic kabbalah, Sabbatean texts, Reuchlin
+- Henry Corbin → Suhrawardi, Ibn 'Arabi, Persian Sufi and Ishraqi sources
+- Antoine Faivre / Wouter Hanegraaff → the esoteric primary-source canon broadly
+For these queries: set HINT to not_in_collection, narration acknowledges the figure is out of scope but their sources are here, terms and image_terms point to those primary sources.
 
 Query: "${query}"
 
@@ -77,7 +91,7 @@ Reply in this EXACT XML format:
 HINT = images_first | books_first | not_in_collection
 - images_first: visual art, painting, diagram, illustration
 - books_first: texts, concepts, authors, traditions
-- not_in_collection: outside scope
+- not_in_collection: outside scope OR post-1900 figure whose sources we have
 
 TERMS = 3-5 search terms the visitor wouldn't think of — period-appropriate synonyms, Latin titles, original-language names, specific authors. These DRIVE additional searches.
 IMAGE_TERMS = 2-3 specific artworks, visual subjects, or iconographic themes. These DRIVE gallery image searches.


### PR DESCRIPTION
## Summary
- The 'ai-expand' search guide previously had no date-range awareness and no plan for post-1900 scholars whose subjects are in the library but whose works are not. Searches for Jung/Eliade/Yates/Scholem fell through to embedding noise.
- Adds explicit corpus scope (antiquity → ~1850, sparse after) plus a modern-figure redirect rule with concrete source mappings: Jung → Dorn/Khunrath/Ripley/Rosarium/Splendor Solis, Eliade → gnostic and shamanic primaries, Yates → Bruno/Ficino/Dee, Scholem → Zohar/Lurianic kabbalah, Corbin → Suhrawardi/Ibn Arabi.
- 'not_in_collection' is a layout signal only (no scary banner), so the books lane still surfaces what we do have natively.

Generalizes the spirit of the Jung alias fix (#1701) to the whole class of 20th-century esoteric-studies scholars without per-author plumbing.

## Test plan
- [ ] Preview: search 'carl jung' — narration redirects to alchemy sources; terms include Dorn / Khunrath / Rosarium
- [ ] Preview: search 'mircea eliade' — narration redirects; terms point to gnostic/shamanic primaries
- [ ] Preview: search 'frances yates' — terms include Bruno / Ficino / Dee
- [ ] Preview: search 'gershom scholem' — terms point at kabbalah primaries
- [ ] Preview: search 'plato' — still books_first, terms expand into Ficino translations etc. (no regression on in-scope queries)
- [ ] Preview: search 'phoenix' — image_terms still surface artwork (visual queries still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)