### PR TITLE
BPH cover backfill: fix 80 of 85 flagged covers (#1679 step 2)

### DIFF
--- a/.claude/docs/bph-cover-audit-2026-05-12.json
+++ b/.claude/docs/bph-cover-audit-2026-05-12.json
@@ -1,0 +1,78 @@
+{
+  "audit_date": "2026-05-12",
+  "tenant": {
+    "slug": "bph",
+    "id": "bce03f71-c18d-4460-b8ad-224c817f9aa0"
+  },
+  "counts": {
+    "ok": 2275,
+    "MISSING": 0,
+    "BLANK": 4,
+    "PLACEHOLDER": 1,
+    "TINY": 0,
+    "total_flagged": 5,
+    "total_books": 2280
+  },
+  "results": [
+    {
+      "id": "6974b64619126e775cf6d7e1",
+      "slug": "argonautica-rhodius",
+      "title": "[Greek] Argonauticon libri IIII",
+      "author": "Apollonius Rhodius",
+      "read_count": 5,
+      "state": "BLANK",
+      "reason": "page 2 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/uploads/6974b64619126e775cf6d7e3/6975cf074d40d43aed55fb9e.jpg",
+      "cover_page_number": 2,
+      "book_url": "https://sourcelibrary.org/book/argonautica-rhodius"
+    },
+    {
+      "id": "6970e3729b09d309d780a29e",
+      "slug": "three-dialogues-on-love-abrabanel",
+      "title": "De amore dialogi tres",
+      "author": "Abrabanel, Jehuda",
+      "read_count": 5,
+      "state": "BLANK",
+      "reason": "page 1 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/uploads/6970e3729b09d309d780a2a0/6974c9c561bd780d0f4bc7f3.jpg",
+      "cover_page_number": 1,
+      "book_url": "https://sourcelibrary.org/book/three-dialogues-on-love-abrabanel"
+    },
+    {
+      "id": "69b41863f1200e2ab53cf76f",
+      "slug": "definition-of-chemistry-18th-century-latin-ms",
+      "title": "Chemiae definitio, objectum, origo, usus, et divisio (PH164 bis)",
+      "author": "Unknown",
+      "read_count": 0,
+      "state": "BLANK",
+      "reason": "page 3 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/pages/69b41863f1200e2ab53cf76f/sp69f678d32f484c063061bb61.jpg",
+      "cover_page_number": 3,
+      "book_url": "https://sourcelibrary.org/book/definition-of-chemistry-18th-century-latin-ms"
+    },
+    {
+      "id": "69b418932b0edf3eaa2dd59a",
+      "slug": "hermes-trismegistus-on-the-revolutions-of-nativities-trismegistus",
+      "title": "Hermetis philosophi de revolutionibus nativitatum (PH216)",
+      "author": "Hermes Trismegistus",
+      "read_count": 0,
+      "state": "BLANK",
+      "reason": "page 3 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/pages/69b418932b0edf3eaa2dd59a/sp69f69f4fce732b30b522a9e8.jpg",
+      "cover_page_number": 3,
+      "book_url": "https://sourcelibrary.org/book/hermes-trismegistus-on-the-revolutions-of-nativities-trismegistus"
+    },
+    {
+      "id": "698420e0acbeea3119317589",
+      "slug": "revelation-of-jesus-christ-lautensack",
+      "title": "Offenbahrung Jesu Christi: das ist: ein Beweisz durch den Titul uber das Creutz Jesu Christi",
+      "author": "Lautensack, Paulus",
+      "read_count": 0,
+      "state": "PLACEHOLDER",
+      "reason": "OCR matches digitizer-insert/library-stamp pattern",
+      "cover_url": "https://images.sourcelibrary.org/uploads/698420e0acbeea3119317589/698420e968d949f750af3e57.jpg",
+      "cover_page_number": 2,
+      "book_url": "https://sourcelibrary.org/book/revelation-of-jesus-christ-lautensack"
+    }
+  ]
+}

--- a/.claude/docs/bph-cover-audit-2026-05-12.md
+++ b/.claude/docs/bph-cover-audit-2026-05-12.md
@@ -1,0 +1,27 @@
+# BPH cover-quality audit — 2026-05-12
+
+Issue #1679, step 1. Read-only audit of BPH books with missing, blank, placeholder, or tiny cover thumbnails. Sorted by `read_count` so the most-visited broken covers come first.
+
+## Summary
+
+| Bucket | Count |
+|---|---|
+| Total BPH books | 2280 |
+| OK | 2275 |
+| MISSING | 0 |
+| BLANK | 4 |
+| PLACEHOLDER | 1 |
+| TINY | 0 |
+| **Total flagged** | **5** |
+
+## Top 5 books to fix (by read_count)
+
+| # | State | Reads | Title | Author | Reason | Book |
+|---|---|---:|---|---|---|---|
+| 1 | BLANK | 5 | [Greek] Argonauticon libri IIII | Apollonius Rhodius | page 2 classified as blank | [link](https://sourcelibrary.org/book/argonautica-rhodius) |
+| 2 | BLANK | 5 | De amore dialogi tres | Abrabanel, Jehuda | page 1 classified as blank | [link](https://sourcelibrary.org/book/three-dialogues-on-love-abrabanel) |
+| 3 | BLANK | 0 | Chemiae definitio, objectum, origo, usus, et divisio (PH164 bis) | Unknown | page 3 classified as blank | [link](https://sourcelibrary.org/book/definition-of-chemistry-18th-century-latin-ms) |
+| 4 | BLANK | 0 | Hermetis philosophi de revolutionibus nativitatum (PH216) | Hermes Trismegistus | page 3 classified as blank | [link](https://sourcelibrary.org/book/hermes-trismegistus-on-the-revolutions-of-nativities-trismegistus) |
+| 5 | PLACEHOLDER | 0 | Offenbahrung Jesu Christi: das ist: ein Beweisz durch den Titul uber das Creutz  | Lautensack, Paulus | OCR matches digitizer-insert/library-stamp pattern | [link](https://sourcelibrary.org/book/revelation-of-jesus-christ-lautensack) |
+
+Full ranked list (all 5 flagged books) is in `bph-cover-audit-2026-05-12.json`.

--- a/.claude/docs/bph-cover-fix-2026-05-12-applied.json
+++ b/.claude/docs/bph-cover-fix-2026-05-12-applied.json
@@ -1,0 +1,1432 @@
+{
+  "run_date": "2026-05-12",
+  "mode": "apply",
+  "counts": {
+    "fixed": 82,
+    "skipped": 3,
+    "manual": 0
+  },
+  "fixed": [
+    {
+      "id": "6909d388cf28baa1b4cb0103",
+      "slug": "raphael-explaining-the-art-of-medicine-hafenreffer",
+      "title": "Raphael artem medicam explanans",
+      "read_count": 9,
+      "from": {
+        "page": 4,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/archived/6909d388cf28baa1b4cb0103/4.jpg"
+      },
+      "to": {
+        "page": 6,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/archived/6909d388cf28baa1b4cb0103/6.jpg"
+      }
+    },
+    {
+      "id": "6975158ca88d83c830d99e32",
+      "slug": "aurea-catena-homeri-homer-s-golden-chain-kirchweger",
+      "title": "Aurea Catena Homeri. Das ist: eine Beschreibung von dem Ursprung der Natur",
+      "read_count": 9,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6975158ca88d83c830d99e32/6976560cadf9bff4b18d1351.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/uploads/6975158ca88d83c830d99e32/697656112b32fa340abe4e9e.jpg"
+      }
+    },
+    {
+      "id": "6909aba7cf28baa1b4caef69",
+      "slug": "four-volumes-of-divine-and-human-marvels-champier",
+      "title": "Mirabilium divinorum humanorumque volumina quattuor",
+      "read_count": 7,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/6909aba7cf28baa1b4caef69/sp69f68ed772ffd456014ca2f4-thumb.jpg"
+      },
+      "to": {
+        "page": 5,
+        "strategy": "early:pg5",
+        "url": "https://images.sourcelibrary.org/cropped/6909aba7cf28baa1b4caef69/69f68ed772ffd456014ca2f9.jpg"
+      }
+    },
+    {
+      "id": "6974b64619126e775cf6d7e1",
+      "slug": "argonautica-rhodius",
+      "title": "[Greek] Argonauticon libri IIII",
+      "read_count": 5,
+      "from": {
+        "page": 2,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/cropped/6974b64619126e775cf6d7e3/6975cf174d40d43aed55fba0.jpg"
+      },
+      "to": {
+        "page": 2,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6974b64619126e775cf6d7e3/6975cf074d40d43aed55fb9e.jpg"
+      }
+    },
+    {
+      "id": "6978ee3af4d5bdc7b3df604c",
+      "slug": "chemical-writings-valentinus",
+      "title": "Chymische Schriften",
+      "read_count": 5,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6978ee3af4d5bdc7b3df604c/6978ef5ddf9d25133f71ff71.jpg"
+      },
+      "to": {
+        "page": 6,
+        "page_type": "frontispiece",
+        "strategy": "frontispiece",
+        "url": "https://images.sourcelibrary.org/uploads/6978ee3af4d5bdc7b3df604c/6978ef27df9d25133f71ff6e.jpg"
+      }
+    },
+    {
+      "id": "6970e35c9b09d309d780a25c",
+      "slug": "documentary-account-of-the-german-union-hoffmann",
+      "title": "Aktenmässige Darstellung der Deutschen Union, und ihrer Verbindung mit dem Illuminaten-Freimaurer und Rosenkreuzer-Orden",
+      "read_count": 4,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6970e35c9b09d309d780a25c/6973acf2305e5bdd620129d4.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6970e35c9b09d309d780a25c/6973ad1c305e5bdd620129db.jpg"
+      }
+    },
+    {
+      "id": "6970e3639b09d309d780a270",
+      "slug": "alchymia-denudata-alchemical-unveiled-naxagoras",
+      "title": "Alchymia denudata revisa et aucta, oder Das biss anhero nie recht geglaubte, durch die Experienz nunmehro aber würcklich beglaubte und aus allen Zweiffel gesetzte [...] Wunder der Natur",
+      "read_count": 4,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6970e3639b09d309d780a270/697445fc48817c1381f884fc.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/uploads/6970e3639b09d309d780a270/6974460148817c1381f884ff.jpg"
+      }
+    },
+    {
+      "id": "6977a719ed849ecd7e62d673",
+      "slug": "the-chemical-cato-hanneman",
+      "title": "Cato chemicus tractatus quo verae ac genuinae philosophiae hermeticae, & fucatae ac sophisticae pseudo chemiae & utriusque magistrorum characterismi accurate delineantur",
+      "read_count": 4,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6977a719ed849ecd7e62d673/6977a9203c41d13ddedacadc.jpg"
+      },
+      "to": {
+        "page": 9,
+        "page_type": "text",
+        "strategy": "early:pg9",
+        "url": "https://images.sourcelibrary.org/uploads/6977a719ed849ecd7e62d673/6977a9253c41d13ddedacae3.jpg"
+      }
+    },
+    {
+      "id": "6974b64919126e775cf6d7ed",
+      "slug": "on-the-great-art-democritus",
+      "title": "De arte magna",
+      "read_count": 4,
+      "from": {
+        "page": 11,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6974b64919126e775cf6d7ed/69760527973fcdf772aa9a7e.jpg"
+      },
+      "to": {
+        "page": 9,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6974b64919126e775cf6d7ed/697604c66ab59fe02ae4bb5d.jpg"
+      }
+    },
+    {
+      "id": "697c8e0f6000fdec2f13060c",
+      "slug": "new-geomancy-weigel",
+      "title": "Geomantia nova",
+      "read_count": 4,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697c8e0f6000fdec2f13060c/697c8eb55089aaebdcee2e27.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697c8e0f6000fdec2f13060e/697c8e6c5089aaebdcee2e1c.jpg"
+      }
+    },
+    {
+      "id": "6970e3869b09d309d780a2e0",
+      "slug": "the-open-chest-of-the-most-artful-secret-grasshoff",
+      "title": "Aperta arca arcani artificiosissimi. Das ist: eröffneter und offenstehender Kasten",
+      "read_count": 3,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6970e3869b09d309d780a2e0/697527e3fd0a15987759a8a9.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/uploads/6970e3869b09d309d780a2e0/697527e7fd0a15987759a8ac.jpg"
+      }
+    },
+    {
+      "id": "6979446ddcf302c58a41a4d5",
+      "slug": "commentary-on-the-apocalypse-of-john-deutz",
+      "title": "Commentariorum in Johannis Apocalypsin",
+      "read_count": 3,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6979446ddcf302c58a41a4d5/6979457455e3b340167df4d3.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "illustration",
+        "strategy": "illustration",
+        "url": "https://images.sourcelibrary.org/uploads/6979446ddcf302c58a41a4d5/6979447023681e9d52cdb0ce.jpg"
+      }
+    },
+    {
+      "id": "6988a59e0d60689cec71ff35",
+      "slug": "the-rosicrucian-exposed-ecker-und-eckhoffen",
+      "title": "Der Rosenkreuzer in seiner Blösse. Zum Nutzen der Staaten hingestellt durch Zweifel wider die wahre Weisheit der so genannten ächten Freymäurer oder goldnen Rosenkreutzer des alten Systems",
+      "read_count": 3,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6988a59e0d60689cec71ff35/6988a5f8fa85f66b0f2a6e4e.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6988a59e0d60689cec71ff35/6988a65e2d2e3fb8e08a295e.jpg"
+      }
+    },
+    {
+      "id": "698255f2460ac42327bd5e3b",
+      "slug": "book-25-of-the-muses-urania-to-dominicus-bonifacio",
+      "title": "Musarum liber XXV. Urania ad Dominicum",
+      "read_count": 2,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/cropped/698255f2460ac42327bd5e3b/698256dd085853f3b754009a.jpg"
+      },
+      "to": {
+        "page": 4,
+        "strategy": "early:pg4",
+        "url": "https://images.sourcelibrary.org/uploads/698255f2460ac42327bd5e3b/6982575a4c2728c151b3dbee.jpg"
+      }
+    },
+    {
+      "id": "697e23ca0293c2dd47709e4e",
+      "slug": "on-the-secret-fire-of-the-magi-and-philosophers-khunrath",
+      "title": "De igne magorum philosophorumque secreto externo et visibili, das ist, philosophische Erklärung. Philosophisch-kabalistischen Judicio",
+      "read_count": 2,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697e23ca0293c2dd47709e4e/697e24e79e6e3fef5a871eaa.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/uploads/697e23ca0293c2dd47709e4e/697e25310fbbcf58999ce302.jpg"
+      }
+    },
+    {
+      "id": "6974b643457dd8909910b9e7",
+      "slug": "on-the-secrets-of-state-clapmarius",
+      "title": "De arcanis rerumpublicarum. De eadem materia discursus",
+      "read_count": 1,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6974b643457dd8909910b9e7/697587fbf8d6f5bb2ad27b04.jpg"
+      },
+      "to": {
+        "page": 9,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6974b643457dd8909910b9e7/697588f7a14f0847e2e1514d.jpg"
+      }
+    },
+    {
+      "id": "697a642bb981745f5fac1d74",
+      "slug": "on-the-syrian-gods-selden",
+      "title": "De diis Syris syntagmata II",
+      "read_count": 1,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697a642bb981745f5fac1d74/697a6489a28cef5186968f71.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697a642bb981745f5fac1d74/697a64f1564b3e97b1f8f4ad.jpg"
+      }
+    },
+    {
+      "id": "697a78cd367f907242581fef",
+      "slug": "historical-critical-dissertation-on-ancient-and-new-alticotius",
+      "title": "Dissertatio historico-critica de antiquis, novis manichaeis",
+      "read_count": 1,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697a78cd367f907242581fef/697a799f4cb135b062947c0b.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697a78cd367f907242581fef/697a79a44cb135b062947c0f.jpg"
+      }
+    },
+    {
+      "id": "697d9c9b72d515cb07bb3840",
+      "slug": "a-thorough-explanation-of-the-nature-and-properties-of-the-drebbel",
+      "title": "Gründliche Aufflösung von der Natur und Eigenschafft der Elementen",
+      "read_count": 1,
+      "from": {
+        "page": 6,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697d9c9b72d515cb07bb3840/697d9dab07d235c485141659.jpg"
+      },
+      "to": {
+        "page": 8,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/uploads/697d9c9b72d515cb07bb3840/697d9dc03c5713fdfa554dbb.jpg"
+      }
+    },
+    {
+      "id": "69c4ec33a3a4a7c546ee610f",
+      "slug": "the-hieroglyphic-monad-dee-2",
+      "title": "Monas hieroglyphica",
+      "read_count": 1,
+      "from": {
+        "page": 6,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c4ec33a3a4a7c546ee610f/sp69f4bd2c08f76ef1a54672a7.jpg"
+      },
+      "to": {
+        "page": 7,
+        "strategy": "early:pg7",
+        "url": "https://images.sourcelibrary.org/cropped/69c4ec33a3a4a7c546ee610f/69f4bd2f08f76ef1a54672a8.jpg"
+      }
+    },
+    {
+      "id": "6978ee3aa5bfdfb63c9a9f63",
+      "slug": "the-chemical-winnowing-basket-chymica-vannus-anonymous",
+      "title": "Reconditorium ac reclusorium opulentiae sapientiaeque numinis magni, cui deditur in titulum chymica vannus",
+      "read_count": 1,
+      "from": {
+        "page": 9,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6978ee3aa5bfdfb63c9a9f63/6978f04dfdd9fae71ee6f6f1.jpg"
+      },
+      "to": {
+        "page": 15,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6978ee3aa5bfdfb63c9a9f63/6978f1693a7ffaa2e622febe.jpg"
+      }
+    },
+    {
+      "id": "69b418eb2b0edf3eaa2de3d9",
+      "slug": "ripley-starkey-alchemical-works-18th-century-french-ms-starkey",
+      "title": "Alchemical Works — George Ripley & George Starkey (PH223)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b418eb2b0edf3eaa2de3d9/sp69f681c424691a00140ca164.jpg"
+      },
+      "to": {
+        "page": 7,
+        "strategy": "early:pg7",
+        "url": "https://images.sourcelibrary.org/cropped/69b418eb2b0edf3eaa2de3d9/69f681c424691a00140ca168.jpg"
+      }
+    },
+    {
+      "id": "69b4195ef6141ca31143b773",
+      "slug": "catalog-of-ashmole-s-alchemical-manuscripts-bodleian-library-hamilton-jones",
+      "title": "Catalogue of Alchemical MSS of Elias Ashmole, Bodleian (PH377)",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/archived/69b4195ef6141ca31143b773/5.jpg"
+      },
+      "to": {
+        "page": 9,
+        "strategy": "early:pg9",
+        "url": "https://images.sourcelibrary.org/pages/69b4195ef6141ca31143b773/split-6a0193a63041abba7f5402a1-full.jpg"
+      }
+    },
+    {
+      "id": "69b4187ef1200e2ab53cfa5c",
+      "slug": "alchemical-anthology-18th-century-french-ms-various",
+      "title": "Collection of Alchemical Works (PH346)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b4187ef1200e2ab53cfa5c/sp69f6f3368bd5ccffb18c3cca.jpg"
+      },
+      "to": {
+        "page": 9,
+        "strategy": "early:pg9",
+        "url": "https://images.sourcelibrary.org/cropped/69b4187ef1200e2ab53cfa5c/69f6f3368bd5ccffb18c3ccc.jpg"
+      }
+    },
+    {
+      "id": "69b418ae2b0edf3eaa2dd9aa",
+      "slug": "hebrew-kabbalistic-collection-17th-18th-century-ms-various",
+      "title": "Collection of Hebrew Texts on Cabalistic Matters (PH468)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b418ae2b0edf3eaa2dd9aa/sp69f67a4417d01b1010b36d79.jpg"
+      },
+      "to": {
+        "page": 9,
+        "strategy": "early:pg9",
+        "url": "https://images.sourcelibrary.org/cropped/69b418ae2b0edf3eaa2dd9aa/69f67a4517d01b1010b36d7f.jpg"
+      }
+    },
+    {
+      "id": "69b41865f1200e2ab53cf7f4",
+      "slug": "preparation-of-drinkable-gold-marcus-eugenius-bonacina-bonacina",
+      "title": "Compendiolum de praeparatione auri potabilis (PH153 bis)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b41865f1200e2ab53cf7f4/sp69f51229a42366fcf3c03065.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "text",
+        "strategy": "early:pg1",
+        "url": "https://images.sourcelibrary.org/archived/69b41865f1200e2ab53cf7f4/1.jpg"
+      }
+    },
+    {
+      "id": "69b418962b0edf3eaa2dd656",
+      "slug": "corpus-hermeticum-17th-century-english-translation-ms-imming",
+      "title": "Corpus Hermeticum (PH460)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b418962b0edf3eaa2dd656/sp69f6b59e1311683d89a10dde.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "text",
+        "strategy": "early:pg1",
+        "url": "https://images.sourcelibrary.org/archived/69b418962b0edf3eaa2dd656/1.jpg"
+      }
+    },
+    {
+      "id": "69c7bee025ec2ba5ccd7fa5d",
+      "slug": "de-macrocosmus-en-microcosmus-ofte-de-wonderen-van-de-feylingius",
+      "title": "De macrocosmus, en microcosmus, ofte de wonderen van de groote en kleyne werelt",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69c7bee025ec2ba5ccd7fa5d/0002-full.jpg"
+      },
+      "to": {
+        "page": 4,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/69c7bee025ec2ba5ccd7fa5d/4.jpg"
+      }
+    },
+    {
+      "id": "69b41958cea21ec2e5d0e11a",
+      "slug": "siebmacher-introduction-of-man-what-to-study-in-life-1607-siebmacher",
+      "title": "Introduction Hominis — Johann Ambrosius Siebmacher (PH404)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b41958cea21ec2e5d0e11a/sp69f65ce19d5df2b15160c3e5.jpg"
+      },
+      "to": {
+        "page": 9,
+        "strategy": "early:pg9",
+        "url": "https://images.sourcelibrary.org/cropped/69b41958cea21ec2e5d0e11a/69f65ce09d5df2b15160c3df.jpg"
+      }
+    },
+    {
+      "id": "69b418a42b0edf3eaa2dd797",
+      "slug": "introduction-to-kabbalistic-science-johann-pistorius-17th-c-pistorius",
+      "title": "Introduttione alla theorica e prattica della scienza di cabala (PH181)",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b418a42b0edf3eaa2dd797/sp69f6665c5e51277f480cec63.jpg"
+      },
+      "to": {
+        "page": 5,
+        "strategy": "early:pg5",
+        "url": "https://images.sourcelibrary.org/cropped/69b418a42b0edf3eaa2dd797/69f666595e51277f480cec5d.jpg"
+      }
+    },
+    {
+      "id": "698420e0acbeea3119317589",
+      "slug": "revelation-of-jesus-christ-lautensack",
+      "title": "Offenbahrung Jesu Christi: das ist: ein Beweisz durch den Titul uber das Creutz Jesu Christi",
+      "read_count": 0,
+      "from": {
+        "page": 4,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/cropped/698420e0acbeea3119317589/698421afff7d0804aad43f1e.jpg"
+      },
+      "to": {
+        "page": 2,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/698420e0acbeea3119317589/698420e968d949f750af3e57.jpg"
+      }
+    },
+    {
+      "id": "69b4193d2b0edf3eaa2df1bc",
+      "slug": "reusner-pandora-the-noblest-gift-of-god-18th-century-ms-reusner",
+      "title": "Pandora — Hieronymus Reusner (PH190)",
+      "read_count": 0,
+      "from": {
+        "page": 4,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b4193d2b0edf3eaa2df1bc/sp69f69131f38982e36d4f409f.jpg"
+      },
+      "to": {
+        "page": 8,
+        "strategy": "early:pg8",
+        "url": "https://images.sourcelibrary.org/cropped/69b4193d2b0edf3eaa2df1bc/69f69131f38982e36d4f409b.jpg"
+      }
+    },
+    {
+      "id": "69c846296c6f3cc53c8516d9",
+      "slug": "pimander-asclepius-crater-hermetis-hermes-trismegistus",
+      "title": "Pimander. Asclepius. Crater Hermetis",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69c846296c6f3cc53c8516d9/sp69f666569dff5b680e42bdbf.jpg"
+      },
+      "to": {
+        "page": 5,
+        "strategy": "early:pg5",
+        "url": "https://images.sourcelibrary.org/cropped/69c846296c6f3cc53c8516d9/69f666569dff5b680e42bdc1.jpg"
+      }
+    },
+    {
+      "id": "69b419352b0edf3eaa2defb6",
+      "slug": "blood-of-nature-george-moulin-post-1689-english-ms-moulin",
+      "title": "Sanguis Naturae — George Moulin (PH212)",
+      "read_count": 0,
+      "from": {
+        "page": 4,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69b419352b0edf3eaa2defb6/sp69f65c1a1ef4d2a43a933850.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "illustration",
+        "strategy": "illustration",
+        "url": "https://images.sourcelibrary.org/archived/69b419352b0edf3eaa2defb6/1.jpg"
+      }
+    },
+    {
+      "id": "69c889b46c6f3cc53c85a494",
+      "slug": "sepher-ietzirah-hebrew-sefer-jezirah-traduction-du-livre",
+      "title": "Sepher Ietzirah ([Hebrew: Sefer jezirah]). Traduction du livre cabalistique de la création",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "BLANK",
+        "url": "https://images.sourcelibrary.org/pages/69c889b46c6f3cc53c85a494/0003-full.jpg"
+      },
+      "to": {
+        "page": 4,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/69c889b46c6f3cc53c85a494/3.jpg"
+      }
+    },
+    {
+      "id": "69c7433a6a0f3d112faf7eb8",
+      "slug": "biblia-quincuplex-psalterium",
+      "title": "[Biblia]. Quincuplex psalterium",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c7433a6a0f3d112faf7eb8/sp69f6fa418d0069a1e1857ba8.jpg"
+      },
+      "to": {
+        "page": 23,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/cropped/69c7433a6a0f3d112faf7eb8/69f6fa488d0069a1e1857bb6.jpg"
+      }
+    },
+    {
+      "id": "69a027907a1dc5d92b41908f",
+      "slug": "greek-symphonia-novi-testamenti-concordantiae-graecae-door",
+      "title": "[Greek Symphonia. Novi Testamenti concordantiae graecae. [Door Xystus Betuleius]",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69a027907a1dc5d92b41908f/69a028c78653a562c16e71e9.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "dedication",
+        "strategy": "useful:dedication",
+        "url": "https://images.sourcelibrary.org/archived/69a027907a1dc5d92b41908f/7.jpg"
+      }
+    },
+    {
+      "id": "698255f314d583f70c9aee0c",
+      "slug": "curious-medico-physical-miscellanies-anonymous",
+      "title": "[Miscellanea curiosa medico-physica Academiae Naturae Curiosorum sive Ephemeridum medico-physicarum Germanicarum annus]",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/698255f314d583f70c9aee0c/698256eef60d45c401348dae.jpg"
+      },
+      "to": {
+        "page": 32,
+        "page_type": "frontispiece",
+        "strategy": "frontispiece",
+        "url": "https://images.sourcelibrary.org/uploads/698255f314d583f70c9aee0c/69825ea4554057c8eee0e221.jpg"
+      }
+    },
+    {
+      "id": "69b41879f1200e2ab53cf975",
+      "slug": "alchemical-collection-late-17th-century-german-ms-various",
+      "title": "Alchemical Texts (PH291)",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69b41879f1200e2ab53cf975/sp69f657243b8f14ea0a15c9ab.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "illustration",
+        "strategy": "illustration",
+        "url": "https://images.sourcelibrary.org/archived/69b41879f1200e2ab53cf975/1.jpg"
+      }
+    },
+    {
+      "id": "6974b63d19126e775cf6d7d3",
+      "slug": "apostolic-light-and-law-lange",
+      "title": "Apostolisches Licht und Recht",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6974b63d19126e775cf6d7d3/69754a354b38423f1a1eac88.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6974b63d19126e775cf6d7d3/69754a530facee61f7c844a9.jpg"
+      }
+    },
+    {
+      "id": "69751590233423aeec9e88f0",
+      "slug": "select-chemical-treatises-starkey",
+      "title": "Auserlesene chymische Tractätlein",
+      "read_count": 0,
+      "from": {
+        "page": 9,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69751590233423aeec9e88f0/6976b9bc81960e57238da9fc.jpg"
+      },
+      "to": {
+        "page": 11,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/uploads/69751590233423aeec9e88f0/6976b9c081960e57238da9ff.jpg"
+      }
+    },
+    {
+      "id": "69774d1db66c66fb54c69ce2",
+      "slug": "library-of-chemical-philosophers-salmon",
+      "title": "Bibliothèque des philosophes (chymiques)",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69774d1db66c66fb54c69ce2/69774de11f60bdae74e43d65.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/69774d1db66c66fb54c69ce2/69774de6d3bcf1513b9f219e.jpg"
+      }
+    },
+    {
+      "id": "697750b7b66c66fb54c69ce4",
+      "slug": "biblical-historical-light-and-right-lange",
+      "title": "Biblisch-historisches Licht und Recht",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697750b7b66c66fb54c69ce4/697752e7c1f42a16bca372c3.jpg"
+      },
+      "to": {
+        "page": 8,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697750b7b66c66fb54c69ce4/69775361fe05f446450be5a7.jpg"
+      }
+    },
+    {
+      "id": "69c820586c6f3cc53c84a804",
+      "slug": "brevis-de-lithosophistica-erronea-quorundam-de-lapide-lutz",
+      "title": "Brevis, de lithosophistica, erronea quorundam, de lapide philosophico nunc disceptantium doctrina, religioni Christianae incommoda, observatio",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c820586c6f3cc53c84a804/spemyr-0005.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "dedication",
+        "strategy": "useful:dedication",
+        "url": "https://images.sourcelibrary.org/archived/69c820586c6f3cc53c84a804/7.jpg"
+      }
+    },
+    {
+      "id": "69c898cb6c6f3cc53c85cc0d",
+      "slug": "catalogue-des-livres-rares-et-precieux-du-cabinet-de-feu-m-anonymous",
+      "title": "Catalogue des livres rares et précieux du cabinet de feu M. de Saint-Martin",
+      "read_count": 0,
+      "from": {
+        "page": 4,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c898cb6c6f3cc53c85cc0d/sp69f66b59520d65db7749d193.jpg"
+      },
+      "to": {
+        "page": 3,
+        "strategy": "early:pg3",
+        "url": "https://images.sourcelibrary.org/cropped/69c898cb6c6f3cc53c85cc0d/69f66b59520d65db7749d193.jpg"
+      }
+    },
+    {
+      "id": "69c8460b6c6f3cc53c851695",
+      "slug": "christliche-schriffmassige-wolgegrundete-rettunge-der-vier-varenius",
+      "title": "Christliche, schriffmässige, wolgegründete Rettunge der Vier Bücher vom wahren Christenthumb",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c8460b6c6f3cc53c851695/sp69f75557c9b496ddd08692fc.jpg"
+      },
+      "to": {
+        "page": 26,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/cropped/69c8460b6c6f3cc53c851695/69f7555fc9b496ddd086930d.jpg"
+      }
+    },
+    {
+      "id": "69790f99eb0dcfd399123426",
+      "slug": "cimbrian-pagan-religion-arnkiel",
+      "title": "Cimbrische Heyden-Religion",
+      "read_count": 0,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69790f99eb0dcfd399123426/69791103a456635726a47f74.jpg"
+      },
+      "to": {
+        "page": 6,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/69790f99eb0dcfd399123426/697910a3a456635726a47f60.jpg"
+      }
+    },
+    {
+      "id": "69c833c96c6f3cc53c84e32f",
+      "slug": "complement-bon-avisorum-special-neue-avisen-welche-der-felgenhauer",
+      "title": "Complement bon' avisorum. Special neue Avisen, welche der Postilion des grossen Löwens vom geschlecht Juda hat gesehen",
+      "read_count": 0,
+      "from": {
+        "page": 1,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c833c96c6f3cc53c84e32f/spkc7u-0001.jpg"
+      },
+      "to": {
+        "page": 2,
+        "page_type": "text",
+        "strategy": "early:pg2",
+        "url": "https://images.sourcelibrary.org/archived/69c833c96c6f3cc53c84e32f/2.jpg"
+      }
+    },
+    {
+      "id": "6974b648457dd8909910b9fb",
+      "slug": "on-the-art-of-the-kabbalah-reuchlin",
+      "title": "De arte cabalistica",
+      "read_count": 0,
+      "from": {
+        "page": 4,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6974b648457dd8909910b9fb/6975f9d2e2f7260ee34d223e.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "illustration",
+        "strategy": "illustration",
+        "url": "https://images.sourcelibrary.org/uploads/6974b648457dd8909910b9fb/6975f8231e700f44a4accd6d.jpg"
+      }
+    },
+    {
+      "id": "6975158ca88d83c830d99e2e",
+      "slug": "dissertation-on-the-most-august-sacrament-of-the-lord-s-marcellius",
+      "title": "De augustissimo corporis et sanguinis dominici sacramento sex libris distincta Dissertatio",
+      "read_count": 0,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6975158ca88d83c830d99e2e/69764e601151a99e188911e9.jpg"
+      },
+      "to": {
+        "page": 9,
+        "page_type": "dedication",
+        "strategy": "useful:dedication",
+        "url": "https://images.sourcelibrary.org/uploads/6975158ca88d83c830d99e2e/69764e7b4f6aa795277a09c5.jpg"
+      }
+    },
+    {
+      "id": "69c81f486c6f3cc53c84a4d3",
+      "slug": "de-foenicum-literis-postel-2",
+      "title": "De Foenicum literis",
+      "read_count": 0,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c81f486c6f3cc53c84a4d3/sp5hmn-0007.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/69c81f486c6f3cc53c84a4d3/5.jpg"
+      }
+    },
+    {
+      "id": "697b079a90f4fbd2e5f32a57",
+      "slug": "the-first-temple-of-god-in-christ-glusing",
+      "title": "Der erste Tempel Gottes in Christo",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697b079a90f4fbd2e5f32a57/697b087bb31e7ace5686f009.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697b079a90f4fbd2e5f32a57/697b08ee6af4f1dfd5f48934.jpg"
+      }
+    },
+    {
+      "id": "697d9ca3b81580c494bf992a",
+      "slug": "saint-balthasar-a-rosicrucian-brother-anonymous",
+      "title": "Der heilige Balthasar ein Bruder Rosenkreutzer",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697d9ca3b81580c494bf992a/697d9d49dbadd42dc7b64224.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697d9ca3b81580c494bf992a/697d9d4d1a77f35923ec4893.jpg"
+      }
+    },
+    {
+      "id": "697a42340d0e32a21b277187",
+      "slug": "dialogues-of-love-abrabanel-2",
+      "title": "Dialoghi di amore",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697a42340d0e32a21b277187/697a42826a622ae13e48c6be.jpg"
+      },
+      "to": {
+        "page": 3,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697a42340d0e32a21b277187/697a42496a622ae13e48c6ba.jpg"
+      }
+    },
+    {
+      "id": "697c8e114b63479c885455fa",
+      "slug": "the-secret-doctrine-of-the-ancient-orientals-and-jews-hallenberg",
+      "title": "Die geheime Lehre der alten Orientaler und Juden",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697c8e114b63479c885455fa/697c8e81675f5942103e42f4.jpg"
+      },
+      "to": {
+        "page": 3,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697c8e114b63479c885455fa/697c8e61675f5942103e42ef.jpg"
+      }
+    },
+    {
+      "id": "6988a5a17e133dc0c53dfe25",
+      "slug": "the-knights-of-the-temple-of-jerusalem-jeune",
+      "title": "Die Ritter des Tempels zu Jerusalem. Oder pragmatische Geschichte und Vertheidigung des Tempelherrn Ordens aus den gewährtesten Quellen gesammelt",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6988a5a17e133dc0c53dfe25/6988a5f3133de375a85baf25.jpg"
+      },
+      "to": {
+        "page": 9,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6988a5a17e133dc0c53dfe25/6988a6a3037f7fb288d37cb0.jpg"
+      }
+    },
+    {
+      "id": "69c7fe2e6c6f3cc53c8436b4",
+      "slug": "discours-fait-en-une-celebre-assemblee-touchant-le-guerison-digby",
+      "title": "Discours fait en une celebre assemblée [...] touchant le guerison des playes par la poudre de sympathie",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c7fe2e6c6f3cc53c8436b4/sp69f673d486e31a67b72e21ea.jpg"
+      },
+      "to": {
+        "page": 3,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/cropped/69c7fe2e6c6f3cc53c8436b4/69f673d486e31a67b72e21ec.jpg"
+      }
+    },
+    {
+      "id": "69c8068e6c6f3cc53c8455a0",
+      "slug": "dissertatio-academica-de-eddis-islandicis-nording",
+      "title": "Dissertatio academica, de Eddis Islandicis",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c8068e6c6f3cc53c8455a0/sp69f5bad51bcf7b30e904f9a7.jpg"
+      },
+      "to": {
+        "page": 5,
+        "strategy": "early:pg5",
+        "url": "https://images.sourcelibrary.org/cropped/69c8068e6c6f3cc53c8455a0/69f5bad81bcf7b30e904f9a9.jpg"
+      }
+    },
+    {
+      "id": "69c872fa6c6f3cc53c8579c3",
+      "slug": "dissertatio-de-vita-et-scriptis-porphyrii-holstein",
+      "title": "Dissertatio de vita et scriptis Porphyrii",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c872fa6c6f3cc53c8579c3/sp69f682a77f9b64847b96faa3.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/cropped/69c872fa6c6f3cc53c8579c3/69f682a77f9b64847b96faa7.jpg"
+      }
+    },
+    {
+      "id": "697b07997f21d8314d7852fb",
+      "slug": "remarks-on-the-origin-and-history-of-the-rosicrucians-and-nicolai",
+      "title": "Einige Bemerkungen über den Ursprung und die Geschichte der Rosenkreuzer und Freymaurer",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697b07997f21d8314d7852fb/697b08573c2874e3d8a4076c.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697b07997f21d8314d7852fb/697b089e2c2cd40f0d4a0fed.jpg"
+      }
+    },
+    {
+      "id": "69c809096c6f3cc53c845fb9",
+      "slug": "el-mayor-thesoro-tratado-del-arte-de-la-alchimia-o-starkey",
+      "title": "El mayor thesoro. Tratado del arte de la alchimia, o chrysopoeya, que ofrece la entrada abierta, al cerrado palacio del rey",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c809096c6f3cc53c845fb9/sp69f697c3f8479fa28406287e.jpg"
+      },
+      "to": {
+        "page": 3,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/cropped/69c809096c6f3cc53c845fb9/69f697c3f8479fa28406287f.jpg"
+      }
+    },
+    {
+      "id": "69c825ba6c6f3cc53c84ba26",
+      "slug": "essais-de-theodicee-sur-la-bonte-de-dieu-leibnitz",
+      "title": "Essais de theodicée sur la bonté de Dieu",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c825ba6c6f3cc53c84ba26/sp69f70200e826d7c555571e78.jpg"
+      },
+      "to": {
+        "page": 8,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/cropped/69c825ba6c6f3cc53c84ba26/69f70200e826d7c555571e79.jpg"
+      }
+    },
+    {
+      "id": "697c8e1230ece38bd4ca78d6",
+      "slug": "ariadne-s-thread-reibehand",
+      "title": "Filum Ariadnes Das ist, newer chymischer Discurs",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697c8e1230ece38bd4ca78d6/697c8ea5bddabf3a5ff7c7e4.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697c8e1230ece38bd4ca78d6/697c8f17a05a3d2f962b9874.jpg"
+      }
+    },
+    {
+      "id": "697c8e0f150e68b9f40701f4",
+      "slug": "glory-of-the-world-gloria-mundi-anonymous",
+      "title": "Gloria mundi. Sonsten Paradiess-Taffel",
+      "read_count": 0,
+      "from": {
+        "page": 4,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/697c8e0f150e68b9f40701f4/697c91781774013e9a7194d9.jpg"
+      },
+      "to": {
+        "page": 18,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/697c8e0f150e68b9f40701f4/697c91481774013e9a7194ca.jpg"
+      }
+    },
+    {
+      "id": "69c899336c6f3cc53c85cd2a",
+      "slug": "gospel-nicodemus-2",
+      "title": "Gospel",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c899336c6f3cc53c85cd2a/sp3h1b-0003.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/69c899336c6f3cc53c85cd2a/7.jpg"
+      }
+    },
+    {
+      "id": "69c879b86c6f3cc53c858529",
+      "slug": "historica-narratio-de-fratrum-orthodoxonum-ecclesiis-in-camerarius",
+      "title": "Historica narratio de fratrum orthodoxonum ecclesiis in Bohemia, Moravia et Polonia",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c879b86c6f3cc53c858529/sp69f6cfb53484cd32ccfa6022.jpg"
+      },
+      "to": {
+        "page": 27,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/cropped/69c879b86c6f3cc53c858529/69f6cfbc3484cd32ccfa6038.jpg"
+      }
+    },
+    {
+      "id": "6988a5a2c9cb59aebe69eda0",
+      "slug": "the-religion-of-the-gauls-martin",
+      "title": "La religion des Gaulois",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6988a5a2c9cb59aebe69eda0/6988a6d5ad266108b71111c7.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/6988a5a2c9cb59aebe69eda0/6988a71397824c93c54c5d13.jpg"
+      }
+    },
+    {
+      "id": "69804b944fc6323824f38b3f",
+      "slug": "life-and-fates-of-the-notorious-franz-rudolph-von-grossing-wadzeck",
+      "title": "Leben und Schicksale des beruechtigen Franz Rudolph von Grossing",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69804b944fc6323824f38b3f/69804c7011862cca6f48ce40.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/69804b944fc6323824f38b3f/69804cfb2833b9ce14093e02.jpg"
+      }
+    },
+    {
+      "id": "6976d747097b3607ee4be2f7",
+      "slug": "the-adventures-of-the-unknown-philosopher-belin",
+      "title": "Les aventures du philosophe inconnu, en la recherche & en l'invention de la pierre philosophale",
+      "read_count": 0,
+      "from": {
+        "page": 9,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6976d747097b3607ee4be2f7/6976d872a15653038db7a47d.jpg"
+      },
+      "to": {
+        "page": 11,
+        "page_type": "dedication",
+        "strategy": "useful:dedication",
+        "url": "https://images.sourcelibrary.org/uploads/6976d747097b3607ee4be2f7/6976d877a15653038db7a480.jpg"
+      }
+    },
+    {
+      "id": "69c840356c6f3cc53c850672",
+      "slug": "libri-octo-graece-et-latine-dioscorides",
+      "title": "Libri octo graece et latine",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c840356c6f3cc53c850672/sp69f735407b792970e624c6e1.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "text",
+        "strategy": "early:pg1",
+        "url": "https://images.sourcelibrary.org/archived/69c840356c6f3cc53c850672/1.jpg"
+      }
+    },
+    {
+      "id": "69c826b06c6f3cc53c84bd9b",
+      "slug": "magia-divina-oder-grund-und-deutlicher-unterricht-von-denen-anonymous",
+      "title": "Magia divina oder gründ- und deutlicher Unterricht von denen fürnehmsten caballistischen Kunst-Stücken",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c826b06c6f3cc53c84bd9b/sp5npl-0005.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/archived/69c826b06c6f3cc53c84bd9b/7.jpg"
+      }
+    },
+    {
+      "id": "69c87efc6c6f3cc53c858e17",
+      "slug": "mundus-alter-et-idem-hall",
+      "title": "Mundus alter et idem",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c87efc6c6f3cc53c858e17/0002-full.jpg"
+      },
+      "to": {
+        "page": 3,
+        "page_type": "dedication",
+        "strategy": "useful:dedication",
+        "url": "https://images.sourcelibrary.org/archived/69c87efc6c6f3cc53c858e17/3.jpg"
+      }
+    },
+    {
+      "id": "698420e1d453c841a6c1d045",
+      "slug": "the-secret-miracles-of-nature-lemnius",
+      "title": "Occulta naturae miracula",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/698420e1d453c841a6c1d045/6984212b501bb68640347883.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/uploads/698420e1d453c841a6c1d045/6984213da719cbb6e70f59e1.jpg"
+      }
+    },
+    {
+      "id": "6984e8498a2f054f912420c3",
+      "slug": "subterranean-physics-becher",
+      "title": "Physica subterranea. Specimen Beccherianum",
+      "read_count": 0,
+      "from": {
+        "page": 7,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/6984e8498a2f054f912420c3/6984ea061df714da9b420ad9.jpg"
+      },
+      "to": {
+        "page": 6,
+        "page_type": "frontispiece",
+        "strategy": "frontispiece",
+        "url": "https://images.sourcelibrary.org/uploads/6984e8498a2f054f912420c3/6984e9be1df714da9b420ad2.jpg"
+      }
+    },
+    {
+      "id": "69c860796c6f3cc53c8557d5",
+      "slug": "scripture-thesauros-pandens-denuo-possa-eliata-atque-ubi-paltz",
+      "title": "scripture thesauros pandens, denuo possa eliata: atque ubi truncata pri habebat supplemento integrata diligenter atque ez archetypo emendata",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c860796c6f3cc53c8557d5/sp69f723ae25cce7d63cc3e2c0.jpg"
+      },
+      "to": {
+        "page": 1,
+        "page_type": "text",
+        "strategy": "early:pg1",
+        "url": "https://images.sourcelibrary.org/archived/69c860796c6f3cc53c8557d5/1.jpg"
+      }
+    },
+    {
+      "id": "699efa008dfdc5d432c16182",
+      "slug": "sleutel-der-devotie-teellinck",
+      "title": "Sleutel der devotie",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/699efa008dfdc5d432c16182/699efa5c4b33ec35a5010173.jpg"
+      },
+      "to": {
+        "page": 3,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/699efa008dfdc5d432c16182/3.jpg"
+      }
+    },
+    {
+      "id": "69c89bde6c6f3cc53c85d473",
+      "slug": "some-early-ideas-on-rosicrucianism-nolan",
+      "title": "Some early ideas on Rosicrucianism",
+      "read_count": 0,
+      "from": {
+        "page": 1,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/archived/69c89bde6c6f3cc53c85d473/1.jpg"
+      },
+      "to": {
+        "page": 2,
+        "page_type": "text",
+        "strategy": "early:pg2",
+        "url": "https://images.sourcelibrary.org/archived/69c89bde6c6f3cc53c85d473/2.jpg"
+      }
+    },
+    {
+      "id": "69a027907cf58c3e17f32eb6",
+      "slug": "suplement-au-glossaire-du-roman-de-la-rose-damerey",
+      "title": "Suplement au glossaire du roman de la rose",
+      "read_count": 0,
+      "from": {
+        "page": 3,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69a027907cf58c3e17f32eb6/69a0287c8d101a88acb247b1.jpg"
+      },
+      "to": {
+        "page": 7,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/69a027907cf58c3e17f32eb6/7.jpg"
+      }
+    },
+    {
+      "id": "69a027816a20ac4e1fc4051e",
+      "slug": "theologia-sive-mistica-phylosophia-aristoteles",
+      "title": "Theologia sive mistica phylosophia",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/cropped/69a027816a20ac4e1fc4051e/69a0293d98c65348e75e2bf0.jpg"
+      },
+      "to": {
+        "page": 5,
+        "page_type": "title-page",
+        "strategy": "title-page",
+        "url": "https://images.sourcelibrary.org/archived/69a027816a20ac4e1fc4051e/5.jpg"
+      }
+    },
+    {
+      "id": "69c581e34cc41628b775aa82",
+      "slug": "urim-and-thummim-of-moses-which-aaron-wore-in-the-mensenriet",
+      "title": "Urim & Thumim Moysis welches Aaron in Amts-Schildlein getragen Feuer-bleibendes Wasser",
+      "read_count": 0,
+      "from": {
+        "page": 2,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org\n/uploads/69c581e34cc41628b775aa82/69c58216330d210de6179612.jpg"
+      },
+      "to": {
+        "page": 3,
+        "strategy": "early:pg3",
+        "url": "https://images.sourcelibrary.org/cropped/69c581e34cc41628b775aa82/69f4b9043ebaddbc93be1203.jpg"
+      }
+    },
+    {
+      "id": "69c815276c6f3cc53c8484be",
+      "slug": "veritas-sui-vindex-seu-solennis-fidei-declaratio-labadie",
+      "title": "Veritas sui vindex seu solennis fidei declaratio",
+      "read_count": 0,
+      "from": {
+        "page": 9,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c815276c6f3cc53c8484be/sp69f67c43e245ff2ccc164836.jpg"
+      },
+      "to": {
+        "page": 3,
+        "strategy": "early:pg3",
+        "url": "https://images.sourcelibrary.org/cropped/69c815276c6f3cc53c8484be/69f67c43e245ff2ccc164830.jpg"
+      }
+    },
+    {
+      "id": "69c822f86c6f3cc53c84aea4",
+      "slug": "von-der-hermetischenn-philosophia-das-ist-von-dem-insulis",
+      "title": "Von der hermetischenn Philosophia, das ist, von dem gebenedeiten Stain der Weisen  Dicta Alani",
+      "read_count": 0,
+      "from": {
+        "page": 5,
+        "state": "PLACEHOLDER",
+        "url": "https://images.sourcelibrary.org/pages/69c822f86c6f3cc53c84aea4/sp69f501cfcf0b2623d7c320e4.jpg"
+      },
+      "to": {
+        "page": 28,
+        "page_type": "preface",
+        "strategy": "useful:preface",
+        "url": "https://images.sourcelibrary.org/cropped/69c822f86c6f3cc53c84aea4/69f501e6cf0b2623d7c320fb.jpg"
+      }
+    }
+  ],
+  "skipped": [
+    {
+      "id": "6970e3729b09d309d780a29e",
+      "slug": "three-dialogues-on-love-abrabanel",
+      "title": "De amore dialogi tres",
+      "author": "Abrabanel, Jehuda",
+      "read_count": 5,
+      "state": "BLANK",
+      "reason": "page 1 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/uploads/6970e3729b09d309d780a2a0/6974c9c561bd780d0f4bc7f3.jpg",
+      "cover_page_number": 1,
+      "book_url": "https://sourcelibrary.org/book/three-dialogues-on-love-abrabanel",
+      "why": "selector returned same image URL (pg 1)"
+    },
+    {
+      "id": "69b41863f1200e2ab53cf76f",
+      "slug": "definition-of-chemistry-18th-century-latin-ms",
+      "title": "Chemiae definitio, objectum, origo, usus, et divisio (PH164 bis)",
+      "author": "Unknown",
+      "read_count": 0,
+      "state": "BLANK",
+      "reason": "page 3 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/pages/69b41863f1200e2ab53cf76f/sp69f678d32f484c063061bb61.jpg",
+      "cover_page_number": 3,
+      "book_url": "https://sourcelibrary.org/book/definition-of-chemistry-18th-century-latin-ms",
+      "why": "no acceptable replacement page"
+    },
+    {
+      "id": "69b418932b0edf3eaa2dd59a",
+      "slug": "hermes-trismegistus-on-the-revolutions-of-nativities-trismegistus",
+      "title": "Hermetis philosophi de revolutionibus nativitatum (PH216)",
+      "author": "Hermes Trismegistus",
+      "read_count": 0,
+      "state": "BLANK",
+      "reason": "page 3 classified as blank",
+      "cover_url": "https://images.sourcelibrary.org/pages/69b418932b0edf3eaa2dd59a/sp69f69f4fce732b30b522a9e8.jpg",
+      "cover_page_number": 3,
+      "book_url": "https://sourcelibrary.org/book/hermes-trismegistus-on-the-revolutions-of-nativities-trismegistus",
+      "why": "no acceptable replacement page"
+    }
+  ],
+  "manual": []
+}

