### PR TITLE
OCR/translate: route non-Latin scripts to flash, not flash-lite

### DIFF
--- a/scripts/migration/backfill-ocr-near-complete.mjs
+++ b/scripts/migration/backfill-ocr-near-complete.mjs
@@ -50,8 +50,33 @@ function getGeminiApiKey(keyIndex = 0) {
   return GEMINI_BATCH_KEYS[keyIndex] || GEMINI_BATCH_KEYS[0];
 }
 
+// Latin-script languages safe for flash-lite. Non-Latin scripts get flash
+// because flash-lite hallucinates on low-resource scripts. See
+// src/lib/types/ai-models.ts for the canonical list.
+const LATIN_SCRIPT_LANGS_FOR_LITE = new Set([
+  'english', 'en', 'eng', 'latin', 'la', 'lat',
+  'french', 'fr', 'fra', 'italian', 'it', 'ita',
+  'spanish', 'es', 'spa', 'portuguese', 'pt', 'por',
+  'romanian', 'ro', 'ron', 'rum', 'catalan', 'ca', 'cat',
+  'german', 'de', 'deu', 'ger', 'dutch', 'nl', 'nld', 'dut',
+  'swedish', 'sv', 'swe', 'norwegian', 'no', 'nor',
+  'danish', 'da', 'dan', 'finnish', 'fi', 'fin',
+  'icelandic', 'is', 'isl', 'ice',
+  'welsh', 'cy', 'cym', 'wel', 'irish', 'ga', 'gle',
+  'polish', 'pl', 'pol', 'czech', 'cs', 'ces', 'cze',
+  'slovak', 'sk', 'slk', 'slo', 'slovenian', 'sl', 'slv',
+  'croatian', 'hr', 'hrv', 'hungarian', 'hu', 'hun',
+  'estonian', 'et', 'est', 'latvian', 'lv', 'lav',
+  'lithuanian', 'lt', 'lit', 'albanian', 'sq', 'sqi', 'alb',
+  'turkish', 'tr', 'tur', 'indonesian', 'id', 'ind',
+  'vietnamese', 'vi', 'vie', 'malay', 'ms', 'msa',
+  'tagalog', 'tl', 'tgl', 'filipino', 'swahili', 'sw', 'swa',
+]);
+
 function getOcrModelForBook(book) {
   if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
+  const lang = (book?.language || '').toLowerCase().trim();
+  if (!lang || !LATIN_SCRIPT_LANGS_FOR_LITE.has(lang)) return MODEL_FLASH;
   return MODEL_LITE;
 }
 

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -79,9 +79,55 @@ async function saveRevisionBeforeOverwrite(db, pageId, field) {
 
 const OCR_MODEL_FLASH = 'gemini-3-flash-preview';
 const OCR_MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+
+// Latin-script languages safe for flash-lite. Anything else (Tibetan, Arabic,
+// Hebrew, CJK, Cyrillic, Greek, Syriac, etc.) routes to flash because
+// flash-lite hallucinates on low-resource scripts — it over-relies on
+// linguistic priors when visual decoding is hard, producing plausible-sounding
+// content that has nothing to do with the page. See src/app/blog/tibetan-ocr/.
+// Must stay in sync with LATIN_SCRIPT_LANGUAGES in src/lib/types/ai-models.ts.
+const LATIN_SCRIPT_LANGS_FOR_LITE = new Set([
+  'english', 'en', 'eng',
+  'latin', 'la', 'lat',
+  'french', 'fr', 'fra',
+  'italian', 'it', 'ita',
+  'spanish', 'es', 'spa',
+  'portuguese', 'pt', 'por',
+  'romanian', 'ro', 'ron', 'rum',
+  'catalan', 'ca', 'cat',
+  'german', 'de', 'deu', 'ger',
+  'dutch', 'nl', 'nld', 'dut',
+  'swedish', 'sv', 'swe',
+  'norwegian', 'no', 'nor',
+  'danish', 'da', 'dan',
+  'finnish', 'fi', 'fin',
+  'icelandic', 'is', 'isl', 'ice',
+  'welsh', 'cy', 'cym', 'wel',
+  'irish', 'ga', 'gle',
+  'polish', 'pl', 'pol',
+  'czech', 'cs', 'ces', 'cze',
+  'slovak', 'sk', 'slk', 'slo',
+  'slovenian', 'sl', 'slv',
+  'croatian', 'hr', 'hrv',
+  'hungarian', 'hu', 'hun',
+  'estonian', 'et', 'est',
+  'latvian', 'lv', 'lav',
+  'lithuanian', 'lt', 'lit',
+  'albanian', 'sq', 'sqi', 'alb',
+  'turkish', 'tr', 'tur',
+  'indonesian', 'id', 'ind',
+  'vietnamese', 'vi', 'vie',
+  'malay', 'ms', 'msa',
+  'tagalog', 'tl', 'tgl', 'filipino',
+  'swahili', 'sw', 'swa',
+]);
+
 function getOcrModelForBook(book) {
   // BPH books use Flash Preview for higher quality on historical manuscripts
   if (book?.image_source?.provider === 'bph') return OCR_MODEL_FLASH;
+  // Non-Latin scripts: flash-lite hallucinates on low-resource pretraining data
+  const lang = (book?.language || '').toLowerCase().trim();
+  if (!lang || !LATIN_SCRIPT_LANGS_FOR_LITE.has(lang)) return OCR_MODEL_FLASH;
   return OCR_MODEL_LITE;
 }
 const OCR_MODEL = OCR_MODEL_FLASH; // Legacy fallback for recitation retry path

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -38,8 +38,52 @@ const SINGLE_PAGE = process.argv.includes('--single-page');
 const MAX_BATCH_OCR_CHARS = 20000; // If total OCR text exceeds this, reduce batch size
 const MODEL_FLASH = 'gemini-3-flash-preview';
 const MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+
+// Latin-script languages safe for flash-lite translation. Non-Latin scripts
+// (Tibetan, Arabic, Hebrew, CJK, Cyrillic, Greek, Syriac, etc.) route to flash.
+// flash-lite hallucinates on low-resource scripts during OCR — translation
+// from those OCR outputs is doubly exposed. Keep in sync with the matching
+// list in src/lib/types/ai-models.ts and pipeline-orchestrator.mjs.
+const LATIN_SCRIPT_LANGS_FOR_LITE = new Set([
+  'english', 'en', 'eng',
+  'latin', 'la', 'lat',
+  'french', 'fr', 'fra',
+  'italian', 'it', 'ita',
+  'spanish', 'es', 'spa',
+  'portuguese', 'pt', 'por',
+  'romanian', 'ro', 'ron', 'rum',
+  'catalan', 'ca', 'cat',
+  'german', 'de', 'deu', 'ger',
+  'dutch', 'nl', 'nld', 'dut',
+  'swedish', 'sv', 'swe',
+  'norwegian', 'no', 'nor',
+  'danish', 'da', 'dan',
+  'finnish', 'fi', 'fin',
+  'icelandic', 'is', 'isl', 'ice',
+  'welsh', 'cy', 'cym', 'wel',
+  'irish', 'ga', 'gle',
+  'polish', 'pl', 'pol',
+  'czech', 'cs', 'ces', 'cze',
+  'slovak', 'sk', 'slk', 'slo',
+  'slovenian', 'sl', 'slv',
+  'croatian', 'hr', 'hrv',
+  'hungarian', 'hu', 'hun',
+  'estonian', 'et', 'est',
+  'latvian', 'lv', 'lav',
+  'lithuanian', 'lt', 'lit',
+  'albanian', 'sq', 'sqi', 'alb',
+  'turkish', 'tr', 'tur',
+  'indonesian', 'id', 'ind',
+  'vietnamese', 'vi', 'vie',
+  'malay', 'ms', 'msa',
+  'tagalog', 'tl', 'tgl', 'filipino',
+  'swahili', 'sw', 'swa',
+]);
+
 function getModelForBook(book) {
   if (book?.image_source?.provider === 'bph') return MODEL_FLASH;
+  const lang = (book?.language || '').toLowerCase().trim();
+  if (!lang || !LATIN_SCRIPT_LANGS_FOR_LITE.has(lang)) return MODEL_FLASH;
   return MODEL_LITE;
 }
 const PROMPT_VERSION = 'v10';

--- a/src/app/api/jobs/queue-books/route.ts
+++ b/src/app/api/jobs/queue-books/route.ts
@@ -105,7 +105,7 @@ export const POST = withAuth(async (request, session) => {
       config: {
         page_ids: pageIds,
         custom_prompt: customPrompt,
-        model: getModelForBook(book as { image_source?: { provider?: string } }),
+        model: getModelForBook(book as { image_source?: { provider?: string }; language?: string | null }),
         language: book.language || "auto-detect"
       },
       initiated_by: 'user',

--- a/src/lib/types/ai-models.ts
+++ b/src/lib/types/ai-models.ts
@@ -14,11 +14,83 @@ export const DEFAULT_LITE_MODEL = 'gemini-3.1-flash-lite-preview';
 export const DEFAULT_BATCH_MODEL = 'gemini-3-flash-preview';
 
 /**
- * Select the appropriate model for a book's OCR/translation.
- * BPH books get full flash; everything else gets flash-lite.
+ * Languages written in Latin script that are well-represented in flash-lite's
+ * pretraining. Books in these languages can safely use the cheaper model.
+ *
+ * Anything outside this allowlist (Tibetan, Sanskrit, Arabic, Hebrew, Greek,
+ * CJK, Cyrillic, Syriac, Ge'ez, etc.) goes to full flash. Per the Tibetan-OCR
+ * blog post: flash-lite hallucinated an entire genre ("ritual manual for
+ * weather control") on a Bhutanese astrological text — it over-relies on
+ * linguistic priors when visual decoding is hard, writing plausible-sounding
+ * content that has nothing to do with the page. Worse than failing.
+ *
+ * Allowlist (not denylist) so unknown/null defaults to the safer model.
  */
-export function getModelForBook(book: { image_source?: { provider?: string } } | null): string {
+const LATIN_SCRIPT_LANGUAGES: ReadonlySet<string> = new Set([
+  // English
+  'english', 'en', 'eng',
+  // Latin
+  'latin', 'la', 'lat',
+  // Romance
+  'french', 'fr', 'fra',
+  'italian', 'it', 'ita',
+  'spanish', 'es', 'spa',
+  'portuguese', 'pt', 'por',
+  'romanian', 'ro', 'ron', 'rum',
+  'catalan', 'ca', 'cat',
+  // Germanic
+  'german', 'de', 'deu', 'ger',
+  'dutch', 'nl', 'nld', 'dut',
+  'swedish', 'sv', 'swe',
+  'norwegian', 'no', 'nor',
+  'danish', 'da', 'dan',
+  'finnish', 'fi', 'fin',
+  'icelandic', 'is', 'isl', 'ice',
+  // Celtic
+  'welsh', 'cy', 'cym', 'wel',
+  'irish', 'ga', 'gle',
+  // Slavic (Latin-script subset)
+  'polish', 'pl', 'pol',
+  'czech', 'cs', 'ces', 'cze',
+  'slovak', 'sk', 'slk', 'slo',
+  'slovenian', 'sl', 'slv',
+  'croatian', 'hr', 'hrv',
+  // Baltic + Finno-Ugric + Albanian + Turkic
+  'hungarian', 'hu', 'hun',
+  'estonian', 'et', 'est',
+  'latvian', 'lv', 'lav',
+  'lithuanian', 'lt', 'lit',
+  'albanian', 'sq', 'sqi', 'alb',
+  'turkish', 'tr', 'tur',
+  // Latinized Asian
+  'indonesian', 'id', 'ind',
+  'vietnamese', 'vi', 'vie',
+  'malay', 'ms', 'msa',
+  'tagalog', 'tl', 'tgl', 'filipino',
+  // African (Latin-script)
+  'swahili', 'sw', 'swa',
+]);
+
+function isLatinScriptLanguage(language: string | null | undefined): boolean {
+  if (!language) return false;
+  return LATIN_SCRIPT_LANGUAGES.has(language.toLowerCase().trim());
+}
+
+/**
+ * Select the appropriate model for a book's OCR/translation.
+ *
+ * - BPH books: full flash (high-quality manuscripts)
+ * - Non-Latin scripts (Tibetan, Arabic, Hebrew, CJK, Cyrillic, etc.): full flash
+ *   to avoid the flash-lite hallucination problem documented in the
+ *   Tibetan-OCR blog post.
+ * - Latin-script European languages: flash-lite (50% cheaper, comparable quality)
+ * - Unknown/null language: full flash (safer default)
+ */
+export function getModelForBook(book: { image_source?: { provider?: string }; language?: string | null } | null): string {
   if (book?.image_source?.provider === 'bph') {
+    return DEFAULT_MODEL;
+  }
+  if (!isLatinScriptLanguage(book?.language)) {
     return DEFAULT_MODEL;
   }
   return DEFAULT_LITE_MODEL;

--- a/src/workers/translation-processor-logic.ts
+++ b/src/workers/translation-processor-logic.ts
@@ -179,7 +179,7 @@ export async function processTranslationPage(message: PageProcessingMessage) {
     }
   }
 
-  const modelId = job.config.model || getModelForBook(bookDoc as { image_source?: { provider?: string } } | null) || DEFAULT_MODEL;
+  const modelId = job.config.model || getModelForBook(bookDoc as { image_source?: { provider?: string }; language?: string | null } | null) || DEFAULT_MODEL;
   const startTime = Date.now();
 
   // Resolve the translation prompt from DB (source of truth for prompt content + version)


### PR DESCRIPTION
## Summary

Gemini 3.1 Flash Lite **hallucinates** on low-resource scripts. The [Tibetan-OCR blog post](https://sourcelibrary.org/blog/tibetan-ocr) documented this directly: flash-lite "read" a Bhutanese astrological text as a "ritual manual for weather control" — coherent Tibetan Buddhist terminology with **no relation to what was on the page**.

| Model | MCR | Notes |
|---|---|---|
| Claude Opus 4.6 | 100% | Correct script + genre + content ID |
| Gemini 3 Flash | 80% | 1 mode-switch in 5 runs |
| **Gemini 3.1 Flash Lite** | **N/A** | **Misidentified genre. Hallucinated genre entirely.** |

The mechanism ("Seeing is Believing?", Wu et al. 2025): VLMs over-rely on linguistic priors when visual decoding is hard. flash-lite writes plausible-sounding text instead of reading the actual page. **Worse than failing** — silent garbage filed as success, then used as input to translation.

Same risk applies to any script with thin pretraining coverage: Tibetan, Sanskrit, Arabic, Hebrew, Syriac, Ge'ez, CJK, Cyrillic, Greek (esp. ancient), etc. Current corpus impact: ~176 of 945 recently-reset books are in non-Latin scripts — they would have been re-OCR'd by flash-lite without this fix.

## Fix

**Latin-script allowlist gate.** Only books whose `language` matches a known-safe Latin-script set (with ISO 639-1/2/3 codes) get flash-lite. Everything else — including unknown/null language — gets flash.

Surface area:
- `src/lib/types/ai-models.ts` — canonical `LATIN_SCRIPT_LANGUAGES` set + updated `getModelForBook`
- `scripts/workers/pipeline-orchestrator.mjs` — `getOcrModelForBook`
- `scripts/workers/translate-worker.mjs` — `getModelForBook`
- `scripts/migration/backfill-ocr-near-complete.mjs` — `getOcrModelForBook`
- 2 TS callers: widened type to include `language`

## Cost impact

~20% of books shift to flash, ~2x cost on those specific books. Alternative is silent hallucinated OCR on thousands of non-Latin pages — much worse.

## Test plan

- [x] `node --check` passes on all 3 modified `.mjs` files
- [x] `npx tsc --noEmit` clean
- [x] 16-case smoke test (BPH override still works; null/empty language goes to flash; ISO codes resolved; case-insensitive)
- [ ] After merge: watch one orchestrator tick; non-Latin reset books (Tibetan, Sanskrit, Arabic, etc.) should be submitted with `gemini-3-flash-preview` in `batch_jobs.model`

## Follow-up (not in this PR)

Books already OCR'd by flash-lite in non-Latin scripts may have garbage content sitting in `pages.ocr.data`. Needs a separate re-OCR audit, gated by language + OCR-quality eval. Estimated scope: ~3,000-5,000 books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)