### PR TITLE
Embed perf: skip dominantProvider query for known partners (BPH 4s → 0.25s)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,15 @@
       "Bash(ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=3 root@46.224.122.120 \"tail -F /var/log/sourcelibrary/hires-backfill.log\")",
       "Bash(grep -E --line-buffered \"Stragglers|Done|FAIL|Error|BPH books|/[0-9]+$\")",
       "Bash(ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=3 root@46.224.122.120 \"tail -F /var/log/sourcelibrary/hires-backfill-retry.log\")",
-      "Bash(ssh -o ServerAliveInterval=30 root@46.224.122.120 \"tail -F /var/log/sourcelibrary/r2-snapshot.log\")"
+      "Bash(ssh -o ServerAliveInterval=30 root@46.224.122.120 \"tail -F /var/log/sourcelibrary/r2-snapshot.log\")",
+      "mcp__chrome-devtools__list_pages",
+      "mcp__chrome-devtools__new_page",
+      "mcp__chrome-devtools__evaluate_script",
+      "mcp__chrome-devtools__navigate_page",
+      "Skill(curator)",
+      "mcp__chrome-devtools__take_screenshot",
+      "mcp__chrome-devtools__list_network_requests",
+      "mcp__chrome-devtools__list_console_messages"
     ]
   }
 }

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -42,12 +42,9 @@ const CATALOG_PARAM_KEYS = [
 const BOOKS_PARAM_KEYS = ['q', 'sort', 'language', 'offset'];
 
 export default async function EmbedTenantRoot({ params, searchParams }: Props) {
-    const __t0 = Date.now();
-    const __tick = (label: string) => console.log(`[embed/[tenant]] ${label} +${Date.now() - __t0}ms`);
     const { tenant } = await params;
     const tenantId = await resolveTenantId(tenant);
     if (!tenantId) notFound();
-    __tick(`resolveTenantId tenant=${tenant}`);
 
     const sp = await searchParams;
     // BPH partner prefers Oldest first so a fresh visit lands on the
@@ -87,10 +84,8 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     }
 
     const db = await getDb();
-    __tick('getDb');
     const tenantDoc = await db.collection('tenants').findOne({ id: tenantId });
     if (!tenantDoc) notFound();
-    __tick('tenants.findOne');
 
     // Cheap pre-check so the Supabase catalogue-id fetch can run in parallel
     // with the main library fetch. dominantProvider is the canonical isBph
@@ -129,7 +124,6 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         knownPartner ? Promise.resolve(null) : getTenantDominantProvider(tenantId),
         probablyBph && !skipHeavyLoaders ? fetchTenantBphCataloguedBookIds() : Promise.resolve(null),
     ]);
-    __tick(`batch1 (skipHeavy=${skipHeavyLoaders}, knownPartner=${!!knownPartner})`);
 
     // Filter the Selected Books row to books that exist in the Supabase
     // catalogue (bph_works.sl_book_id). Consistent with the catalogue list
@@ -155,7 +149,6 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
             fetchTenantBphCatalogTotal(tenantId),
         ])
         : [{} as Record<string, { id: string; slug: string }>, 0];
-    __tick(`batch2 (isBph=${isBph})`);
 
     const basePath = `/embed/${tenant}`;
 

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -42,9 +42,12 @@ const CATALOG_PARAM_KEYS = [
 const BOOKS_PARAM_KEYS = ['q', 'sort', 'language', 'offset'];
 
 export default async function EmbedTenantRoot({ params, searchParams }: Props) {
+    const __t0 = Date.now();
+    const __tick = (label: string) => console.log(`[embed/[tenant]] ${label} +${Date.now() - __t0}ms`);
     const { tenant } = await params;
     const tenantId = await resolveTenantId(tenant);
     if (!tenantId) notFound();
+    __tick(`resolveTenantId tenant=${tenant}`);
 
     const sp = await searchParams;
     // BPH partner prefers Oldest first so a fresh visit lands on the
@@ -84,8 +87,10 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     }
 
     const db = await getDb();
+    __tick('getDb');
     const tenantDoc = await db.collection('tenants').findOne({ id: tenantId });
     if (!tenantDoc) notFound();
+    __tick('tenants.findOne');
 
     // Cheap pre-check so the Supabase catalogue-id fetch can run in parallel
     // with the main library fetch. dominantProvider is the canonical isBph
@@ -116,6 +121,7 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         getTenantDominantProvider(tenantId),
         probablyBph && !skipHeavyLoaders ? fetchTenantBphCataloguedBookIds() : Promise.resolve(null),
     ]);
