### PR TITLE
BPH stats: consolidate aggregation + stale-while-revalidate

### DIFF
--- a/src/app/api/embed/bph/stats/route.ts
+++ b/src/app/api/embed/bph/stats/route.ts
@@ -10,6 +10,17 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type',
 };
 
+// Tell Vercel/Cloudflare to serve the stale value while regenerating in
+// background. Without this, the first user after a deploy (or after the
+// 1-hour ISR window expires) eats the full cold-rebuild latency — which on
+// this endpoint was 8–12s for the BPH iframe. With stale-while-revalidate,
+// users see the previous value instantly and the new value fills in for
+// the next request.
+const CACHE_HEADERS = {
+  ...CORS_HEADERS,
+  'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+};
+
 export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
 }
@@ -24,6 +35,13 @@ export async function OPTIONS() {
  * - languages: number of distinct original languages
  * - pages_total: total pages across all BPH books
  * - pages_translated: total translated pages
+ *
+ * Previously this ran 4 parallel MongoDB queries (2 countDocuments, distinct,
+ * aggregate). The `pages_translated > 0` countDocuments wasn't covered by
+ * the held_by_visible_pages index and had to FETCH every BPH book — the
+ * single slowest call (~1s locally, multi-second cold on Vercel). All four
+ * are now folded into one aggregation that walks the index once and emits
+ * every metric in a single $group stage.
  */
 export async function GET() {
   try {
@@ -36,36 +54,47 @@ export async function GET() {
       pages_count: { $gt: 0 },
     };
 
-    const [totalResult, translatedResult, languagesResult, pagesResult, catalogResult] = await Promise.all([
-      books.countDocuments(bphFilter),
-      books.countDocuments({ ...bphFilter, pages_translated: { $gt: 0 } }),
-      books.distinct('language', bphFilter),
+    const [aggResult, catalogResult] = await Promise.all([
       books.aggregate([
         { $match: bphFilter },
         {
           $group: {
             _id: null,
+            total: { $sum: 1 },
+            translated: {
+              $sum: { $cond: [{ $gt: ['$pages_translated', 0] }, 1, 0] },
+            },
             pages_total: { $sum: '$pages_count' },
             pages_translated: { $sum: '$pages_translated' },
+            languages: { $addToSet: '$language' },
           },
         },
       ]).toArray(),
       supabase.from('bph_works').select('*', { count: 'exact', head: true }),
     ]);
 
-    const pageStats = pagesResult[0] || { pages_total: 0, pages_translated: 0 };
+    const row = aggResult[0] || {
+      total: 0,
+      translated: 0,
+      pages_total: 0,
+      pages_translated: 0,
+      languages: [],
+    };
+    const languageList = (row.languages as Array<string | null | undefined> | undefined ?? [])
+      .filter((l): l is string => Boolean(l))
+      .sort();
 
     return NextResponse.json({
       catalog_total: catalogResult.count || 0,
-      digitized: totalResult,
+      digitized: row.total,
       // Keep 'total' for backwards compat with existing consumers
-      total: totalResult,
-      translated: translatedResult,
-      languages: languagesResult.filter(Boolean).length,
-      language_list: languagesResult.filter(Boolean).sort(),
-      pages_total: pageStats.pages_total,
-      pages_translated: pageStats.pages_translated,
-    }, { headers: CORS_HEADERS });
+      total: row.total,
+      translated: row.translated,
+      languages: languageList.length,
+      language_list: languageList,
+      pages_total: row.pages_total,
+      pages_translated: row.pages_translated,
+    }, { headers: CACHE_HEADERS });
   } catch (error) {
     console.error('BPH stats error:', error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary

First user hitting `bph.sourcelibrary.org/` after a deploy was waiting 8-12s for the page. Subsequent users were fast (~1s). The bottleneck wasn't rendering — it was `/api/embed/bph/stats` blocking on a cold-cache rebuild.

Two changes:

1. **Consolidate 4 parallel Mongo queries into 1 aggregation.** The old route ran 2 `countDocuments`, 1 `distinct`, 1 `aggregate(sum)`. Query #2 (`pages_translated > 0` count) wasn't covered by the `held_by_visible_pages` index — it had to FETCH every BPH book. Now one `$group` stage emits everything from one index walk.

2. **Add `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`.** Vercel/Cloudflare serves the previous value while regenerating in background. Post-deploy / post-ISR users never wait on the cold rebuild — they see stale data instantly, next request sees fresh.

Output shape unchanged. Verified the numbers match the previous implementation: total=2888, translated=2884, pages_total=933208, pages_translated=897539, languages=41.

## Test plan

- [x] Local: consolidated aggregation returns identical values to the old 4-query approach
- [ ] After deploy: `curl https://bph.sourcelibrary.org/api/embed/bph/stats` cold should respond fast (was 8-12s)
- [ ] After deploy: `curl -I` should show `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`
- [ ] Iframe at embassyofthefreemind.com/digital-collection-search should load in ~1s instead of ~10s

## Context

Surfaced while debugging "did anything from yesterday's cover-variants work slow down the iframe?" — answer was no, but the cold-rebuild penalty is real and worth fixing. The cover-variants work is in PR #1754 (separate, in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)