### PR TITLE
Embed: cache dominant provider + tenant-id lookups (BPH SSR fix)

### DIFF
--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -67,16 +67,29 @@ export function getTenantContextFromRequest(
 }
 
 /**
- * Resolve a tenant slug → UUID, using KV cache (5 min TTL) with DB fallback.
+ * Resolve a tenant slug → UUID, with a 5-minute in-memory cache.
  * Returns null if no active/suspended tenant exists for the slug.
  * Used in API routes and server actions that receive a slug param but run
  * outside the [tenant] layout (e.g. /api/platform/tenants/[slug]/invite).
+ *
+ * Slug → id mapping is essentially immutable in practice (renames are rare
+ * and require migration), so the cache is safe to keep long. Negative
+ * results are cached too — a 5-minute window of "no such tenant" is fine
+ * because new tenants take longer than that to fully provision.
  */
+const TENANT_ID_TTL_MS = 5 * 60_000;
+const cachedTenantId = new Map<string, { value: string | null; expiresAt: number }>();
+
 export async function resolveTenantId(slug: string): Promise<string | null> {
+  const now = Date.now();
+  const hit = cachedTenantId.get(slug);
+  if (hit && hit.expiresAt > now) return hit.value;
   const db = await getDb();
   const tenant = await db.collection('tenants').findOne({
     slug,
     status: { $ne: 'deleted' },
   });
-  return tenant ? (tenant.id as string) : null;
+  const value = tenant ? (tenant.id as string) : null;
+  cachedTenantId.set(slug, { value, expiresAt: now + TENANT_ID_TTL_MS });
+  return value;
 }

--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -385,8 +385,20 @@ async function fetchTenantLibraryDataUncached(
 /**
  * Determine the dominant image source provider for a tenant.
  * Used to apply provider-specific defaults (e.g., BPH catalog).
+ *
+ * Group-by aggregation across all tenant books (~17K for BPH) was the
+ * dominant cost in the embed SSR path on warm lambdas — TTFB ~230ms,
+ * total ~5s, with this query accounting for most of the gap. The
+ * dominant provider for a tenant changes on the order of weeks, so a
+ * long-lived per-lambda cache is safe and cheap.
  */
+const TENANT_DOMINANT_PROVIDER_TTL_MS = 5 * 60_000;
+const cachedDominantProvider = new Map<string, { value: string | null; expiresAt: number }>();
+
 export async function getTenantDominantProvider(tenantId: string): Promise<string | null> {
+  const now = Date.now();
+  const hit = cachedDominantProvider.get(tenantId);
+  if (hit && hit.expiresAt > now) return hit.value;
   try {
     const db = await getReadDb();
     const result = await db.collection('books').aggregate([
@@ -395,10 +407,13 @@ export async function getTenantDominantProvider(tenantId: string): Promise<strin
       { $sort: { count: -1 } },
       { $limit: 1 },
     ], { maxTimeMS: 4_000 }).toArray();
-    return result[0]?._id || null;
+    const value = (result[0]?._id as string | undefined) || null;
+    cachedDominantProvider.set(tenantId, { value, expiresAt: now + TENANT_DOMINANT_PROVIDER_TTL_MS });
+    return value;
   } catch (err) {
     console.warn('[tenant-library-loaders] getTenantDominantProvider failed:', err);
-    return null;
+    // Serve stale on error if we have any prior value.
+    return hit?.value ?? null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add 5-min per-Lambda TTL caches around `resolveTenantId` (slug → UUID) and `getTenantDominantProvider` ($group aggregation over tenant books).
- Both were running uncached on every BPH embed render; the dominant-provider aggregation over ~17K BPH books was the dominant cost.

## Why now
BPH embed homepage was timing 3.5–10s wall-clock per request (worse on cold/parallel Lambdas). Same code path on Ficino/Bhutan returns in <300ms. The two uncached Mongo calls scaled with tenant size and crossed a noticeable threshold as BPH grew (recent dedup/import work pushed the catalogue to ~17K books).

PR #1757 capped the main loader; this finishes the job by hardening the two remaining hot calls.

## Expected effect
Warm BPH SSR drops from ~5s to <1s, in line with other tenants.

## Test plan
- [ ] Confirm `https://bph.sourcelibrary.org/` warm TTFB+total under 1s after deploy
- [ ] Confirm `https://sourcelibrary.org/embed/ficino` and `/embed/bhutan` unchanged (<300ms)
- [ ] No regression on `?view=catalogue`/`view=books` (skipHeavyLoaders path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)