+    __tick(`batch1 (skipHeavy=${skipHeavyLoaders})`);
 
     // Filter the Selected Books row to books that exist in the Supabase
     // catalogue (bph_works.sl_book_id). Consistent with the catalogue list
@@ -141,6 +147,7 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
             fetchTenantBphCatalogTotal(tenantId),
         ])
         : [{} as Record<string, { id: string; slug: string }>, 0];
+    __tick(`batch2 (isBph=${isBph})`);
 
     const basePath = `/embed/${tenant}`;
 

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -107,6 +107,14 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     // browser before render finished. Skip them and pass empty placeholders.
     const skipHeavyLoaders = probablyBph && (view === 'catalog' || view === 'books');
 
+    // dominantProvider is only consulted as a fallback when the tenant slug
+    // doesn't map to a known partner — for known slugs (bph, ficino, bhutan,
+    // …) `getPartnerBySlug` already wins. For BPH specifically this
+    // aggregation is a `$group` over ~17K books and was the 4–8s warm SSR
+    // bottleneck on cold lambdas (cache is per-instance and misses often).
+    // Skip the query when we already know the partner from the slug.
+    const knownPartner = getPartnerBySlug(tenant);
+
     const [libraryData, dominantProvider, cataloguedBookIds] = await Promise.all([
         skipHeavyLoaders
             ? Promise.resolve({
@@ -118,10 +126,10 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
                 contributingLibraries: [],
             } as Awaited<ReturnType<typeof fetchTenantLibraryData>>)
             : fetchTenantLibraryData(tenantId, sort, language, offset, q || undefined),
-        getTenantDominantProvider(tenantId),
+        knownPartner ? Promise.resolve(null) : getTenantDominantProvider(tenantId),
         probablyBph && !skipHeavyLoaders ? fetchTenantBphCataloguedBookIds() : Promise.resolve(null),
     ]);
-    __tick(`batch1 (skipHeavy=${skipHeavyLoaders})`);
+    __tick(`batch1 (skipHeavy=${skipHeavyLoaders}, knownPartner=${!!knownPartner})`);
 
     // Filter the Selected Books row to books that exist in the Supabase
     // catalogue (bph_works.sl_book_id). Consistent with the catalogue list
@@ -132,7 +140,7 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         : libraryData.topBooks;
     const { books, total, languages, galleryImages, contributingLibraries } = libraryData;
 
-    const canonicalPartner = getPartnerBySlug(tenant) || (dominantProvider ? getPartnerByProvider(dominantProvider) : undefined);
+    const canonicalPartner = knownPartner || (dominantProvider ? getPartnerByProvider(dominantProvider) : undefined);
     const tenantRecord = tenantDoc as Record<string, unknown>;
     const tenantExternalUrl =
         getOptionalStringField(tenantRecord.url) ||

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -67,16 +67,29 @@ export function getTenantContextFromRequest(
 }
 
 /**
- * Resolve a tenant slug → UUID, using KV cache (5 min TTL) with DB fallback.
+ * Resolve a tenant slug → UUID, with a 5-minute in-memory cache.
  * Returns null if no active/suspended tenant exists for the slug.
  * Used in API routes and server actions that receive a slug param but run
  * outside the [tenant] layout (e.g. /api/platform/tenants/[slug]/invite).
+ *
+ * Slug → id mapping is essentially immutable in practice (renames are rare
+ * and require migration), so the cache is safe to keep long. Negative
+ * results are cached too — a 5-minute window of "no such tenant" is fine
+ * because new tenants take longer than that to fully provision.
  */
+const TENANT_ID_TTL_MS = 5 * 60_000;
+const cachedTenantId = new Map<string, { value: string | null; expiresAt: number }>();
+
 export async function resolveTenantId(slug: string): Promise<string | null> {
+  const now = Date.now();
+  const hit = cachedTenantId.get(slug);
+  if (hit && hit.expiresAt > now) return hit.value;
   const db = await getDb();
   const tenant = await db.collection('tenants').findOne({
     slug,
     status: { $ne: 'deleted' },
   });
-  return tenant ? (tenant.id as string) : null;
+  const value = tenant ? (tenant.id as string) : null;
+  cachedTenantId.set(slug, { value, expiresAt: now + TENANT_ID_TTL_MS });
+  return value;
 }

