### PR TITLE
BPH landing: source Selected Books from Supabase catalogue, not MongoDB

### DIFF
--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -5,6 +5,7 @@ import {
     getTenantDominantProvider,
     fetchTenantBphDigitizedMap,
     fetchTenantBphCatalogTotal,
+    fetchTenantBphCataloguedBookIds,
 } from '@/lib/tenant-library-loaders';
 import { getDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -78,12 +79,28 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     const tenantDoc = await db.collection('tenants').findOne({ id: tenantId });
     if (!tenantDoc) notFound();
 
-    const [libraryData, dominantProvider] = await Promise.all([
+    // Cheap pre-check so the Supabase catalogue-id fetch can run in parallel
+    // with the main library fetch. dominantProvider is the canonical isBph
+    // signal (`canonicalPartner?.providerKey === 'bph'` below) but it
+    // resolves only after the main loaders run; for parallelism we fall back
+    // to the tenant slug here, which matches the current BPH tenant 1:1.
+    const probablyBph = tenant === 'bph';
+
+    const [libraryData, dominantProvider, cataloguedBookIds] = await Promise.all([
+        // (deferred filter applied below once Supabase ids resolve)
         fetchTenantLibraryData(tenantId, sort, language, offset, q || undefined),
         getTenantDominantProvider(tenantId),
+        probablyBph ? fetchTenantBphCataloguedBookIds() : Promise.resolve(null),
     ]);
 
-    const { books, total, topBooks, languages, galleryImages, contributingLibraries } = libraryData;
+    // Filter the Selected Books row to books that exist in the Supabase
+    // catalogue (bph_works.sl_book_id). Consistent with the catalogue list
+    // view, which is the source of truth. No-op today (all top-popular books
+    // are already linked) but prevents future divergence (#1715 follow-up).
+    const topBooks = cataloguedBookIds
+        ? libraryData.topBooks.filter(b => cataloguedBookIds.has(b.id))
+        : libraryData.topBooks;
+    const { books, total, languages, galleryImages, contributingLibraries } = libraryData;
 
     const canonicalPartner = getPartnerBySlug(tenant) || (dominantProvider ? getPartnerByProvider(dominantProvider) : undefined);
     const tenantRecord = tenantDoc as Record<string, unknown>;

--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -268,7 +268,7 @@ export async function fetchTenantLibraryData(
   sort: string,
   language: string,
   offset: number,
-  q?: string
+  q?: string,
 ): Promise<TenantLibraryData> {
   const db = await getReadDb();
 
@@ -400,4 +400,31 @@ export async function fetchTenantBphCatalogTotal(tenantId: string): Promise<numb
     .from('bph_works')
     .select('*', { count: 'exact', head: true });
   return count || 0;
+}
+
+/**
+ * Canonical "is this book in the BPH catalogue?" set, drawn from Supabase
+ * `bph_works.sl_book_id`. Used to keep the Selected Books row consistent
+ * with the catalogue list view (both view the same set of linked books).
+ *
+ * Returns the set of MongoDB book ids that appear as `sl_book_id` on any
+ * bph_works row — about 2,200 books at last count, fits in memory easily.
+ * Paginates around the Supabase 1,000-row default cap.
+ */
+export async function fetchTenantBphCataloguedBookIds(): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let from = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from('bph_works')
+      .select('sl_book_id')
+      .not('sl_book_id', 'is', null)
+      .range(from, from + 999);
+    if (error) break;
+    if (!data || data.length === 0) break;
+    for (const r of data) if (r.sl_book_id) ids.add(r.sl_book_id);
+    if (data.length < 1000) break;
+    from += 1000;
+  }
+  return ids;
 }


### PR DESCRIPTION
## Summary

The Selected Books row on `/embed/bph` (default landing) drew its 5 cards from MongoDB via `fetchTenantLibraryData → browseTenantBooks(sort:popular)`. The catalogue list view a few rows below it queries Supabase (`bph_works.sl_book_id IS NOT NULL`) — two different source-of-truths for "what's in the BPH catalogue". Today they agree (all top-popular books are catalogued), but a future popularity swing could surface an uncatalogued orphan in Selected Books while the catalogue list silently excludes it.

This PR locks both rows to the same Supabase truth.

## The change

- `fetchTenantBphCataloguedBookIds()` — new helper that paginates `bph_works.sl_book_id` and returns the canonical Set of linked MongoDB ids.
- `/embed/[tenant]/page.tsx` — fetches the Set in parallel with the main library load (when `tenant === 'bph'`), filters `topBooks` against it before passing to `<SharedLibraryView>`.

## Verified

Pre-change, the top-12 popular books for the BPH tenant were all catalogued (`sl_book_id` present in `bph_works`). So **visible UI change is zero** — this is purely a consistency lock-in.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 19 integration tests pass
- [ ] Preview deploy: verify the Selected Books row still renders the same 5 cards as before

## Deferred to a separate PR

The other worker's note on **mobile image variants**:

> sl_cover currently returns the 1200px image_display variant. For mobile grids we could fall back to image_thumb (150px) at smaller breakpoints — saves bandwidth.

Real win, but the proper fix needs either dropping down to `<img srcSet=...>` (bypasses Next.js Image), a custom Next.js Image `loader` keyed on viewport, or a `<picture>` wrapper. Worth its own focused PR — not bundling here.

## IIIF UBN backfill suggestion (also from the other worker)

> the 102 IIIF books have stable 11245_3_XXXXX record IDs in their dc_identifiers. A one-shot script that cross-walks those to UBNs (via the BPH spreadsheet or Vault metadata) would close most of the remaining ~70-book gap.

**Already shipped in #1712** — `scripts/backfill-bph-allard-pierson.mjs` synthesised `bph_works` rows for 101 of those 102 books using their **BPH PH-shelfmark** (the BPH-internal manuscript id, stored in `image_source.shelfmark`) as `ubn`, with the AP record id recorded in `field_provenance`. No external cross-walk needed — the data was already in MongoDB's `image_source.shelfmark`. (The 1 book without a shelfmark is in the dedupe-flagged set.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)