### PR TITLE
BookCard: responsive Next.js Image loader cuts mobile R2 egress ~95%

### DIFF
--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { BookOpen, Calendar, FileText } from 'lucide-react';
 import { cn, getBookThumbnailUrl } from '@/lib/utils';
+import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
 import AuthorName from '@/components/AuthorName';
 import { getEffectiveByline } from '@/lib/byline';
@@ -75,6 +76,7 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
           {thumbnailUrl && !imageError ? (
             <Image
               src={thumbnailUrl}
+              loader={bookCoverResponsiveLoader}
               alt={book.display_title || book.title}
               fill
               quality={85}

--- a/src/lib/book-cover-loader.ts
+++ b/src/lib/book-cover-loader.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-image `loader` for the Next.js `<Image>` component, optimised for
+ * book-cover grids.
+ *
+ * The Next.js Image optimiser still runs on top of whatever URL this
+ * returns — it fetches the source from R2 and serves an AVIF/WebP at the
+ * requested width. The only thing the loader controls is **which R2
+ * source URL gets fetched**.
+ *
+ * R2 stores three variants per cover:
+ *   - `*-thumb.jpg`  ≈ 150px   (~10 KB)
+ *   - `*.jpg`        ≈ 1200px  (~200 KB)   ← "display"
+ *   - `*-full.jpg`   = original
+ *
+ * Without a loader, every `<Image fill src={image_display}>` fetches the
+ * 1200px source from R2 at every breakpoint — including mobile 50vw cards
+ * that only need ~187 image pixels. That's a ~95% R2 egress overhead on
+ * the mobile catalogue grid (60 covers × 200 KB instead of 10 KB).
+ *
+ * This loader swaps to the 150px `-thumb.jpg` source for requested
+ * widths ≤ 500. Combined with Next.js's `imageSizes: [150, 400, 800]` +
+ * `deviceSizes: [640, 828, 1200, 1920]`, the srcSet candidates split
+ * cleanly:
+ *
+ *   srcSet width      Loader returns           Picked by
+ *   ──────────────────────────────────────────────────────────────
+ *   150 / 400         thumb URL  (10 KB R2)    mobile, low-DPR small cards
+ *   640+              display URL (200 KB R2)  retina/desktop
+ *
+ * Quality impact: mobile 2x-DPR cards display the 400w srcSet candidate;
+ * the loader returns thumb so the optimiser upscales 150 → 400 (slight
+ * softness on faint engravings — acceptable for thumbnails). 3x DPR
+ * mobile and 2x DPR desktop both pick 640+, getting the crisp 1200 source.
+ * Only 1x DPR desktops (increasingly rare) see thumb-quality grids.
+ *
+ * Falls through to the original `src` for any URL we don't recognise —
+ * external IIIF, Wikimedia, etc. — so it's safe to use as a default
+ * loader anywhere.
+ */
+
+const SOURCELIBRARY_HOST = 'images.sourcelibrary.org';
+const THUMB_WIDTH_THRESHOLD = 500;
+
+export function bookCoverResponsiveLoader({
+  src,
+  width,
+}: {
+  src: string;
+  width: number;
+  quality?: number;
+}): string {
+  if (width > THUMB_WIDTH_THRESHOLD) return src;
+  if (!src.includes(SOURCELIBRARY_HOST)) return src;
+
+  // Standard pages URL: `.../pages/{book_id}/{page}.jpg` → swap to `-thumb.jpg`.
+  // Already-thumb URLs are kept; full-resolution suffix gets normalised.
+  if (src.endsWith('-thumb.jpg')) return src;
+  if (src.endsWith('-full.jpg')) return src.replace(/-full\.jpg$/, '-thumb.jpg');
+  if (src.endsWith('.jpg')) return src.replace(/\.jpg$/, '-thumb.jpg');
+
+  return src;
+}

--- a/tests/unit/book-cover-loader.test.ts
+++ b/tests/unit/book-cover-loader.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
+
+describe('bookCoverResponsiveLoader', () => {
+  const display = 'https://images.sourcelibrary.org/pages/book-abc/0001.jpg';
+  const thumb = 'https://images.sourcelibrary.org/pages/book-abc/0001-thumb.jpg';
+  const full = 'https://images.sourcelibrary.org/pages/book-abc/0001-full.jpg';
+  const external = 'https://gallica.bnf.fr/ark/12148/btv1b8442266h/f1.image';
+
+  describe('mobile widths (≤500): swap to thumb', () => {
+    it('display → thumb for w=150', () => {
+      expect(bookCoverResponsiveLoader({ src: display, width: 150 })).toBe(thumb);
+    });
+
+    it('display → thumb for w=400 (mobile 2x DPR 50vw)', () => {
+      expect(bookCoverResponsiveLoader({ src: display, width: 400 })).toBe(thumb);
+    });
+
+    it('display → thumb for w=500 (boundary)', () => {
+      expect(bookCoverResponsiveLoader({ src: display, width: 500 })).toBe(thumb);
+    });
+
+    it('-full.jpg also gets normalised to thumb', () => {
+      expect(bookCoverResponsiveLoader({ src: full, width: 400 })).toBe(thumb);
+    });
+
+    it('already-thumb URL is left alone', () => {
+      expect(bookCoverResponsiveLoader({ src: thumb, width: 400 })).toBe(thumb);
+    });
+  });
+
+  describe('desktop / retina widths (>500): use display', () => {
+    it('display stays display at w=640', () => {
+      expect(bookCoverResponsiveLoader({ src: display, width: 640 })).toBe(display);
+    });
+
+    it('display stays display at w=1200', () => {
+      expect(bookCoverResponsiveLoader({ src: display, width: 1200 })).toBe(display);
+    });
+
+    it('display stays display at w=1920', () => {
+      expect(bookCoverResponsiveLoader({ src: display, width: 1920 })).toBe(display);
+    });
+  });
+
+  describe('non-sourcelibrary URLs: pass through unchanged', () => {
+    it('external IIIF URL untouched at small width', () => {
+      expect(bookCoverResponsiveLoader({ src: external, width: 150 })).toBe(external);
+    });
+
+    it('external IIIF URL untouched at large width', () => {
+      expect(bookCoverResponsiveLoader({ src: external, width: 1200 })).toBe(external);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Every `<Image fill src={image_display}>` in `CollectionBookCard` forced the Next.js image optimiser to fetch the **1200px** source from R2 at every srcSet breakpoint — including mobile 50vw cards that only need ~187 image pixels. For the BPH catalogue grid (60 covers per page), mobile users on a cold CDN cache cost **~12 MB of R2 egress when ~600 KB would do**.

This PR adds a per-image `loader` that swaps to the **150px** R2 source for requested widths ≤ 500. The Next.js Image optimiser still runs on top — clients still get AVIF/WebP at the breakpoint width — only the **R2 fetch** changes.

## How the split lands

Given `next.config.js`:
- `imageSizes: [150, 400, 800]`
- `deviceSizes: [640, 828, 1200, 1920]`

| srcSet width | Loader returns | Picked by |
| --- | --- | --- |
| 150 / 400 | thumb URL (~10 KB R2) | mobile 1x/2x DPR small cards |
| 640 … 1920 | display URL (~200 KB R2) | retina mobile + desktop |

## Quality impact

| Device class | Picked srcSet | Source fetched | Result |
| --- | --- | --- | --- |
| Mobile 1x DPR 50vw | 400w | 150px thumb | slight softness (acceptable for thumbnails) |
| Mobile 2x DPR 50vw | 400w | 150px thumb | slight softness (acceptable) |
| Mobile 3x DPR 50vw | 640w | 1200px display | crisp |
| Tablet 33vw | 640w | 1200px display | crisp |
| Desktop 2x DPR 20vw | 800w | 1200px display | crisp |
| Desktop 1x DPR 20vw | 400w | 150px thumb | slight softness (1x DPR desktops increasingly rare) |

## Safety

Falls through to the original `src` for non-`images.sourcelibrary.org` URLs (Gallica, Wikimedia, IIIF, etc.) — so it's safe wherever `CollectionBookCard` renders. Same path; unchanged behaviour.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 29 unit + 19 integration tests pass, including 10 new loader tests covering: `w=150/400/500` → thumb URL; `w=640+` → display URL; external URLs untouched; `-full.jpg` normalised to thumb; idempotent (already-thumb stays).
- [ ] Preview deploy: open `/embed/bph/?display=grid` on mobile DevTools — confirm Network panel shows `*-thumb.jpg` requests, not the full `.jpg` source
- [ ] Preview deploy: open same URL on desktop — confirm `*.jpg` (display) is fetched
- [ ] Visual spot-check: confirm the catalogue grid still looks acceptable on both viewports

## Future work

A native R2 medium variant (~600px) would make the threshold split even cleaner — currently the 400w srcSet candidate is fed by a 150px source, so the optimiser upscales by ~2.7x. With a 600px middle variant we'd never upscale. Pipeline work for the cover-generation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)