### PR TITLE
Sign-in-gated downloads; free image downloads for NC-licensed books

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -557,15 +557,23 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
   // Progression: OCR → Translation → Summary → Ask AI / Publish
   const hasOcr = ocrCount > 0;
   const hasTranslations = translatedCount > totalPages / 2; // >50% translated
-  // Image downloads restricted for non-commercial licensed sources (BSB, Bodleian, Vatican, etc.)
-  // Exceptions: BPH (Embassy of the Free Mind — all hermetic/historical material), and any book
-  // published before 1930 (out of copyright in the US) regardless of license metadata.
+  // Image-download access classification (mirrors classifyImageAccess in lib/purchases.ts):
+  //  - 'open': PD / CC-BY / BPH / pre-1930 → flows through the normal member/pay gate
+  //  - 'nc-free': NC-licensed → free for any signed-in user, never charged
+  //  - 'blocked': modern + unknown license + non-BPH → withheld entirely
   const imgLicense = (book as any).image_source?.license || 'unknown';
   const imgProvider = (book as any).image_source?.provider;
   const yearPublished = (book as unknown as { year_published?: number }).year_published;
-  const publicDomainByAge = typeof yearPublished === 'number' && yearPublished < 1930;
-  const licenseRestricted = imgLicense === 'unknown' || /\bnc\b/i.test(imgLicense);
-  const imageRestricted = licenseRestricted && imgProvider !== 'bph' && !publicDomainByAge;
+  const isNcLicense = typeof imgLicense === 'string' && /\bnc\b/i.test(imgLicense);
+  const imageAccess: 'open' | 'nc-free' | 'blocked' =
+    imgProvider === 'bph' || (typeof yearPublished === 'number' && yearPublished < 1930)
+      ? 'open'
+      : isNcLicense
+        ? 'nc-free'
+        : (!imgLicense || imgLicense === 'unknown')
+          ? 'blocked'
+          : 'open';
+  const imageRestricted = imageAccess === 'blocked';
   const bookSummaryObj = (book as unknown as { index?: { bookSummary?: { brief?: string; detailed?: string; abstract?: string } } }).index?.bookSummary;
   const indexBrief = bookSummaryObj?.brief;
   const readingSummary = (book as unknown as { reading_summary?: { overview?: string } }).reading_summary?.overview;
@@ -838,6 +846,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                       hasOcr={hasOcr}
                       hasImages={pages.length > 0}
                       imageRestricted={imageRestricted}
+                      imageAccess={imageAccess}
                       variant="header"
                     />
                     <span className="hidden sm:block w-px h-5 bg-white/10 mx-1" />

--- a/src/app/api/[tenant]/books/[id]/download/route.ts
+++ b/src/app/api/[tenant]/books/[id]/download/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
-import { canDownload, isImageRestricted, PRICES } from '@/lib/purchases';
+import { canDownload, classifyImageAccess, PRICES } from '@/lib/purchases';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -2359,18 +2359,16 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Access check: must be a member or have purchased this book
-    // Skip gating entirely if Stripe isn't configured (monetization dormant)
-    if (process.env.STRIPE_SECRET_KEY) {
-      const session = await auth();
-      const userId = session?.user?.id || null;
-      const allowed = await canDownload(userId, 'book', id);
-      if (!allowed) {
-        return NextResponse.json(
-          { error: 'Purchase required', price: PRICES.book.label, type: 'book', itemId: id },
-          { status: 402 }
-        );
-      }
+    // All downloads require sign-in. Gives us accountability for the attribution
+    // chain (esp. for NC-licensed scans we redistribute under the source library's
+    // non-commercial use).
+    const session = await auth();
+    const userId = session?.user?.id || null;
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Sign in required', requires_signin: true },
+        { status: 401 },
+      );
     }
 
     // Get optional edition_id for scholarly format
@@ -2383,18 +2381,36 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const isScholarly = format === 'epub-scholarly';
     const isBilingual = format === 'epub-bilingual';
     const isImagesZip = format === 'images-zip';
