### PR TITLE
Allow image downloads for BPH books and pre-1930 works

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -558,8 +558,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
   const hasOcr = ocrCount > 0;
   const hasTranslations = translatedCount > totalPages / 2; // >50% translated
   // Image downloads restricted for non-commercial licensed sources (BSB, Bodleian, Vatican, etc.)
+  // Exceptions: BPH (Embassy of the Free Mind — all hermetic/historical material), and any book
+  // published before 1930 (out of copyright in the US) regardless of license metadata.
   const imgLicense = (book as any).image_source?.license || 'unknown';
-  const imageRestricted = imgLicense === 'unknown' || /\bnc\b/i.test(imgLicense);
+  const imgProvider = (book as any).image_source?.provider;
+  const yearPublished = (book as unknown as { year_published?: number }).year_published;
+  const publicDomainByAge = typeof yearPublished === 'number' && yearPublished < 1930;
+  const licenseRestricted = imgLicense === 'unknown' || /\bnc\b/i.test(imgLicense);
+  const imageRestricted = licenseRestricted && imgProvider !== 'bph' && !publicDomainByAge;
   const bookSummaryObj = (book as unknown as { index?: { bookSummary?: { brief?: string; detailed?: string; abstract?: string } } }).index?.bookSummary;
   const indexBrief = bookSummaryObj?.brief;
   const readingSummary = (book as unknown as { reading_summary?: { overview?: string } }).reading_summary?.overview;

--- a/src/lib/purchases.ts
+++ b/src/lib/purchases.ts
@@ -15,15 +15,24 @@ const NC_LICENSE_PATTERNS = [
  * Check if a book's page images carry a non-commercial restriction.
  * Returns true if images CANNOT be sold (NC-restricted).
  * Text-only formats (translation, OCR) are always commercially safe.
+ *
+ * Exemptions to the conservative "unknown = restricted" default:
+ *  - BPH provider (Embassy of the Free Mind): curated hermetic/historical material, all pre-1930.
+ *  - year_published < 1930: out of US copyright regardless of license metadata.
  */
 export async function isImageRestricted(bookId: string): Promise<boolean> {
   const db = await getDb();
   const book = await db.collection('books').findOne(
-    { _id: bookId as any },
-    { projection: { 'image_source.license': 1 } },
+    { $or: [{ id: bookId }, { _id: bookId as any }] },
+    { projection: { 'image_source.license': 1, 'image_source.provider': 1, year_published: 1 } },
   );
-  const license = book?.image_source?.license;
-  if (!license || license === 'unknown') return true; // conservative: unknown = restricted
+  if (!book) return true;
+  const license = book.image_source?.license;
+  const provider = book.image_source?.provider;
+  const year = (book as { year_published?: number }).year_published;
+  if (provider === 'bph') return false;
+  if (typeof year === 'number' && year < 1930) return false;
+  if (!license || license === 'unknown') return true; // conservative default
   return NC_LICENSE_PATTERNS.some(p => p.test(license));
 }
 


### PR DESCRIPTION
## Summary

The image download gate hid the "Download Scans (ZIP)" option on **1,215 BPH books** because their `image_source.license` is `'unknown'`. The other 1,147 BPH books already have `license: 'publicdomain'` and worked fine — this just brings the rest in line.

All BPH content comes from the Embassy of the Free Mind / Bibliotheca Philosophica Hermetica and is pre-1930 hermetic material. The "unknown" license is a metadata gap, not a real restriction.

Changes:
- `src/app/[tenant]/book/[id]/page.tsx` — UI gate exempts `provider === 'bph'` and `year_published < 1930`.
- `src/lib/purchases.ts` — server-side `isImageRestricted()` mirrors the same exemptions. Also fixed the lookup to try the app-level `id` field before `_id`.

Net effect: all ~2,362 BPH books now expose ZIP / facsimile / images-EPUB downloads. A modest secondary win: any non-BPH book with `year_published < 1930` and `license: 'unknown'` also unlocks.

## Test plan

- [ ] Visit a previously-restricted BPH book on the preview deploy (e.g., a PH-shelfmark book under `bph.sourcelibrary.org`) and confirm the Download dropdown shows "Page Scans" → "Download Scans (ZIP)".
- [ ] Click "Download Scans (ZIP)" — confirm 200 + ZIP returns.
- [ ] Confirm a BSB/Bodleian book (NC license) still shows the "non-commercial license" notice.