### PR TITLE
Fix BPH catalogue "Show all" timeout: skip unused loaders on view=catalog/books

### DIFF
--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -86,11 +86,27 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     // to the tenant slug here, which matches the current BPH tenant 1:1.
     const probablyBph = tenant === 'bph';
 
+    // The BPH catalogue + books views render only <BphUnifiedCatalogue>,
+    // which sources its own data via /api/catalog/bph. The hero, gallery,
+    // Selected Books row, and contributing-libraries panel are all hidden,
+    // so the heavy upstream loaders (Mongo + Supabase) are pure dead weight
+    // on those URLs — and `view=catalog&display=list` was timing out in the
+    // browser before render finished. Skip them and pass empty placeholders.
+    const skipHeavyLoaders = probablyBph && (view === 'catalog' || view === 'books');
+
     const [libraryData, dominantProvider, cataloguedBookIds] = await Promise.all([
-        // (deferred filter applied below once Supabase ids resolve)
-        fetchTenantLibraryData(tenantId, sort, language, offset, q || undefined),
+        skipHeavyLoaders
+            ? Promise.resolve({
+                books: [],
+                total: 0,
+                topBooks: [],
+                languages: [],
+                galleryImages: [],
+                contributingLibraries: [],
+            } as Awaited<ReturnType<typeof fetchTenantLibraryData>>)
+            : fetchTenantLibraryData(tenantId, sort, language, offset, q || undefined),
         getTenantDominantProvider(tenantId),
-        probablyBph ? fetchTenantBphCataloguedBookIds() : Promise.resolve(null),
+        probablyBph && !skipHeavyLoaders ? fetchTenantBphCataloguedBookIds() : Promise.resolve(null),
     ]);
 
     // Filter the Selected Books row to books that exist in the Supabase


### PR DESCRIPTION
## Summary
- Clicking **Show all** on `bph.sourcelibrary.org` navigated to `/embed/bph?view=catalog&display=list` and produced `ERR_TIMED_OUT` in the browser (screenshot from Derek).
- The `/embed/[tenant]` route always ran `fetchTenantLibraryData` (books, gallery, languages, contributing-libraries) and `fetchTenantBphCataloguedBookIds` — but on BPH `view=catalog` and `view=books`, `SharedLibraryView` renders only `<BphUnifiedCatalogue>` and hides the hero, Selected Books row, gallery, and contributing-libraries panel. `BphCatalogBrowser` sources its own data via `/api/catalog/bph` client-side, so all that server work was dead weight on the critical path.
- Skip those loaders for the two catalogue-shell views and pass empty placeholders. `dominantProvider`, `fetchTenantBphDigitizedMap`, and `fetchTenantBphCatalogTotal` (cached) still run — they're the only things `BphUnifiedCatalogue` needs.

## Test plan
- [ ] Push deploys a preview; confirm `https://<preview>/embed/bph?view=catalog&display=list` renders the catalogue table without timeout.
- [ ] On the preview, visit `bph.sourcelibrary.org` equivalent (e.g. `?view=books&display=grid`) and click **Show all** — should land on the catalogue list view fast.
- [ ] Confirm `Show digitised & translated` toggle still works and counts match (`2,222 of 27,808` framing).
- [ ] BPH lockdown audit: `node scripts/audit-bph-leaks.mjs` (no new leaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)