### PR TITLE
BPH: still-open partner testing report items (B11, B13, B15)

### DIFF
--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -562,6 +562,34 @@ export default function BphCatalogBrowser({
               </tr>
             </thead>
             <tbody className={loading ? 'opacity-50' : ''}>
+              {/* Skeleton rows while the initial fetch is in flight. Without
+                  these the table renders as column-headers-only, which read
+                  as broken-empty (B15). One row per expected result up to a
+                  reasonable cap. */}
+              {loading && works.length === 0 && (
+                Array.from({ length: 8 }, (_, i) => (
+                  <tr key={`skel-${i}`} className="border-b border-border-light last:border-0">
+                    <td className="px-3 py-3 align-top">
+                      <div className="h-4 w-3/4 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden sm:table-cell">
+                      <div className="h-4 w-1/2 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top tabular-nums">
+                      <div className="h-4 w-10 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden md:table-cell">
+                      <div className="h-4 w-16 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden md:table-cell">
+                      <div className="h-4 w-20 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden lg:table-cell">
+                      <div className="h-5 w-20 bg-border-light/40 rounded-full animate-pulse" />
+                    </td>
+                  </tr>
+                ))
+              )}
               {works.map((w) => {
                 const digitized = resolveDigitized(w);
                 const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
@@ -640,7 +668,19 @@ export default function BphCatalogBrowser({
         // links to the SL book — the catalogue detail page is reserved for
         // list rows where the user is browsing the catalogue itself.
         <div className={loading ? 'opacity-50' : ''}>
-          {works.length > 0 ? (
+          {loading && works.length === 0 ? (
+            // Skeleton tiles for the initial fetch so the grid doesn't read
+            // as empty before hydration completes (B15).
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {Array.from({ length: 12 }, (_, i) => (
+                <div key={`skel-${i}`} className="flex flex-col">
+                  <div className="aspect-[2/3] bg-border-light/40 rounded-md animate-pulse" />
+                  <div className="h-4 w-3/4 bg-border-light/40 rounded mt-2 animate-pulse" />
+                  <div className="h-3 w-1/2 bg-border-light/40 rounded mt-1 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          ) : works.length > 0 ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               {works.map((w) => {
                 const digitized = resolveDigitized(w);

--- a/src/components/ui/CiteButton.tsx
+++ b/src/components/ui/CiteButton.tsx
@@ -53,8 +53,11 @@ function buildCitableUrl(props: CiteButtonProps, origin: string): string {
   }
 
   const vParam = props.editionVersion ? `?v=${props.editionVersion}` : '';
-  const bookPath = props.tenantSlug ? `/${props.tenantSlug}/book/${props.bookId}` : `/book/${props.bookId}`;
-  return `${origin}${bookPath}${vParam}`;
+  // Canonical book URL is /book/{slug} on every host. proxy.ts (380+) 308s
+  // any /{tenant}/book/... back to /book/... so a citation that included the
+  // tenant prefix would just redirect — split the SEO signal across two URLs
+  // and confuse social-share previews (B13). Emit the canonical form here.
+  return `${origin}/book/${props.bookId}${vParam}`;
 }
 
 interface CiteButtonProps {
@@ -81,7 +84,7 @@ function formatAccessedDate(): string {
 }
 
 function generateApa(props: CiteButtonProps, origin: string): string {
-  const { author, title, displayTitle, year, doi, bookId, pageNumber, editionVersion, tenantSlug } = props;
+  const { author, title, displayTitle, year, doi, bookId, pageNumber, editionVersion } = props;
   const url = buildCitableUrl(props, origin);
   const displayName = displayTitle || title;
   const yearStr = year || 'n.d.';

--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -393,13 +393,29 @@ export async function fetchTenantBphDigitizedMap(tenantId: string): Promise<Reco
 
 /**
  * Get BPH catalog total for a tenant.
+ *
+ * Module-level TTL cache keeps the displayed total stable across rapid page
+ * navigations. Without it, ongoing imports (e.g. PR #1712 adding 101 Allard
+ * Pierson manuscripts mid-session) cause the counter to drift between pages
+ * — partner perceived this as a count bug (B11). A 60s window is short
+ * enough to stay near-live but long enough to span a normal browsing
+ * session.
  */
-export async function fetchTenantBphCatalogTotal(tenantId: string): Promise<number> {
-  // For now, return the global BPH catalog total since it's not tenant-scoped in Supabase
+let cachedBphCatalogTotal: { value: number; expiresAt: number } | null = null;
+const BPH_CATALOG_TOTAL_TTL_MS = 60_000;
+
+export async function fetchTenantBphCatalogTotal(_tenantId: string): Promise<number> {
+  const now = Date.now();
+  if (cachedBphCatalogTotal && cachedBphCatalogTotal.expiresAt > now) {
+    return cachedBphCatalogTotal.value;
+  }
+  // bph_works isn't tenant-scoped in Supabase today — return the global total.
   const { count } = await supabase
     .from('bph_works')
     .select('*', { count: 'exact', head: true });
-  return count || 0;
+  const value = count || 0;
+  cachedBphCatalogTotal = { value, expiresAt: now + BPH_CATALOG_TOTAL_TTL_MS };
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary

Picks up the three remaining items from `.claude/handoffs/2026-05-12-bph-testing-report.md` that weren't already addressed by today's earlier PRs (#1708, #1709, #1710, #1711, #1716).

- **B11** — `fetchTenantBphCatalogTotal` now caches the global bph_works count for 60s, so the displayed denominator stops drifting between pages during active imports (partner saw 27,706 → 27,807 mid-session).
- **B13** — `CiteButton.buildCitableUrl` no longer prepends `/<tenant>/` when a tenantSlug is supplied. That path was 308-ing back to `/book/<slug>` via `proxy.ts` anyway, so the citation just included a redirecting URL and split the SEO signal.
- **B15** — `BphCatalogBrowser` renders skeleton rows (list) and skeleton tiles (grid) during the initial fetch. Previously the table SSR'd as column-headers + empty `<tbody>`, which read as broken-empty until hydration completed — partner reported this as "Advanced panel hides the results table".

### Items dropped (already shipped or obsoleted)

- Back-to-catalogue removal → shipped as PR #1711
- B10 (grid Search-within input) → architecturally resolved by PR #1716 (BphCatalogBrowser now drives search for both displays)
- B12 (pagination chrome inconsistency) → architecturally resolved by PR #1716 (unified pagination inside BphCatalogBrowser)

The handoff itself was updated in-place with status tags per bug.

## Test plan

- [ ] `https://bph.sourcelibrary.org/embed/bph` skeleton appears briefly on cold load instead of column-headers-only
- [ ] Switching to grid display shows skeleton tiles before covers fill in
- [ ] Catalog total ("X of 27,807 works") stays stable across rapid page navigations within ~60s
- [ ] Cite button → APA export → URL is `https://bph.sourcelibrary.org/book/<slug>` (no `/bph/` prefix)
- [ ] `node scripts/audit-bph-leaks.mjs` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)