-
-    // Image-containing formats require a commercially-clear license.
-    // NC-restricted books (BSB, Bodleian, Vatican, etc.) block paid image downloads.
     const imageFormat = isFacsimile || isImagesOnly || isImagesZip;
-    if (imageFormat && await isImageRestricted(id)) {
-      return NextResponse.json(
-        {
-          error: 'Image downloads are not available for this book due to the source institution\'s non-commercial license. Text-only formats (TXT, EPUB translation) are available.',
-          license_restricted: true,
-        },
-        { status: 403 },
-      );
+
+    // Image access classifier:
+    //  - 'blocked' (modern unknown-license non-BPH) → 403, no path forward.
+    //  - 'nc-free' (NC-licensed) → free for any signed-in user, skip Stripe gate.
+    //  - 'open' → flows through the normal member/purchase gate below.
+    let imageAccess: 'open' | 'nc-free' | 'blocked' = 'open';
+    if (imageFormat) {
+      imageAccess = await classifyImageAccess(id);
+      if (imageAccess === 'blocked') {
+        return NextResponse.json(
+          {
+            error: 'Image downloads are not available for this book — the source institution has not released the scans under a redistributable license.',
+            license_restricted: true,
+          },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Member-or-purchased gate for paid formats. NC-free image formats bypass
+    // this (charging for an NC scan would cross the commercial line).
+    if (process.env.STRIPE_SECRET_KEY && imageAccess !== 'nc-free') {
+      const allowed = await canDownload(userId, 'book', id);
+      if (!allowed) {
+        return NextResponse.json(
+          { error: 'Purchase required', price: PRICES.book.label, type: 'book', itemId: id },
+          { status: 402 },
+        );
+      }
     }
 
     const db = await getDb();

--- a/src/app/api/access/route.ts
+++ b/src/app/api/access/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import { canDownload, PurchaseType } from '@/lib/purchases';
+import { canDownload, classifyImageAccess, PurchaseType } from '@/lib/purchases';
 
 /**
  * Check if the current user can download a specific item.
- * Returns { allowed: true } if they're a member or have purchased the item.
+ *
+ * Returns:
+ *  - { allowed: true, reason: 'member' | 'purchased' | 'free' }
+ *  - { allowed: false, reason: 'signin' | 'purchase' }
+ *
+ * Also returns `imageAccess` ('open' | 'nc-free' | 'blocked') for book items so
+ * the UI can render NC-licensed image options as "Free with sign-in" without
+ * routing the user through Stripe.
+ *
+ * All downloads require sign-in — anonymous users always get allowed:false.
  */
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -16,24 +25,29 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Missing type or itemId' }, { status: 400 });
   }
 
-  // Payments not configured — everything is free
-  if (!process.env.STRIPE_SECRET_KEY) {
-    return NextResponse.json({ allowed: true, reason: 'free' });
-  }
-
   const userId = session?.user?.id || null;
   const isMember = (session?.user as any)?.membership != null;
 
-  // Members always have access
+  const imageAccess = type === 'book' ? await classifyImageAccess(itemId) : 'open';
+
+  // Sign-in is the floor for all downloads
+  if (!userId) {
+    return NextResponse.json({ allowed: false, reason: 'signin', imageAccess });
+  }
+
+  // Stripe disabled → signed-in is sufficient
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return NextResponse.json({ allowed: true, reason: 'free', imageAccess });
+  }
+
   if (isMember) {
-    return NextResponse.json({ allowed: true, reason: 'member' });
+    return NextResponse.json({ allowed: true, reason: 'member', imageAccess });
   }
 
-  // Check individual purchase
-  if (userId) {
-    const allowed = await canDownload(userId, type, itemId);
-    return NextResponse.json({ allowed, reason: allowed ? 'purchased' : 'none' });
-  }
-
-  return NextResponse.json({ allowed: false, reason: 'none' });
+  const allowed = await canDownload(userId, type, itemId);
+  return NextResponse.json({
+    allowed,
+    reason: allowed ? 'purchased' : 'purchase',
+    imageAccess,
+  });
 }

--- a/src/app/api/books/[id]/download/route.ts
+++ b/src/app/api/books/[id]/download/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { auth } from '@/lib/auth';
-import { canDownload, isImageRestricted, PRICES } from '@/lib/purchases';
+import { canDownload, classifyImageAccess, PRICES } from '@/lib/purchases';
 import type { Book, Page, TranslationEdition } from '@/lib/types';
 import epub from 'epub-gen-memory';
 import archiver from 'archiver';
@@ -2353,18 +2353,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    // Access check: must be a member or have purchased this book
-    // Skip gating entirely if Stripe isn't configured (monetization dormant)
-    if (process.env.STRIPE_SECRET_KEY) {
-      const session = await auth();
-      const userId = session?.user?.id || null;
-      const allowed = await canDownload(userId, 'book', id);
-      if (!allowed) {
-        return NextResponse.json(
-          { error: 'Purchase required', price: PRICES.book.label, type: 'book', itemId: id },
-          { status: 402 }
-        );
-      }
+    // All downloads require sign-in.
+    const session = await auth();
+    const userId = session?.user?.id || null;
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Sign in required', requires_signin: true },
+        { status: 401 },
+      );
     }
 
     // Get optional edition_id for scholarly format
