### PR TITLE
Fix enrich-worker stuck runs + fault-isolate search lanes

### DIFF
--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -78,6 +78,9 @@ const BOOK_CONCURRENCY = parseInt(process.env.ENRICH_CONCURRENCY || '8');
 const MAX_BATCH_CONCURRENCY = 20; // Cap parallel Gemini calls per book (prevents 100+ simultaneous calls for huge books)
 const SINGLE_BOOK = args.find(a => a.startsWith('--book='))?.split('=')[1];
 const MAX_RUNTIME_MS = 90 * 60 * 1000; // 90 min hard cap — prevents 12h runs blocking the scheduler
+const PHASE_7_BOOK_TIMEOUT_MS = 5 * 60 * 1000;  // 5 min per book for chapter extraction
+const PHASE_7_5_BOOK_TIMEOUT_MS = 2 * 60 * 1000; // 2 min per book for quality scoring (one Gemini call)
+const PHASE_7_6_BATCH_TIMEOUT_MS = 3 * 60 * 1000; // 3 min per collection-assignment batch
 const PROCESS_START = Date.now();
 const PER_BOOK_TIMEOUT_MS = 10 * 60 * 1000; // 10 min per book max
 
@@ -1542,6 +1545,11 @@ async function main() {
       const chQueue = [...books];
       const chWorkers = Array.from({ length: Math.min(BOOK_CONCURRENCY, chQueue.length) }, async () => {
         while (chQueue.length > 0) {
+          if (Date.now() - PROCESS_START > MAX_RUNTIME_MS) {
+            console.log(`  Runtime limit reached (${Math.round(MAX_RUNTIME_MS / 60000)}min) — stopping Phase 7`);
+            chQueue.length = 0;
+            break;
+          }
           const book = chQueue.shift();
           try {
             if ((book.pages_count || 0) < 10) {
@@ -1551,7 +1559,10 @@ async function main() {
             }
 
             await setPipelineStatus(db, book.id, 'chapters');
-            await extractChaptersForBook(db, book.id);
+            await Promise.race([
+              extractChaptersForBook(db, book.id),
+              new Promise((_, reject) => setTimeout(() => reject(new Error(`Phase 7 timeout after ${Math.round(PHASE_7_BOOK_TIMEOUT_MS / 60000)}min`)), PHASE_7_BOOK_TIMEOUT_MS)),
+            ]);
             await setPipelineStatus(db, book.id, 'chapters_complete', { 'pipeline_auto.retry_count': 0 });
             revalidateBookPage(book.id).catch(() => {});
             chaptersExtracted++;
@@ -1612,6 +1623,10 @@ async function main() {
     console.log(`  Unscored books found: ${unscoredBooks.length}`);
 
     for (const book of unscoredBooks) {
+      if (Date.now() - PROCESS_START > MAX_RUNTIME_MS) {
+        console.log(`  Runtime limit reached (${Math.round(MAX_RUNTIME_MS / 60000)}min) — stopping Phase 7.5`);
+        break;
+      }
       const title = book.display_title || book.title;
       try {
         const galleryCount = await db.collection('gallery_images').countDocuments({ book_id: book.id });
@@ -1653,7 +1668,10 @@ Guidelines:
           generationConfig: { temperature: 0.1, maxOutputTokens: 2048, responseMimeType: 'application/json' },
         });
 
-        const result = await model.generateContent(prompt);
+        const result = await Promise.race([
+          model.generateContent(prompt),
+          new Promise((_, reject) => setTimeout(() => reject(new Error(`Phase 7.5 Gemini timeout after ${Math.round(PHASE_7_5_BOOK_TIMEOUT_MS / 60000)}min`)), PHASE_7_5_BOOK_TIMEOUT_MS)),
+        ]);
         const text = result.response.text().trim();
         const usageMeta = result.response.usageMetadata;
 
@@ -1800,6 +1818,10 @@ NO explanation, just the JSON array.`;
       if (unclassifiedBooks.length > 0 && !DRY_RUN) {
         // Process in batches of COLLECTION_BATCH_SIZE
         for (let i = 0; i < unclassifiedBooks.length; i += COLLECTION_BATCH_SIZE) {
+          if (Date.now() - PROCESS_START > MAX_RUNTIME_MS) {
+            console.log(`  Runtime limit reached (${Math.round(MAX_RUNTIME_MS / 60000)}min) — stopping Phase 7.6`);
+            break;
+          }
           const batch = unclassifiedBooks.slice(i, i + COLLECTION_BATCH_SIZE);
 
           const booksText = batch.map((b, idx) => {
@@ -1821,7 +1843,10 @@ NO explanation, just the JSON array.`;
                 systemInstruction: collectionSystemPrompt,
               });
 
-              const result = await model.generateContent(prompt);
+              const result = await Promise.race([
+                model.generateContent(prompt),
+                new Promise((_, reject) => setTimeout(() => reject(new Error(`Phase 7.6 Gemini timeout after ${Math.round(PHASE_7_6_BATCH_TIMEOUT_MS / 60000)}min`)), PHASE_7_6_BATCH_TIMEOUT_MS)),
+              ]);
               const text = result.response.text().trim();
               const usageMeta = result.response.usageMetadata;
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -161,47 +161,54 @@ export const GET = withApiAuth(async (request: NextRequest) => {
       // --- Book search via Supabase trigram (fast, no cold-start penalty) ---
       (async () => {
         if (bookId || pagesOnly) return [];
-        const matchingIds = await searchBookIds(query, { limit: limit * 2 });
-        const bookFilters = buildBookFilters();
-        const bookProjection = { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, is_first_translation: 1, quality_score: 1, summary: 1, reading_summary: 1, work_id: 1 };
+        try {
+          const matchingIds = await searchBookIds(query, { limit: limit * 2 });
+          const bookFilters = buildBookFilters();
+          const bookProjection = { id: 1, slug: 1, title: 1, display_title: 1, author: 1, editor: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, language: 1, published: 1, pages_count: 1, pages_translated: 1, doi: 1, categories: 1, is_first_translation: 1, quality_score: 1, summary: 1, reading_summary: 1, work_id: 1 };
 
-        let books: any[] = [];
-        if (matchingIds.length > 0) {
-          books = await db.collection('books')
-            .find({ id: { $in: matchingIds }, ...bookFilters })
-            .project(bookProjection)
-            .limit(limit)
-            .maxTimeMS(5000)
-            .toArray();
-        }
-
-        // Metadata fallback: search categories/subject_keywords/language in MongoDB
-        // Only fires when Supabase found nothing (avoids slow regex on common queries)
-        if (books.length === 0) {
-          const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
-          const words = matchQuery.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
-          if (words.length >= 2) {
-            const wordRegexes = words.map((w: string) => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+          let books: any[] = [];
+          if (matchingIds.length > 0) {
             books = await db.collection('books')
-              .find({
-                $and: wordRegexes.map(rx => ({
-                  $or: [
-                    { categories: rx },
-                    { subject_keywords: rx },
-                    { language: rx },
-                    { title: rx },
-                    { display_title: rx },
-                  ],
-                })),
-                ...bookFilters,
-              })
+              .find({ id: { $in: matchingIds }, ...bookFilters })
               .project(bookProjection)
               .limit(limit)
-              .maxTimeMS(3000)
+              .maxTimeMS(5000)
               .toArray();
           }
+
+          // Metadata fallback: search categories/subject_keywords/language in MongoDB
+          // Only fires when Supabase found nothing (avoids slow regex on common queries)
+          if (books.length === 0) {
+            const STOPWORDS = new Set(['a', 'an', 'and', 'at', 'by', 'de', 'der', 'des', 'di', 'du', 'el', 'en', 'et', 'for', 'from', 'in', 'la', 'le', 'les', 'of', 'on', 'or', 'the', 'to', 'und', 'von', 'with']);
+            const words = matchQuery.trim().split(/\s+/).filter((w: string) => w.length >= 3 && !STOPWORDS.has(w.toLowerCase()));
+            if (words.length >= 2) {
+              const wordRegexes = words.map((w: string) => new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+              books = await db.collection('books')
+                .find({
+                  $and: wordRegexes.map(rx => ({
+                    $or: [
+                      { categories: rx },
+                      { subject_keywords: rx },
+                      { language: rx },
+                      { title: rx },
+                      { display_title: rx },
+                    ],
+                  })),
+                  ...bookFilters,
+                })
+                .project(bookProjection)
+                .limit(limit)
+                .maxTimeMS(3000)
+                .toArray();
+            }
+          }
+          return books;
+        } catch (err) {
+          // Fail-soft: a Supabase trigram timeout or MongoDB error should not 500 the whole route.
+          // The other 3 lanes (Atlas Search, semantic books, semantic pages) can still produce results.
+          console.warn('[search] Book lane failed:', err instanceof Error ? err.message : String(err));
+          return [];
         }
-        return books;
       })(),
 
       // --- Page content search (aggregation pipeline truncates text for snippets) ---


### PR DESCRIPTION
## Summary
Two fixes for the Atlas write saturation incident that started **2026-05-14 23:00 UTC**. PR #1759 throttled archive-bulk; these address the other two failure modes that surfaced during diagnosis.

## enrich-worker: timeout guards on Phase 7, 7.5, 7.6
Phase 6 (Summary+Index) already had \`MAX_RUNTIME_MS\` and a per-book \`Promise.race\`. The later phases had neither — a single hung Gemini call could (and did) keep the worker alive for **14h 26min** with no log output, holding the lock and burning 90% CPU.

- \`MAX_RUNTIME_MS\` check at the top of each phase loop
- Per-book \`Promise.race\` timeouts: 5min (Phase 7), 2min (7.5), 3min (7.6)
- Hard caps named so they can be tuned without re-deriving the magic numbers

## /api/search: fault-isolate the book search lane
The 4 search lanes (Supabase trigram books, Atlas Search pages, semantic books, semantic pages) run via \`Promise.all\`. Three of the four had try/catch returning \`[]\`. The book lane did not — when \`searchBookIds\` or the MongoDB call threw under load, the whole route 500'd even though three other lanes were ready to serve degraded results.

Wrapping the book lane in try/catch turns "search broken" into "search slower but functional" during incidents.

## Context
- Incident report and diagnosis: traced via \`mcp_tool_calls\` (PR #1755) + \`api_usage\` time-series
- Repro: \`active intellect\`, \`common sense\`, \`general will\` all 500'd at ~3s during the incident — \`universal intellect\` worked at 5s
- Killed stuck enrich-worker (PID 2130028) and cleaned 1.4GB of leaked \`/tmp/sl-bulk-ita-bnc-ald-*\` on Hetzner during triage

## Test plan
- [ ] Verify enrich-worker runs that would have hung now log \`Runtime limit reached\` or \`Phase 7 timeout\` instead
- [ ] Verify \`/api/search?q=active%20intellect\` returns 200 (with whatever degraded results the surviving lanes produce) instead of 500
- [ ] Confirm the existing MCP feedback issue (#1756) becomes easier to verify once search returns honest results

🤖 Generated with [Claude Code](https://claude.com/claude-code)