### PR TITLE
BPH book page: close Catalogue record by default

### DIFF
--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -105,11 +105,11 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
   );
 
   return (
-    // Open by default so the full bibliographic record sits at the same
-    // prominence as on the white /catalog/{ubn} page — partner-reported
-    // confusion was that the dark book page's biblio looked "compressed"
-    // compared to the catalog page (B7). Users can still collapse it.
-    <details className="mt-4" open>
+    // Closed by default on the book detail page: the catalogue record is
+    // reference material, and the primary action here is to start reading.
+    // Users arrive from bph.sourcelibrary.org expecting the book, not the
+    // bibliographic dossier — they can expand it when they want the detail.
+    <details className="mt-4">
       <summary className="cursor-pointer text-sm text-stone-400 hover:text-stone-200 transition-colors list-none flex items-center gap-2 [&::-webkit-details-marker]:hidden">
         <svg className="w-4 h-4 transition-transform [details[open]_&]:rotate-180" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="m6 9 6 6 6-6"/>


### PR DESCRIPTION
## Summary
- On `bph.sourcelibrary.org/book/...`, the Catalogue record accordion now starts **closed** instead of open.
- Reverses the open-by-default behaviour from #1724.
- Rationale: visitors clicking a book from BPH are there to read; the bibliographic dossier is reference material and pushes the start-reading affordances below the fold. One tap to expand when needed.

Component: `src/components/book/BphCatalogueRecord.tsx` — used only on the BPH tenant book route (`src/app/[tenant]/book/[id]/page.tsx`).

## Test plan
- [ ] On a BPH book page (e.g. `https://bph.sourcelibrary.org/book/<slug>`), the "Catalogue record (BPH UBN …)" row is collapsed on first load.
- [ ] Clicking the summary expands the full record.
- [ ] `/catalog/{ubn}` page is unaffected (renders the full record directly, not in an accordion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)