### PR TITLE
BPH catalogue entry: show cover thumbnail + keep page for digitised works

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -1,10 +1,10 @@
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { BookMarked, ExternalLink, BookOpen } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { getReadDb } from '@/lib/mongodb';
 import { tenantBookUrl } from '@/lib/slugify';
-import { formatAuthor } from '@/lib/utils';
+import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 
 interface Props {
   params: Promise<{ tenant: string; ubn: string }>;
@@ -72,6 +72,10 @@ interface SlBook {
   is_first_translation?: boolean;
   doi?: string;
   reading_summary?: { overview?: string };
+  image_display?: string | null;
+  image_thumb?: string | null;
+  thumbnail?: string | null;
+  thumbnail_blob?: string | null;
 }
 
 async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
@@ -106,6 +110,7 @@ async function fetchSlBook(ubn: string): Promise<SlBook | null> {
           pages_count: 1, pages_ocr: 1, pages_translated: 1,
           categories: 1, is_first_translation: 1, doi: 1,
           'reading_summary.overview': 1,
+          image_display: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1,
         },
         maxTimeMS: 8_000,
       }
@@ -129,6 +134,10 @@ async function fetchSlBook(ubn: string): Promise<SlBook | null> {
       is_first_translation: book.is_first_translation as boolean | undefined,
       doi: book.doi as string | undefined,
       reading_summary: book.reading_summary as { overview?: string } | undefined,
+      image_display: book.image_display as string | null | undefined,
+      image_thumb: book.image_thumb as string | null | undefined,
+      thumbnail: book.thumbnail as string | null | undefined,
+      thumbnail_blob: book.thumbnail_blob as string | null | undefined,
     };
   } catch {
     return null;
@@ -157,15 +166,7 @@ export default async function CatalogEntryPage({ params }: Props) {
 
   const displayTitle = work.title || work.parallel_title || work.uniform_title || `(untitled — UBN ${work.ubn})`;
   const slBookHref = slBook ? tenantBookUrl({ id: slBook.id, slug: slBook.slug }, tenant) : null;
-
-  // When a digitised SL copy exists, the reading view is the canonical place
-  // for this work — it now side-loads the BPH catalogue record inline via
-  // <BphCatalogueRecord />. Redirect so the partner stops seeing two pages
-  // for the same book (issue #1688). Catalogue-only entries (no SL book)
-  // continue to render below.
-  if (slBook && slBookHref) {
-    redirect(slBookHref);
-  }
+  const slCoverUrl = slBook ? getBookThumbnailUrl(slBook, 'display') : null;
   const canonicalAuthor = slBook?.author ? formatAuthor(slBook.author).name : null;
   const translationPct = slBook && slBook.pages_translated && slBook.pages_ocr
     ? Math.round((slBook.pages_translated / Math.max(slBook.pages_ocr, 1)) * 100)
@@ -205,6 +206,20 @@ export default async function CatalogEntryPage({ params }: Props) {
               <BookMarked className="w-4 h-4 text-accent-rust" />
               <h2 className="text-sm font-medium text-accent-rust uppercase tracking-wide">Digitised copy</h2>
             </div>
+
+            <div className="flex gap-4">
+              {slCoverUrl && (
+                <a href={slBookHref} className="shrink-0">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={slCoverUrl}
+                    alt={slBook.display_title || slBook.title || displayTitle}
+                    className="w-28 sm:w-32 rounded shadow-sm border border-border-light bg-cream object-cover"
+                    loading="lazy"
+                  />
+                </a>
+              )}
+              <div className="flex-1 min-w-0">
 
             {slBook.display_title && slBook.display_title !== work.title && (
               <p className="text-lg text-primary font-display leading-snug mb-1">
@@ -268,6 +283,8 @@ export default async function CatalogEntryPage({ params }: Props) {
               <BookOpen className="w-4 h-4" />
               Read the digitised copy
             </a>
+              </div>
+            </div>
           </section>
         )}
 


### PR DESCRIPTION
## Summary
- Drop the server-side redirect on `/embed/[tenant]/catalog/[ubn]` so digitised works show the catalogue entry instead of jumping straight to the reading view.
- Render a clickable cover thumbnail in the existing "Digitised copy" section (the section already had the CTA, metadata, and reading summary — only the thumbnail was missing, and it was previously unreachable due to the redirect).
- Only fires for entries with a matching SL book (`slBook && slBookHref`); catalogue-only entries are unchanged.

This reverses the redirect added to fix #1688 — per Derek's call, the catalogue entry should be the landing page so partners see the full bibliographic record next to a clear "Read the digitised copy" CTA + cover.

## Test plan
- [ ] Visit a BPH catalogue entry for a digitised work (e.g. via list view at https://bph.sourcelibrary.org/catalog → click any title with a "Digitised copy" badge). Page should render with cover + CTA, NOT redirect.
- [ ] Visit a catalogue-only entry (no SL book). Should render the full metadata view with no Digitised-copy section, same as before.
- [ ] Click the cover thumbnail — should land on `/book/{slug}` (reading view).
- [ ] Click "Read the digitised copy" button — same destination.
- [ ] Spot-check on Vercel preview that cover image loads (URLs come from `getBookThumbnailUrl(book, 'display')` which handles R2 + Wikimedia patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)