### PR TITLE
Add match_semantic SQL migration (the missing RPC)

### DIFF
--- a/scripts/migration/add-match-semantic-rpc.sql
+++ b/scripts/migration/add-match-semantic-rpc.sql
@@ -1,0 +1,62 @@
+-- Global page-level semantic search RPC.
+-- Companion to match_books_semantic (book-level) and match_pages_in_books (scoped).
+-- Used by semanticPageSearchGlobal in src/lib/semantic-search.ts.
+--
+-- Why this RPC didn't exist: the lib function semanticPageSearchGlobal was added
+-- before the SQL function was deployed. It silently returned empty results for
+-- months because supabase.rpc() rejects with "function not found" and the lib
+-- catches the error and returns []. Discovered 2026-05-15 while shipping the
+-- MCP search_concept tool that depends on this.
+--
+-- Tenant filter: page_translations doesn't currently carry a tenant_id column,
+-- so we accept the parameter for API compatibility but ignore it. Add a
+-- tenant_id column + filter clause once multi-tenant page scoping is needed.
+
+CREATE OR REPLACE FUNCTION match_semantic(
+  query_embedding vector(768),
+  match_threshold FLOAT DEFAULT 0.3,
+  match_count INT DEFAULT 15,
+  filter_tenant_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  page_id TEXT,
+  book_id TEXT,
+  page_number INT,
+  translation TEXT,
+  book_title TEXT,
+  book_author TEXT,
+  book_language TEXT,
+  book_year INT,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.page_id,
+    p.book_id,
+    p.page_number,
+    p.translation,
+    p.book_title,
+    p.book_author,
+    p.book_language,
+    p.book_year,
+    1 - (p.embedding <=> query_embedding) AS similarity
+  FROM page_translations p
+  WHERE p.embedding IS NOT NULL
+    AND 1 - (p.embedding <=> query_embedding) > match_threshold
+    -- filter_tenant_id is accepted for API parity with match_books_semantic but
+    -- is currently a no-op: page_translations has no tenant_id column.
+  ORDER BY p.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+-- Note: relies on the existing HNSW index on page_translations.embedding.
+-- If query latency is slow (>1s on 4M rows), check:
+--   SELECT indexname FROM pg_indexes WHERE tablename = 'page_translations';
+-- Add if missing:
+--   CREATE INDEX page_translations_embedding_idx
+--     ON page_translations USING hnsw (embedding vector_cosine_ops)
+--     WITH (m = 16, ef_construction = 64);


### PR DESCRIPTION
The lib function \`semanticPageSearchGlobal\` calls \`supabase.rpc('match_semantic')\`, but the SQL function was **never deployed**. The lib's error path swallowed "function not found" and returned \`[]\`, so every page-level semantic call has silently failed for months — until today.

## What this PR does
- Adds the SQL definition for \`match_semantic(query_embedding, match_threshold, match_count, filter_tenant_id)\` to \`scripts/migration/\`. Modelled on the working \`match_pages_in_books\` minus the book_ids scope.
- The function has **already been applied to production Supabase** (via the Hetzner DB connection during today's session). This PR captures the SQL in git so the next environment (staging, local dev, backup restore) doesn't lose it.

## Live verification (function already running in prod)
| Query | Top result | Similarity |
|---|---|---|
| memory palace | Quintilian, Art of Memory, Simonides Redivivus | 0.76 |
| active intellect | Albert the Great, Secret of Secrets | 0.74 |
| transmutation of metals | Paracelsus, Chemical Theater | 0.79 |
| ouroboros | Greek alchemy on serpent eating tail | 0.74 |
| distributed cognition | Philosophy of History, Cassirer | 0.64 |
| social contract | Spinoza, Durkheim | 0.73 |

Latencies 150ms–1.1s on ~3.9M page embeddings.

## Why this matters for the MCP feedback (#1756 item 2)
The \`search_concept\` MCP tool shipped in PR #1764 depends on this RPC. Without the SQL, the tool returned 0 for every query. With it: model can submit "distributed cognition" and get back Plotinus / Cassirer / Dilthey — exactly what the original Claude submitter asked for.

## Lesson recorded
Adding to memory: when a lib function calls a Supabase RPC, the SQL definition must live in \`scripts/migration/\` and be applied as part of the same deploy. Caught-and-swallowed errors are a great place for infrastructure gaps to hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)