### PR TITLE
ChaptersDropdown: drop broken tenant prefix from chapter href

### DIFF
--- a/src/components/book/ChaptersDropdown.tsx
+++ b/src/components/book/ChaptersDropdown.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ChevronDown, List } from 'lucide-react';
 
@@ -14,8 +13,6 @@ interface Chapter {
 
 export default function ChaptersDropdown({ chapters, bookSlug }: { chapters: Chapter[]; bookSlug: string }) {
   const [open, setOpen] = useState(false);
-  const params = useParams<{ tenant: string }>();
-  const tenantPrefix = params?.tenant ? `/${params.tenant}` : '';
 
   return (
     <div className="card mt-6 overflow-hidden">
@@ -35,7 +32,7 @@ export default function ChaptersDropdown({ chapters, bookSlug }: { chapters: Cha
             {chapters.map((ch, i) => (
               <Link
                 key={i}
-                href={`${tenantPrefix}/book/${bookSlug}/page-number/${ch.pageNumber}`}
+                href={`/book/${bookSlug}/page-number/${ch.pageNumber}`}
                 className="flex items-baseline gap-2 py-1.5 px-2 -mx-2 rounded hover:bg-stone-100 dark:hover:bg-stone-800/50 transition-colors group"
                 style={{ paddingLeft: `${(ch.level - 1) * 1.25 + 0.5}rem` }}
               >


### PR DESCRIPTION
## Summary
- Reported: on `bph.sourcelibrary.org`, clicking a chapter on a book detail page kicked the visitor back to the catalogue grid instead of opening the chapter's first page.
- Root cause: `ChaptersDropdown` built the href as `${tenantPrefix}/book/{slug}/page-number/{N}` where `tenantPrefix` came from `useParams().tenant`. Under the embed route that resolves to `bph`, so the link became `/bph/book/{slug}/page-number/{N}` — a path that doesn't match any specific branch in the proxy.ts tenant-subdomain block, so the catch-all rewrites it to `/embed/bph` (the catalogue).
- Fix: use the clean tenant-agnostic `/book/{slug}/page-number/{N}`. `proxy.ts` (line 345) already rewrites this path correctly on tenant subdomains, and the main-host rewrite at line 485 covers `sourcelibrary.org`.

Mirrors #1737, which fixed the same pattern for the page-thumbnail grid.

## Test plan
- [ ] On `bph.sourcelibrary.org`, open a book with chapters, expand the "Chapters & Sections" panel, and click a chapter — should land on `/book/{slug}/page-number/{N}` reader view, not the catalogue.
- [ ] On `sourcelibrary.org`, same flow — chapter click still works.
- [ ] BPH leak audit still passes: `node scripts/audit-bph-leaks.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)