### PR TITLE
BPH cover variants: write all 3 sizes + retroactive fix

### DIFF
--- a/.claude/docs/supabase.md
+++ b/.claude/docs/supabase.md
@@ -99,6 +99,55 @@ Supabase (reads)
   └── /api/ustc/search ──reads──→ ustc_editions + ustc_enrichments
 ```
 
+## Sync Points (Complete Map)
+
+Audited 2026-05-14. Every Mongo→Supabase write path in the codebase:
+
+| # | Path | Trigger | Schedule | Fields | Status |
+|---|---|---|---|---|---|
+| 1 | MongoDB books → `books_catalog` | Hetzner `scripts/workers/sync-books-catalog.mjs` | every 5 min, last-10-min window | ~40 fields incl. `thumbnail`, `thumbnail_blob`, title, author, language, pages_count, pages_ocr/translated/blank, categories, collections, cover_image, summary_text, doi, published, place_published, publisher | ⚠️ window-only, no retry; **missing `held_by`, `image_display`, `image_thumb`** |
+| 2 | MongoDB books → `books_catalog` | PATCH `/api/books/[id]` → `mirrorBookToCatalog()` | on curator edit | ~11 fields: title, display_title, author, thumbnail, thumbnail_blob, language, published, categories, publisher, place_published, doi | ⚠️ **only fires from the PATCH route**; direct DB updates from `scripts/` bypass it |
+| 3 | MongoDB books → `bph_works.sl_book_id` | Vercel cron `/api/cron/sync-bph-sl-book-ids` | every 6h | `sl_book_id`, `sl_book_slug` | ✓ Honors `bph_catalog_link: false` opt-out (PR #1752, 2026-05-14) |
+| 4 | MongoDB pages → `pages_images` | Hetzner `scripts/workers/supabase-sync.mjs` | every 5 min, last-10-min window | id, book_id, page_number, archived_photo, display_photo, thumbnail_blob | ⚠️ window-only; no retry/backfill if a sync window misses a row |
+| 5 | MongoDB → 5 analytics tables | Hetzner `scripts/workers/supabase-sync.mjs` | every 5 min | pipeline_snapshots, analytics_pageviews, analytics_events, cron_runs, loading_metrics | ✓ |
+| 6 | MongoDB entities → `entities` | `scripts/workers/sync-entities.mjs` | manual / one-shot | id, name, canonical_name, type, book_count, mentions, aliases, wikidata_id, portrait_url | ⚠️ no recurring trigger; new entities go stale |
+| 7 | MongoDB book.gemini_usage → `gemini_usage` | Synchronous dual-write in `gemini-logger.ts` | per Gemini call | usage rows | ✓ Fire-and-forget (see Gotchas) |
+| 8 | (runtime, no stored sync) `bph_works.sl_cover` | Computed in `/api/catalog/bph` from MongoDB at request time | per request | — | ✓ Always fresh; bottleneck is MongoDB freshness |
+
+## Known Sync Gaps
+
+These have bitten us before and will bite again. Documented so the next debugger doesn't relearn it.
+
+### A. PATCH bypass — scripts that update MongoDB directly never call `mirrorBookToCatalog`
+
+Symptom: a curator clicks "set cover" and the BPH grid updates instantly (PATCH mirrors immediately). But `scripts/migration/foo.mjs` runs `db.books.updateOne(...)` directly — the same field change shows up in `books_catalog` only after the 5-min Hetzner sync, *if* the sync window catches it. If the sync misses it (see B), the BPH grid is stale indefinitely.
+
+Concrete example (2026-05-13/14): I fixed 10 BPH spread-cover URLs via a script that wrote MongoDB directly. 4 made it to Supabase within a sync window; 6 were stranded — the BPH home grid kept showing the old spread covers until I manually `UPDATE`d `books_catalog`.
+
+Mitigations to consider:
+- Extract `mirrorBookToCatalog` to a shared module any maintenance script can import.
+- Or have the Hetzner sync use `supabase_synced_at < mongo updated_at` instead of a fixed 10-min window.
+
+### B. Hetzner sync uses a fixed last-10-min window with no retry
+
+`scripts/workers/sync-books-catalog.mjs` and `supabase-sync.mjs` look at MongoDB documents whose `updated_at > now() - 10 min`. There's no record of which rows have been mirrored — if a tick fails mid-batch, the missed rows are stranded until *another* edit re-bumps `updated_at`. Same shape applies to `pages_images`.
+
+Mitigations to consider:
+- Track `supabase_synced_at` on MongoDB docs and pick the diff each tick.
+- Or run a daily "catch-up" pass with a wider window (last 24h).
+
+### C. `held_by` is in MongoDB but not in `books_catalog`
+
+Flagged in `.claude/handoffs/2026-04-24-bph-full-catalog.md` ("Supabase `books_catalog` sync doesn't include `held_by` yet"). Still open. Catalogue/BPH-filter code has to round-trip MongoDB to filter by holding library; Supabase-only browse pages can't filter.
+
+### D. Entities sync is manual only
+
+`scripts/workers/sync-entities.mjs` was run once during the encyclopedia backfill. There's no cron — new entities added in MongoDB don't reach Supabase unless someone re-runs the script. Low impact today (entities don't change often), but worth a recurring cron if entity edits become common.
+
+### E. No central inventory of sync state
+
+This table is the inventory. Before this section, sync points were scattered across `vercel.json` (Vercel crons), Hetzner crontab (worker scripts), and route file headers. Always update this table when adding or modifying a sync path.
+
 ## pg_cron Jobs
 
 All prefixed `sl-`. Managed inside Supabase (no external cron needed).

--- a/.claude/docs/system-map.md
+++ b/.claude/docs/system-map.md
@@ -94,7 +94,7 @@ Supabase serves derived reads for performance-critical paths. MongoDB remains so
 | `ustc_editions` / `ustc_enrichments` | USTC catalog | Direct import |
 | `contributing_library` | Library pages (was 5s timeout) | Materialized view |
 
-Key: `src/lib/supabase.ts` (client), `.claude/docs/supabase.md` (full reference)
+Key: `src/lib/supabase.ts` (client), `.claude/docs/supabase.md` (full reference — see **Sync Points (Complete Map)** for every Mongo→Supabase write path and **Known Sync Gaps** for documented edge cases like the PATCH-bypass)
 
 ## Author Pages (added 2026-03-30+)
 

--- a/scripts/migration/backfill-fullres-split-pages.mjs
+++ b/scripts/migration/backfill-fullres-split-pages.mjs
@@ -1,0 +1,201 @@
+/**
+ * Backfill full-res cropped halves for split pages
+ *
+ * Previously cropAndUploadHalf capped at 2000px. This script re-crops
+ * from the source spread at full resolution and uploads all three variants:
+ *   - pages/{bookId}/{num}-full.jpg  (full-res crop)
+ *   - pages/{bookId}/{num}.jpg       (1200px display)
+ *   - pages/{bookId}/{num}-thumb.jpg (150px thumbnail)
+ *
+ * All three variants MUST be written together or readers (e.g.
+ * getBookThumbnailUrl in src/lib/utils.ts) get confused when the rewrite
+ * `-full → bare` returns inconsistent content. The May 2026 BPH cover-fix
+ * bug came from an earlier version that only wrote -full + display, leaving
+ * -thumb stale and (in some cases) the bare .jpg never being overwritten —
+ * see scripts/regenerate-cover-variants.mjs for the retroactive fix.
+ *
+ * Prioritizes pages with detected_images (gallery quality matters most).
+ *
+ * Run: set -a; source .env.production.local; set +a; node scripts/migration/backfill-fullres-split-pages.mjs
+ * Options:
+ *   --dry-run       Preview without writing
+ *   --limit N       Process at most N pages (default: all)
+ *   --batch N       Concurrent pages per batch (default: 5)
+ *   --detections-only  Only process pages with detected_images
+ */
+
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const DISPLAY_WIDTH = 1200;
+const THUMB_WIDTH = 150;
+const DISPLAY_QUALITY = 85;
+const THUMB_QUALITY = 80;
+const FULL_QUALITY = 90;
+const BATCH_SIZE = parseInt(process.argv.find(a => a.startsWith('--batch='))?.split('=')[1] || '5');
+const LIMIT = parseInt(process.argv.find(a => a.startsWith('--limit='))?.split('=')[1] || '0');
+const DRY_RUN = process.argv.includes('--dry-run');
+const DETECTIONS_ONLY = process.argv.includes('--detections-only');
+
+// R2 setup
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+  },
+});
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+const R2_PUBLIC = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+async function uploadToR2(key, buffer) {
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: 'image/jpeg',
+  }));
+  return `${R2_PUBLIC}/${key}`;
+}
+
+function pagePaths(bookId, pageNumber) {
+  const num = String(pageNumber).padStart(4, '0');
+  const base = `pages/${bookId}/${num}`;
+  return { full: `${base}-full.jpg`, display: `${base}.jpg`, thumb: `${base}-thumb.jpg` };
+}
+
+async function fetchImage(url) {
+  const resp = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${url}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function processPage(db, page) {
+  // Get the source spread image
+  const sourceUrl = page.archived_photo || page.photo_original;
+  if (!sourceUrl || sourceUrl.startsWith('failed:')) {
+    return { status: 'skip', reason: 'no source' };
+  }
+
+  const buffer = await fetchImage(sourceUrl);
+  const metadata = await sharp(buffer).metadata();
+  const imgWidth = metadata.width || 1000;
+  const imgHeight = metadata.height || 1000;
+
+  // Crop
+  const left = Math.round((page.crop.xStart / 1000) * imgWidth);
+  const cropWidth = Math.round(((page.crop.xEnd - page.crop.xStart) / 1000) * imgWidth);
+
+  const fullResBuffer = await sharp(buffer)
+    .extract({
+      left,
+      top: 0,
+      width: Math.min(cropWidth, imgWidth - left),
+      height: imgHeight,
+    })
+    .jpeg({ quality: FULL_QUALITY, progressive: true })
+    .toBuffer();
+
+  const displayBuffer = await sharp(fullResBuffer)
+    .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
+    .toBuffer();
+  const thumbBuffer = await sharp(fullResBuffer)
+    .resize(THUMB_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: THUMB_QUALITY, progressive: true })
+    .toBuffer();
+
+  const paths = pagePaths(page.book_id, page.page_number);
+
+  if (DRY_RUN) {
+    const fullMeta = await sharp(fullResBuffer).metadata();
+    return { status: 'dry-run', fullRes: `${fullMeta.width}x${fullMeta.height}`, bytes: fullResBuffer.length };
+  }
+
+  const [fullUrl] = await Promise.all([
+    uploadToR2(paths.full, fullResBuffer),
+    uploadToR2(paths.display, displayBuffer),
+    uploadToR2(paths.thumb, thumbBuffer),
+  ]);
+
+  // Update page record — cropped_photo points to full-res
+  await db.collection('pages').updateOne(
+    { id: page.id },
+    { $set: { cropped_photo: fullUrl, updated_at: new Date() } }
+  );
+
+  return { status: 'ok', fullUrl };
+}
+
+async function run() {
+  const client = await MongoClient.connect(process.env.MONGODB_URI);
+  const db = client.db('bookstore');
+
+  const query = { 'crop.xStart': { $exists: true } };
+  if (DETECTIONS_ONLY) {
+    query['detected_images.0'] = { $exists: true };
+  }
+
+  // Skip slow count — we know: 403K split, 33K with detections
+  const totalCount = DETECTIONS_ONLY ? 33657 : 403186;
+  console.log(`Estimated ${totalCount} split pages${DETECTIONS_ONLY ? ' with detections' : ''}`);
+  if (DRY_RUN) console.log('DRY RUN — no writes');
+
+  const cursor = db.collection('pages')
+    .find(query, {
+      projection: {
+        id: 1, book_id: 1, page_number: 1, crop: 1,
+        archived_photo: 1, photo_original: 1,
+      },
+    })
+    // Process pages with detections first (sort by detected_images existence)
+    .sort({ 'detected_images.0': -1 });
+
+  if (LIMIT > 0) cursor.limit(LIMIT);
+
+  let processed = 0, ok = 0, skipped = 0, errors = 0;
+  let batch = [];
+
+  for await (const page of cursor) {
+    batch.push(page);
+    if (batch.length >= BATCH_SIZE) {
+      const results = await Promise.allSettled(
+        batch.map(p => processPage(db, p).catch(e => ({ status: 'error', msg: e.message })))
+      );
+      for (const r of results) {
+        processed++;
+        const val = r.status === 'fulfilled' ? r.value : { status: 'error', msg: r.reason?.message };
+        if (val.status === 'ok') ok++;
+        else if (val.status === 'dry-run') { ok++; console.log(`  dry-run: ${val.fullRes}, ${Math.round(val.bytes/1024)}KB`); }
+        else if (val.status === 'skip') { skipped++; console.log(`  skip: ${val.reason}`); }
+        else { errors++; if (errors <= 10) console.error(`  Error: ${val.msg}`); }
+      }
+      if (processed % 100 === 0 || processed >= totalCount) {
+        const pct = ((processed / totalCount) * 100).toFixed(1);
+        console.log(`${processed}/${totalCount} (${pct}%) — ok:${ok} skip:${skipped} err:${errors}`);
+      }
+      batch = [];
+    }
+  }
+
+  // Final batch
+  if (batch.length > 0) {
+    const results = await Promise.allSettled(
+      batch.map(p => processPage(db, p).catch(e => ({ status: 'error', msg: e.message })))
+    );
+    for (const r of results) {
+      processed++;
+      const val = r.status === 'fulfilled' ? r.value : { status: 'error', msg: r.reason?.message };
+      if (val.status === 'ok' || val.status === 'dry-run') ok++;
+      else if (val.status === 'skip') skipped++;
+      else errors++;
+    }
+  }
+
+  console.log(`\nDone. Processed: ${processed}, OK: ${ok}, Skipped: ${skipped}, Errors: ${errors}`);
+  await client.close();
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/regenerate-cover-variants.mjs
+++ b/scripts/regenerate-cover-variants.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Regenerate the missing `{NNNN}.jpg` (1200px display) and `{NNNN}-thumb.jpg`
+ * (150px thumbnail) variants from the existing `{NNNN}-full.jpg` (cropped
+ * single-page content) on R2. Restores the 3-variant convention for books
+ * whose covers were cropped by `backfill-fullres-split-pages.mjs` (which only
+ * wrote 2 of 3 variants).
+ *
+ * Originals at `archived/{bookId}/{N}.jpg` are NEVER touched — that's where
+ * primary-source provenance lives.
+ *
+ * Idempotent: if the bare `.jpg` already matches the `-full.jpg` content
+ * (same aspect ratio within 2%), we skip — no regeneration needed.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/regenerate-cover-variants.mjs --dry-run --ids 69099634cf28baa1b4cae779
+ *   node scripts/regenerate-cover-variants.mjs --ids id1,id2,id3
+ *   node scripts/regenerate-cover-variants.mjs --scope all-bph-full     # all BPH books with image_display ending in -full.jpg
+ *   node scripts/regenerate-cover-variants.mjs --scope all-bph-full --apply
+ */
+
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const DISPLAY_WIDTH = 1200;
+const THUMB_WIDTH = 150;
+const DISPLAY_QUALITY = 85;
+const THUMB_QUALITY = 80;
+// Aspect-ratio match tolerance — if bare and -full agree this closely, the
+// variants are already consistent and we skip the book.
+const ASPECT_TOLERANCE = 0.02;
+
+const argv = process.argv.slice(2);
+const APPLY = argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const idsArg = argv.find((_, i) => argv[i - 1] === '--ids');
+const scopeArg = argv.find((_, i) => argv[i - 1] === '--scope');
+if (!idsArg && !scopeArg) {
+  console.error('Need --ids id1,id2 or --scope all-bph-full');
+  process.exit(1);
+}
+
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+  },
+});
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
+const R2_PUBLIC = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+async function fetchImage(url) {
+  const resp = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${url}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function dims(buf) {
+  const m = await sharp(buf).metadata();
+  return { w: m.width || 0, h: m.height || 0, ratio: m.width && m.height ? m.width / m.height : null };
+}
+
+async function uploadR2(key, buffer) {
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET,
+    Key: key,
+    Body: buffer,
+    ContentType: 'image/jpeg',
+  }));
+  return `${R2_PUBLIC}/${key}`;
+}
+
+function parseFullPath(url) {
+  // Match pages/{bookId}/{NNNN}-full.jpg OR pages/{bookId}/{name}-full.jpg
+  const m = url.match(/\/pages\/([^/]+)\/(.+)-full\.jpg$/);
+  if (!m) return null;
+  return { bookId: m[1], base: m[2], fullKey: `pages/${m[1]}/${m[2]}-full.jpg`, displayKey: `pages/${m[1]}/${m[2]}.jpg`, thumbKey: `pages/${m[1]}/${m[2]}-thumb.jpg` };
+}
+
+async function processBook(book) {
+  const url = book.image_display;
+  if (!url || !url.endsWith('-full.jpg')) return { status: 'skip', reason: 'image_display not -full.jpg' };
+  const paths = parseFullPath(url);
+  if (!paths) return { status: 'skip', reason: 'unparseable url' };
+
+  // 1. Fetch -full.jpg (cropped content, source of truth)
+  let fullBuf;
+  try { fullBuf = await fetchImage(url); }
+  catch (e) { return { status: 'error', reason: `fetch -full: ${e.message}` }; }
+  const fullDims = await dims(fullBuf);
+
+  // 2. Check current bare .jpg for consistency
+  const displayUrl = `${R2_PUBLIC}/${paths.displayKey}`;
+  let bareDims = null;
+  try {
+    const bareBuf = await fetchImage(displayUrl);
+    bareDims = await dims(bareBuf);
+  } catch {
+    // bare doesn't exist — definitely need to regenerate
+  }
+
+  let consistent = false;
+  if (bareDims && fullDims.ratio && bareDims.ratio) {
+    consistent = Math.abs(fullDims.ratio - bareDims.ratio) < ASPECT_TOLERANCE;
+  }
+
+  if (consistent) {
+    return { status: 'ok-noop', fullDims: `${fullDims.w}x${fullDims.h}`, bareDims: `${bareDims.w}x${bareDims.h}` };
+  }
+
+  // 3. Generate display + thumb from -full content
+  const displayBuf = await sharp(fullBuf)
+    .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
+    .toBuffer();
+  const thumbBuf = await sharp(fullBuf)
+    .resize(THUMB_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: THUMB_QUALITY, progressive: true })
+    .toBuffer();
+
+  if (DRY_RUN) {
+    const dDims = await dims(displayBuf);
+    const tDims = await dims(thumbBuf);
+    return { status: 'dry-run', fullDims: `${fullDims.w}x${fullDims.h}`, bareDimsBefore: bareDims ? `${bareDims.w}x${bareDims.h}` : '(missing)', wouldWriteDisplay: `${dDims.w}x${dDims.h}`, wouldWriteThumb: `${tDims.w}x${tDims.h}` };
+  }
+
+  // 4. Apply
+  await uploadR2(paths.displayKey, displayBuf);
+  await uploadR2(paths.thumbKey, thumbBuf);
+  return { status: 'fixed', fullDims: `${fullDims.w}x${fullDims.h}`, bareDimsBefore: bareDims ? `${bareDims.w}x${bareDims.h}` : '(missing)' };
+}
+
+async function main() {
+  const c = new MongoClient(process.env.MONGODB_URI);
+  await c.connect();
+  const db = c.db('bookstore');
+
+  let books;
+  if (idsArg) {
+    const ids = idsArg.split(',').map(s => s.trim()).filter(Boolean);
+    books = await db.collection('books').find({ id: { $in: ids } }, { projection: { id: 1, slug: 1, title: 1, image_display: 1 } }).toArray();
+  } else if (scopeArg === 'all-bph-full') {
+    books = await db.collection('books').find({ held_by: 'bph', image_display: { $regex: '-full\\.jpg$' } }, { projection: { id: 1, slug: 1, title: 1, image_display: 1 } }).toArray();
+  } else {
+    throw new Error(`unknown scope: ${scopeArg}`);
+  }
+
+  console.log(`${DRY_RUN ? 'DRY-RUN' : 'APPLY'} — processing ${books.length} books\n`);
+  const counts = { fixed: 0, 'ok-noop': 0, 'dry-run': 0, skip: 0, error: 0 };
+  for (const b of books) {
+    const r = await processBook(b);
+    counts[r.status] = (counts[r.status] || 0) + 1;
+    const slug = (b.slug || b.id).slice(0, 50);
+    if (r.status === 'fixed') console.log(`  ✓ fixed   ${slug.padEnd(52)} full=${r.fullDims} (was ${r.bareDimsBefore})`);
+    else if (r.status === 'dry-run') console.log(`  • would   ${slug.padEnd(52)} full=${r.fullDims} write display=${r.wouldWriteDisplay} thumb=${r.wouldWriteThumb} (bare was ${r.bareDimsBefore})`);
+    else if (r.status === 'ok-noop') console.log(`  ◦ noop    ${slug.padEnd(52)} already consistent (${r.fullDims} ≈ ${r.bareDims})`);
+    else if (r.status === 'skip') console.log(`  - skip    ${slug.padEnd(52)} ${r.reason}`);
+    else console.log(`  ✗ ERR     ${slug.padEnd(52)} ${r.reason}`);
+  }
+  console.log(`\n${JSON.stringify(counts)}`);
+  await c.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Fixes BPH catalogue grid showing original spread scans where the curator chose a cropped single-page cover. Detail page rendered correctly; only the grid was wrong.

**Root cause**: `getBookThumbnailUrl` rewrites `-full.jpg → bare .jpg` at display time, assuming the three variants per page (`-thumb`, bare, `-full`) are different sizes of the same content. The spread-splitting backfill at `scripts/migration/backfill-fullres-split-pages.mjs` violated the convention — wrote `-full.jpg` (cropped) but never `-thumb.jpg`, and for some books the bare `.jpg` remained the original spread. The rewrite then served the spread.

## Two-part fix

1. **Pipeline (`backfill-fullres-split-pages.mjs`)** — writes all 3 variants together (`-full`, bare 1200px, `-thumb` 150px). Was 2-of-3 before, now 3-of-3 matching what `split-processing.ts` already does. Prevents recurrence.
2. **Retroactive (`scripts/regenerate-cover-variants.mjs`)** — for books whose variants are already inconsistent, regenerates display + thumb from the existing `-full.jpg`. Idempotent (aspect-ratio match check skips already-consistent books). Originals at `archived/{bookId}/{N}.jpg` are **never touched** — primary-source provenance is preserved.

## Scope applied today

- 6 BPH books had inconsistent variants — all fixed live: eckartshausen, weigel, cabalistic-science, opera-alexandrinus, marrow-of-the-soul, romance-of-the-rose.
- 154 BPH books using `-full.jpg` covers were already consistent — script no-ops on them.
- 5 books used `/artwork/...` URL family (different rewrite branch, not affected).

## Docs

Also adds full Mongo↔Supabase sync map in `.claude/docs/supabase.md` ("Sync Points (Complete Map)" + "Known Sync Gaps") and links from `system-map.md`. The PATCH-bypass and fixed-window-sync gaps that contributed to debugging this bug are described — first central inventory of sync state.

## Test plan
- [x] Verified live: `bph.sourcelibrary.org/` grid now serves single-page cover for Eckartshausen (1200×1833 portrait, was 1200×999 landscape)
- [x] Original spread still preserved at `archived/69099634cf28baa1b4cae779/8.jpg`
- [x] Script is idempotent — re-running on already-fixed books is a no-op (sample-tested)
- [ ] After merge: spot-check the other 5 fixed books on the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)