--- a/scripts/fix-bph-flagged-covers.mjs
+++ b/scripts/fix-bph-flagged-covers.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+/**
+ * Step 2 of issue #1679 — fix the 85 BPH books flagged by the cover-quality
+ * audit (`.claude/docs/bph-cover-audit-2026-05-11.json`).
+ *
+ * For each flagged book, walks the pages collection and picks a better cover
+ * via this priority chain:
+ *   1. page_type === 'title-page' (page_number ≤ 30)
+ *   2. page_type === 'frontispiece' that isn't a digitizer insert (≤ 50)
+ *   3. page_type === 'illustration' (≤ 15)
+ *   4. first page with a useful page_type (not blank / digitizer / bookplate /
+ *      exlibris / text / toc / index / errata / appendix), with a usable image
+ *      and OCR that doesn't match digitizer-insert/library-stamp patterns (≤ 30)
+ *   5. for books with no page_type metadata: first early page (≤ 10) that has
+ *      an image, isn't blank, and doesn't match bad-cover OCR patterns.
+ *
+ * Updates ALL cover fields on the book in one pass:
+ *   image_display, image_thumb, thumbnail, thumbnail_blob, cover_page,
+ *   thumbnail_source='auto-fix-1679'
+ *
+ * Skip rules:
+ *   - books with thumbnail_source === 'manual' (curator override)
+ *   - books where no better page can be found (logged as SKIP)
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/fix-bph-flagged-covers.mjs --dry-run     # preview
+ *   node scripts/fix-bph-flagged-covers.mjs               # apply
+ *   node scripts/fix-bph-flagged-covers.mjs --only 10     # limit to first N
+ *   node scripts/fix-bph-flagged-covers.mjs --id <book_id>  # single book
+ */
+
+import { MongoClient } from 'mongodb';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const ONLY_N = (() => {
+  const idx = args.indexOf('--only');
+  return idx !== -1 ? parseInt(args[idx + 1], 10) : null;
+})();
+const ONLY_ID = (() => {
+  const idx = args.indexOf('--id');
+  return idx !== -1 ? args[idx + 1] : null;
+})();
+
+const AUDIT_PATH = resolve(REPO_ROOT, '.claude/docs/bph-cover-audit-2026-05-11.json');
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+// Patterns that indicate a page is a digitizer insert / library stamp / bookplate.
+// Keep in sync with scripts/audit/bph-cover-quality.mjs and scripts/fix-bad-covers.mjs.
+const BAD_COVER_PATTERNS = [
+  /internet\s+archive/i,
+  /digitized\s+by\s+google/i,
+  /google\s+logo/i,
+  /digitization\s+credit/i,
+  /inserted\s+by\s+the\s+internet/i,
+  /library\s+of\s+the\s+university/i,
+  /digital\s+library/i,
+  /california\s+digital/i,
+  /barcode/i,
+  /ex[\s\-.]?libris/i,
+  /bookplate/i,
+  /philosophia\s+hermetica/i,
+  /bibliotheca\s+philosophica/i,
+];
+
+function isBadCoverOcr(ocrText) {
+  if (!ocrText) return false;
+  return BAD_COVER_PATTERNS.some(p => p.test(ocrText.substring(0, 1500)));
+}
+
+function isBlankOcr(ocrText) {
+  if (!ocrText) return false;
+  return /<page-type>\s*blank\s*<\/page-type>/i.test(ocrText) ||
+         /<meta>\s*blank\b/i.test(ocrText);
+}
+
+const BAD_PAGE_TYPES = new Set(['blank', 'digitizer-insert', 'bookplate', 'exlibris', 'archived-spread']);
+// `archived-spread` pages have negative page_numbers — they are the
+// pre-split 2-page spread images kept around for provenance, and live
+// outside the user-visible page sequence. They must never be used as covers.
+
+// Page types that aren't visually appealing covers even if they're not "bad":
+const POOR_COVER_TYPES = new Set(['text', 'toc', 'index', 'errata', 'appendix', 'notes', 'colophon']);
+
+const PAGE_PROJECTION = {
+  page_number: 1, page_type: 1,
+  cropped_photo: 1, archived_photo: 1, photo: 1, photo_original: 1,
+  image_display: 1, image_thumb: 1, thumbnail_blob: 1,
+  image_width: 1, image_height: 1,
+  'ocr.data': 1,
+};
+
+function pageDisplayUrl(p) {
+  return p.image_display || p.archived_photo || p.cropped_photo || p.photo || p.photo_original || null;
+}
+function pageThumbUrl(p) {
+  return p.image_thumb || p.thumbnail_blob || pageDisplayUrl(p);
+}
+
+function pageHasImage(p) {
+  return !!(p.archived_photo || p.cropped_photo || p.photo || p.photo_original || p.image_display);
+}
+
+function pageIsBlankOrBad(p) {
+  if (BAD_PAGE_TYPES.has(p.page_type)) return true;
+  const ocr = p.ocr?.data || '';
+  return isBlankOcr(ocr) || isBadCoverOcr(ocr);
+}
+
+async function pickReplacement(db, bookId) {
+  // 1) explicit title-page within first 30 visible pages (page_number > 0
+  //    excludes archived-spread pages, which carry negative page numbers).
+  const titlePages = await db.collection('pages').find(
+    { book_id: bookId, page_type: 'title-page', page_number: { $gt: 0, $lte: 30 } },
+    { projection: PAGE_PROJECTION, sort: { page_number: 1 }, limit: 5 }
+  ).toArray();
+  let candidate = titlePages.find(p => pageHasImage(p) && !pageIsBlankOrBad(p));
+  if (candidate) return { page: candidate, strategy: 'title-page' };
+
+  // 2) frontispiece that isn't a digitizer insert
+  const fronts = await db.collection('pages').find(
+    { book_id: bookId, page_type: 'frontispiece', page_number: { $gt: 0, $lte: 50 } },
+    { projection: PAGE_PROJECTION, sort: { page_number: 1 }, limit: 5 }
+  ).toArray();
+  candidate = fronts.find(p => pageHasImage(p) && !pageIsBlankOrBad(p));
+  if (candidate) return { page: candidate, strategy: 'frontispiece' };
+
+  // 3) illustration within first 15 pages
+  const illos = await db.collection('pages').find(
+    { book_id: bookId, page_type: 'illustration', page_number: { $gt: 0, $lte: 15 } },
+    { projection: PAGE_PROJECTION, sort: { page_number: 1 }, limit: 5 }
+  ).toArray();
+  candidate = illos.find(p => pageHasImage(p) && !pageIsBlankOrBad(p));
+  if (candidate) return { page: candidate, strategy: 'illustration' };
+
+  // 4) any usefully-typed page in first 30 (not blank/digitizer/text/toc/...)
+  const useful = await db.collection('pages').find(
+    {
+      book_id: bookId,
+      page_number: { $gt: 0, $lte: 30 },
+      page_type: { $nin: [...BAD_PAGE_TYPES, ...POOR_COVER_TYPES, null] },
+    },
+    { projection: PAGE_PROJECTION, sort: { page_number: 1 }, limit: 10 }
+  ).toArray();
+  candidate = useful.find(p => pageHasImage(p) && !pageIsBlankOrBad(p));
+  if (candidate) return { page: candidate, strategy: `useful:${candidate.page_type}` };
+
+  // 5) first non-blank/non-bad early page (no page_type filter)
+  const early = await db.collection('pages').find(
+    { book_id: bookId, page_number: { $gt: 0, $lte: 10 } },
+    { projection: PAGE_PROJECTION, sort: { page_number: 1 }, limit: 10 }
+  ).toArray();
+  candidate = early.find(p => pageHasImage(p) && !pageIsBlankOrBad(p));
+  if (candidate) return { page: candidate, strategy: `early:pg${candidate.page_number}` };
+
+  return null;
+}
+
+async function main() {
+  const audit = JSON.parse(readFileSync(AUDIT_PATH, 'utf8'));
+  let flagged = audit.results.filter(r => r.state === 'BLANK' || r.state === 'PLACEHOLDER');
+  if (ONLY_ID) flagged = flagged.filter(r => r.id === ONLY_ID);
+  if (ONLY_N) flagged = flagged.slice(0, ONLY_N);
+
+  console.log(`Loaded ${audit.results.length} flagged books from audit; processing ${flagged.length}.`);
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN (no writes)' : 'APPLY'}`);
+
+  const client = new MongoClient(MONGODB_URI, {
+    serverSelectionTimeoutMS: 30_000,
+    socketTimeoutMS: 180_000,
+  });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  const report = { fixed: [], skipped: [], manual: [] };
+
+  for (const r of flagged) {
+    const book = await db.collection('books').findOne(
+      { id: r.id },
+      { projection: {
+          id: 1, slug: 1, title: 1,
+          image_display: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1,
+          cover_page: 1, thumbnail_source: 1,
+        }, maxTimeMS: 10_000 }
+    );
+    if (!book) {
+      report.skipped.push({ ...r, why: 'book not found' });
+      console.log(`  MISS ${r.id} — book not found`);
+      continue;
+    }
+
+    if (book.thumbnail_source === 'manual') {
+      report.manual.push({ id: r.id, title: r.title });
+      console.log(`  MANUAL ${r.title} — thumbnail_source=manual, skipping`);
+      continue;
+    }
+
+    const pick = await pickReplacement(db, r.id);
+    if (!pick) {
+      report.skipped.push({ ...r, why: 'no acceptable replacement page' });
+      console.log(`  SKIP "${r.title}" (page ${r.cover_page_number}, ${r.state}) — no replacement`);
+      continue;
+    }
+
+    const { page, strategy } = pick;
+    const newDisplay = pageDisplayUrl(page);
+    const newThumb = pageThumbUrl(page);
+
+    if (!newDisplay) {
+      report.skipped.push({ ...r, why: 'replacement page has no image URL' });
+      console.log(`  SKIP "${r.title}" — replacement page ${page.page_number} has no image URL`);
+      continue;
+    }
+
+    // Only skip as "SAME" if the picked URL matches the existing cover URL.
+    // (Some books have multiple page docs at the same page_number — e.g. a
+    //  blank/digitizer doc plus the real title-page doc — so equal page numbers
+    //  don't imply equal pictures.)
+    const currentDisplay = book.image_display || book.thumbnail || null;
+    if (newDisplay === currentDisplay) {
+      report.skipped.push({ ...r, why: `selector returned same image URL (pg ${page.page_number})` });
+      console.log(`  SAME "${r.title}" — selector returned same URL (pg ${page.page_number}, ${strategy})`);
+      continue;
+    }
+
+    const update = {
+      image_display: newDisplay,
+      image_thumb: newThumb,
+      thumbnail: newDisplay,
+      thumbnail_blob: newThumb,
+      cover_page: page.page_number,
+      thumbnail_source: 'auto-fix-1679',
+    };
+
+    const entry = {
+      id: r.id,
+      slug: r.slug,
+      title: r.title,
+      read_count: r.read_count,
+      from: { page: r.cover_page_number, state: r.state, url: r.cover_url },
+      to: { page: page.page_number, page_type: page.page_type, strategy, url: newDisplay },
+    };
+    report.fixed.push(entry);
+
+    console.log(`  FIX [${r.state} pg${r.cover_page_number}→${page.page_number} ${page.page_type}|${strategy}] "${r.title.slice(0, 60)}"`);
+
+    if (!DRY_RUN) {
+      await db.collection('books').updateOne({ id: r.id }, { $set: update });
+    }
+  }
+
+  console.log(`\n=== Summary ===`);
+  console.log(`  Flagged processed: ${flagged.length}`);
+  console.log(`  Fixed:    ${report.fixed.length}`);
+  console.log(`  Skipped:  ${report.skipped.length}`);
+  console.log(`  Manual:   ${report.manual.length}`);
+
+  // Persist the report for diff-against / verification.
+  const outDir = resolve(REPO_ROOT, '.claude/docs');
+  mkdirSync(outDir, { recursive: true });
+  const stamp = DRY_RUN ? 'dryrun' : 'applied';
+  const reportPath = resolve(outDir, `bph-cover-fix-2026-05-12-${stamp}.json`);
+  writeFileSync(reportPath, JSON.stringify({
+    run_date: '2026-05-12',
+    mode: DRY_RUN ? 'dry-run' : 'apply',
+    counts: { fixed: report.fixed.length, skipped: report.skipped.length, manual: report.manual.length },
+    fixed: report.fixed,
+    skipped: report.skipped,
+    manual: report.manual,
+  }, null, 2));
+  console.log(`  Report: ${reportPath}`);
+
+  await client.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Step 2 of #1679 (closing out Chiara's feedback batch). The 2026-05-11 audit flagged 85 BPH books with broken covers (20 BLANK + 65 PLACEHOLDER, no MISSING/TINY). This walks each one, re-picks a cover from `pages`, and writes the new selection to MongoDB.

**Result: 2275 / 2280 BPH books now have OK covers (was 2195). 80 fixed.**

## Approach

`scripts/fix-bph-flagged-covers.mjs` loads the audit JSON and for each flagged book walks this cascade:

1. `page_type === 'title-page'` (page_number > 0, ≤ 30)
2. `page_type === 'frontispiece'` not matching digitizer/library-stamp OCR (≤ 50)
3. `page_type === 'illustration'` (≤ 15)
4. Any useful-typed page (not blank/digitizer/bookplate/text/toc/index/...) (≤ 30)
5. First non-blank/non-bad early page (≤ 10)

Writes `image_display`, `image_thumb`, `thumbnail`, `thumbnail_blob`, `cover_page`, `thumbnail_source='auto-fix-1679'`.

## Edge cases hit during development

- **`archived-spread` pages must be excluded.** They have negative `page_number`s (they're the pre-split 2-page spread images kept around for provenance) and aren't part of the visible reading flow. First dry-run picked several of these (e.g. page -162 for "Mirabilium"). Added to `BAD_PAGE_TYPES`.
- **Duplicate page docs at the same `page_number`.** Some books have two `pages` docs with the same `page_number` — one with `page_type: 'blank'` and one with `page_type: 'title-page'`, pointing at different image URLs. The original audit picked up the blank one; the selector picks the title-page one. Originally my "no-op" check compared `page_number`, which incorrectly flagged these as no-ops. Switched to URL comparison.
- **Title-pages that are themselves blank.** Step 1 now applies the same `pageIsBlankOrBad` filter as steps 2–5, so a title-page with `<page-type>blank</page-type>` OCR falls through instead of being accepted.

## What's left (5 books)

- 2 audit false positives ([Greek] Argonauticon, De amore dialogi tres) — duplicate-page-doc artefact in the audit; covers are visually correct on the live site.
- 3 BPH-owned manuscripts (PH164 Chemiae definitio, PH216 Hermetis philosophi, Offenbahrung Jesu Christi) where every early page carries a BPH ownership stamp / blank. These need curator picks.

## Files

- `scripts/fix-bph-flagged-covers.mjs` — fix script (dry-run + apply modes)
- `.claude/docs/bph-cover-fix-2026-05-12-applied.json` — per-book before/after report (id, slug, read_count, old page+url, new page+page_type+strategy+url)
- `.claude/docs/bph-cover-audit-2026-05-12.{md,json}` — post-fix audit (5 flagged)

## Test plan

- [x] Dry-run on all 85 books, inspect the strategy distribution (35 title-page picks, 13 preface, plus illustration/frontispiece/early fallbacks)
- [x] Spot-check 12 candidate URLs across all strategies — all return real JPEGs via range GET
- [x] Apply, then re-run the audit script → flagged count drops 85 → 5
- [ ] Visual smoke-test on `bph.sourcelibrary.org` digitised grid after merge