@@ -2377,18 +2373,31 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const isScholarly = format === 'epub-scholarly';
     const isBilingual = format === 'epub-bilingual';
     const isImagesZip = format === 'images-zip';
-
-    // Image-containing formats require a commercially-clear license.
-    // NC-restricted books (BSB, Bodleian, Vatican, etc.) block paid image downloads.
     const imageFormat = isFacsimile || isImagesOnly || isImagesZip;
-    if (imageFormat && await isImageRestricted(id)) {
-      return NextResponse.json(
-        {
-          error: 'Image downloads are not available for this book due to the source institution\'s non-commercial license. Text-only formats (TXT, EPUB translation) are available.',
-          license_restricted: true,
-        },
-        { status: 403 },
-      );
+
+    let imageAccess: 'open' | 'nc-free' | 'blocked' = 'open';
+    if (imageFormat) {
+      imageAccess = await classifyImageAccess(id);
+      if (imageAccess === 'blocked') {
+        return NextResponse.json(
+          {
+            error: 'Image downloads are not available for this book — the source institution has not released the scans under a redistributable license.',
+            license_restricted: true,
+          },
+          { status: 403 },
+        );
+      }
+    }
+
+    // NC-free image formats skip the paid gate (charging would cross the NC line).
+    if (process.env.STRIPE_SECRET_KEY && imageAccess !== 'nc-free') {
+      const allowed = await canDownload(userId, 'book', id);
+      if (!allowed) {
+        return NextResponse.json(
+          { error: 'Purchase required', price: PRICES.book.label, type: 'book', itemId: id },
+          { status: 402 },
+        );
+      }
     }
 
     const db = await getDb();

--- a/src/components/ui/DownloadButton.tsx
+++ b/src/components/ui/DownloadButton.tsx
@@ -6,6 +6,8 @@ import { toast } from 'sonner';
 import { Download, ChevronDown, FileText, Languages, Layers, BookOpen, Columns, Image, GraduationCap } from 'lucide-react';
 import { BookDownloadFormats, books } from '@/lib/api-client';
 
+type ImageAccess = 'open' | 'nc-free' | 'blocked';
+
 interface DownloadButtonProps {
   bookId: string;
   bookTitle?: string;
@@ -13,10 +15,11 @@ interface DownloadButtonProps {
   hasOcr: boolean;
   hasImages?: boolean;
   imageRestricted?: boolean;
+  imageAccess?: ImageAccess;
   variant?: 'default' | 'header';
 }
 
-export default function DownloadButton({ bookId, bookTitle, hasTranslations, hasOcr, hasImages = true, imageRestricted = false, variant = 'default' }: DownloadButtonProps) {
+export default function DownloadButton({ bookId, bookTitle, hasTranslations, hasOcr, hasImages = true, imageRestricted = false, imageAccess = 'open', variant = 'default' }: DownloadButtonProps) {
   const { data: session } = useSession();
   const isMember = (session?.user as any)?.membership != null;
   const [isOpen, setIsOpen] = useState(false);
@@ -27,34 +30,27 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Check if payments are enabled; if not, everyone gets free access
-    fetch('/api/config').then(r => r.json()).then(cfg => {
-      if (!cfg.payments) {
-        setHasAccess(true);
-        setAccessChecked(true);
-        return;
-      }
-      if (isMember) {
-        setHasAccess(true);
-        setAccessChecked(true);
-        return;
-      }
-      if (session?.user) {
-        fetch(`/api/access?type=book&itemId=${bookId}`)
-          .then(r => r.json())
-          .then(data => {
-            setHasAccess(data.allowed);
-            setAccessChecked(true);
-          })
-          .catch(() => setAccessChecked(true));
-      } else {
-        setAccessChecked(true);
-      }
-    }).catch(() => {
-      // Config fetch failed — default to free access
+    // All downloads require sign-in. Anonymous users see a Sign-in prompt
+    // instead of the format menu.
+    if (!session?.user) {
+      setHasAccess(false);
+      setAccessChecked(true);
+      return;
+    }
+    if (isMember) {
       setHasAccess(true);
       setAccessChecked(true);
-    });
+      return;
+    }
+    fetch(`/api/access?type=book&itemId=${bookId}`)
+      .then(r => r.json())
+      .then(data => {
+        // `allowed` here gates the paid (text + open-image) formats. NC-free
+        // image formats bypass this and are handled per-format in handleDownload.
+        setHasAccess(!!data.allowed);
+        setAccessChecked(true);
+      })
+      .catch(() => setAccessChecked(true));
   }, [bookId, session, isMember]);
 
   useEffect(() => {
@@ -67,9 +63,21 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const isImageFormat = (f: BookDownloadFormats) =>
+    f === 'images-zip' || f === 'epub-images' || f === 'epub-facsimile';
+  const isNcFreeFormat = (f: BookDownloadFormats) =>
+    imageAccess === 'nc-free' && isImageFormat(f);
+
   const handleDownload = async (format: BookDownloadFormats) => {
-    // If no access, redirect to purchase
-    if (accessChecked && !hasAccess) {
+    // Anonymous → send to sign-in
+    if (!session?.user) {
+      window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+      return;
+    }
+
+    // Signed-in but no purchase: NC-free image formats are free; everything
+    // else still routes through the paid flow.
+    if (accessChecked && !hasAccess && !isNcFreeFormat(format)) {
       handlePurchase();
       return;
     }
@@ -78,6 +86,11 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
     try {
       const response = await books.download(bookId, format);
 
+      if (response.status === 401) {
+        setDownloading(null);
+        window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+        return;
+      }
       if (response.status === 402) {
         setDownloading(null);
         handlePurchase();
@@ -142,7 +155,9 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
     return null;
   }
 
-  const needsPurchase = accessChecked && !hasAccess;
+  const isAnonymous = accessChecked && !session?.user;
+  const needsPurchase = accessChecked && !!session?.user && !hasAccess;
+  const ncImagesFree = imageAccess === 'nc-free';
 
   const buttonClass = variant === 'header'
     ? "flex items-center gap-2 px-3 py-1.5 text-stone-300 hover:text-white hover:bg-white/10 rounded-lg text-sm transition-colors"
@@ -162,7 +177,24 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
       {isOpen && (
         <div className="absolute right-0 top-full mt-2 w-64 bg-white rounded-lg shadow-xl border border-stone-200 py-2 z-50">
 
-          {/* Quiet download prompt for non-members */}
+          {/* Sign-in wall — all downloads require an account */}
+          {isAnonymous && (
+            <div className="px-3 py-3 border-b border-stone-100">
+              <button
+                onClick={() => {
+                  window.location.href = `/auth/signin?callbackUrl=${encodeURIComponent(window.location.pathname)}`;
+                }}
+                className="w-full py-2.5 bg-stone-900 hover:bg-stone-800 text-white rounded-lg text-sm font-medium transition-colors"
+              >
+                Sign in to download
+              </button>
+              <p className="mt-2 text-xs text-stone-400 text-center">
+                {ncImagesFree ? 'Page scans are free; other formats may require a member account.' : 'Free for members.'}
+              </p>
+            </div>
+          )}
+
+          {/* Quiet purchase prompt for signed-in non-members */}
           {needsPurchase && (
             <div className="px-3 py-3 border-b border-stone-100">
               <button
@@ -173,7 +205,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
                 {purchasing ? 'Redirecting...' : 'Download this book ($5)'}
               </button>
               <p className="mt-2 text-xs text-stone-400 text-center">
-                All formats included
+                {ncImagesFree ? 'Page scans are free; other formats included with purchase.' : 'All formats included'}
               </p>
             </div>
           )}
@@ -240,8 +272,11 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
 
           {hasImages && !imageRestricted && (
             <>
-              <div className="px-3 py-2 text-xs font-medium text-stone-500 uppercase tracking-wide border-t border-stone-100 mt-2">
-                Page Scans
+              <div className="px-3 py-2 border-t border-stone-100 mt-2 flex items-center justify-between">
+                <span className="text-xs font-medium text-stone-500 uppercase tracking-wide">Page Scans</span>
+                {ncImagesFree && (
+                  <span className="text-[10px] font-medium text-emerald-700 uppercase tracking-wide">Free with sign-in</span>
+                )}
               </div>
               <FormatOption format="images-zip" label="Download Scans (ZIP)" desc="All page images, lossless"
                 icon={<Image className="w-4 h-4 text-stone-600" />}
@@ -254,8 +289,7 @@ export default function DownloadButton({ bookId, bookTitle, hasTranslations, has
           {hasImages && imageRestricted && (
             <div className="px-3 py-2 border-t border-stone-100 mt-2">
               <p className="text-xs text-stone-400">
-                Image downloads unavailable &mdash; source institution&rsquo;s non-commercial license.
-                View images on the book page.
+                Image downloads unavailable &mdash; the source institution has not released the scans under a redistributable license. View images on the book page.
               </p>
             </div>
           )}

--- a/src/lib/purchases.ts
+++ b/src/lib/purchases.ts
@@ -11,29 +11,36 @@ const NC_LICENSE_PATTERNS = [
   /non.?commercial/i,
 ];
 
+export type ImageAccess =
+  | 'open'      // No license concern — flows through the normal member-or-pay gate
+  | 'nc-free'   // NC-licensed — free for any signed-in user, never enters the paid flow
+  | 'blocked';  // Unknown license + no public-domain signal — withheld entirely
+
 /**
- * Check if a book's page images carry a non-commercial restriction.
- * Returns true if images CANNOT be sold (NC-restricted).
- * Text-only formats (translation, OCR) are always commercially safe.
+ * Classify how a book's page images can be downloaded.
  *
- * Exemptions to the conservative "unknown = restricted" default:
- *  - BPH provider (Embassy of the Free Mind): curated hermetic/historical material, all pre-1930.
- *  - year_published < 1930: out of US copyright regardless of license metadata.
+ *  - 'open': public domain, CC-BY, BPH provider, or year_published < 1930.
+ *           Flows through the normal canDownload() / Stripe gate.
+ *  - 'nc-free': any NoC-NC / CC-BY-NC variant. We're a non-commercial scholarly
+ *              platform, so redistribution is fine — but charging for an NC scan
+ *              would cross the commercial line. So: free for any signed-in user.
+ *  - 'blocked': unknown license, non-BPH, not pre-1930. Conservative default.
  */
-export async function isImageRestricted(bookId: string): Promise<boolean> {
+export async function classifyImageAccess(bookId: string): Promise<ImageAccess> {
   const db = await getDb();
   const book = await db.collection('books').findOne(
     { $or: [{ id: bookId }, { _id: bookId as any }] },
     { projection: { 'image_source.license': 1, 'image_source.provider': 1, year_published: 1 } },
   );
-  if (!book) return true;
+  if (!book) return 'blocked';
   const license = book.image_source?.license;
   const provider = book.image_source?.provider;
   const year = (book as { year_published?: number }).year_published;
-  if (provider === 'bph') return false;
-  if (typeof year === 'number' && year < 1930) return false;
-  if (!license || license === 'unknown') return true; // conservative default
-  return NC_LICENSE_PATTERNS.some(p => p.test(license));
+  if (provider === 'bph') return 'open';
+  if (typeof year === 'number' && year < 1930) return 'open';
+  if (license && NC_LICENSE_PATTERNS.some(p => p.test(license))) return 'nc-free';
+  if (!license || license === 'unknown') return 'blocked';
+  return 'open';
 }
 
 export type PurchaseType = keyof typeof PRICES;


### PR DESCRIPTION
Closes #1735.

## Summary

- Sign-in is now the floor for every download path. Anonymous users see "Sign in to download" instead of the Stripe prompt.
- New classifier `classifyImageAccess(bookId)` returns `'open' | 'nc-free' | 'blocked'`.
- NC-licensed page scans become **free for any signed-in user** — they bypass the \$5 gate, since charging for an NC scan crosses the commercial line.
- Text formats and "open" image formats keep the existing member-or-purchase flow.

## Gating matrix

| Book type        | Text formats               | Image formats                       |
|------------------|---------------------------|-------------------------------------|
| Public domain    | Free for members; \$5     | Free for members; \$5               |
| BPH              | Free for members; \$5     | Free for members; \$5               |
| Pre-1930 unknown | Free for members; \$5     | Free for members; \$5               |
| **NC-restricted**| Free for members; \$5     | **Free for any signed-in user**     |
| Modern unknown   | Free for members; \$5     | Blocked entirely                    |
| Anonymous        | Sign-in required          | Sign-in required                    |

## Files

- `src/lib/purchases.ts` — `classifyImageAccess`; `isImageRestricted` deleted (no remaining callers).
- `src/app/api/[tenant]/books/[id]/download/route.ts` — 401 if anonymous, 403 if blocked, NC-free skips Stripe.
- `src/app/api/books/[id]/download/route.ts` — same gating, applied to the non-tenant route.
- `src/app/api/access/route.ts` — also requires sign-in, returns `imageAccess` so the UI can render NC state.
- `src/components/ui/DownloadButton.tsx` — Sign-in CTA for anonymous; "Free with sign-in" badge on NC Page Scans.
- `src/app/[tenant]/book/[id]/page.tsx` — computes `imageAccess` server-side, passes to DownloadButton.

## Test plan

- [ ] **Anonymous on any book** — Download dropdown shows "Sign in to download"; clicking any format also redirects to /auth/signin.
- [ ] **Signed-in non-member on NC book** (e.g., a Bodleian or Vatican book) — Page Scans show with "Free with sign-in" badge; ZIP downloads succeed; text formats still prompt \$5.
- [ ] **Signed-in non-member on PD book** — \$5 prompt as before for all formats.
- [ ] **Member on NC book** — All formats download free; no \$5 prompt.
- [ ] **Signed-in user on modern unknown-license book** (the 'blocked' case) — Page Scans section shows the unavailability notice; text formats still work.
- [ ] **Direct API hit while signed out** — `GET /api/books/<id>/download?format=images-zip` returns 401 with `{requires_signin: true}`.