### PR TITLE
Fix React #418 hydration mismatches + broken-thumbnail cleanup script

### DIFF
--- a/scripts/fix-broken-thumbnails.mjs
+++ b/scripts/fix-broken-thumbnails.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Find books whose `thumbnail` field points at an R2 URL that 404s, and clear
+ * the field so BookCard falls through to its placeholder icon instead of
+ * cycling through display → thumb → broken before giving up.
+ *
+ * Why this is a problem:
+ *   - 7.3K books have legacy /archived/{bookId}/{N}.jpg thumbnail URLs.
+ *   - getBookThumbnailUrl() rewrites those to /pages/{bookId}/{padded}.jpg
+ *     when building cards. About 3% of books had no pages actually uploaded
+ *     to R2, so the rewritten URL 404s. The user sees a flash of broken
+ *     image before BookCard's onError settles on the placeholder.
+ *   - These rewrites happen at render time on every page that shows the
+ *     book card, repeatedly hammering R2 with requests we know will 404.
+ *
+ * What this does:
+ *   - Streams over visible books with /archived/ thumbnails.
+ *   - HEAD-checks each rewritten URL with bounded concurrency.
+ *   - On 404, unsets `book.thumbnail` so the card renders the icon state
+ *     from the first paint.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/fix-broken-thumbnails.mjs            # dry run (default)
+ *   node scripts/fix-broken-thumbnails.mjs --apply    # actually update
+ *   node scripts/fix-broken-thumbnails.mjs --apply --limit 500  # bounded
+ */
+
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const limitArg = process.argv.find(a => a.startsWith('--limit='));
+const LIMIT = limitArg ? parseInt(limitArg.split('=')[1], 10) : Infinity;
+const CONCURRENCY = 24;
+
+function rewriteThumbToDisplayUrl(thumbnail) {
+  const m = thumbnail.match(/\/archived\/([^/]+)\/(\d+)\.jpg$/);
+  if (!m) return null;
+  const padded = m[2].padStart(4, '0');
+  return `https://images.sourcelibrary.org/pages/${m[1]}/${padded}.jpg`;
+}
+
+async function head(url) {
+  try {
+    const r = await fetch(url, { method: 'HEAD' });
+    return r.status;
+  } catch {
+    return 0;
+  }
+}
+
+async function main() {
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI not set. source .env.production.local first.');
+    process.exit(1);
+  }
+  const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 15000 });
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+  const books = db.collection('books');
+
+  const cursor = books.find(
+    { visible: true, thumbnail: /\/archived\// },
+    { projection: { _id: 1, id: 1, slug: 1, title: 1, thumbnail: 1 } }
+  ).limit(Number.isFinite(LIMIT) ? LIMIT : 0);
+
+  console.log(`mode: ${APPLY ? 'APPLY (writes will happen)' : 'DRY RUN (no writes)'}`);
+  console.log(`scanning visible books with /archived/ thumbnail...`);
+
+  let scanned = 0;
+  let broken = 0;
+  let cleared = 0;
+  let queue = [];
+
+  const flush = async () => {
+    if (queue.length === 0) return;
+    const batch = queue.splice(0, queue.length);
+    await Promise.all(batch.map(async (book) => {
+      const display = rewriteThumbToDisplayUrl(book.thumbnail);
+      if (!display) return;
+      const status = await head(display);
+      if (status === 404) {
+        broken++;
+        if (APPLY) {
+          await books.updateOne(
+            { _id: book._id },
+            { $unset: { thumbnail: '', thumbnail_blob: '' } }
+          );
+          cleared++;
+        }
+        const slug = book.slug || book.id || String(book._id);
+        console.log(`  404  ${slug}  (${book.title?.slice(0, 60) || ''})`);
+      }
+    }));
+  };
+
+  for await (const book of cursor) {
+    scanned++;
+    queue.push(book);
+    if (queue.length >= CONCURRENCY) await flush();
+    if (scanned % 500 === 0) console.log(`  ...scanned ${scanned}, broken so far ${broken}`);
+  }
+  await flush();
+
+  console.log('---');
+  console.log(`scanned: ${scanned}`);
+  console.log(`broken:  ${broken}`);
+  console.log(`cleared: ${cleared}${APPLY ? '' : ' (dry run — re-run with --apply)'}`);
+
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err);
+  process.exit(1);
+});

--- a/src/app/[tenant]/admin/api-keys/usage/page.tsx
+++ b/src/app/[tenant]/admin/api-keys/usage/page.tsx
@@ -111,8 +111,8 @@ export default function ApiKeyUsagePage() {
           {/* Summary cards */}
           <div className="grid grid-cols-4 gap-4 mb-8">
             {[
-              { label: 'Total Requests', value: data.totals.total_requests.toLocaleString() },
-              { label: 'Pages Served', value: data.totals.total_pages.toLocaleString() },
+              { label: 'Total Requests', value: data.totals.total_requests.toLocaleString('en-US') },
+              { label: 'Pages Served', value: data.totals.total_pages.toLocaleString('en-US') },
               { label: 'Active Keys', value: data.totals.active_keys },
               { label: 'Total Keys', value: data.totals.total_keys },
             ].map(card => (
@@ -163,10 +163,10 @@ export default function ApiKeyUsagePage() {
                         </span>
                       </td>
                       <td className="px-4 py-3 text-right font-mono text-stone-700">
-                        {k.total_requests.toLocaleString()}
+                        {k.total_requests.toLocaleString('en-US')}
                       </td>
                       <td className="px-4 py-3 text-right font-mono text-stone-700">
-                        {k.total_pages.toLocaleString()}
+                        {k.total_pages.toLocaleString('en-US')}
                       </td>
                       <td className="px-4 py-3">
                         <Sparkline data={sparkData} />
@@ -210,8 +210,8 @@ export default function ApiKeyUsagePage() {
                           {endpoints.map(([ep, stats]) => (
                             <tr key={ep} className="border-b border-stone-50">
                               <td className="py-1.5 font-mono text-xs text-stone-700">{ep}</td>
-                              <td className="py-1.5 text-right text-stone-600">{stats.requests.toLocaleString()}</td>
-                              <td className="py-1.5 text-right text-stone-600">{stats.pages.toLocaleString()}</td>
+                              <td className="py-1.5 text-right text-stone-600">{stats.requests.toLocaleString('en-US')}</td>
+                              <td className="py-1.5 text-right text-stone-600">{stats.pages.toLocaleString('en-US')}</td>
                             </tr>
                           ))}
                         </tbody>
@@ -238,8 +238,8 @@ export default function ApiKeyUsagePage() {
                             {sorted.map(d => (
                               <tr key={d.date} className="border-b border-stone-50">
                                 <td className="py-1.5 text-stone-700">{d.date}</td>
-                                <td className="py-1.5 text-right text-stone-600">{d.requests.toLocaleString()}</td>
-                                <td className="py-1.5 text-right text-stone-600">{d.pages.toLocaleString()}</td>
+                                <td className="py-1.5 text-right text-stone-600">{d.requests.toLocaleString('en-US')}</td>
+                                <td className="py-1.5 text-right text-stone-600">{d.pages.toLocaleString('en-US')}</td>
                               </tr>
                             ))}
                           </tbody>

--- a/src/app/[tenant]/admin/catalog-coverage/page.tsx
+++ b/src/app/[tenant]/admin/catalog-coverage/page.tsx
@@ -242,19 +242,19 @@ node scripts/catalog-coverage/build.mjs`}
             <div className="mb-10 space-y-6">
               <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
                 <div>
-                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{t.editions.toLocaleString()}</div>
+                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{t.editions.toLocaleString('en-US')}</div>
                   <div className="text-sm text-[#6b6560] mt-1">editions catalogued</div>
                 </div>
                 <div>
-                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{nonEnglish.toLocaleString()}</div>
+                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{nonEnglish.toLocaleString('en-US')}</div>
                   <div className="text-sm text-[#6b6560] mt-1">non-English editions</div>
                 </div>
                 <div>
-                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{totalWorks.toLocaleString()}</div>
+                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{totalWorks.toLocaleString('en-US')}</div>
                   <div className="text-sm text-[#6b6560] mt-1">distinct works</div>
                 </div>
                 <div>
-                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{t.with_scan.toLocaleString()}</div>
+                  <div className="font-['Cormorant_Garamond'] text-4xl font-semibold text-[#1a1612]">{t.with_scan.toLocaleString('en-US')}</div>
                   <div className="text-sm text-[#6b6560] mt-1">with digital scans <span className="text-[#a09a92]">({pct(t.with_scan, t.editions)}%)</span></div>
                 </div>
               </div>
@@ -275,13 +275,13 @@ node scripts/catalog-coverage/build.mjs`}
           <div className="border border-[#e8e4dc] rounded-lg p-6 mb-10 bg-[#f5f0e8]">
             <h2 className="font-['Cormorant_Garamond'] text-xl font-semibold text-[#1a1612] mb-2">The Opportunity</h2>
             <p className="text-[#444]">
-              <span className="font-['Cormorant_Garamond'] text-3xl font-semibold text-[#9e4a3a]">{scannedNotTranslated.toLocaleString()}</span>{' '}
+              <span className="font-['Cormorant_Garamond'] text-3xl font-semibold text-[#9e4a3a]">{scannedNotTranslated.toLocaleString('en-US')}</span>{' '}
               non-English works have been digitized but never translated into English.
               They are waiting to be read.
             </p>
             {works.works_neither > 0 && (
               <p className="text-sm text-[#6b6560] mt-2">
-                Another {works.works_neither.toLocaleString()} works have not yet been digitized at all.
+                Another {works.works_neither.toLocaleString('en-US')} works have not yet been digitized at all.
                 Knowing which of these to scan first is itself a form of scholarship.
               </p>
             )}
@@ -333,7 +333,7 @@ node scripts/catalog-coverage/build.mjs`}
                       active ? 'border-[#9e4a3a] bg-[#f5f0e8] text-[#9e4a3a]' : 'border-[#e8e4dc] text-[#6b6560] hover:border-[#d4cfc4]'
                     }`}
                   >
-                    {g.label}{g.count !== undefined && <span className="ml-1 font-medium">{g.count.toLocaleString()}</span>}
+                    {g.label}{g.count !== undefined && <span className="ml-1 font-medium">{g.count.toLocaleString('en-US')}</span>}
                   </button>
                 );
               })}
@@ -349,7 +349,7 @@ node scripts/catalog-coverage/build.mjs`}
 
             {searching && <div className="text-center py-8"><BookLoader /></div>}
             {!searching && searchTotal > 0 && (
-              <p className="text-sm text-[#6b6560] mb-3">{searchTotal.toLocaleString()} editions</p>
+              <p className="text-sm text-[#6b6560] mb-3">{searchTotal.toLocaleString('en-US')} editions</p>
             )}
             {!searching && searchResults.length > 0 && <SearchResultsTable results={searchResults} />}
           </div>
@@ -410,7 +410,7 @@ node scripts/catalog-coverage/build.mjs`}
               </button>
             </div>
 
-            {searchTotal > 0 && <p className="text-sm text-[#6b6560] mb-3">{searchTotal.toLocaleString()} results</p>}
+            {searchTotal > 0 && <p className="text-sm text-[#6b6560] mb-3">{searchTotal.toLocaleString('en-US')} results</p>}
             {searchResults.length > 0 && <SearchResultsTable results={searchResults} />}
           </div>
         )}
