### PR TITLE
Likes API: prefer server session over client-supplied visitor_id

### DIFF
--- a/src/app/api/[tenant]/likes/mine/route.ts
+++ b/src/app/api/[tenant]/likes/mine/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
 import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
 import { buildCropUrl } from '@/lib/social-image-selector';
@@ -22,8 +23,9 @@ export async function GET(
       return NextResponse.json({ error: 'Tenant not found' }, { status: 400 });
     }
 
+    const session = await auth();
     const { searchParams } = new URL(request.url);
-    const visitorId = searchParams.get('visitor_id');
+    const visitorId = session?.user?.id || searchParams.get('visitor_id');
     const targetType = searchParams.get('type') as LikeTargetType | null;
 
     if (!visitorId) {

--- a/src/app/api/[tenant]/likes/route.ts
+++ b/src/app/api/[tenant]/likes/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { LikeTargetType } from '@/lib/types';
@@ -22,8 +23,12 @@ export async function POST(
       return NextResponse.json({ error: 'Tenant not found' }, { status: 400 });
     }
 
+    const session = await auth();
     const body = await request.json();
-    const { target_type, target_id, visitor_id } = body;
+    const { target_type, target_id } = body;
+    // Prefer authenticated user id over client-supplied visitor_id so likes
+    // stay attached to the account regardless of client-side hydration state.
+    const visitor_id: string | undefined = session?.user?.id || body.visitor_id;
 
     if (!target_type || !target_id || !visitor_id) {
       return NextResponse.json(
@@ -117,9 +122,10 @@ export async function GET(
       return NextResponse.json({ error: 'Tenant not found' }, { status: 400 });
     }
 
+    const session = await auth();
     const { searchParams } = new URL(request.url);
     const targetsJson = searchParams.get('targets');
-    const visitorId = searchParams.get('visitor_id');
+    const visitorId = session?.user?.id || searchParams.get('visitor_id');
 
     if (!targetsJson) {
       return NextResponse.json({ error: 'targets parameter is required' }, { status: 400 });
@@ -188,9 +194,12 @@ export async function GET(
       }
     }
 
+    const cacheControl = session?.user?.id
+      ? 'private, max-age=30'
+      : 'public, max-age=60, stale-while-revalidate=300';
     return NextResponse.json(
       { results },
-      { headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' } }
+      { headers: { 'Cache-Control': cacheControl } }
     );
   } catch (error) {
     console.error('Error getting likes:', error);

--- a/src/app/api/gallery/route.ts
+++ b/src/app/api/gallery/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
 import { getReadDb } from '@/lib/mongodb';
 import { getTenantContextFromRequest, resolveTenantId } from '@/lib/tenant-context';
 import { supabase } from '@/lib/supabase';
@@ -385,8 +386,11 @@ export async function GET(request: NextRequest) {
       total = await db.collection('gallery_images').estimatedDocumentCount();
     }
 
-    // Fetch like counts (and visitor's liked status) for these images
-    const visitorId = searchParams.get('visitor_id');
+    // Fetch like counts (and visitor's liked status) for these images.
+    // Prefer the authenticated user id so likedByVisitor stays correct
+    // even when the client hasn't hydrated its session yet.
+    const session = await auth();
+    const visitorId = session?.user?.id || searchParams.get('visitor_id');
     const imageIds = items.map(doc => `${doc.page_id}-${doc.detection_index}`);
     let likesMap: Record<string, { count: number; liked: boolean }> = {};
     if (imageIds.length > 0) {

--- a/src/app/api/likes/mine/route.ts
+++ b/src/app/api/likes/mine/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
 import { getReadDb } from '@/lib/mongodb';
 import { LikeTargetType } from '@/lib/types';
 import { buildCropUrl } from '@/lib/social-image-selector';
@@ -21,9 +22,13 @@ import { getTenantContextFromRequest } from '@/lib/tenant-context';
  */
 export async function GET(request: NextRequest) {
   try {
+    const session = await auth();
     const { searchParams } = new URL(request.url);
     const tenantContext = getTenantContextFromRequest(request.headers);
-    const visitorId = searchParams.get('visitor_id');
+    // Authenticated users always see their own likes regardless of any
+    // stale visitor_id the client passes (favorites page still reads
+    // localStorage). Anonymous visitors fall back to the supplied param.
+    const visitorId = session?.user?.id || searchParams.get('visitor_id');
     const targetType = searchParams.get('type') as LikeTargetType | null;
 
     if (tenantContext.slug && !tenantContext.id) {

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { LikeTargetType } from '@/lib/types';
@@ -69,8 +70,16 @@ async function resolveTargetTenantId(
  */
 export async function POST(request: NextRequest) {
   try {
+    const session = await auth();
     const body = await request.json();
-    const { target_type, target_id, visitor_id } = body;
+    const { target_type, target_id } = body;
+
+    // Prefer the authenticated user id; fall back to client-supplied
+    // visitor_id for anonymous visitors. This is what keeps likes attached to
+    // the user account across devices and survives the client-side session
+    // hydration race that previously stranded authenticated likes under
+    // anonymous v_… ids.
+    const visitor_id: string | undefined = session?.user?.id || body.visitor_id;
 
     if (!target_type || !target_id || !visitor_id) {
       return NextResponse.json(
@@ -186,9 +195,12 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
+    const session = await auth();
     const { searchParams } = new URL(request.url);
     const targetsJson = searchParams.get('targets');
-    const visitorId = searchParams.get('visitor_id');
+    // Authenticated session takes precedence over the query param so the
+    // "liked" lookup hits the same id the POST now files under.
+    const visitorId = session?.user?.id || searchParams.get('visitor_id');
 
     if (!targetsJson) {
       return NextResponse.json(
@@ -278,8 +290,14 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // Public cache is only safe when the response is keyed purely by URL.
+    // Once we mix in the NextAuth cookie to compute `liked`, we must mark it
+    // private so a CDN doesn't serve one user's state to another.
+    const cacheControl = session?.user?.id
+      ? 'private, max-age=30'
+      : 'public, max-age=60, stale-while-revalidate=300';
     return NextResponse.json({ results }, {
-      headers: { 'Cache-Control': 'public, max-age=60, stale-while-revalidate=300' },
+      headers: { 'Cache-Control': cacheControl },
     });
   } catch (error) {
     console.error('Error getting likes:', error);

--- a/tests/integration/tenant-isolation-api.test.ts
+++ b/tests/integration/tenant-isolation-api.test.ts
@@ -89,14 +89,18 @@ describe('Tenant API isolation', () => {
     const db = getTestDb();
 
     // Same target across both tenants; alpha has 2 likes, beta has 1.
+    // The authenticated test user (TEST_USER_ID) owns one of the alpha likes
+    // so `liked` reflects the server-side session, which takes precedence
+    // over any client-supplied visitor_id.
     await db.collection('likes').insertMany([
-      { target_type: 'page', target_id: 'page-1', visitor_id: 'v1', tenantId: 'tenant-alpha', created_at: new Date() },
+      { target_type: 'page', target_id: 'page-1', visitor_id: TEST_USER_ID, tenantId: 'tenant-alpha', created_at: new Date() },
       { target_type: 'page', target_id: 'page-1', visitor_id: 'v2', tenantId: 'tenant-alpha', created_at: new Date() },
       { target_type: 'page', target_id: 'page-1', visitor_id: 'v3', tenantId: 'tenant-beta', created_at: new Date() },
     ]);
 
     const targets = encodeURIComponent(JSON.stringify([{ type: 'page', id: 'page-1' }]));
-    const req = makeGet(`/api/alpha/likes?targets=${targets}&visitor_id=v1`);
+    // visitor_id=spoofed is ignored — auth() wins, so liked is computed for TEST_USER_ID.
+    const req = makeGet(`/api/alpha/likes?targets=${targets}&visitor_id=spoofed`);
 
     const res = await likesGet(req as any, { params: Promise.resolve({ tenant: 'alpha' }) });
     const data = await res.json();
@@ -225,12 +229,14 @@ describe('Tenant API isolation', () => {
       { id: 'book-b', title: 'Beta Favorites', tenantId: 'tenant-beta' },
     ]);
 
+    // Likes filed under the authenticated user — auth() now wins over the
+    // visitor_id query param, so the favorites listing follows the session.
     await db.collection('likes').insertMany([
-      { target_type: 'book', target_id: 'book-a', visitor_id: 'visitor-1', tenantId: 'tenant-alpha', created_at: new Date() },
-      { target_type: 'book', target_id: 'book-b', visitor_id: 'visitor-1', tenantId: 'tenant-beta', created_at: new Date() },
+      { target_type: 'book', target_id: 'book-a', visitor_id: TEST_USER_ID, tenantId: 'tenant-alpha', created_at: new Date() },
+      { target_type: 'book', target_id: 'book-b', visitor_id: TEST_USER_ID, tenantId: 'tenant-beta', created_at: new Date() },
     ]);
 
-    const req = makeGet('/api/likes/mine?visitor_id=visitor-1&type=book', {
+    const req = makeGet('/api/likes/mine?visitor_id=spoofed&type=book', {
       'x-tenant-slug': 'alpha',
       'x-tenant-id': 'tenant-alpha',
     });


### PR DESCRIPTION
## Summary

- Likes endpoints (`/api/likes`, `/api/[tenant]/likes`, plus their `/mine` variants and gallery `likedByVisitor`) take `visitor_id` from the **client** request body/query.
- `LikeButton` fills that from `useIdentity()`, which depends on `useStableSession()` having hydrated to `authenticated`. When it hasn't (right after navigation, on tenant subdomains, after a `session.update()` blip), identity falls back to an anonymous `v_…` id and the like is filed against that — never against the user's account.
- DB confirms: a recently authenticated user has 10 `reading_history` rows under her `user_id` (that endpoint reads `auth()` server-side) and **zero** likes under the same id. Site-wide we haven't recorded a like in 3 days.

## Fix

Take visitor identity from the server-side NextAuth session when present; fall back to client-supplied `visitor_id` only for anonymous visitors — the pattern `reading-history` already uses.

- `POST /api/likes`, `POST /api/[tenant]/likes`: `session.user.id` wins over `body.visitor_id`.
- `GET /api/likes`, `GET /api/[tenant]/likes`: `session.user.id` wins over `query.visitor_id`. `Cache-Control` flips to `private, max-age=30` when the response is shaped by the cookie, so a CDN can't leak one user's liked state to another. Anonymous requests keep the old `public` cache.
- `GET /api/likes/mine`, `GET /api/[tenant]/likes/mine`: same precedence so the `/favorites` page (still reads `sl_visitor_id` from localStorage) shows the authenticated user's likes regardless of what the client sent.
- `GET /api/gallery`: same precedence for the per-image `likedByVisitor` flag in the list response.

No client changes — `LikeButton` keeps sending `identity.id`, the server now ignores it when a session cookie is present.

## Test plan

- [ ] Sign in via Google, click heart on `/book/<slug>` → like persists across refresh, DB row has `visitor_id = session.user.id`.
- [ ] Sign in, click heart on `/bph/...` (tenant subdomain) → same as above, scoped to tenant.
- [ ] `/favorites` shows likes attributed to the authenticated account, not the anonymous v_-id.
- [ ] Anonymous visitor (logged out, fresh incognito) still likes via the v_… fallback path.
- [ ] `/gallery` rendering of `likedByVisitor` matches reality for an authenticated user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)