### PR TITLE
BPH: remove Back-to-catalogue link from digitised book page

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
 import { deduplicateByDHash } from '@/lib/dhash';
 import { getBookDetail } from '@/lib/books-catalog';
-import { Calendar, Globe, FileText, BookMarked, Images, BookOpen, ArrowLeft } from 'lucide-react';
+import { Calendar, Globe, FileText, BookMarked, Images, BookOpen } from 'lucide-react';
 import ArtworkInfo from '@/components/artwork/ArtworkInfo';
 import SearchPanel from '@/components/search/SearchPanel';
 import BookPagesSection from '@/components/book/BookPagesSection';
@@ -1109,29 +1109,9 @@ export default async function BookDetailPage({ params, isEmbedded = false }: Pag
   const tenantId = await getCachedTenantId(tenant);
   const tenantSlug = tenant;
 
-  // In tenant-embed mode, surface a "Back to catalogue" link above the dark
-  // hero. The partner reported "back arrow disabled" — what they wanted is a
-  // visible in-page affordance that mirrors the white catalog page's header
-  // link (#1688/B6). Only BPH has a public catalogue today, so gate on slug.
-  const showBackToCatalogue = isEmbedded && tenant === 'bph';
-
   return (
     <div className={isEmbedded ? "" : "min-h-screen bg-cream"}>
       {!isEmbedded && <ConditionalSiteHeader variant="light" />}
-
-      {showBackToCatalogue && (
-        <div className="bg-stone-900 text-white">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <Link
-              href="/?view=catalog&display=list"
-              className="inline-flex items-center gap-1 text-sm text-stone-300 hover:text-white transition-colors"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Back to catalogue
-            </Link>
-          </div>
-        </div>
-      )}
 
       {/* Book content streams in */}
       <Suspense fallback={


### PR DESCRIPTION
## Summary

PR #1711 removed the back-to-catalogue affordance from the white catalog detail page (`/embed/[tenant]/catalog/[ubn]`) but missed the dark hero book detail page (`/[tenant]/book/[id]`). Partner's screenshot of `bph.sourcelibrary.org/book/novum-lumen-chymicum-sendivogius-restored-from-1713` still showed the link, so this strip the matching block. Browser back is the only navigation affordance now, consistent across both detail templates.

## Test plan

- [ ] `https://bph.sourcelibrary.org/book/<slug>` no longer shows "← Back to catalogue"
- [ ] `https://bph.sourcelibrary.org/catalog/<ubn>` (white page) still shows no back link (already stripped by #1711)
- [ ] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)