@@ -479,30 +479,30 @@ function LanguageTable({ data, onLanguageClick }: { data: LanguageStat[]; onLang
             return (
               <tr key={l.language} className="border-b border-[#f5f0e8] hover:bg-[#f5f0e8]/50">
                 <td className="py-3 pr-4 text-[#1a1612]">{l.language}</td>
-                <td className="py-3 px-4 text-right text-[#444] tabular-nums">{l.editions.toLocaleString()}</td>
+                <td className="py-3 px-4 text-right text-[#444] tabular-nums">{l.editions.toLocaleString('en-US')}</td>
                 <td className="py-3 px-4 text-right tabular-nums">
-                  <span className="text-[#444]">{l.with_scan.toLocaleString()}</span>
+                  <span className="text-[#444]">{l.with_scan.toLocaleString('en-US')}</span>
                   <span className="text-[#a09a92] ml-1 text-xs">{l.pct_scanned}%</span>
                   {(l.scans_high > 0 || l.scans_low > 0) && (
                     <div className="text-[10px] text-[#a09a92] mt-0.5">
-                      {l.scans_high > 0 && <span className="text-[#8b9a7d]">{l.scans_high.toLocaleString()} high</span>}
+                      {l.scans_high > 0 && <span className="text-[#8b9a7d]">{l.scans_high.toLocaleString('en-US')} high</span>}
                       {l.scans_high > 0 && l.scans_low > 0 && ' · '}
-                      {l.scans_low > 0 && <span className="text-[#c9a86c]">{l.scans_low.toLocaleString()} microfilm</span>}
+                      {l.scans_low > 0 && <span className="text-[#c9a86c]">{l.scans_low.toLocaleString('en-US')} microfilm</span>}
                     </div>
                   )}
                 </td>
                 <td className="py-3 px-4 text-right tabular-nums">
-                  <span className="text-[#444]">{l.with_translation.toLocaleString()}</span>
+                  <span className="text-[#444]">{l.with_translation.toLocaleString('en-US')}</span>
                   <span className="text-[#a09a92] ml-1 text-xs">{l.pct_translated}%</span>
                 </td>
-                <td className="py-3 px-4 text-right text-[#444] tabular-nums">{l.in_source_library.toLocaleString()}</td>
+                <td className="py-3 px-4 text-right text-[#444] tabular-nums">{l.in_source_library.toLocaleString('en-US')}</td>
                 <td className="py-3 pl-4 text-right">
                   {gap > 0 ? (
                     <button
                       onClick={() => onLanguageClick(l.language)}
                       className="text-[#9e4a3a] hover:underline tabular-nums"
                     >
-                      {gap.toLocaleString()}
+                      {gap.toLocaleString('en-US')}
                     </button>
                   ) : (
                     <span className="text-[#d4cfc4]">{'\u2014'}</span>
@@ -536,11 +536,11 @@ function TimelineChart({ data }: { data: TimelineDecade[] }) {
               <div className="absolute inset-y-0 left-0 bg-[#c9a86c] rounded-sm" style={{ width: `${(d.with_scan / maxEditions) * 100}%` }} />
               <div className="absolute inset-y-0 left-0 bg-[#8b9a7d] rounded-sm" style={{ width: `${(d.with_translation / maxEditions) * 100}%` }} />
               <div className="absolute inset-0 flex items-center px-2 text-[11px] text-[#444] opacity-0 group-hover:opacity-100 transition-opacity">
-                {d.editions.toLocaleString()} editions {'\u00B7'} {d.pct_scanned}% scanned {'\u00B7'} {d.pct_translated}% translated
+                {d.editions.toLocaleString('en-US')} editions {'\u00B7'} {d.pct_scanned}% scanned {'\u00B7'} {d.pct_translated}% translated
               </div>
             </div>
             <div className="w-16 text-xs text-[#a09a92] text-right shrink-0 tabular-nums">
-              {d.editions.toLocaleString()}
+              {d.editions.toLocaleString('en-US')}
             </div>
           </div>
         ))}

--- a/src/app/[tenant]/admin/kdp/page.tsx
+++ b/src/app/[tenant]/admin/kdp/page.tsx
@@ -1280,7 +1280,7 @@ function StatCard({ label, value, sub, icon, color }: {
         <span className="text-xs uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>{label}</span>
       </div>
       <div className="text-2xl font-serif tabular-nums" style={{ color: 'var(--text-primary)' }}>
-        {typeof value === 'number' ? value.toLocaleString() : value}
+        {typeof value === 'number' ? value.toLocaleString('en-US') : value}
       </div>
       <div className="text-xs mt-0.5" style={{ color: 'var(--text-faint)' }}>{sub}</div>
     </div>

--- a/src/app/[tenant]/admin/pipeline-viz/page.tsx
+++ b/src/app/[tenant]/admin/pipeline-viz/page.tsx
@@ -52,7 +52,7 @@ const EDGES: [string, string][] = [
 function fmt(n: number): string {
   if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-  return n.toLocaleString();
+  return n.toLocaleString('en-US');
 }
 
 function getHealthColor(count: number, stageId: string): string {
@@ -147,9 +147,9 @@ export default function PipelineViz() {
               Pipeline Flow
             </h1>
             <p style={{ color: 'var(--text-muted)', fontSize: 14, margin: '4px 0 0' }}>
-              {totalInPipeline.toLocaleString()} in pipeline &middot; {totalComplete.toLocaleString()} complete
+              {totalInPipeline.toLocaleString('en-US')} in pipeline &middot; {totalComplete.toLocaleString('en-US')} complete
               {failedCount > 0 && <span style={{ color: 'var(--accent-rust)' }}> &middot; {failedCount} failed</span>}
-              {notEnrolled > 0 && <span> &middot; {notEnrolled.toLocaleString()} not enrolled</span>}
+              {notEnrolled > 0 && <span> &middot; {notEnrolled.toLocaleString('en-US')} not enrolled</span>}
             </p>
           </div>
           <button
@@ -261,7 +261,7 @@ export default function PipelineViz() {
                   </text>
 
                   {/* Hover tooltip area */}
-                  <title>{`${stage.label} (Phase ${stage.phase})\n${count.toLocaleString()} books\n${stage.description}`}</title>
+                  <title>{`${stage.label} (Phase ${stage.phase})\n${count.toLocaleString('en-US')} books\n${stage.description}`}</title>
                 </g>
               );
             })}

--- a/src/app/[tenant]/admin/pipeline/page.tsx
+++ b/src/app/[tenant]/admin/pipeline/page.tsx
@@ -225,8 +225,8 @@ export default function PipelineDashboard() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             <StatCard
               label="Pipeline Queue"
-              value={inFlightCount.toLocaleString()}
-              sub={`${completedCount.toLocaleString()} complete`}
+              value={inFlightCount.toLocaleString('en-US')}
+              sub={`${completedCount.toLocaleString('en-US')} complete`}
               icon={<BookOpen className="w-4 h-4" />}
               color="var(--accent-violet)"
             />
@@ -289,7 +289,7 @@ export default function PipelineDashboard() {
                       className="text-xs tabular-nums w-12 text-right"
                       style={{ color: 'var(--text-secondary)', fontWeight: isActive ? 600 : 400 }}
                     >
-                      {s.count.toLocaleString()}
+                      {s.count.toLocaleString('en-US')}
                     </span>
                     {isFailed && s.count > 0 && (
                       <button
@@ -310,7 +310,7 @@ export default function PipelineDashboard() {
                   <CheckCircle className="w-3 h-3 inline mr-1" />complete
                 </span>
                 <span className="text-sm tabular-nums" style={{ color: 'var(--accent-sage)' }}>
-                  {completedCount.toLocaleString()}
+                  {completedCount.toLocaleString('en-US')}
                 </span>
               </div>
             </div>

--- a/src/app/[tenant]/admin/processing/page.tsx
+++ b/src/app/[tenant]/admin/processing/page.tsx
@@ -152,7 +152,7 @@ export default function ProcessingPage() {
               className="text-xs px-2 py-0.5 rounded-full"
               style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)' }}
             >
-              {filtered.length.toLocaleString()} / {rows.length.toLocaleString()} books
+              {filtered.length.toLocaleString('en-US')} / {rows.length.toLocaleString('en-US')} books
             </span>
           </div>
 

--- a/src/app/[tenant]/admin/r2-coverage/page.tsx
+++ b/src/app/[tenant]/admin/r2-coverage/page.tsx
@@ -108,14 +108,14 @@ export default function R2CoveragePage() {
             <>
               <h2 style={{ fontSize: 16, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 24, marginBottom: 8 }}>Library-wide</h2>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12, marginBottom: 8 }}>
-                <Card label="R2 coverage" value={`${snap.library.r2_pct}%`} hint={`${snap.library.r2_pages.toLocaleString()} of ${snap.library.total_pages.toLocaleString()} pages`} />
-                <Card label="Books fully on R2" value={snap.coverage_buckets.full.toLocaleString()} hint="≥99% archived" good />
-                <Card label="Books partially on R2" value={(snap.coverage_buckets.partial_high + snap.coverage_buckets.partial_med + snap.coverage_buckets.partial_low).toLocaleString()} hint={`high ${snap.coverage_buckets.partial_high}, med ${snap.coverage_buckets.partial_med}, low ${snap.coverage_buckets.partial_low}`} warn />
-                <Card label="Books with zero R2" value={snap.coverage_buckets.none.toLocaleString()} hint="have pages but never archived" warn />
-                <Card label="Pages to archive" value={snap.library.unarchived_pages.toLocaleString()} hint={`${snap.library.failed_pages.toLocaleString()} permanently failed`} warn />
+                <Card label="R2 coverage" value={`${snap.library.r2_pct}%`} hint={`${snap.library.r2_pages.toLocaleString('en-US')} of ${snap.library.total_pages.toLocaleString('en-US')} pages`} />
+                <Card label="Books fully on R2" value={snap.coverage_buckets.full.toLocaleString('en-US')} hint="≥99% archived" good />
+                <Card label="Books partially on R2" value={(snap.coverage_buckets.partial_high + snap.coverage_buckets.partial_med + snap.coverage_buckets.partial_low).toLocaleString('en-US')} hint={`high ${snap.coverage_buckets.partial_high}, med ${snap.coverage_buckets.partial_med}, low ${snap.coverage_buckets.partial_low}`} warn />
+                <Card label="Books with zero R2" value={snap.coverage_buckets.none.toLocaleString('en-US')} hint="have pages but never archived" warn />
+                <Card label="Pages to archive" value={snap.library.unarchived_pages.toLocaleString('en-US')} hint={`${snap.library.failed_pages.toLocaleString('en-US')} permanently failed`} warn />
               </div>
               <p style={{ fontSize: 11, color: '#8b949e', marginTop: 0, marginBottom: 24 }}>
-                Snapshot computed {new Date(snap.computed_at).toLocaleString()} in {(snap.computation_ms / 1000).toFixed(1)}s. Refresh: <code style={{ background: '#161b22', padding: '1px 5px', borderRadius: 3 }}>node scripts/workers/r2-coverage-snapshot.mjs</code>
+                Snapshot computed {new Date(snap.computed_at).toLocaleString('en-US')} in {(snap.computation_ms / 1000).toFixed(1)}s. Refresh: <code style={{ background: '#161b22', padding: '1px 5px', borderRadius: 3 }}>node scripts/workers/r2-coverage-snapshot.mjs</code>
               </p>
             </>
           ) : (
@@ -133,8 +133,8 @@ export default function R2CoveragePage() {
                   return (
                     <div key={provider} style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: 8, padding: '10px 14px', minWidth: 180 }}>
                       <div style={{ fontSize: 12, color: '#8b949e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{provider}</div>
-                      <div style={{ fontSize: 16, marginTop: 2 }}>{p.books.toLocaleString()} books · {pct}% R2</div>
-                      <div style={{ fontSize: 11, color: '#8b949e', marginTop: 2 }}>{(p.pages - p.r2 - p.failed).toLocaleString()} pages to archive</div>
+                      <div style={{ fontSize: 16, marginTop: 2 }}>{p.books.toLocaleString('en-US')} books · {pct}% R2</div>
+                      <div style={{ fontSize: 11, color: '#8b949e', marginTop: 2 }}>{(p.pages - p.r2 - p.failed).toLocaleString('en-US')} pages to archive</div>
                     </div>
                   );
                 })}
@@ -213,8 +213,8 @@ function StuckTable({ rows }: { rows: StuckBook[] }) {
               </Td>
               <Td>{b.language}</Td>
               <Td>{b.provider}</Td>
-              <Td align="right">{b.pages_r2.toLocaleString()} / {b.pages_total.toLocaleString()}</Td>
-              <Td align="right" warn={b.pages_unarchived > 0}>{b.pages_unarchived.toLocaleString()}</Td>
+              <Td align="right">{b.pages_r2.toLocaleString('en-US')} / {b.pages_total.toLocaleString('en-US')}</Td>
+              <Td align="right" warn={b.pages_unarchived > 0}>{b.pages_unarchived.toLocaleString('en-US')}</Td>
               <Td align="right"><Bar pct={b.r2_pct} /></Td>
             </tr>
           ))}
@@ -228,7 +228,7 @@ function PartialTable({ rows, totalAvailable, showing }: { rows: PartialBook[]; 
   return (
     <>
       {totalAvailable > showing && (
-        <p style={{ fontSize: 12, color: '#8b949e', margin: '0 0 8px' }}>Showing top {showing} of {totalAvailable.toLocaleString()} partial-R2 books (sorted by unarchived pages).</p>
+        <p style={{ fontSize: 12, color: '#8b949e', margin: '0 0 8px' }}>Showing top {showing} of {totalAvailable.toLocaleString('en-US')} partial-R2 books (sorted by unarchived pages).</p>
       )}
       <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
@@ -254,8 +254,8 @@ function PartialTable({ rows, totalAvailable, showing }: { rows: PartialBook[]; 
                 <Td>{b.language}</Td>
                 <Td>{b.provider}</Td>
                 <Td>{b.status || '—'}</Td>
-                <Td align="right">{b.r2.toLocaleString()} / {b.pages.toLocaleString()}</Td>
-                <Td align="right" warn={b.unarchived > 0}>{b.unarchived.toLocaleString()}</Td>
+                <Td align="right">{b.r2.toLocaleString('en-US')} / {b.pages.toLocaleString('en-US')}</Td>
+                <Td align="right" warn={b.unarchived > 0}>{b.unarchived.toLocaleString('en-US')}</Td>
                 <Td align="right"><Bar pct={b.pct} /></Td>
               </tr>
             ))}
@@ -270,7 +270,7 @@ function NoR2Table({ rows, totalAvailable, showing }: { rows: NoR2Book[]; totalA
   return (
     <>
       {totalAvailable > showing && (
-        <p style={{ fontSize: 12, color: '#8b949e', margin: '0 0 8px' }}>Showing top {showing} of {totalAvailable.toLocaleString()} zero-R2 books (sorted by pages).</p>
+        <p style={{ fontSize: 12, color: '#8b949e', margin: '0 0 8px' }}>Showing top {showing} of {totalAvailable.toLocaleString('en-US')} zero-R2 books (sorted by pages).</p>
       )}
       <div style={{ overflowX: 'auto', background: '#161b22', border: '1px solid #30363d', borderRadius: 8 }}>
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
@@ -294,7 +294,7 @@ function NoR2Table({ rows, totalAvailable, showing }: { rows: NoR2Book[]; totalA
                 <Td>{b.language}</Td>
                 <Td>{b.provider}</Td>
                 <Td>{b.status || '—'}</Td>
-                <Td align="right" warn>{b.pages.toLocaleString()}</Td>
+                <Td align="right" warn>{b.pages.toLocaleString('en-US')}</Td>
               </tr>
             ))}
           </tbody>

--- a/src/app/[tenant]/admin/realtime/page.tsx
+++ b/src/app/[tenant]/admin/realtime/page.tsx
@@ -210,22 +210,22 @@ export default function RealtimeDashboard() {
             />
             <StatCard
               label="Pages in Flight"
-              value={totalActivePages.toLocaleString()}
-              sub={`${totalCompletedPages.toLocaleString()} done, ${totalFailedPages} failed`}
+              value={totalActivePages.toLocaleString('en-US')}
+              sub={`${totalCompletedPages.toLocaleString('en-US')} done, ${totalFailedPages} failed`}
               icon={<Zap className="w-4 h-4" />}
               color="var(--accent-gold)"
             />
             <StatCard
               label="Last Hour"
-              value={data.hourly.totalCalls.toLocaleString()}
+              value={data.hourly.totalCalls.toLocaleString('en-US')}
               sub={`$${data.hourly.totalCost.toFixed(3)} spent`}
               icon={<Clock className="w-4 h-4" />}
               color="var(--accent-sage)"
             />
             <StatCard
               label="Pipeline Queue"
-              value={sortedFunnel.reduce((s, f) => s + f.count, 0).toLocaleString()}
-              sub={`${completedCount.toLocaleString()} complete, ${failedCount} failed`}
+              value={sortedFunnel.reduce((s, f) => s + f.count, 0).toLocaleString('en-US')}
+              sub={`${completedCount.toLocaleString('en-US')} complete, ${failedCount} failed`}
               icon={<BookOpen className="w-4 h-4" />}
               color="var(--accent-violet)"
             />
@@ -249,7 +249,7 @@ export default function RealtimeDashboard() {
                         style={{ background: TYPE_COLORS[t.type] || 'var(--text-muted)' }}
                       />
                       <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                        {t.count.toLocaleString()}
+                        {t.count.toLocaleString('en-US')}
                       </span>
                       <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
                         {t.type}
@@ -350,7 +350,7 @@ export default function RealtimeDashboard() {
                       className="text-xs tabular-nums w-12 text-right"
                       style={{ color: 'var(--text-secondary)', fontWeight: isActive ? 600 : 400 }}
                     >
-                      {s.count.toLocaleString()}
+                      {s.count.toLocaleString('en-US')}
                     </span>
                   </div>
                 );
@@ -361,7 +361,7 @@ export default function RealtimeDashboard() {
                   <CheckCircle className="w-3 h-3 inline mr-1" />complete
                 </span>
                 <span className="text-sm tabular-nums" style={{ color: 'var(--accent-sage)' }}>
-                  {completedCount.toLocaleString()}
+                  {completedCount.toLocaleString('en-US')}
                 </span>
                 {failedCount > 0 && (
                   <>

--- a/src/app/[tenant]/admin/social/page.tsx
+++ b/src/app/[tenant]/admin/social/page.tsx
@@ -1307,7 +1307,7 @@ export default function SocialAdminPage() {
                       <p className="text-xs text-stone-400 mt-2">{tag.relevance}</p>
                       {tag.followers && (
                         <p className="text-xs text-stone-500 mt-1">
-                          {tag.followers.toLocaleString()} followers
+                          {tag.followers.toLocaleString('en-US')} followers
                         </p>
                       )}
                     </div>
@@ -1459,7 +1459,7 @@ export default function SocialAdminPage() {
               </div>
               {config.usage.last_tweet_at && (
                 <p className="text-sm text-stone-500 mt-4">
-                  Last tweet: {new Date(config.usage.last_tweet_at).toLocaleString()}
+                  Last tweet: {new Date(config.usage.last_tweet_at).toLocaleString('en-US')}
                 </p>
               )}
             </div>
@@ -1701,25 +1701,25 @@ function PostCard({
           <div className="mt-3 flex flex-wrap gap-3 py-2 px-3 bg-stone-800/50 rounded-lg">
             <div className="flex items-center gap-1 text-xs">
               <Eye className="w-3.5 h-3.5 text-stone-400" />
-              <span className="text-stone-300">{post.metrics.impressions.toLocaleString()}</span>
+              <span className="text-stone-300">{post.metrics.impressions.toLocaleString('en-US')}</span>
               <span className="text-stone-500">views</span>
             </div>
             <div className="flex items-center gap-1 text-xs">
               <Heart className="w-3.5 h-3.5 text-red-400" />
-              <span className="text-stone-300">{post.metrics.likes.toLocaleString()}</span>
+              <span className="text-stone-300">{post.metrics.likes.toLocaleString('en-US')}</span>
             </div>
             <div className="flex items-center gap-1 text-xs">
               <Repeat className="w-3.5 h-3.5 text-green-400" />
-              <span className="text-stone-300">{post.metrics.retweets.toLocaleString()}</span>
+              <span className="text-stone-300">{post.metrics.retweets.toLocaleString('en-US')}</span>
             </div>
             <div className="flex items-center gap-1 text-xs">
               <MessageCircle className="w-3.5 h-3.5 text-sky-400" />
-              <span className="text-stone-300">{post.metrics.replies.toLocaleString()}</span>
+              <span className="text-stone-300">{post.metrics.replies.toLocaleString('en-US')}</span>
             </div>
             {post.metrics.url_clicks > 0 && (
               <div className="flex items-center gap-1 text-xs">
                 <ExternalLink className="w-3.5 h-3.5 text-violet-400" />
-                <span className="text-stone-300">{post.metrics.url_clicks.toLocaleString()}</span>
+                <span className="text-stone-300">{post.metrics.url_clicks.toLocaleString('en-US')}</span>
                 <span className="text-stone-500">clicks</span>
               </div>
             )}

--- a/src/app/[tenant]/artwork/page.tsx
+++ b/src/app/[tenant]/artwork/page.tsx
@@ -78,7 +78,7 @@ export default async function ArtworkLandingPage() {
             Paintings, prints, sculptures, and manuscripts from antiquity to the nineteenth century — cross-referenced with the texts that inspired them.
           </p>
           <div className="flex flex-wrap items-center gap-6 mt-10 text-sm text-stone-500">
-            <span className="font-medium text-stone-400">{totalCount.toLocaleString()} works</span>
+            <span className="font-medium text-stone-400">{totalCount.toLocaleString('en-US')} works</span>
             <span className="w-px h-4 bg-stone-700" />
             <span>{collections.length} collections</span>
             <span className="w-px h-4 bg-stone-700" />

--- a/src/app/[tenant]/browse/subjects/[...code]/page.tsx
+++ b/src/app/[tenant]/browse/subjects/[...code]/page.tsx
@@ -201,7 +201,7 @@ export default async function SubjectCategoryPage({ params }: Props) {
           </h1>
           <div className="flex items-center gap-4">
             <p style={{ color: 'var(--text-muted)' }}>
-              {node ? `${node.count.toLocaleString()} images` : 'No indexed images'}
+              {node ? `${node.count.toLocaleString('en-US')} images` : 'No indexed images'}
             </p>
             <a
               href={`https://iconclass.org/${encodeURIComponent(code)}`}
@@ -248,7 +248,7 @@ export default async function SubjectCategoryPage({ params }: Props) {
                   <div className="absolute bottom-0 left-0 right-0 p-3">
                     <p className="text-white font-display text-sm leading-tight">{child.label}</p>
                     <p className="text-white/70 text-xs mt-0.5">
-                      <span className="font-mono">{child.code}</span> · {child.count.toLocaleString()}
+                      <span className="font-mono">{child.code}</span> · {child.count.toLocaleString('en-US')}
                     </p>
                   </div>
                 </Link>

--- a/src/app/[tenant]/browse/subjects/page.tsx
+++ b/src/app/[tenant]/browse/subjects/page.tsx
@@ -45,7 +45,7 @@ export default async function SubjectsPage() {
             Browse by Subject
           </h1>
           <p className="text-lg" style={{ color: 'var(--text-muted)' }}>
-            Explore {tree ? tree.total_items.toLocaleString() : ''} classified images through the{' '}
+            Explore {tree ? tree.total_items.toLocaleString('en-US') : ''} classified images through the{' '}
             <a
               href="https://iconclass.org"
               target="_blank"
@@ -95,7 +95,7 @@ export default async function SubjectsPage() {
                   <div className="absolute bottom-0 left-0 right-0 p-3">
                     <p className="text-white font-display text-sm leading-tight">{div.label}</p>
                     <p className="text-white/70 text-xs mt-0.5">
-                      {node.count.toLocaleString()} images
+                      {node.count.toLocaleString('en-US')} images
                     </p>
                   </div>
                 </Link>

--- a/src/app/[tenant]/collections/[id]/page.tsx
+++ b/src/app/[tenant]/collections/[id]/page.tsx
@@ -800,7 +800,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                     <div className="absolute inset-0 flex flex-col justify-end p-3 sm:p-4">
                       {child.book_count ? (
                         <p className="text-white/50 text-xs mb-1 hidden sm:block">
-                          {child.book_count.toLocaleString()} {itemLabel}
+                          {child.book_count.toLocaleString('en-US')} {itemLabel}
                         </p>
                       ) : null}
                       <h3 className="font-serif text-sm sm:text-base lg:text-lg text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">
@@ -827,7 +827,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                 href={galleryCollectionSlug ? (tenantSlug ? `/${tenantSlug}/gallery/collections/${galleryCollectionSlug}` : `/gallery/collections/${galleryCollectionSlug}`) : (tenantSlug ? `/${tenantSlug}/gallery?collection=${id}` : `/gallery?collection=${id}`)}
                 className="text-sm text-muted hover:text-accent-rust transition-colors"
               >
-                Browse all {galleryTotalImages.toLocaleString()}
+                Browse all {galleryTotalImages.toLocaleString('en-US')}
               </Link>
             </div>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4 mt-5">
@@ -874,7 +874,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                   className="group relative aspect-square rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 transition-all hover:shadow-md bg-cream flex flex-col items-center justify-center gap-2 text-center"
                 >
                   <span className="text-sm font-medium text-muted group-hover:text-accent-rust transition-colors px-3">
-                    View all {galleryTotalImages.toLocaleString()}
+                    View all {galleryTotalImages.toLocaleString('en-US')}
                   </span>
                 </Link>
               )}

--- a/src/app/[tenant]/curated/page.tsx
+++ b/src/app/[tenant]/curated/page.tsx
@@ -106,7 +106,7 @@ function PublishedCard({ col, priority = false }: { col: CuratedCollection; prio
         )}
         {col.book_count > 0 && (
           <p className="text-xs text-white/40 mt-2">
-            {col.book_count.toLocaleString()} books
+            {col.book_count.toLocaleString('en-US')} books
           </p>
         )}
       </div>

--- a/src/app/[tenant]/encyclopedia/page.tsx
+++ b/src/app/[tenant]/encyclopedia/page.tsx
@@ -218,19 +218,19 @@ export default async function EncyclopediaPage({
         {/* Stats */}
         <div className="grid grid-cols-4 gap-4 mb-6">
           <div className="bg-white rounded-lg border border-stone-200 p-4 text-center">
-            <div className="text-2xl font-bold text-stone-900">{stats.total.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-stone-900">{stats.total.toLocaleString('en-US')}</div>
             <div className="text-sm text-stone-500">Total</div>
           </div>
           <div className="bg-white rounded-lg border border-stone-200 p-4 text-center">
-            <div className="text-2xl font-bold text-accent-rust">{stats.people.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-accent-rust">{stats.people.toLocaleString('en-US')}</div>
             <div className="text-sm text-stone-500">People</div>
           </div>
           <div className="bg-white rounded-lg border border-stone-200 p-4 text-center">
-            <div className="text-2xl font-bold text-accent-sage">{stats.places.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-accent-sage">{stats.places.toLocaleString('en-US')}</div>
             <div className="text-sm text-stone-500">Places</div>
           </div>
           <div className="bg-white rounded-lg border border-stone-200 p-4 text-center">
-            <div className="text-2xl font-bold text-accent-violet">{stats.concepts.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-accent-violet">{stats.concepts.toLocaleString('en-US')}</div>
             <div className="text-sm text-stone-500">Concepts</div>
           </div>
         </div>
@@ -299,7 +299,7 @@ export default async function EncyclopediaPage({
         {/* Results count */}
         {(activeLetter || hasQuery || page > 1) && (
           <p className="text-sm text-stone-500 mb-4">
-            {total.toLocaleString()} result{total !== 1 ? 's' : ''}
+            {total.toLocaleString('en-US')} result{total !== 1 ? 's' : ''}
             {activeLetter && !hasQuery && <> starting with &ldquo;{activeLetter}&rdquo;</>}
             {hasQuery && <> for &ldquo;{params.q}&rdquo;</>}
           </p>

--- a/src/app/[tenant]/explore/map/page.tsx
+++ b/src/app/[tenant]/explore/map/page.tsx
@@ -102,7 +102,7 @@ export default async function MapPage() {
         header={
           <ContentHeader
             title="Map"
-            subtitle={`${locationCount.toLocaleString()} locations across Europe and beyond — publication cities, birthplaces, and institutions`}
+            subtitle={`${locationCount.toLocaleString('en-US')} locations across Europe and beyond — publication cities, birthplaces, and institutions`}
           >
             <div className="mt-5">
               <ExploreTabBar />

--- a/src/app/[tenant]/jobs/_archived/batch-job-card.tsx
+++ b/src/app/[tenant]/jobs/_archived/batch-job-card.tsx
@@ -96,7 +96,7 @@ export function BatchJobCard({ job }: Props) {
           )}
 
           <div className="text-xs text-stone-500 mt-2">
-            Created {new Date(job.created_at).toLocaleString()}
+            Created {new Date(job.created_at).toLocaleString('en-US')}
           </div>
         </div>
       </div>

--- a/src/app/[tenant]/jobs/job-card.tsx
+++ b/src/app/[tenant]/jobs/job-card.tsx
@@ -51,7 +51,7 @@ function getProgress(job: Job) {
 }
 
 function formatDate(date: Date | string) {
-    return new Date(date).toLocaleString();
+    return new Date(date).toLocaleString('en-US');
 }
 
 export function JobCard({ job, onRetry, onDelete }: JobCardProps) {

--- a/src/app/[tenant]/jobs/stats-cards.tsx
+++ b/src/app/[tenant]/jobs/stats-cards.tsx
@@ -63,7 +63,7 @@ export function StatsCards({
                     className="text-2xl font-medium mt-1"
                     style={{ color: 'var(--accent-gold)' }}
                 >
-                    {stats.total_pages_needing_ocr.toLocaleString()}
+                    {stats.total_pages_needing_ocr.toLocaleString('en-US')}
                 </div>
                 <div className="text-xs mt-1" style={{ color: 'var(--text-faint)' }}>
                     {stats.books_needing_ocr} books
@@ -88,7 +88,7 @@ export function StatsCards({
                     className="text-2xl font-medium mt-1"
                     style={{ color: 'var(--accent-sage)' }}
                 >
-                    {stats.total_pages_needing_translation.toLocaleString()}
+                    {stats.total_pages_needing_translation.toLocaleString('en-US')}
                 </div>
                 <div className="text-xs mt-1" style={{ color: 'var(--text-faint)' }}>
                     {stats.books_needing_translation} books

--- a/src/app/[tenant]/languages/[code]/page.tsx
+++ b/src/app/[tenant]/languages/[code]/page.tsx
@@ -198,7 +198,7 @@ export default async function LanguageDetailPage({ params, searchParams }: Props
           </h1>
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-            <span>{total.toLocaleString()} books</span>
+            <span>{total.toLocaleString('en-US')} books</span>
             {firstTranslationCount > 0 && (
               <>
                 <span className="w-px h-4 bg-white/20" />
@@ -259,7 +259,7 @@ export default async function LanguageDetailPage({ params, searchParams }: Props
           <div>
             <h2 className="text-2xl sm:text-3xl text-primary font-display">All Books</h2>
             <p className="text-sm text-muted mt-1">
-              {total.toLocaleString()} {langName} texts
+              {total.toLocaleString('en-US')} {langName} texts
             </p>
           </div>
 

--- a/src/app/[tenant]/languages/page.tsx
+++ b/src/app/[tenant]/languages/page.tsx
@@ -94,7 +94,7 @@ export default async function LanguagesPage() {
     <ContentPageLayout>
       <ContentHeader
         title="Languages"
-        subtitle={`${totalBooks.toLocaleString()} books across ${languages.length} languages, spanning five millennia of human thought.`}
+        subtitle={`${totalBooks.toLocaleString('en-US')} books across ${languages.length} languages, spanning five millennia of human thought.`}
         image={major.find(l => l.heroImage)?.heroImage}
         imageAlt="Multilingual manuscript page"
       />
@@ -122,7 +122,7 @@ export default async function LanguagesPage() {
             <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-6">
               <div className="flex items-center gap-2 mb-2">
                 <span className="px-2.5 py-0.5 text-xs text-white/80 bg-white/15 backdrop-blur-sm rounded-full">
-                  {lang.bookCount.toLocaleString()} books
+                  {lang.bookCount.toLocaleString('en-US')} books
                 </span>
                 {lang.yearRange && (
                   <span className="text-xs text-white/50">{lang.yearRange}</span>

--- a/src/app/[tenant]/processing/page.tsx
+++ b/src/app/[tenant]/processing/page.tsx
@@ -212,10 +212,10 @@ export default function ProcessingPage() {
         {/* Summary cards */}
         {data && (
           <div className="grid grid-cols-4 gap-4">
-            <SummaryCard icon={<Layers className="w-5 h-5" />} label="Total Steps" value={data.summary.total_steps.toLocaleString()} />
+            <SummaryCard icon={<Layers className="w-5 h-5" />} label="Total Steps" value={data.summary.total_steps.toLocaleString('en-US')} />
             <SummaryCard icon={<DollarSign className="w-5 h-5" />} label="Total Cost" value={formatCost(data.summary.total_cost)} />
-            <SummaryCard icon={<BookOpen className="w-5 h-5" />} label="Books Processed" value={data.summary.books_processed.toLocaleString()} />
-            <SummaryCard icon={<FileText className="w-5 h-5" />} label="Pages Processed" value={data.summary.pages_processed.toLocaleString()} />
+            <SummaryCard icon={<BookOpen className="w-5 h-5" />} label="Books Processed" value={data.summary.books_processed.toLocaleString('en-US')} />
+            <SummaryCard icon={<FileText className="w-5 h-5" />} label="Pages Processed" value={data.summary.pages_processed.toLocaleString('en-US')} />
           </div>
         )}
 
@@ -282,7 +282,7 @@ export default function ProcessingPage() {
                         {formatDate(row.date_start, row.date_end)}
                       </td>
                       <td className="px-4 py-3 text-right tabular-nums" style={{ color: 'var(--text-secondary)' }}>
-                        {row.pages.toLocaleString()}
+                        {row.pages.toLocaleString('en-US')}
                       </td>
                       <td className="px-4 py-3 text-right tabular-nums" style={{ color: 'var(--text-secondary)' }}>
                         {formatCost(row.cost_usd)}
@@ -307,7 +307,7 @@ export default function ProcessingPage() {
             {totalPages > 1 && (
               <div className="flex items-center justify-between px-4 py-3" style={{ borderTop: '1px solid var(--border-light)', background: 'var(--bg-warm)' }}>
                 <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
-                  {offset + 1}-{Math.min(offset + PAGE_SIZE, data.total)} of {data.total.toLocaleString()}
+                  {offset + 1}-{Math.min(offset + PAGE_SIZE, data.total)} of {data.total.toLocaleString('en-US')}
                 </span>
                 <div className="flex items-center gap-2">
                   <button
@@ -414,13 +414,13 @@ function StepBadge({ step, mode }: { step: string; mode?: string }) {
 
 function StatusCell({ success, failed }: { success: number; failed: number }) {
   if (failed === 0) {
-    return <span style={{ color: '#16a34a' }}>{success.toLocaleString()}</span>;
+    return <span style={{ color: '#16a34a' }}>{success.toLocaleString('en-US')}</span>;
   }
   return (
     <span>
-      <span style={{ color: '#16a34a' }}>{success.toLocaleString()}</span>
+      <span style={{ color: '#16a34a' }}>{success.toLocaleString('en-US')}</span>
       <span style={{ color: 'var(--text-muted)' }}> / </span>
-      <span style={{ color: '#dc2626' }}>{failed.toLocaleString()}</span>
+      <span style={{ color: '#dc2626' }}>{failed.toLocaleString('en-US')}</span>
     </span>
   );
 }

--- a/src/app/[tenant]/qa/page.tsx
+++ b/src/app/[tenant]/qa/page.tsx
@@ -82,7 +82,7 @@ export default function QASamplingPage() {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
               <div className="bg-white rounded-lg border border-stone-200 p-4">
                 <div className="text-2xl font-bold text-stone-900">
-                  {data.population.translatedPages.toLocaleString()}
+                  {data.population.translatedPages.toLocaleString('en-US')}
                 </div>
                 <div className="text-sm text-stone-500">Translated Pages</div>
               </div>
@@ -119,7 +119,7 @@ export default function QASamplingPage() {
                       <div>
                         <div className="font-medium text-sm">{stat.model}</div>
                         <div className="text-xs text-stone-500">
-                          {stat.count} pages, avg {stat.avgLength.toLocaleString()} chars
+                          {stat.count} pages, avg {stat.avgLength.toLocaleString('en-US')} chars
                         </div>
                       </div>
                       <div className="text-right">
@@ -149,7 +149,7 @@ export default function QASamplingPage() {
                       <div>
                         <div className="font-medium text-sm">{stat.model}</div>
                         <div className="text-xs text-stone-500">
-                          {stat.count} pages, avg {stat.avgLength.toLocaleString()} chars
+                          {stat.count} pages, avg {stat.avgLength.toLocaleString('en-US')} chars
                         </div>
                       </div>
                       <div className="text-right">

--- a/src/app/[tenant]/research/[id]/page.tsx
+++ b/src/app/[tenant]/research/[id]/page.tsx
@@ -95,7 +95,7 @@ export default async function ResearchSessionPage({ params }: PageProps) {
       {/* Stats */}
       <div className="flex gap-6 text-sm text-muted mb-8">
         <span>{s.message_count} messages</span>
-        <span>{s.word_count.toLocaleString()} words</span>
+        <span>{s.word_count.toLocaleString('en-US')} words</span>
         <span>{s.duration_minutes} min</span>
         {s.books_imported.length > 0 && (
           <span>{s.books_imported.length} books imported</span>

--- a/src/app/[tenant]/research/concept-diffusion/page.tsx
+++ b/src/app/[tenant]/research/concept-diffusion/page.tsx
@@ -160,9 +160,9 @@ export default function ConceptDiffusionPage() {
     >
       {/* Summary cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
-        <StatCard label="Books indexed" value={corpus.totalBooks.toLocaleString()} />
-        <StatCard label="English keywords" value={keywords.length.toLocaleString()} />
-        <StatCard label="Original vocabulary" value={vocab.length.toLocaleString()} />
+        <StatCard label="Books indexed" value={corpus.totalBooks.toLocaleString('en-US')} />
+        <StatCard label="English keywords" value={keywords.length.toLocaleString('en-US')} />
+        <StatCard label="Original vocabulary" value={vocab.length.toLocaleString('en-US')} />
         <StatCard label="Date range" value={dateRange} />
       </div>
 
@@ -170,8 +170,8 @@ export default function ConceptDiffusionPage() {
       <div className="bg-white rounded-lg border border-[var(--border-light)] p-4 sm:p-6 mb-8">
         <h2 className="font-serif text-xl mb-1">Term Frequency Over Time</h2>
         <p className="text-[var(--text-muted)] text-sm mb-4">
-          Search {keywords.length.toLocaleString()} English keywords or{' '}
-          {vocab.length.toLocaleString()} original-language vocabulary terms. Each line shows how
+          Search {keywords.length.toLocaleString('en-US')} English keywords or{' '}
+          {vocab.length.toLocaleString('en-US')} original-language vocabulary terms. Each line shows how
           often a term appears across 50-year periods. Toggle between keywords (from AI translations)
           and vocabulary (from OCR of original texts).
         </p>
@@ -262,20 +262,20 @@ export default function ConceptDiffusionPage() {
         <h3 className="font-serif text-lg mb-2">Methodology</h3>
         <p className="mb-2">
           This dataset draws on two complementary extraction methods applied to{' '}
-          {corpus.totalBooks.toLocaleString()} pre-modern texts from {corpus.periods[0]} to{' '}
+          {corpus.totalBooks.toLocaleString('en-US')} pre-modern texts from {corpus.periods[0]} to{' '}
           {corpus.periods[corpus.periods.length - 1] + 50}:
         </p>
         <p className="mb-2">
           <strong>English keywords</strong> are extracted by AI (Gemini) from each page&apos;s
           translated text. Every page produces a set of &lt;keywords&gt; tags identifying the key
-          concepts discussed on that page. The {keywords.length.toLocaleString()} keywords shown here
+          concepts discussed on that page. The {keywords.length.toLocaleString('en-US')} keywords shown here
           each appear in 50 or more books. Keywords are grouped by subject category based on which
           category of books most frequently produces each keyword.
         </p>
         <p className="mb-2">
           <strong>Original vocabulary</strong> is extracted from OCR output of the original texts —
           Latin, German, Greek, French, Sanskrit, and other languages. These{' '}
-          {vocab.length.toLocaleString()} terms (each appearing in 20+ books) are grouped by primary
+          {vocab.length.toLocaleString('en-US')} terms (each appearing in 20+ books) are grouped by primary
           language. This preserves the actual terminology used by historical authors, complementing
           the standardized English keywords.
         </p>

--- a/src/app/[tenant]/research/translation-lag/page.tsx
+++ b/src/app/[tenant]/research/translation-lag/page.tsx
@@ -131,8 +131,8 @@ export default async function TranslationLagPage() {
     >
       {/* Summary cards */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
-        <StatCard label="Books analyzed" value={data.length.toLocaleString()} />
-        <StatCard label="First translations" value={firstTranslations.length.toLocaleString()} />
+        <StatCard label="Books analyzed" value={data.length.toLocaleString('en-US')} />
+        <StatCard label="First translations" value={firstTranslations.length.toLocaleString('en-US')} />
         <StatCard label="Average lag" value={`${avgLag} years`} />
         <StatCard label="Median lag" value={`${medianLag} years`} />
       </div>
@@ -203,7 +203,7 @@ export default async function TranslationLagPage() {
                   <td className="py-2 pr-4 text-[var(--text-muted)]">{d.composed_display}</td>
                   <td className="py-2 pr-4">{d.year}</td>
                   <td className="py-2 pr-4">{d.language}</td>
-                  <td className="py-2 pr-4 text-right font-medium">{d.lag.toLocaleString()}y</td>
+                  <td className="py-2 pr-4 text-right font-medium">{d.lag.toLocaleString('en-US')}y</td>
                 </tr>
               ))}
             </tbody>
@@ -224,7 +224,7 @@ export default async function TranslationLagPage() {
           For translations and later editions, the &ldquo;lag&rdquo; represents how long it took for the text to reach
           this particular linguistic community — not necessarily the total time before any printed edition existed.
           Works with estimated composition dates (e.g., &ldquo;c. 3rd century CE&rdquo;) use the midpoint of the estimated range.
-          {data.length.toLocaleString()} of {'>'}2,400 visible books have computable composition dates.
+          {data.length.toLocaleString('en-US')} of {'>'}2,400 visible books have computable composition dates.
         </p>
       </div>
     </ContentPageLayout>
@@ -252,7 +252,7 @@ function LagBar({ label, value, max, count }: { label: string; value: number; ma
         />
       </div>
       <div className="w-20 text-sm text-right text-[var(--text-muted)]">
-        {value.toLocaleString()}y <span className="text-xs">({count})</span>
+        {value.toLocaleString('en-US')}y <span className="text-xs">({count})</span>
       </div>
     </div>
   );

--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -1073,7 +1073,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
             <div className="mb-4 flex items-center justify-between flex-wrap gap-2">
               {!browseImageLoading && browseImageTotal > 0 && (
                 <div className="text-muted">
-                  <span className="font-medium text-primary">{browseImageTotal.toLocaleString()}</span> images
+                  <span className="font-medium text-primary">{browseImageTotal.toLocaleString('en-US')}</span> images
                   {browseImageTotal > resultsPerPage && (
                     <span className="ml-2 text-faint">
                       (showing {offset + 1}&ndash;{Math.min(offset + resultsPerPage, browseImageTotal)})
@@ -1459,7 +1459,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                 Catalog matches
                 {catalogTotal > 0 && (
                   <span className="ml-1 text-muted/70 normal-case">
-                    · {catalogTotal.toLocaleString()} {catalogTotal === 1 ? 'work' : 'works'}
+                    · {catalogTotal.toLocaleString('en-US')} {catalogTotal === 1 ? 'work' : 'works'}
                   </span>
                 )}
               </h2>
@@ -1846,7 +1846,7 @@ function SearchCollectionCard({ col }: { col: { slug: string; name: string; book
       <div className="absolute inset-0 bg-gradient-to-t from-[rgba(26,22,18,0.85)] via-[rgba(26,22,18,0.35)] to-transparent" />
       <div className="absolute inset-0 flex flex-col justify-end p-3">
         <p className="text-white/50 text-[11px] mb-1">
-          {col.book_count.toLocaleString()} books
+          {col.book_count.toLocaleString('en-US')} books
         </p>
         <h3 className="font-serif text-sm sm:text-base text-white font-semibold leading-tight line-clamp-2 group-hover:text-accent-gold transition-colors">
           {col.name}

--- a/src/app/[tenant]/timeline/TimelineClient.tsx
+++ b/src/app/[tenant]/timeline/TimelineClient.tsx
@@ -349,7 +349,7 @@ export default function TimelineClient({ initialData }: Props) {
           </button>
         )}
         <span className="text-sm text-stone-500 ml-auto font-body">
-          {filteredSummary.total.toLocaleString()} texts
+          {filteredSummary.total.toLocaleString('en-US')} texts
         </span>
       </div>
 
@@ -480,7 +480,7 @@ export default function TimelineClient({ initialData }: Props) {
                   </span>
                 )}
                 <span className="ml-3 text-base font-sans font-normal text-stone-500">
-                  {booksTotal.toLocaleString()} {viewMode === 'art' ? (booksTotal === 1 ? 'artist' : 'artists') : (booksTotal === 1 ? 'text' : 'texts')}
+                  {booksTotal.toLocaleString('en-US')} {viewMode === 'art' ? (booksTotal === 1 ? 'artist' : 'artists') : (booksTotal === 1 ? 'text' : 'texts')}
                 </span>
               </h2>
 

--- a/src/app/[tenant]/topics/[slug]/page.tsx
+++ b/src/app/[tenant]/topics/[slug]/page.tsx
@@ -335,7 +335,7 @@ export default async function TopicDetailPage({ params }: Props) {
             </p>
 
             <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-              <span>{data.totalBooks.toLocaleString()} books</span>
+              <span>{data.totalBooks.toLocaleString('en-US')} books</span>
               {data.languages.length > 0 && (
                 <>
                   <span className="w-px h-4 bg-white/20" />

--- a/src/app/[tenant]/topics/clusters/page.tsx
+++ b/src/app/[tenant]/topics/clusters/page.tsx
@@ -120,7 +120,7 @@ export default async function TopicsPage() {
       header={
         <ContentHeader
           title="Browse by Topic"
-          subtitle={`${totalBooks.toLocaleString()} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
+          subtitle={`${totalBooks.toLocaleString('en-US')} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
         />
       }
     >

--- a/src/app/[tenant]/topics/page.tsx
+++ b/src/app/[tenant]/topics/page.tsx
@@ -138,7 +138,7 @@ function FacetValueCard({ value, facetId }: { value: FacetCount; facetId: string
             {value.label}
           </h3>
           <span className="text-xs text-muted whitespace-nowrap flex-shrink-0">
-            {value.count.toLocaleString()}
+            {value.count.toLocaleString('en-US')}
           </span>
         </div>
       </div>
@@ -204,7 +204,7 @@ export default async function TopicsPage() {
       header={
         <ContentHeader
           title="Browse the Library"
-          subtitle={`${totalBooks.toLocaleString()} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
+          subtitle={`${totalBooks.toLocaleString('en-US')} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
         />
       }
     >

--- a/src/app/[tenant]/work/[id]/page.tsx
+++ b/src/app/[tenant]/work/[id]/page.tsx
@@ -96,7 +96,7 @@ export default async function WorkPage({ params }: PageProps) {
           )}
           {earliest && earliest === latest && <span>{earliest}</span>}
           {languages.length > 0 && <span>{languages.join(', ')}</span>}
-          <span>{totalPages.toLocaleString()} pages</span>
+          <span>{totalPages.toLocaleString('en-US')} pages</span>
           <span>{editions.length} editions</span>
           {editions.filter(e => (e.pages_translated || 0) > 0).length >= 2 && (
             <Link

--- a/src/app/about/by-the-numbers/page.tsx
+++ b/src/app/about/by-the-numbers/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   alternates: { canonical: '/about/by-the-numbers' },
 };
 
-const fmt = (n: number) => n.toLocaleString();
+const fmt = (n: number) => n.toLocaleString('en-US');
 
 // ---------- Data (snapshot 2026-05-07) ----------
 

--- a/src/app/about/processing/page.tsx
+++ b/src/app/about/processing/page.tsx
@@ -90,7 +90,7 @@ async function getStats() {
 function fmt(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
   if (n >= 1_000) return (n / 1_000).toFixed(n >= 10_000 ? 0 : 1) + 'k';
-  return n.toLocaleString();
+  return n.toLocaleString('en-US');
 }
 
 /* ── Pipeline stages ── */

--- a/src/app/api/analytics/broken-image/route.ts
+++ b/src/app/api/analytics/broken-image/route.ts
@@ -2,13 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 
 /**
- * Log broken image reports from the client.
- * Fire-and-forget — never fails to the client.
+ * Log broken-image reports from the client.
+ *
+ * Bot traffic is dropped at the door: link-preview crawlers (Meta, Slack,
+ * etc.) request every page on the site and trigger image-load errors at
+ * scale, drowning out the human signal. Bot reports get silently 200'd.
  *
  * POST /api/analytics/broken-image
  * Body: { urls: string[], page: string, timestamp: string }
  */
 const DB_TIMEOUT_MS = 3000;
+
+const BOT_RE = /bot|crawler|spider|preview|facebookexternalhit|meta-externalagent|slurp|slackbot|googlebot|bingbot|twitterbot|whatsapp|linkedinbot|telegrambot|discordbot|applebot|pingdom|uptime|monitor|headless/i;
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,10 +22,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true });
     }
 
+    const ua = request.headers.get('user-agent') || '';
+    if (BOT_RE.test(ua)) {
+      return NextResponse.json({ ok: true });
+    }
+
     // Cap at 20 per report to prevent abuse
     const capped = urls.slice(0, 20);
-
-    const ua = request.headers.get('user-agent') || '';
     const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
 
     const dbWork = (async () => {

--- a/src/app/api/nde/dataset/route.ts
+++ b/src/app/api/nde/dataset/route.ts
@@ -59,10 +59,10 @@ export async function GET() {
       '@language': 'en',
       '@value':
         `Digital facsimiles, OCR transcriptions, and AI-assisted English translations of ${totalBooks} books ` +
-        `(${pageTotals.pages.toLocaleString()} pages) from the Bibliotheca Philosophica Hermetica (BPH), ` +
+        `(${pageTotals.pages.toLocaleString('en-US')} pages) from the Bibliotheca Philosophica Hermetica (BPH), ` +
         `housed at the Embassy of the Free Mind in Amsterdam. The collection covers Hermetica, alchemy, ` +
         `Kabbalah, Rosicrucianism, and Western esoteric traditions from the 15th–19th centuries. ` +
-        `${pageTotals.translated.toLocaleString()} pages have been translated into English.`,
+        `${pageTotals.translated.toLocaleString('en-US')} pages have been translated into English.`,
     },
     url: 'https://sourcelibrary.org/libraries/bibliotheca-philosophica-hermetica',
     mainEntityOfPage: 'https://sourcelibrary.org/libraries/bibliotheca-philosophica-hermetica',
@@ -141,7 +141,7 @@ export async function GET() {
     dateModified: new Date().toISOString().split('T')[0],
     measurementTechnique:
       'OCR via Google Gemini AI; English translations via Google Gemini AI with cross-page context.',
-    size: `${totalBooks} books, ${pageTotals.pages.toLocaleString()} pages`,
+    size: `${totalBooks} books, ${pageTotals.pages.toLocaleString('en-US')} pages`,
   };
 
   return new NextResponse(JSON.stringify(dataset, null, 2), {

--- a/src/app/artwork/page.tsx
+++ b/src/app/artwork/page.tsx
@@ -79,7 +79,7 @@ export default async function ArtworkLandingPage() {
             Paintings, prints, sculptures, and manuscripts from antiquity to the nineteenth century — cross-referenced with the texts that inspired them.
           </p>
           <div className="flex flex-wrap items-center gap-6 mt-10 text-sm text-stone-500">
-            <span className="font-medium text-stone-400">{totalCount.toLocaleString()} works</span>
+            <span className="font-medium text-stone-400">{totalCount.toLocaleString('en-US')} works</span>
             <span className="w-px h-4 bg-stone-700" />
             <span>{collections.length} collections</span>
             <span className="w-px h-4 bg-stone-700" />

--- a/src/app/blog/2000-first-translations/page.tsx
+++ b/src/app/blog/2000-first-translations/page.tsx
@@ -447,7 +447,7 @@ export default function TwoThousandFirstTranslations() {
                       }}
                     >
                       <span className="text-white text-sm font-semibold drop-shadow-sm whitespace-nowrap">
-                        {t.gap.toLocaleString()} years
+                        {t.gap.toLocaleString('en-US')} years
                       </span>
                     </div>
                   </div>

--- a/src/app/blog/worlds-largest-collection/page.tsx
+++ b/src/app/blog/worlds-largest-collection/page.tsx
@@ -137,7 +137,7 @@ export default function WorldsLargestCollectionPage() {
                 <div className="flex justify-between items-baseline mb-1">
                   <span className="text-sm text-secondary font-medium">{col.name}</span>
                   <span className="text-xs text-muted">
-                    {col.count.toLocaleString()} texts &middot; {col.access}
+                    {col.count.toLocaleString('en-US')} texts &middot; {col.access}
                   </span>
                 </div>
                 <div className="w-full bg-cream rounded-full h-6 overflow-hidden">
@@ -148,7 +148,7 @@ export default function WorldsLargestCollectionPage() {
                       backgroundColor: col.color,
                     }}
                   >
-                    <span className="text-xs text-white font-medium">{col.count.toLocaleString()}</span>
+                    <span className="text-xs text-white font-medium">{col.count.toLocaleString('en-US')}</span>
                   </div>
                 </div>
               </div>
@@ -330,7 +330,7 @@ export default function WorldsLargestCollectionPage() {
                   <tr key={lib.name} className="border-b border-border-light">
                     <td className="py-2.5 text-secondary font-medium">{lib.name}</td>
                     <td className="py-2.5 text-right px-4 text-muted tabular-nums">
-                      {lib.translations ? `~${lib.translations.toLocaleString()}` : 'thousands'}
+                      {lib.translations ? `~${lib.translations.toLocaleString('en-US')}` : 'thousands'}
                     </td>
                     <td className="py-2.5">
                       {lib.newTranslations ? (

--- a/src/app/catalog/scholar/page.tsx
+++ b/src/app/catalog/scholar/page.tsx
@@ -32,7 +32,7 @@ export default async function ScholarCatalogPage() {
           Catalog
         </h1>
         <p className="text-lg mb-10" style={{ color: 'var(--text-muted)' }}>
-          {browseResult.total.toLocaleString()} works. Bibliographic records with permalinks, OCR status, and translation coverage.
+          {browseResult.total.toLocaleString('en-US')} works. Bibliographic records with permalinks, OCR status, and translation coverage.
         </p>
 
         <ScholarCatalog

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -850,7 +850,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                 href={galleryCollectionSlug ? `/gallery/collections/${galleryCollectionSlug}` : `/gallery?collection=${id}`}
                 className="text-sm text-muted hover:text-accent-rust transition-colors"
               >
-                Browse all {galleryTotalImages.toLocaleString()}
+                Browse all {galleryTotalImages.toLocaleString('en-US')}
               </Link>
             </div>
             <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 gap-4 mt-5">
@@ -897,7 +897,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                   className="group relative aspect-square rounded-lg overflow-hidden border border-border-light hover:border-accent-rust/40 transition-all hover:shadow-md bg-cream flex flex-col items-center justify-center gap-2 text-center"
                 >
                   <span className="text-sm font-medium text-muted group-hover:text-accent-rust transition-colors px-3">
-                    View all {galleryTotalImages.toLocaleString()}
+                    View all {galleryTotalImages.toLocaleString('en-US')}
                   </span>
                 </Link>
               )}

--- a/src/app/collections/sacred-texts/page.tsx
+++ b/src/app/collections/sacred-texts/page.tsx
@@ -197,7 +197,7 @@ export default async function SacredTextsPortal() {
 
           <div className="flex flex-wrap gap-8 text-sm text-white/40">
             <div>
-              <span className="text-2xl font-semibold text-white/80 block">{totalBooks.toLocaleString()}</span>
+              <span className="text-2xl font-semibold text-white/80 block">{totalBooks.toLocaleString('en-US')}</span>
               core texts
             </div>
             <div>

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -75,7 +75,7 @@ export default async function ParticipatePage() {
             world&apos;s rarest books
           </h1>
           <p className="text-lg md:text-xl text-stone-300 max-w-2xl mb-10 leading-relaxed">
-            {stats.totalBooks.toLocaleString()} texts from {stats.languageCount} languages, scanned from {' '}
+            {stats.totalBooks.toLocaleString('en-US')} texts from {stats.languageCount} languages, scanned from {' '}
             13 digital archives. Open, translated by AI, and free forever.
             We need human eyes to make the translations good.
           </p>
@@ -98,7 +98,7 @@ export default async function ParticipatePage() {
         <div className="max-w-5xl mx-auto px-6 py-6">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
             <div>
-              <div className="text-2xl md:text-3xl font-semibold text-primary">{stats.totalBooks.toLocaleString()}</div>
+              <div className="text-2xl md:text-3xl font-semibold text-primary">{stats.totalBooks.toLocaleString('en-US')}</div>
               <div className="text-sm text-muted mt-0.5">rare books</div>
             </div>
             <div>
@@ -106,7 +106,7 @@ export default async function ParticipatePage() {
               <div className="text-sm text-muted mt-0.5">manuscript pages</div>
             </div>
             <div>
-              <div className="text-2xl md:text-3xl font-semibold text-primary">{stats.translatedCount.toLocaleString()}</div>
+              <div className="text-2xl md:text-3xl font-semibold text-primary">{stats.translatedCount.toLocaleString('en-US')}</div>
               <div className="text-sm text-muted mt-0.5">books with translations</div>
             </div>
             <div>

--- a/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
+++ b/src/app/contribute/wikipedia/WikipediaPlaybook.tsx
@@ -78,7 +78,7 @@ function TalkPageCard({
             </span>
           </div>
           <div className="text-sm text-muted mt-0.5">
-            {post.pages.toLocaleString()} pages, {post.pct}% translated
+            {post.pages.toLocaleString('en-US')} pages, {post.pct}% translated
           </div>
         </div>
         <span

--- a/src/app/contribute/wikipedia/page.tsx
+++ b/src/app/contribute/wikipedia/page.tsx
@@ -197,8 +197,8 @@ function buildWikiText(config: typeof FEATURED_BOOKS[number], book: BookStats, f
   const lang = book.language || 'Latin';
   const langNote = lang !== 'English' ? ` Original ${lang} alongside translation.` : '';
   const desc = config.wikiDesc
-    ? `${config.wikiDesc}. ${book.pages_count.toLocaleString()} pages, ${pct}% complete.`
-    : `page-by-page English translation. ${book.pages_count.toLocaleString()} pages, ${pct}% complete.`;
+    ? `${config.wikiDesc}. ${book.pages_count.toLocaleString('en-US')} pages, ${pct}% complete.`
+    : `page-by-page English translation. ${book.pages_count.toLocaleString('en-US')} pages, ${pct}% complete.`;
 
   const heading = config.slug.includes('corpus-hermeticum') || config.slug.includes('pymander')
     ? '== External link suggestion: 1532 Latin edition at Source Library =='
@@ -220,7 +220,7 @@ function buildWikiText(config: typeof FEATURED_BOOKS[number], book: BookStats, f
   if (config.slug === 'history-of-both-worlds-macrocosm-fludd' && fludd2) {
     const f2denom = Math.max(fludd2.pages_count - (fludd2.pages_blank || 0), 1);
     const f2pct = fludd2.pages_count > 0 ? Math.round(fludd2.pages_translated / f2denom * 100) : 0;
-    body += `\n* [https://sourcelibrary.org/book/history-of-both-worlds-microcosm-fludd Utriusque Cosmi Historia Vol. 2 (1619)] — ${fludd2.pages_count.toLocaleString()} pages, ${f2pct}% complete.`;
+    body += `\n* [https://sourcelibrary.org/book/history-of-both-worlds-microcosm-fludd Utriusque Cosmi Historia Vol. 2 (1619)] — ${fludd2.pages_count.toLocaleString('en-US')} pages, ${f2pct}% complete.`;
   }
 
   return `${heading}\n\n{{edit COI}} I'm affiliated with Source Library.\n\n${body}\n\n~~~~`;

--- a/src/app/developers/pipeline/page.tsx
+++ b/src/app/developers/pipeline/page.tsx
@@ -95,7 +95,7 @@ async function getPipelineStats() {
 function fmt(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
   if (n >= 1_000) return (n / 1_000).toFixed(n >= 10_000 ? 0 : 1) + 'k';
-  return n.toLocaleString();
+  return n.toLocaleString('en-US');
 }
 
 /* ── Stage definitions for diagram ── */

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -83,7 +83,7 @@ export default function FeedbackPage() {
                       {item.page}
                     </Link>
                   )}
-                  <span>{new Date(item.created_at).toLocaleString()}</span>
+                  <span>{new Date(item.created_at).toLocaleString('en-US')}</span>
                   {!item.read && (
                     <span className="px-1.5 py-0.5 rounded text-xs font-medium" style={{ background: 'rgba(217, 119, 6, 0.1)', color: 'var(--accent-amber)' }}>
                       new

--- a/src/app/languages/[code]/page.tsx
+++ b/src/app/languages/[code]/page.tsx
@@ -198,7 +198,7 @@ export default async function LanguageDetailPage({ params, searchParams }: Props
           </h1>
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-            <span>{total.toLocaleString()} books</span>
+            <span>{total.toLocaleString('en-US')} books</span>
             {firstTranslationCount > 0 && (
               <>
                 <span className="w-px h-4 bg-white/20" />
@@ -259,7 +259,7 @@ export default async function LanguageDetailPage({ params, searchParams }: Props
           <div>
             <h2 className="text-2xl sm:text-3xl text-primary font-display">All Books</h2>
             <p className="text-sm text-muted mt-1">
-              {total.toLocaleString()} {langName} texts
+              {total.toLocaleString('en-US')} {langName} texts
             </p>
           </div>
 

--- a/src/app/languages/page.tsx
+++ b/src/app/languages/page.tsx
@@ -94,7 +94,7 @@ export default async function LanguagesPage() {
     <ContentPageLayout>
       <ContentHeader
         title="Languages"
-        subtitle={`${totalBooks.toLocaleString()} books across ${languages.length} languages, spanning five millennia of human thought.`}
+        subtitle={`${totalBooks.toLocaleString('en-US')} books across ${languages.length} languages, spanning five millennia of human thought.`}
         image={major.find(l => l.heroImage)?.heroImage}
         imageAlt="Multilingual manuscript page"
       />
@@ -122,7 +122,7 @@ export default async function LanguagesPage() {
             <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-6">
               <div className="flex items-center gap-2 mb-2">
                 <span className="px-2.5 py-0.5 text-xs text-white/80 bg-white/15 backdrop-blur-sm rounded-full">
-                  {lang.bookCount.toLocaleString()} books
+                  {lang.bookCount.toLocaleString('en-US')} books
                 </span>
                 {lang.yearRange && (
                   <span className="text-xs text-white/50">{lang.yearRange}</span>

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -187,7 +187,7 @@ function PartnerCard({ partner, heroImage, count, languages, size = 'normal' }: 
         <div className={`flex items-center gap-3 ${isHero || isFeatured ? 'mt-5' : 'mt-3'}`}>
           <span className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium text-white/90 bg-white/15 backdrop-blur-sm rounded-full">
             <BookOpen className="w-3 h-3" />
-            {count.toLocaleString()} books
+            {count.toLocaleString('en-US')} books
           </span>
           {topLangs && (
             <span className="inline-flex items-center gap-1.5 text-xs text-white/50">
@@ -238,7 +238,7 @@ export default async function LibrariesPage() {
         <div className="relative max-w-[var(--container-wide)] mx-auto px-6">
           <h1 className="font-serif text-4xl md:text-5xl tracking-tight mb-4">Libraries</h1>
           <p className="text-lg md:text-xl text-stone-300 max-w-2xl font-body leading-relaxed">
-            {totalBooks.toLocaleString()} books sourced from {partners.length} libraries and archives
+            {totalBooks.toLocaleString('en-US')} books sourced from {partners.length} libraries and archives
             {totalInstitutions > 0 ? ` across ${totalInstitutions} contributing institutions` : ''} worldwide.
           </p>
         </div>

--- a/src/app/timeline/TimelineClient.tsx
+++ b/src/app/timeline/TimelineClient.tsx
@@ -333,7 +333,7 @@ export default function TimelineClient({ initialData }: Props) {
           </button>
         )}
         <span className="text-sm text-stone-500 ml-auto font-body">
-          {filteredSummary.total.toLocaleString()} texts
+          {filteredSummary.total.toLocaleString('en-US')} texts
         </span>
       </div>
 
@@ -464,7 +464,7 @@ export default function TimelineClient({ initialData }: Props) {
                   </span>
                 )}
                 <span className="ml-3 text-base font-sans font-normal text-stone-500">
-                  {booksTotal.toLocaleString()} {viewMode === 'art' ? (booksTotal === 1 ? 'artist' : 'artists') : (booksTotal === 1 ? 'text' : 'texts')}
+                  {booksTotal.toLocaleString('en-US')} {viewMode === 'art' ? (booksTotal === 1 ? 'artist' : 'artists') : (booksTotal === 1 ? 'text' : 'texts')}
                 </span>
               </h2>
 

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -335,7 +335,7 @@ export default async function TopicDetailPage({ params }: Props) {
             </p>
 
             <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-              <span>{data.totalBooks.toLocaleString()} books</span>
+              <span>{data.totalBooks.toLocaleString('en-US')} books</span>
               {data.languages.length > 0 && (
                 <>
                   <span className="w-px h-4 bg-white/20" />

--- a/src/app/topics/clusters/page.tsx
+++ b/src/app/topics/clusters/page.tsx
@@ -120,7 +120,7 @@ export default async function TopicsPage() {
       header={
         <ContentHeader
           title="Browse by Topic"
-          subtitle={`${totalBooks.toLocaleString()} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
+          subtitle={`${totalBooks.toLocaleString('en-US')} books organized into ${topics.length} topics, discovered by clustering the library's keyword indexes.`}
         />
       }
     >

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -138,7 +138,7 @@ function FacetValueCard({ value, facetId }: { value: FacetCount; facetId: string
             {value.label}
           </h3>
           <span className="text-xs text-muted whitespace-nowrap flex-shrink-0">
-            {value.count.toLocaleString()}
+            {value.count.toLocaleString('en-US')}
           </span>
         </div>
       </div>
@@ -204,7 +204,7 @@ export default async function TopicsPage() {
       header={
         <ContentHeader
           title="Browse the Library"
-          subtitle={`${totalBooks.toLocaleString()} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
+          subtitle={`${totalBooks.toLocaleString('en-US')} books across six dimensions. Click any tag to explore, or combine tags to narrow your search.`}
         />
       }
     >

--- a/src/components/BrokenImageReporter.tsx
+++ b/src/components/BrokenImageReporter.tsx
@@ -3,11 +3,22 @@
 import { useEffect } from 'react';
 
 /**
- * Global broken image reporter. Listens for image load errors
- * across the entire page and reports them to the analytics endpoint.
+ * Global broken-image reporter. Listens for image load errors and reports
+ * truly-broken images to the analytics endpoint.
  *
- * Debounces and deduplicates: reports at most one batch per page load,
- * and never reports the same URL twice per session.
+ * Why the verify-after-tick logic: cards like BookCard handle errors by
+ * swapping to a fallback URL on the same <img> element (display variant →
+ * thumb variant). The original error event still fires, but the user ends
+ * up seeing a working image. We only want to report when the *final*
+ * rendered state is broken, not every intermediate failure.
+ *
+ * Algorithm:
+ *   1. Capture the error event + the src that failed.
+ *   2. After ~1s, re-check the element:
+ *      - If unmounted → drop (component disappeared, irrelevant).
+ *      - If src changed → drop (a fallback swap succeeded or is in-flight).
+ *      - If complete && naturalWidth === 0 with the same src → genuinely
+ *        broken, queue for batched reporting.
  */
 
 const reported = new Set<string>();
@@ -20,7 +31,6 @@ function flush() {
   pending = [];
   flushTimer = null;
 
-  // Fire and forget — never block UI
   fetch('/api/analytics/broken-image', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -29,25 +39,34 @@ function flush() {
       page: window.location.pathname,
       timestamp: new Date().toISOString(),
     }),
-  }).catch(() => {}); // swallow errors
+  }).catch(() => {});
 }
 
 function handleError(e: Event) {
   const el = e.target;
   if (!(el instanceof HTMLImageElement)) return;
 
-  const src = el.currentSrc || el.src;
-  if (!src || reported.has(src)) return;
+  const failedSrc = el.currentSrc || el.src;
+  if (!failedSrc || reported.has(failedSrc)) return;
 
-  // Only report images from our own domain
-  if (!src.includes('images.sourcelibrary.org') && !src.includes('/api/image')) return;
+  if (!failedSrc.includes('images.sourcelibrary.org') && !failedSrc.includes('/api/image')) return;
 
-  reported.add(src);
-  pending.push(src);
+  // Dedup early so we don't queue multiple verify-checks for the same URL.
+  reported.add(failedSrc);
 
-  // Batch: wait 2s after last error to flush (catches cascading failures)
-  if (flushTimer) clearTimeout(flushTimer);
-  flushTimer = setTimeout(flush, 2000);
+  // Verify after a tick: if a component-level fallback (BookCard, PageCard, etc.)
+  // swaps the src and loads successfully, drop the report.
+  setTimeout(() => {
+    if (!el.isConnected) return;
+    const currentSrc = el.currentSrc || el.src;
+    if (currentSrc !== failedSrc) return; // src swapped, treat as recovered
+    // complete=true with naturalWidth=0 is the canonical "fetched but no image" state.
+    if (!el.complete || el.naturalWidth !== 0) return;
+
+    pending.push(failedSrc);
+    if (flushTimer) clearTimeout(flushTimer);
+    flushTimer = setTimeout(flush, 2000);
+  }, 1000);
 }
 
 export default function BrokenImageReporter() {

--- a/src/components/analytics/shared/formatters.ts
+++ b/src/components/analytics/shared/formatters.ts
@@ -6,11 +6,11 @@ export function formatDuration(ms: number): string {
 }
 
 export function formatTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleString();
+  return new Date(timestamp).toLocaleString('en-US');
 }
 
 export function formatNumber(n: number): string {
-  return n.toLocaleString();
+  return n.toLocaleString('en-US');
 }
 
 export function formatCost(cost: number): string {

--- a/src/components/analytics/tabs/PipelineTab.tsx
+++ b/src/components/analytics/tabs/PipelineTab.tsx
@@ -128,9 +128,9 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
               )}
             </div>
             <div className="text-sm" style={{ color: 'var(--text-muted)' }}>
-              {ec!.translation.toLocaleString()} / {ec!.ocr.toLocaleString()} books with OCR
+              {ec!.translation.toLocaleString('en-US')} / {ec!.ocr.toLocaleString('en-US')} books with OCR
               {progressBar.etaDays > 0 && translateRate > 0 && (
-                <span> &middot; ~{progressBar.etaDays < 1 ? `${progressBar.etaHours}h` : `${progressBar.etaDays}d`} remaining at {translateRate.toLocaleString()}/hr</span>
+                <span> &middot; ~{progressBar.etaDays < 1 ? `${progressBar.etaHours}h` : `${progressBar.etaDays}d`} remaining at {translateRate.toLocaleString('en-US')}/hr</span>
               )}
             </div>
           </div>
@@ -145,7 +145,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
           </div>
           <div className="flex justify-between mt-1">
             <span className="text-xs" style={{ color: 'var(--text-muted)' }}>{progressBar.pct}% have translation</span>
-            <span className="text-xs" style={{ color: 'var(--text-muted)' }}>{progressBar.fullyDone.toLocaleString()} pipeline complete ({progressBar.fullyPct}%)</span>
+            <span className="text-xs" style={{ color: 'var(--text-muted)' }}>{progressBar.fullyDone.toLocaleString('en-US')} pipeline complete ({progressBar.fullyPct}%)</span>
           </div>
         </div>
       )}
@@ -182,14 +182,14 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
         <div className="p-5 rounded-xl" style={{ background: 'linear-gradient(135deg, var(--bg-white), #fffbeb)', border: '1px solid var(--border-light)' }}>
           <div className="text-sm font-medium uppercase mb-1" style={{ color: 'var(--text-muted)' }}>First Translations</div>
           <div className="text-3xl font-bold" style={{ color: 'var(--accent-gold-dark)' }}>
-            {(pipelineData.milestones?.firstTranslations || 0).toLocaleString()}
+            {(pipelineData.milestones?.firstTranslations || 0).toLocaleString('en-US')}
           </div>
           <div className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>into English</div>
         </div>
         <div className="p-5 rounded-xl" style={{ background: 'linear-gradient(135deg, var(--bg-white), #fdf4ff)', border: '1px solid var(--border-light)' }}>
           <div className="text-sm font-medium uppercase mb-1" style={{ color: 'var(--text-muted)' }}>&gt;90% Translated</div>
           <div className="text-3xl font-bold" style={{ color: '#a855f7' }}>
-            {(pipelineData.milestones?.nearComplete || 0).toLocaleString()}
+            {(pipelineData.milestones?.nearComplete || 0).toLocaleString('en-US')}
           </div>
           <div className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>books</div>
         </div>
@@ -260,7 +260,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
                     />
                   </div>
                   <div className="w-16 text-xs font-bold text-right" style={{ color: 'var(--text-secondary)' }}>
-                    {count.toLocaleString()}
+                    {count.toLocaleString('en-US')}
                   </div>
                 </div>
               ))}
@@ -300,7 +300,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
               )}
             </h2>
             <p className="text-xs mb-4" style={{ color: 'var(--text-muted)' }}>
-              {total.toLocaleString()} books with pages &middot; {cov.galleryImages.toLocaleString()} gallery images
+              {total.toLocaleString('en-US')} books with pages &middot; {cov.galleryImages.toLocaleString('en-US')} gallery images
             </p>
             <div className="space-y-2.5">
               {phases.map(({ label, count, color }) => {
@@ -317,7 +317,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
                       />
                     </div>
                     <div className="w-24 text-xs text-right" style={{ color: 'var(--text-secondary)' }}>
-                      <span className="font-bold">{count.toLocaleString()}</span>
+                      <span className="font-bold">{count.toLocaleString('en-US')}</span>
                       <span className="ml-1" style={{ color: 'var(--text-muted)' }}>({pct}%)</span>
                     </div>
                   </div>
@@ -453,7 +453,7 @@ export default function PipelineTab({ hours }: PipelineTabProps) {
                       <td className="py-2.5 pr-4 font-medium" style={{ color: 'var(--text-primary)' }}>{name}</td>
                       <td className="py-2.5 pr-4" style={{ color: 'var(--text-muted)' }}>
                         {timeSince !== null ? (
-                          <span title={new Date(health.lastRun!).toLocaleString()}>
+                          <span title={new Date(health.lastRun!).toLocaleString('en-US')}>
                             {timeSince < 60 ? `${timeSince}m ago` : `${Math.round(timeSince / 60)}h ago`}
                           </span>
                         ) : 'Never'}

--- a/src/components/analytics/tabs/TrafficTab.tsx
+++ b/src/components/analytics/tabs/TrafficTab.tsx
@@ -49,7 +49,7 @@ export default function TrafficTab() {
                 <span className="text-sm font-medium uppercase" style={{ color: 'var(--text-muted)' }}>Total Visitors</span>
               </div>
               <div className="text-4xl font-bold" style={{ color: 'var(--text-primary)' }}>
-                {data.totalVisitors.toLocaleString()}
+                {data.totalVisitors.toLocaleString('en-US')}
               </div>
             </div>
           )}
@@ -60,7 +60,7 @@ export default function TrafficTab() {
                 <span className="text-sm font-medium uppercase" style={{ color: 'var(--text-muted)' }}>Total Pageviews</span>
               </div>
               <div className="text-4xl font-bold" style={{ color: 'var(--text-primary)' }}>
-                {data.totalPageviews.toLocaleString()}
+                {data.totalPageviews.toLocaleString('en-US')}
               </div>
             </div>
           )}
@@ -86,7 +86,7 @@ export default function TrafficTab() {
             {data.topPages.map((page, idx) => (
               <div key={idx} className="flex items-center justify-between pb-3" style={{ borderBottom: idx < data.topPages!.length - 1 ? '1px solid var(--border-light)' : 'none' }}>
                 <p className="font-medium truncate" style={{ color: 'var(--text-primary)' }}>{page.path}</p>
-                <p className="text-sm ml-4" style={{ color: 'var(--text-muted)' }}>{page.count.toLocaleString()} views</p>
+                <p className="text-sm ml-4" style={{ color: 'var(--text-muted)' }}>{page.count.toLocaleString('en-US')} views</p>
               </div>
             ))}
           </div>
@@ -102,7 +102,7 @@ export default function TrafficTab() {
               {data.topReferrers.map((referrer, idx) => (
                 <div key={idx} className="flex items-center justify-between pb-3" style={{ borderBottom: idx < data.topReferrers!.length - 1 ? '1px solid var(--border-light)' : 'none' }}>
                   <p className="font-medium truncate" style={{ color: 'var(--text-primary)' }}>{referrer.referrer || 'Direct traffic'}</p>
-                  <p className="text-sm ml-4" style={{ color: 'var(--text-muted)' }}>{referrer.count.toLocaleString()} visitors</p>
+                  <p className="text-sm ml-4" style={{ color: 'var(--text-muted)' }}>{referrer.count.toLocaleString('en-US')} visitors</p>
                 </div>
               ))}
             </div>
@@ -119,7 +119,7 @@ export default function TrafficTab() {
               {data.topCountries.map((country, idx) => (
                 <div key={idx} className="flex items-center justify-between pb-3" style={{ borderBottom: idx < data.topCountries!.length - 1 ? '1px solid var(--border-light)' : 'none' }}>
                   <p className="font-medium" style={{ color: 'var(--text-primary)' }}>{country.country}</p>
-                  <p className="text-sm ml-4" style={{ color: 'var(--text-muted)' }}>{country.count.toLocaleString()} visitors</p>
+                  <p className="text-sm ml-4" style={{ color: 'var(--text-muted)' }}>{country.count.toLocaleString('en-US')} visitors</p>
                 </div>
               ))}
             </div>

--- a/src/components/analytics/tabs/UsageTab.tsx
+++ b/src/components/analytics/tabs/UsageTab.tsx
@@ -263,10 +263,10 @@ function PipelineFunnel({ funnel }: { funnel: Array<{ status: string; count: num
                 background: tier.color,
                 clipPath: `polygon(${50 - topPct / 2}% 0, ${50 + topPct / 2}% 0, ${50 + botPct / 2}% 100%, ${50 - botPct / 2}% 100%)`,
               }}
-              title={`${tier.label}: ${tier.count.toLocaleString()} books${i > 0 ? ` (${Math.round((tier.count / tiers[0].count) * 100)}% of enrolled)` : ''}`}
+              title={`${tier.label}: ${tier.count.toLocaleString('en-US')} books${i > 0 ? ` (${Math.round((tier.count / tiers[0].count) * 100)}% of enrolled)` : ''}`}
             >
               <span className="font-medium mr-2">{tier.label}</span>
-              <span className="font-bold">{tier.count.toLocaleString()}</span>
+              <span className="font-bold">{tier.count.toLocaleString('en-US')}</span>
             </div>
           );
         })}
@@ -283,7 +283,7 @@ function PipelineFunnel({ funnel }: { funnel: Array<{ status: string; count: num
           ))}
           {notEnrolled > 0 && (
             <span className="text-xs px-2 py-1 rounded-full" style={{ background: 'var(--bg-warm)', color: 'var(--text-muted)' }}>
-              {notEnrolled.toLocaleString()} not enrolled
+              {notEnrolled.toLocaleString('en-US')} not enrolled
             </span>
           )}
           {needsAttention > 0 && (

--- a/src/components/book/BookLibrary.tsx
+++ b/src/components/book/BookLibrary.tsx
@@ -392,7 +392,7 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
         </h2>
         {showCollections && (
           <p className="text-stone-500 mt-2">
-            {totalBooks.toLocaleString()} texts across {collections.length} collections
+            {totalBooks.toLocaleString('en-US')} texts across {collections.length} collections
           </p>
         )}
       </div>
@@ -544,7 +544,7 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
               onClick={() => setBrowseAll(true)}
               className="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-700 transition-colors"
             >
-              Browse all {totalBooks.toLocaleString()} books
+              Browse all {totalBooks.toLocaleString('en-US')} books
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
               </svg>

--- a/src/components/catalog/CatalogBrowser.tsx
+++ b/src/components/catalog/CatalogBrowser.tsx
@@ -201,9 +201,9 @@ export default function CatalogBrowser({ initialBooks, initialTotal, languages }
         <div className="flex items-center gap-3">
           <p className="text-sm text-muted">
             {query || language ? (
-              `${total.toLocaleString()} of ${initialTotal.toLocaleString()} books`
+              `${total.toLocaleString('en-US')} of ${initialTotal.toLocaleString('en-US')} books`
             ) : (
-              `${total.toLocaleString()} books`
+              `${total.toLocaleString('en-US')} books`
             )}
           </p>
           <a

--- a/src/components/catalog/ScholarCatalog.tsx
+++ b/src/components/catalog/ScholarCatalog.tsx
@@ -375,8 +375,8 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
         <div className="flex items-center gap-3">
           <p className="text-sm text-muted">
             {query || hasActiveFilters
-              ? `${total.toLocaleString()} of ${initialTotal.toLocaleString()} books`
-              : `${total.toLocaleString()} books`}
+              ? `${total.toLocaleString('en-US')} of ${initialTotal.toLocaleString('en-US')} books`
+              : `${total.toLocaleString('en-US')} books`}
           </p>
           <a
             href={csvUrl}
@@ -546,7 +546,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
         <div className="mb-8 p-4 rounded-lg border border-border-light bg-warm/30">
           <h3 className="text-xs uppercase tracking-wide text-muted font-medium mb-3 flex items-center gap-1.5">
             <FileText className="w-3.5 h-3.5" />
-            Content matches ({contentTotal.toLocaleString()} results)
+            Content matches ({contentTotal.toLocaleString('en-US')} results)
           </h3>
           <div className="space-y-2">
             {contentMatches.map((match, i) => {
@@ -576,7 +576,7 @@ export default function ScholarCatalog({ initialBooks, initialTotal, languages }
               href={`/search?q=${encodeURIComponent(query)}${filters.language ? `&language=${filters.language}` : ''}`}
               className="inline-block mt-3 text-xs text-accent-rust hover:underline"
             >
-              See all {contentTotal.toLocaleString()} content matches →
+              See all {contentTotal.toLocaleString('en-US')} content matches →
             </Link>
           )}
         </div>

--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -248,12 +248,12 @@ export default function CollectionAllBooks({
           <p className="text-sm text-muted mt-1">
             {expanded ? (
               loading
-                ? `Loading ${total.toLocaleString()} ${itemLabel}…`
+                ? `Loading ${total.toLocaleString('en-US')} ${itemLabel}…`
                 : query || language
-                  ? `${sorted.length.toLocaleString()} of ${allBooks.length.toLocaleString()} ${itemLabel}`
-                  : `${allBooks.length.toLocaleString()} ${itemLabel} in this collection`
+                  ? `${sorted.length.toLocaleString('en-US')} of ${allBooks.length.toLocaleString('en-US')} ${itemLabel}`
+                  : `${allBooks.length.toLocaleString('en-US')} ${itemLabel} in this collection`
             ) : (
-              `${total.toLocaleString()} ${itemLabel} in this collection`
+              `${total.toLocaleString('en-US')} ${itemLabel} in this collection`
             )}
           </p>
         </div>
@@ -416,7 +416,7 @@ export default function CollectionAllBooks({
                   <ArrowRight className="w-5 h-5 text-stone-400" />
                 </div>
                 <span className="text-sm font-medium text-stone-300 group-hover:text-white transition-colors">
-                  See all {total.toLocaleString()}
+                  See all {total.toLocaleString('en-US')}
                 </span>
                 <span className="text-xs text-stone-500">{itemLabel}</span>
               </button>
@@ -480,7 +480,7 @@ export default function CollectionAllBooks({
               </div>
               <div className="relative z-10 text-center px-3">
                 <span className="text-sm font-medium text-primary group-hover:text-accent-rust transition-colors block">
-                  See all {total.toLocaleString()}
+                  See all {total.toLocaleString('en-US')}
                 </span>
                 <span className="text-xs text-muted">{itemLabel}</span>
               </div>

--- a/src/components/collections/EraTimeline.tsx
+++ b/src/components/collections/EraTimeline.tsx
@@ -131,7 +131,7 @@ export default function EraTimeline({ decades, total }: Props) {
               Browse by era
             </h2>
             <p className="text-stone-500 text-sm font-body">
-              {total.toLocaleString()} texts across three millennia
+              {total.toLocaleString('en-US')} texts across three millennia
             </p>
           </div>
 
@@ -204,7 +204,7 @@ export default function EraTimeline({ decades, total }: Props) {
                           {era.tagline}
                         </p>
                         <span className="text-xs text-stone-600 shrink-0 tabular-nums">
-                          {count.toLocaleString()} texts
+                          {count.toLocaleString('en-US')} texts
                         </span>
                       </div>
 

--- a/src/components/explore/BookMap.tsx
+++ b/src/components/explore/BookMap.tsx
@@ -199,7 +199,7 @@ export default function BookMap({ locations }: BookMapProps) {
           className="text-base font-semibold tracking-tight mb-2.5"
           style={{ fontFamily: 'var(--font-heading)', color: 'var(--text-primary)' }}
         >
-          {bookCount.toLocaleString()} books across {cityPins.length.toLocaleString()} cities
+          {bookCount.toLocaleString('en-US')} books across {cityPins.length.toLocaleString('en-US')} cities
         </h1>
 
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">

--- a/src/components/explore/ConstellationCanvas.tsx
+++ b/src/components/explore/ConstellationCanvas.tsx
@@ -449,7 +449,7 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
         />
         {searchQuery && highlightedIds && (
           <span className="self-center text-xs text-stone-500 bg-white/90 backdrop-blur-sm rounded-lg px-2 py-1.5 shadow-sm">
-            {highlightedIds.size.toLocaleString()} matches
+            {highlightedIds.size.toLocaleString('en-US')} matches
           </span>
         )}
       </div>
@@ -481,7 +481,7 @@ export default function ConstellationCanvas({ points }: { points: ConstellationP
 
       {/* Stats */}
       <div className="absolute bottom-4 left-4 z-20 text-xs text-stone-400 bg-white/80 backdrop-blur-sm rounded px-2 py-1">
-        {points.length.toLocaleString()} items &middot; scroll to zoom &middot; drag to pan &middot; click to open
+        {points.length.toLocaleString('en-US')} items &middot; scroll to zoom &middot; drag to pan &middot; click to open
       </div>
 
       {/* Tooltip */}

--- a/src/components/explore/DataSources.tsx
+++ b/src/components/explore/DataSources.tsx
@@ -36,7 +36,7 @@ export default function DataSources({ sources }: DataSourcesProps) {
                 {source.label}
               </span>
               <span className="text-sm font-mono" style={{ color: 'var(--text-secondary)' }}>
-                {source.count.toLocaleString()}
+                {source.count.toLocaleString('en-US')}
               </span>
             </div>
             <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>

--- a/src/components/explore/EntityMap.tsx
+++ b/src/components/explore/EntityMap.tsx
@@ -300,7 +300,7 @@ export default function EntityMap({ entities, stats }: EntityMapProps) {
 
           {/* Count */}
           <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
-            {filtered.length.toLocaleString()} / {entities.length.toLocaleString()}
+            {filtered.length.toLocaleString('en-US')} / {entities.length.toLocaleString('en-US')}
           </span>
         </div>
       </div>

--- a/src/components/explore/ExploreNav.tsx
+++ b/src/components/explore/ExploreNav.tsx
@@ -88,7 +88,7 @@ function CardContent({ card, count }: { card: typeof VIZ_CARDS[number]; count: n
         {card.description}
       </p>
       <div className="text-sm font-medium" style={{ color: card.color }}>
-        {count.toLocaleString()} {card.statLabel}
+        {count.toLocaleString('en-US')} {card.statLabel}
       </div>
     </>
   );

--- a/src/components/explore/ExploreStats.tsx
+++ b/src/components/explore/ExploreStats.tsx
@@ -28,7 +28,7 @@ export default function ExploreStats({ totals }: ExploreStatsProps) {
           style={{ background: 'var(--bg-white, #fff)', border: '1px solid var(--border-light)' }}
         >
           <div className="text-2xl sm:text-3xl font-semibold" style={{ color: 'var(--text-primary)' }}>
-            {totals[key].toLocaleString()}
+            {totals[key].toLocaleString('en-US')}
           </div>
           <div className="text-sm font-medium mt-1" style={{ color: 'var(--text-secondary)' }}>
             {label}

--- a/src/components/explore/Timeline.tsx
+++ b/src/components/explore/Timeline.tsx
@@ -579,7 +579,7 @@ export default function Timeline({ entities, stats }: TimelineProps) {
         <span className="w-px h-5 mx-1 hidden sm:block" style={{ background: 'var(--border-light)' }} />
 
         <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
-          {filtered.length.toLocaleString()} / {parsed.length.toLocaleString()} entities
+          {filtered.length.toLocaleString('en-US')} / {parsed.length.toLocaleString('en-US')} entities
           &nbsp;&middot;&nbsp;
           {viewStart}–{viewEnd}
         </span>

--- a/src/components/gallery/CurateClient.tsx
+++ b/src/components/gallery/CurateClient.tsx
@@ -933,7 +933,7 @@ export default function CurateClient() {
                 </>
               )}
               {' / '}
-              <span>{total.toLocaleString()}</span> total
+              <span>{total.toLocaleString('en-US')}</span> total
             </span>
           </div>
 

--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -98,13 +98,22 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   const pathParts = pathname.split('/').filter(Boolean);
   const tenantPrefix = pathParts[1] === 'gallery' && pathParts[0] ? `/${pathParts[0]}` : '';
 
-  // Shuffle initial items client-side so order varies each visit
-  const [data, setData] = useState<GalleryResponse>(() => ({
-    ...initialData,
-    items: shuffle(initialData.items),
-  }));
-  // Accumulated items for "Load More" pattern
-  const [allItems, setAllItems] = useState<GalleryItem[]>(() => shuffle(initialData.items));
+  // Render the server-provided order on first paint (matches SSR HTML so we
+  // don't trip React error #418 hydration mismatch), then shuffle once we're
+  // past hydration. Math.random() inside a useState initializer ran twice —
+  // once on the server, once on the client — and produced different orders.
+  const [data, setData] = useState<GalleryResponse>(initialData);
+  const [allItems, setAllItems] = useState<GalleryItem[]>(initialData.items);
+  const [hasShuffled, setHasShuffled] = useState(false);
+  useEffect(() => {
+    if (hasShuffled) return;
+    const shuffled = shuffle(initialData.items);
+    setData(prev => ({ ...prev, items: shuffled }));
+    setAllItems(shuffled);
+    setHasShuffled(true);
+    // initialData is the prop from the server — stable for the lifetime of this mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -614,7 +623,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
               <div className="mb-4">
                 <h2 className="text-2xl font-serif text-stone-800 mb-1">Browse Images</h2>
                 <p className="text-stone-500 text-base">
-                  {data.total.toLocaleString()} illustrations from rare historical manuscripts.
+                  {data.total.toLocaleString('en-US')} illustrations from rare historical manuscripts.
                 </p>
               </div>
             )}
@@ -639,7 +648,7 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
                   )}
-                  {loadingMore ? 'Loading...' : `Load more (${remainingCount.toLocaleString()} remaining)`}
+                  {loadingMore ? 'Loading...' : `Load more (${remainingCount.toLocaleString('en-US')} remaining)`}
                 </button>
               </div>
             )}

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -447,7 +447,7 @@ export default function BphCatalogBrowser({
 
         {!hideInlineCount && !sortLivesInHeader && (
           <span className="text-sm text-muted ml-auto">
-            {total.toLocaleString()} works
+            {total.toLocaleString('en-US')} works
           </span>
         )}
       </div>
@@ -460,8 +460,8 @@ export default function BphCatalogBrowser({
       {sortLivesInHeader && (
         <div className="flex flex-wrap items-center gap-3 mb-4">
           <span className="text-sm text-muted">
-            <span className="font-medium text-primary">{total.toLocaleString()}</span>
-            {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString()} works` : ' works'}
+            <span className="font-medium text-primary">{total.toLocaleString('en-US')}</span>
+            {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString('en-US')} works` : ' works'}
           </span>
           <div className="flex items-center gap-3 ml-auto">
             <label className="inline-flex items-center gap-2 text-sm text-muted">

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -189,7 +189,7 @@ export default function SharedLibraryView({
                   className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors mt-3"
                 >
                   <Search className="w-3.5 h-3.5" />
-                  Browse the full catalogue ({catalogTotal.toLocaleString()} works)
+                  Browse the full catalogue ({catalogTotal.toLocaleString('en-US')} works)
                 </Link>
               ) : (
                 <Link
@@ -206,12 +206,12 @@ export default function SharedLibraryView({
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
             {isBph && catalogTotal > 0 ? (
               <>
-                <span>{catalogTotal.toLocaleString()} works in catalogue</span>
+                <span>{catalogTotal.toLocaleString('en-US')} works in catalogue</span>
                 <span className="w-px h-4 bg-white/20" />
-                <span>{total.toLocaleString()} digitised on Source Library</span>
+                <span>{total.toLocaleString('en-US')} digitised on Source Library</span>
               </>
             ) : (
-              <span>{total.toLocaleString()} translated books</span>
+              <span>{total.toLocaleString('en-US')} translated books</span>
             )}
             {languages.length > 0 && (
               <>
@@ -353,7 +353,7 @@ export default function SharedLibraryView({
                     All Books
                   </h2>
                   <p className="text-sm text-muted mt-1">
-                    {total.toLocaleString()} books from {partner.name}
+                    {total.toLocaleString('en-US')} books from {partner.name}
                   </p>
                 </div>
 
@@ -457,7 +457,7 @@ export default function SharedLibraryView({
                   Selected Books
                 </h2>
                 <p className="text-sm text-muted mb-4">
-                  {total.toLocaleString()} books from the BPH collection translated on Source Library.
+                  {total.toLocaleString('en-US')} books from the BPH collection translated on Source Library.
                 </p>
                 <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-4">
                   {topBooks.map((book, i) => (
@@ -508,7 +508,7 @@ export default function SharedLibraryView({
                     Library Catalogue
                   </h2>
                   <p className="text-sm text-muted mt-1">
-                    Complete catalogue of the Bibliotheca Philosophica Hermetica — {catalogTotal.toLocaleString()} works in the collection.
+                    Complete catalogue of the Bibliotheca Philosophica Hermetica — {catalogTotal.toLocaleString('en-US')} works in the collection.
                     Works available on Source Library are marked with a book icon.
                   </p>
                 </div>

--- a/src/components/pipeline/PipelineDiagram.tsx
+++ b/src/components/pipeline/PipelineDiagram.tsx
@@ -110,7 +110,7 @@ export default function PipelineDiagram({ stages }: { stages: StageData[] }) {
                           color: stage.textColor,
                         }}
                       >
-                        {stage.count.toLocaleString()}
+                        {stage.count.toLocaleString('en-US')}
                       </span>
                       <svg
                         className={`w-4 h-4 text-muted transition-transform ${isExpanded ? 'rotate-180' : ''}`}

--- a/src/components/reader/RevisionHistory.tsx
+++ b/src/components/reader/RevisionHistory.tsx
@@ -224,7 +224,7 @@ export default function RevisionHistory({ pageId, field, currentSource, editedBy
                       </div>
                       <div className="flex items-center justify-between">
                         <span className="text-[10px]" style={{ color: 'var(--text-faint)' }}>
-                          {rev.data.length.toLocaleString()} chars
+                          {rev.data.length.toLocaleString('en-US')} chars
                         </span>
                         <button
                           onClick={(e) => { e.stopPropagation(); handleRestore(rev.id); }}

--- a/src/components/research/BookConstellationViz.tsx
+++ b/src/components/research/BookConstellationViz.tsx
@@ -711,10 +711,10 @@ export default function BookConstellationViz({ data, initialColorMode }: { data:
           onClick={(e) => e.stopPropagation()}
         >
           <div className="grid grid-cols-2 gap-3 mb-4">
-            <div><div className="text-gray-800 font-mono text-xl">{stats.totalBooks.toLocaleString()}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Books</div></div>
+            <div><div className="text-gray-800 font-mono text-xl">{stats.totalBooks.toLocaleString('en-US')}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Books</div></div>
             <div><div className="text-gray-800 font-mono text-xl">{stats.nClusters}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Clusters</div></div>
             <div><div className="text-gray-800 font-mono text-xl">{stats.nLanguages}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Languages</div></div>
-            <div><div className="text-gray-800 font-mono text-xl">{stats.firstTranslations.toLocaleString()}</div><div className="text-gray-400 text-xs uppercase tracking-wider">First Trans.</div></div>
+            <div><div className="text-gray-800 font-mono text-xl">{stats.firstTranslations.toLocaleString('en-US')}</div><div className="text-gray-400 text-xs uppercase tracking-wider">First Trans.</div></div>
           </div>
           <div className="border-t border-gray-200 pt-3 text-gray-500 text-sm leading-relaxed space-y-2">
             <p>

--- a/src/components/research/ConceptDiffusionViz.tsx
+++ b/src/components/research/ConceptDiffusionViz.tsx
@@ -297,8 +297,8 @@ export default function ConceptDiffusionViz({
             onBlur={() => setTimeout(() => setShowDropdown(false), 200)}
             placeholder={
               mode === 'keywords'
-                ? `Search ${terms.length.toLocaleString()} keywords...`
-                : `Search ${terms.length.toLocaleString()} terms...`
+                ? `Search ${terms.length.toLocaleString('en-US')} keywords...`
+                : `Search ${terms.length.toLocaleString('en-US')} terms...`
             }
             className="px-3 py-1.5 text-sm border border-[var(--border-light)] rounded-lg bg-white w-56"
           />

--- a/src/components/research/ImageConstellationViz.tsx
+++ b/src/components/research/ImageConstellationViz.tsx
@@ -617,7 +617,7 @@ export default function ImageConstellationViz({ data }: { data: ConstellationDat
         </a>
         <div className="text-white/70 font-serif text-xl leading-tight">Image Atlas</div>
         <div className="text-white/25 text-xs mt-0.5 font-mono">
-          {stats.totalImages.toLocaleString()} illustrations from {stats.nBooks.toLocaleString()} books
+          {stats.totalImages.toLocaleString('en-US')} illustrations from {stats.nBooks.toLocaleString('en-US')} books
         </div>
       </div>
 
@@ -685,10 +685,10 @@ export default function ImageConstellationViz({ data }: { data: ConstellationDat
           onClick={(e) => e.stopPropagation()}
         >
           <div className="grid grid-cols-2 gap-3 mb-4">
-            <div><div className="text-gray-800 font-mono text-xl">{stats.totalImages.toLocaleString()}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Images</div></div>
+            <div><div className="text-gray-800 font-mono text-xl">{stats.totalImages.toLocaleString('en-US')}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Images</div></div>
             <div><div className="text-gray-800 font-mono text-xl">{stats.nClusters}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Clusters</div></div>
             <div><div className="text-gray-800 font-mono text-xl">{stats.nTypes}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Image Types</div></div>
-            <div><div className="text-gray-800 font-mono text-xl">{stats.nBooks.toLocaleString()}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Books</div></div>
+            <div><div className="text-gray-800 font-mono text-xl">{stats.nBooks.toLocaleString('en-US')}</div><div className="text-gray-400 text-xs uppercase tracking-wider">Books</div></div>
           </div>
           <div className="border-t border-gray-200 pt-3 text-gray-500 text-sm leading-relaxed space-y-2">
             <p>

--- a/src/components/research/ImagePixPlotViz.tsx
+++ b/src/components/research/ImagePixPlotViz.tsx
@@ -223,7 +223,7 @@ export default function ImagePixPlotViz({ data }: { data: ConstellationData }) {
       <div className="absolute top-4 left-5 z-10 pointer-events-none">
         <a href="/" className="text-white/30 hover:text-white/60 text-xs font-mono tracking-[0.2em] uppercase transition-colors pointer-events-auto">Source Library</a>
         <div className="text-white/70 font-serif text-xl leading-tight">Image Atlas</div>
-        <div className="text-white/25 text-xs mt-0.5 font-mono">{stats.total.toLocaleString()} illustrations from {stats.books.toLocaleString()} books</div>
+        <div className="text-white/25 text-xs mt-0.5 font-mono">{stats.total.toLocaleString('en-US')} illustrations from {stats.books.toLocaleString('en-US')} books</div>
         <div className="text-white/15 text-xs mt-0.5 font-mono">{loadStatus}</div>
       </div>
 

--- a/src/components/research/SessionCard.tsx
+++ b/src/components/research/SessionCard.tsx
@@ -39,7 +39,7 @@ export default function SessionCard({ session }: { session: CuratorSessionListIt
               </span>
               <span className="text-stone-300">|</span>
               <span className="text-sm text-muted">
-                {session.word_count.toLocaleString()} words
+                {session.word_count.toLocaleString('en-US')} words
               </span>
               {session.duration_minutes > 1 && (
                 <>

--- a/src/components/research/TranslationLagViz.tsx
+++ b/src/components/research/TranslationLagViz.tsx
@@ -289,7 +289,7 @@ export default function TranslationLagViz({ data }: { data: DataPoint[] }) {
             {tooltip.point.year} ({tooltip.point.language})
           </div>
           <div className="text-xs font-medium mt-1" style={{ color: 'var(--accent-rust)' }}>
-            {tooltip.point.lag.toLocaleString()} year lag
+            {tooltip.point.lag.toLocaleString('en-US')} year lag
           </div>
           {tooltip.point.is_first_translation && (
             <div className="text-xs text-[var(--accent-gold-dark)] mt-0.5">First English translation</div>

--- a/src/components/taxonomy/TaxonomyExplorer.tsx
+++ b/src/components/taxonomy/TaxonomyExplorer.tsx
@@ -277,7 +277,7 @@ export function TaxonomyExplorer() {
         </div>
         <p className="text-stone-500 text-sm">
           {data.total_clusters} clusters &middot; {data.total_subclusters}{' '}
-          subclusters &middot; {data.total_books.toLocaleString()} books
+          subclusters &middot; {data.total_books.toLocaleString('en-US')} books
         </p>
       </div>
 

--- a/src/components/topics/DomainTreemap.tsx
+++ b/src/components/topics/DomainTreemap.tsx
@@ -180,7 +180,7 @@ export default function DomainTreemap({ domains, totalBooks }: Props) {
         className="w-full h-auto rounded-lg"
         style={{ background: '#f5f0e8' }}
         role="img"
-        aria-label={`${totalBooks.toLocaleString()} books across ${domains.length} knowledge domains`}
+        aria-label={`${totalBooks.toLocaleString('en-US')} books across ${domains.length} knowledge domains`}
       >
         {/* Level 1: Group backgrounds + headers */}
         {(root.children as RNode[] | undefined)?.map((group) => {
@@ -225,7 +225,7 @@ export default function DomainTreemap({ domains, totalBooks }: Props) {
                     fontSize={9} fontWeight={600} opacity={0.9}
                     fontFamily="var(--font-display, 'Playfair Display'), serif"
                     style={{ pointerEvents: 'none' }}>
-                    {dd.name} ({(domain.value || 0).toLocaleString()})
+                    {dd.name} ({(domain.value || 0).toLocaleString('en-US')})
                   </text>
                 )}
               </g>
@@ -302,7 +302,7 @@ export default function DomainTreemap({ domains, totalBooks }: Props) {
                   fontSize={fontSize-2} opacity={0.6}
                   fontFamily="var(--font-sans, Inter), sans-serif"
                   style={{ pointerEvents: 'none', textShadow: '0 1px 1px rgba(0,0,0,0.1)' }}>
-                  {(leaf.value || 0).toLocaleString()}
+                  {(leaf.value || 0).toLocaleString('en-US')}
                 </text>
               )}
             </g>
@@ -329,7 +329,7 @@ export default function DomainTreemap({ domains, totalBooks }: Props) {
             {tooltip.label}
           </div>
           <div className="text-xs text-secondary mt-0.5">
-            {tooltip.count.toLocaleString()} books
+            {tooltip.count.toLocaleString('en-US')} books
           </div>
         </div>
       )}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,6 +27,21 @@ export function isUsableImageUrl(url: string | undefined | null): url is string 
 }
 
 /**
+ * Locale-stable number formatter. Pins locale to en-US so server-side
+ * rendering (Node's default) and client-side rendering (the user's browser
+ * locale) produce identical strings — otherwise we trip React error #418
+ * hydration mismatches for visitors whose browser locale isn't en-US.
+ *
+ * Use this instead of `n.toLocaleString()` anywhere a number is rendered to
+ * JSX text. The bare `.toLocaleString()` is fine in side-effects and event
+ * handlers, but not in render output.
+ */
+export function formatNumber(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return '';
+  return n.toLocaleString('en-US');
+}
+
+/**
  * Return the best book image URL for the given display context.
  *
  * R2 image variants (see src/lib/storage.ts for path helpers):


### PR DESCRIPTION
## Summary

Two distinct hydration bugs were firing on /collections (12/day), /book/[slug] (4), /gallery (3), and /collections/[slug] (1) — together producing ~18 React error #418 client-side aborts per day from real users.

### Bug 1: Math.random() in useState initializer (gallery)

`GalleryClient` used `useState(() => shuffle(initialData.items))` which ran on both server and client during initial render, producing different orders. Every gallery view was a hydration mismatch.

**Fix**: render the server-provided quality-sorted order on first paint; shuffle once in a post-mount `useEffect`. The brief visible delta beats an aborted page render.

### Bug 2: Locale-dependent number formatting (everywhere)

`(n).toLocaleString()` with no locale uses Node's default (en-US) on the server and the browser's locale on the client. For visitors with a non-en-US browser locale (most of Europe), `'17,234'` on the server became `'17.234'` on the client. Pure text mismatch on every page with a counter.

**Fix**: pin every render-path `.toLocaleString()` to `'en-US'`. Bulk applied across `src/components` + `src/app` (83 files). Added `formatNumber()` helper in `src/lib/utils.ts` for new code.

### Broken-thumbnail cleanup script

`scripts/fix-broken-thumbnails.mjs`: HEAD-checks every visible book with a legacy `/archived/{bookId}/{N}.jpg` thumbnail. The rewriter in `getBookThumbnailUrl()` turns those into `/pages/{bookId}/{padded}.jpg` URLs, but ~3% of books had no pages actually uploaded to R2, so the rewritten URL 404s. The card cycles display → thumb → broken on every render.

Script clears the stale `thumbnail` field; `BookCard`'s empty-state icon renders from the first paint.

- Dry-run by default (no writes)
- `--apply` to actually update
- `--limit=N` to bound the scan

Smoke-tested with `--limit=80`: 0 broken (within statistical noise of the ~3% rate). Should be run with `--apply` in a controlled window after merge — not bundled into this PR's deploy.

## Test plan
- [ ] Visit /gallery in a Firefox/Chrome window with a non-en-US locale (`Accept-Language: de`); verify no React error #418 in console.
- [ ] Visit /collections; verify the era timeline counter renders without a hydration warning.
- [ ] Visit /book/{slug}; verify page numbers render consistently.
- [ ] `node scripts/fix-broken-thumbnails.mjs --limit=200` — verify dry-run output looks sane.
- [ ] After merge, run `node scripts/fix-broken-thumbnails.mjs --apply` to scrub legacy /archived/ thumbnails that 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)