### PR TITLE
BPH sync: honor bph_catalog_link skip flag

### DIFF
--- a/scripts/backfill-bph-sl-book-ids.mjs
+++ b/scripts/backfill-bph-sl-book-ids.mjs
@@ -70,10 +70,16 @@ async function main() {
   const db = client.db('bookstore');
 
   console.log('Loading BPH books with dc_identifier from MongoDB…');
+  // `bph_catalog_link: false` opts a book out of the catalog link, matching
+  // the cron at src/app/api/cron/sync-bph-sl-book-ids/route.ts.
   const docs = await db
     .collection('books')
     .find(
-      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true, $ne: '' } },
+      {
+        'image_source.provider': 'bph',
+        'dublin_core.dc_identifier': { $exists: true, $ne: '' },
+        bph_catalog_link: { $ne: false },
+      },
       { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 } }
     )
     .toArray();

--- a/src/app/api/cron/sync-bph-sl-book-ids/route.ts
+++ b/src/app/api/cron/sync-bph-sl-book-ids/route.ts
@@ -25,6 +25,11 @@ export const dynamic = 'force-dynamic';
  *
  * Out of scope: BPH books imported via IIIF where `dc_identifier` is a manifest
  * URL rather than a numeric UBN. Those need a separate IIIF-URL → UBN resolver.
+ *
+ * Opt-out: setting `bph_catalog_link: false` on a book's MongoDB doc removes
+ * it from the linkable set, so an unlink in Supabase persists across cron
+ * runs. Used to set books aside for partner review without losing the
+ * MongoDB record. Clear the flag to resume linking.
  */
 
 const PARALLEL = 10;
@@ -72,10 +77,15 @@ export async function GET(request: NextRequest) {
   const db = await getDb();
 
   // Read all BPH books with a dc_identifier and project just the fields we need.
+  // `bph_catalog_link: false` opts a book out of the sync (see header comment).
   const docs = await db
     .collection('books')
     .find(
-      { 'image_source.provider': 'bph', 'dublin_core.dc_identifier': { $exists: true, $ne: '' } },
+      {
+        'image_source.provider': 'bph',
+        'dublin_core.dc_identifier': { $exists: true, $ne: '' },
+        bph_catalog_link: { $ne: false },
+      },
       { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 30_000 },
     )
     .toArray();


### PR DESCRIPTION
## Summary

Lets us set BPH books aside for partner review without the sync cron undoing the unlink.

The `sync-bph-sl-book-ids` cron runs every 6 hours, reads BPH books from MongoDB, and PATCHes `bph_works.sl_book_id` for each. So when we manually unlinked UBN 7137 in Supabase (per #1751), the next cron run re-linked it and the catalogue count went back up to 2,223.

This PR adds an opt-out: setting `bph_catalog_link: false` on a book's MongoDB doc excludes it from the linkable set. The flag is also honored by `scripts/backfill-bph-sl-book-ids.mjs` (the one-shot companion to the cron) so they stay in lock-step.

Default behavior is unchanged — books without the flag (or `bph_catalog_link: true`) link as before. Restoring a flagged book is a one-field unset; the next cron tick relinks it.

## How it was used immediately

For #1751:
1. `db.books.updateOne({ id: '697e23cb32e94c72715dd0cf' }, { $set: { bph_catalog_link: false } })`
2. `UPDATE bph_works SET sl_book_id=NULL, sl_book_slug=NULL WHERE ubn='7137'`
3. Catalogue digitised count: **2,223 → 2,222** (verified live)

After this PR ships, the next cron tick will respect the flag and the count stays at 2,222 until the issue is reviewed.

## Test plan
- [ ] After deploy, trigger the cron manually (or wait 6h) and verify UBN 7137 stays `sl_book_id=NULL`
- [ ] Verify catalogue API still returns 2,222: `curl https://bph.sourcelibrary.org/api/catalog/bph?digitized=sl | jq .total`
- [ ] Confirm cron summary shows `total_bph_books: ~3535, linkable_count: ~3534` (one fewer than before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)