### PR TITLE
PagesGrid: fix page-thumbnail href bouncing to catalogue on tenant subdomains

### DIFF
--- a/src/components/book/PagesGrid.tsx
+++ b/src/components/book/PagesGrid.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { useParams, usePathname } from 'next/navigation';
 import { CheckCircle2, GripVertical, Loader2, ImageIcon, FileText, RefreshCw } from 'lucide-react';
 import type { Page } from '@/lib/types';
 import { AuthCheck } from '@/components/auth/AuthCheck';
@@ -69,10 +68,6 @@ export default function PagesGrid({
   totalCount,
 }: PagesGridProps) {
   const displayTotal = totalCount || pages.length;
-  const params = useParams<{ tenant: string }>();
-  const pathname = usePathname();
-  const isOnEmbedRoute = pathname?.startsWith('/embed/');
-  const tenantPrefix = params?.tenant ? `${isOnEmbedRoute ? '/embed' : ''}/${params.tenant}` : '';
   // CSS brightness filter — only apply when not default (1.0)
   const brightnessStyle = brightness && brightness !== 1.0
     ? { filter: `brightness(${brightness})` }
@@ -173,7 +168,7 @@ export default function PagesGrid({
             return (
               <div key={page.id} className="group relative">
                 <a
-                  href={`${tenantPrefix}/book/${bookId}/page/${page.id}`}
+                  href={`/book/${bookId}/page/${page.id}`}
                 >
                   <div className="aspect-[3/4] bg-white border border-stone-200 rounded-lg overflow-hidden hover:shadow-md transition-shadow relative" style={brightnessStyle}>
                     {imageUrl ? (


### PR DESCRIPTION
## Summary
Page thumbnails on the book detail page were producing hrefs like \`/bph/book/{id}/page/{N}\` on \`bph.sourcelibrary.org\`. That path doesn't match any specific proxy handler, so the catch-all at the end of \`src/proxy.ts\`'s tenant block sent every click to \`/embed/{tenant}\` — the catalogue homepage.

Root cause: \`PagesGrid.tsx\` was building \`tenantPrefix\` from \`useParams().tenant\` + a check on \`usePathname().startsWith('/embed/')\`. On the BPH subdomain the URL bar shows \`/book/{slug}\` post-proxy-rewrite, so \`usePathname()\` returns that — making \`isOnEmbedRoute\` false and producing \`/bph/...\` instead of \`/embed/bph/...\`. Reported by Derek with a screenshot of the URL bar showing exactly that.

Fix: drop the tenant prefix entirely. The href is now just \`/book/{id}/page/{N}\`. proxy.ts already handles this URL on both tenant subdomains (line 345, rewrites to \`/embed/{tenant}/book/...\`) and the main host (line 485, rewrites to \`/{tenant}/book/...\`).

## Test plan
- [ ] On https://bph.sourcelibrary.org/book/the-holy-bible-die-heilige-schrift, click any page thumbnail — should open the page reader, not bounce to the catalogue.
- [ ] Same test on a non-BPH book on sourcelibrary.org — should also open the page reader.
- [ ] URL bar after click: clean \`/book/{id}/page/{N}\` on both hosts (no \`/bph/\` or \`/embed/bph/\` exposure).
- [ ] Existing reorder/cover-set buttons inside thumbnails (with stopPropagation) still work in admin/inner-circle mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)