### PR TITLE
Throttle archive-bulk worker (Atlas write saturation fix)

### DIFF
--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -198,11 +198,11 @@ const WORKERS = [
   },
   {
     name: 'archive-bulk',
-    cmd: 'node scripts/workers/archive-bulk.mjs --limit=100 --concurrency=3',
+    cmd: 'node scripts/workers/archive-bulk.mjs --limit=30 --concurrency=1',
     lock: '/tmp/sl-archive-bulk.lock',
     connections: 5,
     tier: 4,
-    interval: 600,      // every 10 min
+    interval: 1200,     // every 20 min — throttled 2026-05-15 after bulk import caused 8s search latency (Atlas write saturation from concurrent JP2 decompression + page inserts)
     healthMin: 'degraded',
     log: '/var/log/sourcelibrary/archive-bulk.log',
   },


### PR DESCRIPTION
## Summary
- Reduces archive-bulk worker from `--limit=100 --concurrency=3` to `--limit=30 --concurrency=1`
- Bumps interval from 10 min → 20 min
- Net ~9× lower load on Atlas + Hetzner CPU during bulk-import waves

## Context
On 2026-05-15, the BNCF Aldine bulk-import (739 books) caused MongoDB Atlas write saturation. Symptoms:
- Search latency for uncached queries: 8.2s (normal: <1s)
- Hetzner load avg: 22 (normal: ~10)
- 400+ books in concurrent \`archiving\` state, each triggering ~300 page inserts and JP2 decompressions

The scheduler was patched on Hetzner immediately to relieve site pressure. This PR captures that patch in git so it doesn't drift.

## Test plan
- [ ] Verify archive-bulk fires every 20 min (next scheduled run after merge)
- [ ] Verify only 1 \`opj_decompress\` process at a time
- [ ] Verify search latency stays <2s while bulk-imports are queued
- [ ] Verify \`pipeline_auto.status: archiving\` queue drains over time (slower but steady)

🤖 Generated with [Claude Code](https://claude.com/claude-code)