### PR TITLE
Broken-image reporter: drop bot noise + verify-after-tick

### DIFF
--- a/src/app/api/analytics/broken-image/route.ts
+++ b/src/app/api/analytics/broken-image/route.ts
@@ -2,13 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 
 /**
- * Log broken image reports from the client.
- * Fire-and-forget — never fails to the client.
+ * Log broken-image reports from the client.
+ *
+ * Bot traffic is dropped at the door: link-preview crawlers (Meta, Slack,
+ * etc.) request every page on the site and trigger image-load errors at
+ * scale, drowning out the human signal. Bot reports get silently 200'd.
  *
  * POST /api/analytics/broken-image
  * Body: { urls: string[], page: string, timestamp: string }
  */
 const DB_TIMEOUT_MS = 3000;
+
+const BOT_RE = /bot|crawler|spider|preview|facebookexternalhit|meta-externalagent|slurp|slackbot|googlebot|bingbot|twitterbot|whatsapp|linkedinbot|telegrambot|discordbot|applebot|pingdom|uptime|monitor|headless/i;
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,10 +22,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true });
     }
 
+    const ua = request.headers.get('user-agent') || '';
+    if (BOT_RE.test(ua)) {
+      return NextResponse.json({ ok: true });
+    }
+
     // Cap at 20 per report to prevent abuse
     const capped = urls.slice(0, 20);
-
-    const ua = request.headers.get('user-agent') || '';
     const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
 
     const dbWork = (async () => {

--- a/src/components/BrokenImageReporter.tsx
+++ b/src/components/BrokenImageReporter.tsx
@@ -3,11 +3,22 @@
 import { useEffect } from 'react';
 
 /**
- * Global broken image reporter. Listens for image load errors
- * across the entire page and reports them to the analytics endpoint.
+ * Global broken-image reporter. Listens for image load errors and reports
+ * truly-broken images to the analytics endpoint.
  *
- * Debounces and deduplicates: reports at most one batch per page load,
- * and never reports the same URL twice per session.
+ * Why the verify-after-tick logic: cards like BookCard handle errors by
+ * swapping to a fallback URL on the same <img> element (display variant →
+ * thumb variant). The original error event still fires, but the user ends
+ * up seeing a working image. We only want to report when the *final*
+ * rendered state is broken, not every intermediate failure.
+ *
+ * Algorithm:
+ *   1. Capture the error event + the src that failed.
+ *   2. After ~1s, re-check the element:
+ *      - If unmounted → drop (component disappeared, irrelevant).
+ *      - If src changed → drop (a fallback swap succeeded or is in-flight).
+ *      - If complete && naturalWidth === 0 with the same src → genuinely
+ *        broken, queue for batched reporting.
  */
 
 const reported = new Set<string>();
@@ -20,7 +31,6 @@ function flush() {
   pending = [];
   flushTimer = null;
 
-  // Fire and forget — never block UI
   fetch('/api/analytics/broken-image', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -29,25 +39,34 @@ function flush() {
       page: window.location.pathname,
       timestamp: new Date().toISOString(),
     }),
-  }).catch(() => {}); // swallow errors
+  }).catch(() => {});
 }
 
 function handleError(e: Event) {
   const el = e.target;
   if (!(el instanceof HTMLImageElement)) return;
 
-  const src = el.currentSrc || el.src;
-  if (!src || reported.has(src)) return;
+  const failedSrc = el.currentSrc || el.src;
+  if (!failedSrc || reported.has(failedSrc)) return;
 
-  // Only report images from our own domain
-  if (!src.includes('images.sourcelibrary.org') && !src.includes('/api/image')) return;
+  if (!failedSrc.includes('images.sourcelibrary.org') && !failedSrc.includes('/api/image')) return;
 
-  reported.add(src);
-  pending.push(src);
+  // Dedup early so we don't queue multiple verify-checks for the same URL.
+  reported.add(failedSrc);
 
-  // Batch: wait 2s after last error to flush (catches cascading failures)
-  if (flushTimer) clearTimeout(flushTimer);
-  flushTimer = setTimeout(flush, 2000);
+  // Verify after a tick: if a component-level fallback (BookCard, PageCard, etc.)
+  // swaps the src and loads successfully, drop the report.
+  setTimeout(() => {
+    if (!el.isConnected) return;
+    const currentSrc = el.currentSrc || el.src;
+    if (currentSrc !== failedSrc) return; // src swapped, treat as recovered
+    // complete=true with naturalWidth=0 is the canonical "fetched but no image" state.
+    if (!el.complete || el.naturalWidth !== 0) return;
+
+    pending.push(failedSrc);
+    if (flushTimer) clearTimeout(flushTimer);
+    flushTimer = setTimeout(flush, 2000);
+  }, 1000);
 }
 
 export default function BrokenImageReporter() {


### PR DESCRIPTION
## Summary
Footer feedback ("Broken images" on /collections/indic-magic, May 9) led me to look at the `broken_image_reports` collection. **597 reports in the last 24h, only 52 from real humans, only a handful actually broken.**

Two sources of noise:

1. **The global reporter fires on every image error event** — including intermediate failures that components recover from. `BookCard` swaps display→thumb variant on 404; the user sees a working image, but the original URL still got logged as "broken."
2. **Link-preview crawlers** (Meta, Slack, etc.) request every page on the site and trigger image errors at scale, drowning out the human signal.

## Changes

- **`BrokenImageReporter.tsx`** — capture the error event, dedup the failed URL, then verify *after a tick*. If the `<img>` was unmounted, the src changed (fallback swap), or it's not in the canonical broken state (`complete && naturalWidth === 0`), drop the report.
- **`api/analytics/broken-image/route.ts`** — bot user-agents (Facebook, Meta, Slackbot, Google/Bingbot, Twitter, WhatsApp, LinkedIn, Telegram, Discord, Apple, headless browsers, uptime monitors) get a silent 200 with no DB insert.

After this lands, `broken_image_reports` should reflect actual human encounters with images that didn't load — the channel becomes actionable instead of drowning.

## Test plan
- [ ] Visit homepage → no broken_image_reports inserted for BookCards that fall back display→thumb successfully.
- [ ] Visit /collections/indic-magic (or any page that previously logged) → only reports persist for images that are actually visibly broken at 1s+ after load.
- [ ] Curl with `User-Agent: facebookexternalhit/1.1` against `/api/analytics/broken-image` with a valid body → 200, but no row appears in `broken_image_reports`.
- [ ] Curl with a normal browser UA → row appears as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)