### PR TITLE
BPH: open Catalogue record by default on book page (B7)

### DIFF
--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -105,7 +105,11 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
   );
 
   return (
-    <details className="mt-4">
+    // Open by default so the full bibliographic record sits at the same
+    // prominence as on the white /catalog/{ubn} page — partner-reported
+    // confusion was that the dark book page's biblio looked "compressed"
+    // compared to the catalog page (B7). Users can still collapse it.
+    <details className="mt-4" open>
       <summary className="cursor-pointer text-sm text-stone-400 hover:text-stone-200 transition-colors list-none flex items-center gap-2 [&::-webkit-details-marker]:hidden">
         <svg className="w-4 h-4 transition-transform [details[open]_&]:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="m6 9 6 6 6-6"/>


### PR DESCRIPTION
## Summary

One-line fix for B7 (last open testing-report item that's actually code, not curation/feature work).

Partner noted that the dark `/book/{slug}` page felt biblio-light compared to the white `/catalog/{ubn}` page. Both routes read the same Supabase \`bph_works\` row via \`BphCatalogueRecord\`, but the dark page wrapped it in a closed \`<details>\` accordion. Open it by default so the full record (variant titles, imprint, shelfmark, provenance, IA/USTC identifiers) is immediately visible without a click. Users can still collapse it.

This closes the visual-parity gap the partner reported. Full template unification into one route is not done here (and may not be needed — PR #1699's catalog→book redirect means users never see both routes for the same book).

## Test plan

- [ ] `https://bph.sourcelibrary.org/book/<slug>` shows the Catalogue record expanded by default
- [ ] Clicking the summary still collapses it
- [ ] White `/catalog/<ubn>` for catalog-only entries is unaffected (it never used the accordion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)