### PR TITLE
orchestrator: preserve live slug on warehouse→live update

### DIFF
--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -3325,10 +3325,15 @@ Rules:
             if (!book) continue;
 
             // Check if book already exists in live (can have different _id)
-            const existingLive = await db.collection('books').findOne({ id: candidate.id }, { projection: { _id: 1 } });
+            const existingLive = await db.collection('books').findOne({ id: candidate.id }, { projection: { _id: 1, slug: 1 } });
             if (existingLive) {
-              // Update in place, preserving live _id
+              // Update in place, preserving live _id and live slug.
+              // The live slug may have been disambiguated on first promotion
+              // (e.g. `foo-2`), while warehouse still holds the original `foo`.
+              // Overwriting would re-trigger E11000 against the record that
+              // owns `foo` in live.
               const { _id, ...bookWithoutId } = book;
+              if (existingLive.slug) delete bookWithoutId.slug;
               await db.collection('books').updateOne({ id: candidate.id }, { $set: bookWithoutId });
             } else {
               // Fresh insert — deduplicate slug to avoid E11000 on books_slug_idx


### PR DESCRIPTION
## Summary

The promote routine in `pipeline-orchestrator.mjs` has two branches:
- **Fresh insert** (no live record with this id yet): disambiguates `slug` → `slug-2` → `slug-3`... to avoid E11000 on the unique slug index.
- **Existing live** (record was already promoted): `updateOne($set: warehouse fields)` — overwrites the live slug with whatever is on the warehouse doc.

When a book was first inserted as e.g. `foo-2` because some other record owned `foo`, every subsequent promote tick re-overwrites the live slug back to `foo` (which is still what's on `books_warehouse`), colliding with the same record again. Result: noisy E11000 errors on every orchestrator run for the same handful of books.

## Real offenders found today

- *Speculum sapientiae* (Cyrillus, e-rara): live slug `speculum-sapientiae-cyrillus-4`. Warehouse still has the bare slug. A hidden BSB record from 1474 owns the bare slug.
- *Vocabularius breviloquus* (Reuchlin, e-rara): live slug `vocabularius-breviloquus-reuchlin-3`. Same pattern.

Both books are otherwise stuck on a separate issue (image-download failures from e-rara, 3 weeks old) — but the slug noise was hiding in the orchestrator's `error_count > 0` cron_runs.

## Fix

Include `slug` in the `existingLive` projection. If the live record already has a slug, drop `slug` from the `$set` payload. The disambiguation done on first promotion is the source of truth from then on.

## Test plan

- [x] `node --check scripts/workers/pipeline-orchestrator.mjs` passes
- [ ] After merge, watch one orchestrator tick: the 15:40Z-style `Promote ... E11000 ... books_slug_idx dup key` errors for these two slugs should stop appearing in `cron_runs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)