### PR TITLE
Capture errors the dashboard was missing (global error.tsx + onRequestError)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import Link from 'next/link';
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
+import { reportError } from '@/components/providers/ErrorReporter';
 
 export default function GlobalError({
   error,
@@ -13,6 +14,11 @@ export default function GlobalError({
 }) {
   useEffect(() => {
     console.error('Application error:', error);
+    reportError({
+      message: error.digest ? `${error.message} [digest:${error.digest}]` : error.message,
+      stack: error.stack,
+      source: 'app_error_boundary',
+    });
   }, [error]);
 
   return (

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,77 @@
+/**
+ * Next.js instrumentation hook — runs once per server process at startup.
+ * The `onRequestError` export is invoked for every unhandled error during
+ * server rendering, route handlers, server actions, and middleware.
+ *
+ * Without this hook, server-render errors only surface as a React `digest`
+ * in the response HTML and a stack in Vercel logs — never reaching the
+ * `application_errors` collection. That made the BPH iframe outage on
+ * 2026-05-15 invisible to the admin error dashboard.
+ *
+ * What this does:
+ *   1. Always console.error a structured line so Vercel logs reliably catch
+ *      it even when the Atlas write path itself is failing.
+ *   2. Fire-and-forget POST to /api/errors so the row lands in
+ *      `application_errors` when Atlas is healthy.
+ */
+
+export function register() {
+  // No global setup needed — onRequestError is the workhorse.
+}
+
+type RequestErrorRequest = {
+  path: string;
+  method: string;
+  headers: { [key: string]: string };
+};
+
+type RequestErrorContext = {
+  routerKind: 'Pages Router' | 'App Router';
+  routePath: string;
+  routeType: 'render' | 'route' | 'action' | 'middleware';
+  renderSource?: string;
+  renderType?: string;
+};
+
+export async function onRequestError(
+  err: (Error & { digest?: string }) | unknown,
+  request: RequestErrorRequest,
+  context: RequestErrorContext
+): Promise<void> {
+  const e = err instanceof Error ? err : new Error(String(err));
+  const digest = (e as { digest?: string }).digest;
+
+  const payload = {
+    message: digest ? `${e.message} [digest:${digest}]` : e.message,
+    stack: e.stack,
+    source: `server_${context.routeType}`,
+    url: request.path,
+    userAgent: request.headers['user-agent'],
+    componentStack: `${context.routerKind} ${context.routePath} (${context.renderSource || 'n/a'})`,
+  };
+
+  console.error('[onRequestError]', JSON.stringify({
+    msg: payload.message,
+    path: request.path,
+    method: request.method,
+    routeType: context.routeType,
+    digest,
+  }));
+
+  // Best-effort POST to /api/errors. Uses the request's own host so it
+  // works in any environment (preview, prod, local). Swallows failures
+  // because the error path must never throw.
+  try {
+    const host = request.headers.host;
+    if (!host) return;
+    const proto = request.headers['x-forwarded-proto'] || 'https';
+    await fetch(`${proto}://${host}/api/errors`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    // Already logged via console.error above.
+  }
+}


### PR DESCRIPTION
## Summary

The 2026-05-15 BPH iframe outage made user-visible errors invisible to the admin dashboard. Two distinct gaps:

1. **`src/app/error.tsx`** (the Next.js global boundary that renders "Something went wrong") only `console.error`'d. It never called `reportError()`, so the very pages users were complaining about never reached `application_errors`.
2. **Server-side render failures bypass the client `ErrorReporter` entirely.** They surface only as a React `digest` in the response HTML and a stack in Vercel logs. During the BPH outage, every broken iframe load left a digest in the body but no admin-dashboard row.

## Changes

- `src/app/error.tsx`: now calls `reportError({ source: 'app_error_boundary', ... })` with the digest appended to `message` so client and server crashes can be correlated.
- `src/instrumentation.ts` (new): Next.js `onRequestError` hook. Always emits a structured `console.error` line (so Vercel logs catch it even when Atlas is down — important during DB incidents) and best-effort POSTs to `/api/errors`.

## Test plan

- [ ] After deploy: throw from a server component in a preview, confirm a row lands in `application_errors` with `source: server_render`
- [ ] Trigger the client error boundary (e.g. via DevTools), confirm a row with `source: app_error_boundary`
- [ ] Verify `console.error('[onRequestError]', ...)` lines appear in `vercel logs` for any 500
- [ ] Verify the hook does not slow the happy path — instrumentation only fires on error

## Why now

Next outage of this shape (Atlas saturation, Supabase slowness, dependency timeout) should fill the dashboard with rows naming the broken route + digest, so triage starts with data instead of a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)