### PR TITLE
Accept ?view=catalogue as alias for ?view=catalog

### DIFF
--- a/src/app/[tenant]/page.tsx
+++ b/src/app/[tenant]/page.tsx
@@ -32,7 +32,8 @@ export default async function TenantRoot({ params, searchParams }: Props) {
   const language = typeof sp.language === 'string' ? sp.language : '';
   const q = typeof sp.q === 'string' ? sp.q : '';
   const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0') || 0;
-  const view = typeof sp.view === 'string' ? sp.view : '';
+  const rawView = typeof sp.view === 'string' ? sp.view : '';
+  const view = rawView === 'catalogue' ? 'catalog' : rawView;
   const displayParam = typeof sp.display === 'string' ? sp.display : '';
   const display: 'list' | 'grid' | undefined =
     displayParam === 'list' || displayParam === 'grid' ? displayParam : undefined;

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -48,7 +48,8 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     const language = typeof sp.language === 'string' ? sp.language : '';
     const q = typeof sp.q === 'string' ? sp.q : '';
     const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0', 10) || 0;
-    const view = typeof sp.view === 'string' ? sp.view : 'books';
+    const rawView = typeof sp.view === 'string' ? sp.view : 'books';
+    const view = rawView === 'catalogue' ? 'catalog' : rawView;
     // Display dimension is independent of the view filter. When unset, default
     // matches what the partner mockup leads with: catalog→list, books→grid.
     // Once the user picks an icon, their choice persists across filter switches.

--- a/src/app/libraries/[slug]/page.tsx
+++ b/src/app/libraries/[slug]/page.tsx
@@ -204,7 +204,8 @@ export default async function LibraryDetailPage({ params, searchParams }: Props)
   const language = typeof sp.language === 'string' ? sp.language : '';
   const q = typeof sp.q === 'string' ? sp.q : '';
   const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0') || 0;
-  const view = typeof sp.view === 'string' ? sp.view : '';
+  const rawView = typeof sp.view === 'string' ? sp.view : '';
+  const view = rawView === 'catalogue' ? 'catalog' : rawView;
 
   const isBph = partner.providerKey === 'bph';
 


### PR DESCRIPTION
## Summary
- `?view=catalogue` (British spelling) now resolves to the same catalogue list view as `?view=catalog`.
- Normalized in the three pages that read `sp.view`: `/embed/[tenant]`, `/[tenant]`, `/libraries/[slug]`.

## Why
BPH partners refer to "the catalogue" everywhere in their copy (BphUnifiedCatalogue, etc.), so it's natural to type `?view=catalogue`. Before this change, the URL silently fell back to the default `books` view.

## Test plan
- [ ] https://bph.sourcelibrary.org/?view=catalogue renders the same list view as `?view=catalog`
- [ ] https://bph.sourcelibrary.org/?view=catalog still works
- [ ] https://bph.sourcelibrary.org/?view=books still works
- [ ] Run `node scripts/audit-bph-leaks.mjs` to confirm no off-subdomain leaks introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)