### PR TITLE
Book detail: keep cover image height fixed when bibliographic info expands

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -602,7 +602,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
       {/* Book Info */}
       <div className="bg-gradient-to-b from-stone-800 to-stone-900 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
-          <div className="flex flex-col sm:flex-row gap-6 sm:gap-8">
+          <div className="flex flex-col sm:flex-row sm:items-start gap-6 sm:gap-8">
             {/* Thumbnail - clickable to change */}
             <div className="flex-shrink-0 flex justify-center sm:justify-start">
               <CoverImagePicker

--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -102,8 +102,8 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
   return (
     <details className="mt-4">
       <summary className="cursor-pointer text-sm text-stone-400 hover:text-stone-200 transition-colors list-none flex items-center gap-2 [&::-webkit-details-marker]:hidden">
-        <svg className="w-4 h-4 transition-transform [details[open]_&]:rotate-90" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fillRule="evenodd" d="M6.5 4a.5.5 0 01.854-.354l6 6a.5.5 0 010 .708l-6 6A.5.5 0 016.5 16V4z" clipRule="evenodd"/>
+        <svg className="w-4 h-4 transition-transform [details[open]_&]:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="m6 9 6 6 6-6"/>
         </svg>
         Catalogue record (BPH UBN {work.ubn})
       </summary>


### PR DESCRIPTION
## Summary
- The book detail hero (`/[tenant]/book/[id]`) used default flex `align-items: stretch`, so expanding **Bibliographic Info** or the **BPH catalogue record** grew the right column and stretched the thumbnail wrapper vertically — overriding `aspect-[3/4]` on the cover button and visibly expanding the image.
- Added `sm:items-start` on the hero row so the thumbnail keeps its natural aspect-ratio height when the right column grows. Mobile column layout is unchanged (still centered).

## Test plan
- [ ] Open a book detail page (e.g. https://sourcelibrary.org/book/...), expand Bibliographic Info — cover image height should not change.
- [ ] On a BPH book with a UBN, expand the catalogue record — cover image height should not change.
- [ ] Verify mobile (column) layout still centers the cover image horizontally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)