### PR TITLE
MCP: per-tool usage logging

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,6 +1,8 @@
 import type { NextRequest } from 'next/server';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { withApiAuth } from '@/lib/api-auth';
+import { logMcpToolCall } from '@/lib/mcp-usage';
+import { getClientIp } from '@/lib/rate-limit';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -394,7 +396,7 @@ async function fetchImageBase64(url: string): Promise<{ data: string; mimeType: 
 
 // ── Create a fresh MCP server instance (stateless per-request) ─────
 
-function createServer() {
+function createServer(reqContext: { ip: string; userAgent: string | null }) {
   const server = new Server(
     { name: 'source-library', version: '4.2.0' },
     { capabilities: { tools: {} } },
@@ -409,8 +411,14 @@ function createServer() {
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
+    const argsObj = (args || {}) as ToolArgs;
+    const started = Date.now();
     try {
-      const result = await handleToolCall(name, (args || {}) as ToolArgs);
+      const result = await handleToolCall(name, argsObj);
+      logMcpToolCall({
+        tool: name, args: argsObj, ms: Date.now() - started,
+        ip: reqContext.ip, userAgent: reqContext.userAgent,
+      });
 
       // search_images: return image content blocks alongside text metadata
       if (name === 'search_images' && result && typeof result === 'object' && 'images' in result) {
@@ -437,8 +445,13 @@ function createServer() {
       const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
       return { content: [{ type: 'text' as const, text }] };
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logMcpToolCall({
+        tool: name, args: argsObj, ms: Date.now() - started, error: message,
+        ip: reqContext.ip, userAgent: reqContext.userAgent,
+      });
       return {
-        content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}` }],
+        content: [{ type: 'text' as const, text: `Error: ${message}` }],
         isError: true,
       };
     }
@@ -479,7 +492,10 @@ export const POST = withApiAuth(async (req: NextRequest) => {
       sessionIdGenerator: undefined, // Stateless for serverless
       enableJsonResponse: true,
     });
-    const server = createServer();
+    const server = createServer({
+      ip: getClientIp(req),
+      userAgent: req.headers.get('user-agent'),
+    });
     await server.connect(transport);
     try {
       return await transport.handleRequest(fixedReq, { parsedBody: body });

--- a/src/lib/mcp-usage.ts
+++ b/src/lib/mcp-usage.ts
@@ -1,0 +1,79 @@
+/**
+ * Append-only per-tool log for the MCP server. One doc per tool call.
+ *
+ * The HTTP-level `api_usage` log captures every POST to /api/mcp but doesn't
+ * know which tool was invoked. This log fills that gap so we can answer
+ * "which tools are getting used, how often, how fast, and where they fail."
+ *
+ * Indexes (created lazily on first write):
+ *   - { ts: 1 } TTL 90 days
+ *   - { tool: 1, ts: -1 } for "how is search_translations doing"
+ *   - { ip_hash: 1, ts: -1 } for per-client analysis
+ *
+ * Fire-and-forget; logging failures never affect the tool response.
+ */
+import { createHash } from 'crypto';
+import { getDb } from '@/lib/mongodb';
+
+const COLLECTION = 'mcp_tool_calls';
+
+let indexesEnsured = false;
+async function ensureIndexes() {
+  if (indexesEnsured) return;
+  indexesEnsured = true;
+  try {
+    const db = await getDb();
+    const col = db.collection(COLLECTION);
+    await Promise.all([
+      col.createIndex({ ts: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 90 }),
+      col.createIndex({ tool: 1, ts: -1 }),
+      col.createIndex({ ip_hash: 1, ts: -1 }),
+    ]);
+  } catch {
+    indexesEnsured = false;
+  }
+}
+
+function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+export interface LogMcpToolCallInput {
+  tool: string;
+  args: Record<string, unknown>;
+  ms: number;
+  error?: string | null;
+  ip: string;
+  userAgent: string | null;
+}
+
+export function logMcpToolCall(input: LogMcpToolCallInput): void {
+  void writeEntry(input).catch(() => {});
+}
+
+async function writeEntry(input: LogMcpToolCallInput) {
+  await ensureIndexes();
+  const db = await getDb();
+
+  // Truncated, JSON-safe arg summary. We keep keys + small string/number values
+  // so we can see "what does search_translations get queried for" without
+  // storing megabyte payloads or arbitrary nested user input.
+  const argSummary: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input.args || {})) {
+    if (v == null) argSummary[k] = v;
+    else if (typeof v === 'string') argSummary[k] = v.slice(0, 200);
+    else if (typeof v === 'number' || typeof v === 'boolean') argSummary[k] = v;
+    else argSummary[k] = typeof v;
+  }
+
+  await db.collection(COLLECTION).insertOne({
+    ts: new Date(),
+    tool: input.tool,
+    args: argSummary,
+    ms: input.ms,
+    ok: !input.error,
+    error: input.error || null,
+    ip_hash: hashIp(input.ip),
+    user_agent: (input.userAgent || '').slice(0, 200),
+  });
+}


### PR DESCRIPTION
## Summary
- New \`mcp_tool_calls\` collection captures tool name, truncated args, latency, error flag, ip_hash, UA per MCP tool invocation.
- \`api_usage\` already logs every POST to \`/api/mcp\`, but can't tell which tool was called or whether it errored. This fills that gap.
- Fire-and-forget; logging failures never affect the tool response. TTL 90 days.

## Why
We have ~6.7k MCP calls/week and zero visibility into which tools are being used or where they fail. Today's Claude-via-MCP feedback (see linked issue) flagged that \`search_translations\` returns 0 results on most multi-word queries — we have no way to verify the scope of that problem without tool-level logs.

## Test plan
- [ ] Hit the MCP from \`claude.ai\` after deploy
- [ ] Confirm \`mcp_tool_calls\` collection appears in Atlas with one doc per tool call
- [ ] Check \`{ tool: 1, ts: -1 }\` and \`{ ts: 1 }\` TTL indexes were created

🤖 Generated with [Claude Code](https://claude.com/claude-code)