### PR TITLE
Reading history: record from canonical /book URLs

### DIFF
--- a/src/app/api/reading-history/route.ts
+++ b/src/app/api/reading-history/route.ts
@@ -9,6 +9,12 @@ const SESSION_GAP_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * POST /api/reading-history — record a page view (sendBeacon)
+ *
+ * The proxy attaches a tenant header on tenant subdomains and `/[tenant]/`
+ * paths. For canonical `/book/{slug}` URLs there is no tenant in the path and
+ * no referer slug to infer from, so we resolve the tenant from the book
+ * itself — same pattern the likes route uses.
+ *
  * Silent no-op for anonymous users.
  */
 export async function POST(request: NextRequest) {
@@ -26,15 +32,24 @@ export async function POST(request: NextRequest) {
     }
 
     const userId = session.user.id;
-    const { id: tenantId } = getTenantContextFromRequest(request);
-    if (!tenantId) {
-      return NextResponse.json({ success: true }); // silent fail
-    }
-
     const now = new Date();
 
     const dbWork = (async () => {
       const db = await getDb();
+
+      // Tenant from proxy header if available; otherwise look up the book.
+      let tenantId = getTenantContextFromRequest(request).id;
+      let resolvedBookId = book_id;
+      if (!tenantId) {
+        const book = await db.collection('books').findOne(
+          { $or: [{ id: book_id }, { slug: book_id }] },
+          { projection: { id: 1, tenantId: 1 } }
+        );
+        tenantId = (book?.tenantId as string) || null;
+        if (book?.id) resolvedBookId = book.id as string;
+      }
+      if (!tenantId) return; // unknown book/tenant — silent fail
+
       const collection = db.collection('reading_history');
       const cutoff = new Date(now.getTime() - SESSION_GAP_MS);
 
@@ -42,7 +57,7 @@ export async function POST(request: NextRequest) {
       const existing = await collection.findOne(
         {
           user_id: userId,
-          book_id,
+          book_id: resolvedBookId,
           tenantId,
           updated_at: { $gte: cutoff },
         },
@@ -60,13 +75,12 @@ export async function POST(request: NextRequest) {
             },
             $inc: { pages_viewed: 1 },
             $addToSet: { pages_read: { page_id, page_number } },
-          tenantId,
           }
         );
       } else {
         await collection.insertOne({
           user_id: userId,
-          book_id,
+          book_id: resolvedBookId,
           first_page_id: page_id,
           first_page_number: page_number,
           last_page_id: page_id,
@@ -75,6 +89,7 @@ export async function POST(request: NextRequest) {
           pages_read: [{ page_id, page_number }],
           started_at: now,
           updated_at: now,
+          tenantId,
           ...(referrer ? { referrer } : {}),
         });
       }
@@ -92,23 +107,27 @@ export async function POST(request: NextRequest) {
 }
 
 /**
- * GET /api/reading-history — list reading history (auth required)
+ * GET /api/reading-history — list reading history (auth required).
+ *
+ * Scopes to the tenant if the proxy injected a tenant header (e.g. on
+ * bph.sourcelibrary.org or /[tenant]/reading-history). On the canonical
+ * /reading-history page there is no tenant context and we show every book
+ * the user has read across the library.
  */
 export const GET = withAuth(async (request, session) => {
   const { searchParams } = new URL(request.url);
   const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 200);
   const offset = parseInt(searchParams.get('offset') || '0');
-  const userId = session.user!.id;
+  const userId = session.user!.id as string;
   const { id: tenantId } = getTenantContextFromRequest(request);
 
-  if (!tenantId) {
-    return NextResponse.json({ entries: [], total: 0 });
-  }
+  const baseMatch: Record<string, string> = { user_id: userId };
+  if (tenantId) baseMatch.tenantId = tenantId;
 
   const db = await getDb();
 
   const pipeline = [
-    { $match: { user_id: userId, tenantId } },
+    { $match: baseMatch },
     { $sort: { updated_at: -1 as const } },
     { $skip: offset },
     { $limit: limit },
@@ -160,7 +179,7 @@ export const GET = withAuth(async (request, session) => {
 
   const [entries, totalResult] = await Promise.all([
     db.collection('reading_history').aggregate(pipeline).toArray(),
-    db.collection('reading_history').countDocuments({ user_id: userId, tenantId }),
+    db.collection('reading_history').countDocuments(baseMatch),
   ]);
 
   return NextResponse.json({ entries, total: totalResult, offset, limit });

--- a/src/lib/api-client/reading-history.ts
+++ b/src/lib/api-client/reading-history.ts
@@ -1,4 +1,4 @@
-import { apiClient, getTenantSlug } from './client';
+import { apiClient } from './client';
 
 export interface ReadingHistoryEntry {
   book_id: string;
@@ -34,6 +34,12 @@ export interface ReadingHistoryResponse {
   limit: number;
 }
 
+// All routes target the global `/api/reading-history` namespace. The proxy
+// attaches a tenant header on tenant subdomains and `/[tenant]/...` paths;
+// the global routes also resolve tenant from the book itself when needed,
+// so canonical `/book/{slug}` URLs work the same way.
+const BASE = '/api/reading-history';
+
 export const readingHistory = {
   /**
    * Record a page view (fire-and-forget via sendBeacon)
@@ -41,8 +47,6 @@ export const readingHistory = {
    */
   record: (bookId: string, pageId: string, pageNumber: number, referrer?: string) => {
     if (typeof navigator === 'undefined' || !navigator.sendBeacon) return;
-    const tenant = getTenantSlug();
-    if (!tenant) return;
 
     const payload = JSON.stringify({
       book_id: bookId,
@@ -51,26 +55,24 @@ export const readingHistory = {
       ...(referrer ? { referrer } : {}),
     });
 
-    navigator.sendBeacon(`/api/${tenant}/reading-history`, new Blob([payload], { type: 'application/json' }));
+    navigator.sendBeacon(BASE, new Blob([payload], { type: 'application/json' }));
   },
 
   /**
    * List reading history (requires auth)
    */
   list: async (params?: { limit?: number; offset?: number }): Promise<ReadingHistoryResponse> => {
-    const tenant = getTenantSlug();
     const qs = new URLSearchParams();
     if (params?.limit) qs.set('limit', String(params.limit));
     if (params?.offset) qs.set('offset', String(params.offset));
     const query = qs.toString();
-    return await apiClient.get(`/api/${tenant}/reading-history${query ? `?${query}` : ''}`);
+    return await apiClient.get(`${BASE}${query ? `?${query}` : ''}`);
   },
 
   /**
    * Clear reading history (one book or all)
    */
   clear: async (bookId?: string): Promise<{ success: boolean; deleted: number }> => {
-    const tenant = getTenantSlug();
-    return await apiClient.post(`/api/${tenant}/reading-history/clear`, bookId ? { book_id: bookId } : {});
+    return await apiClient.post(`${BASE}/clear`, bookId ? { book_id: bookId } : {});
   },
 };


### PR DESCRIPTION
## Summary

Sibling of #1747 for reading-history. `POST /api/reading-history` required a proxy-injected tenant header, silently no-op'ing when absent. The proxy only attaches that header on tenant subdomains and `/[tenant]/...` paths — not on the canonical `/book/{slug}` URLs the homepage and search link straight to. The client beacon also gated on `getTenantSlug()` and never fired from canonical pages. Result: anyone reading via `/book/{slug}` accumulated zero reading history.

DB confirms: all reading_history entries in the last 7d are on tenant-prefixed paths. Nothing recorded for canonical browsing.

## Fix

Same pattern as #1691 / #1747:

- Server resolves `tenantId` from the book itself when the proxy header is missing.
- Inserts now carry `tenantId` on the row (the existing global POST was also dropping it and had a stray `tenantId,` inside the update operator — pre-existing bugs in the never-hit code path).
- GET drops the tenant requirement when there is no tenant header: canonical `/reading-history` shows everything the user has read across tenants. Tenant subdomain still scopes via header.
- Client `record()` drops the `if (!tenant) return` short-circuit and always posts to `/api/reading-history`. `list()` and `clear()` move to the same global namespace.

## Test plan

- [ ] Sign in, navigate pages on `/book/<slug>` → new entries appear in `bookstore.reading_history` with the user's `user_id` and the book's `tenantId`.
- [ ] Same on `bph.sourcelibrary.org/book/<slug>` → entries land scoped to BPH tenant.
- [ ] `/reading-history` (canonical) lists entries across all tenants the user has read in.
- [ ] `/bph/reading-history` lists only BPH entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)