--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -349,8 +349,20 @@ export async function fetchTenantLibraryData(
 /**
  * Determine the dominant image source provider for a tenant.
  * Used to apply provider-specific defaults (e.g., BPH catalog).
+ *
+ * Group-by aggregation across all tenant books (~17K for BPH) was the
+ * dominant cost in the embed SSR path on warm lambdas — TTFB ~230ms,
+ * total ~5s, with this query accounting for most of the gap. The
+ * dominant provider for a tenant changes on the order of weeks, so a
+ * long-lived per-lambda cache is safe and cheap.
  */
+const TENANT_DOMINANT_PROVIDER_TTL_MS = 5 * 60_000;
+const cachedDominantProvider = new Map<string, { value: string | null; expiresAt: number }>();
+
 export async function getTenantDominantProvider(tenantId: string): Promise<string | null> {
+  const now = Date.now();
+  const hit = cachedDominantProvider.get(tenantId);
+  if (hit && hit.expiresAt > now) return hit.value;
   try {
     const db = await getReadDb();
     const result = await db.collection('books').aggregate([
@@ -359,10 +371,13 @@ export async function getTenantDominantProvider(tenantId: string): Promise<strin
       { $sort: { count: -1 } },
       { $limit: 1 },
     ], { maxTimeMS: 4_000 }).toArray();
-    return result[0]?._id || null;
+    const value = (result[0]?._id as string | undefined) || null;
+    cachedDominantProvider.set(tenantId, { value, expiresAt: now + TENANT_DOMINANT_PROVIDER_TTL_MS });
+    return value;
   } catch (err) {
     console.warn('[tenant-library-loaders] getTenantDominantProvider failed:', err);
-    return null;
+    // Serve stale on error if we have any prior value.
+    return hit?.value ?? null;
   }
 }
 


### PR DESCRIPTION
## Why

BPH embed SSR was rendering at ~4s warm on Vercel (vs ~200ms for ficino/bhutan baseline) — TTFB fast but body trickling in over seconds. Earlier diagnoses (slow loaders, cold lambdas) led to PR #1757 + PR #1767 adding caches, but those didn't fix it — caches are per-Vercel-instance and Vercel keeps spinning fresh lambdas under load.

Targeted instrumentation (now reverted) on the SSR `await`s identified the actual culprit: `getTenantDominantProvider` — a Mongo `\$group` aggregation over ~17K BPH books — was the only call doing real work in the warm Promise.all, and it was hanging for 4-8s on every fresh lambda instance.

## What
`src/app/embed/[tenant]/page.tsx`:
- When the tenant slug matches a known partner via `getPartnerBySlug(tenant)` (bph, ficino, bhutan, …), skip `getTenantDominantProvider` entirely. The dominant-provider value is only consulted as a fallback for the `canonicalPartner` derivation; if the slug match already returned a partner, the value is never read.

`src/lib/tenant-library-loaders.ts` (already in earlier commits in this branch):
- Per-lambda TTL cache on `getTenantDominantProvider` (5 min) — still useful for custom tenants that don't match a known partner.

`src/lib/tenant-context.ts`:
- Per-lambda TTL cache on `resolveTenantId` (5 min). The docstring already promised a cache; implementation now matches.

## Measured impact
Tested on preview deploy `4o0b0z2sy`:

| Try | BPH total | Notes |
|---:|---:|---|
| 1 (cold) | 5.5s | First request to fresh lambda |
| 2 | 3.9s | Warming |
| 3 | 2.1s | Warming |
| 4 | **0.42s** | Warm — matches ficino baseline |
| 5 | **0.25s** | Warm |

Ficino baseline on same preview: **0.31s**.

Warm-state BPH SSR: **4s → 0.25s** = ~16× faster. EFM iframe should be near-instant from now on.

## Test plan
- [x] Preview verified — 5 consecutive requests, content rendered, no RSC errors.
- [ ] After merge & prod deploy: verify `https://sourcelibrary.org/embed/bph` consistently <500ms warm.
- [ ] Verify EFM iframe (`https://embassyofthefreemind.com/digital-collection-search`) loads quickly end-to-end.
- [ ] Spot-check other tenants (`/embed/ficino`, `/embed/bhutan`) haven't regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)