### PR TITLE
embed/tenant: TTL cache around fetchTenantLibraryData (iframe 4-6s → ~instant)

### DIFF
--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -260,10 +260,46 @@ function sanitizeGalleryImageDoc(doc: Record<string, unknown>): Record<string, u
   };
 }
 
+// In-memory TTL cache for fetchTenantLibraryData.
+// The function runs 5+ queries (Mongo + Supabase) and gates the entire embed
+// /embed/[tenant] render. Without a cache, every iframe load eats the full
+// 4-6s rebuild because pages with `await searchParams` are dynamic — Next.js
+// can't cache them with `revalidate`. A 5-min in-memory TTL is enough to
+// span normal browsing sessions while staying near-live. Cache is per-Vercel-
+// function-instance (no shared cross-instance state needed); cold function
+// starts pay the rebuild but warm ones serve from RAM.
+const TENANT_LIBRARY_CACHE_TTL_MS = 5 * 60_000;
+const tenantLibraryCache = new Map<string, { value: TenantLibraryData; expiresAt: number }>();
+
 /**
  * Fetch all library data for a tenant, scoped by tenantId instead of provider.
  */
 export async function fetchTenantLibraryData(
+  tenantId: string,
+  sort: string,
+  language: string,
+  offset: number,
+  q?: string,
+): Promise<TenantLibraryData> {
+  const cacheKey = JSON.stringify([tenantId, sort, language, offset, q || '']);
+  const now = Date.now();
+  const cached = tenantLibraryCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) return cached.value;
+
+  const result = await fetchTenantLibraryDataUncached(tenantId, sort, language, offset, q);
+  tenantLibraryCache.set(cacheKey, { value: result, expiresAt: now + TENANT_LIBRARY_CACHE_TTL_MS });
+
+  // Trim if cache grows unbounded (shouldn't, but defence-in-depth).
+  if (tenantLibraryCache.size > 200) {
+    const cutoff = now;
+    for (const [k, v] of tenantLibraryCache) {
+      if (v.expiresAt <= cutoff) tenantLibraryCache.delete(k);
+    }
+  }
+  return result;
+}
+
+async function fetchTenantLibraryDataUncached(
   tenantId: string,
   sort: string,
   language: string,


### PR DESCRIPTION
## Summary

The EFM iframe (`embassyofthefreemind.com/digital-collection-search`) takes 4-6s on every render because the underlying page (`/embed/bph`) is dynamic — Next.js can't statically cache it. Most of that time is `fetchTenantLibraryData`, which runs 5+ queries including an unbounded `contributing_library` SELECT over the full `books_catalog` table.

Wraps the function in a per-instance in-memory TTL cache (5 min) keyed by all 5 parameters. First hit pays the rebuild; subsequent identical requests return from RAM.

Same pattern already established in this file by `cachedBphCatalogTotal` and `cachedBphDigitizedMap`.

## Why per-instance is fine

- Iframe traffic concentrates on one URL (no params), so even one warm instance covers most users
- Cache survives across requests on a warm function
- Cold function starts pay the rebuild but warm up immediately for following users
- No cross-instance shared state to manage / invalidate

## Test plan
- [ ] After deploy: first `/embed/bph` hit ~4s (cold), subsequent hits well under 1s
- [ ] Iframe at embassyofthefreemind.com/digital-collection-search loads fast on second+ open
- [ ] Curator edits (covers, books) become visible within 5 min — acceptable staleness for the embed iframe

## Related

The stats endpoint got similar treatment in #1761 (consolidated aggregation + stale-while-revalidate). This is the same fix at the page-render layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)