### PR TITLE
Fix BPH cover divergence: sync 290 books + canonical reader on detail page

### DIFF
--- a/scripts/audit-cover-field-divergence.mjs
+++ b/scripts/audit-cover-field-divergence.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Audit cover-field divergence: for every visible book (optionally scoped to a
+ * tenant), count how many have `image_display` and `thumbnail` pointing at
+ * different URLs (after light normalization). This surfaces books where
+ * different writers updated different fields — the cause of the issue where
+ * /book/<slug> shows one cover and /embed/<tenant> shows another.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/audit-cover-field-divergence.mjs                # all visible books
+ *   node scripts/audit-cover-field-divergence.mjs --tenant bph   # BPH only
+ *   node scripts/audit-cover-field-divergence.mjs --tenant bph --sample 20
+ */
+
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const TENANT = (() => {
+  const i = args.indexOf('--tenant');
+  return i !== -1 ? args[i + 1] : null;
+})();
+const SAMPLE = (() => {
+  const i = args.indexOf('--sample');
+  return i !== -1 ? parseInt(args[i + 1], 10) : 10;
+})();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+const client = new MongoClient(MONGODB_URI);
+
+function normalize(u) {
+  if (!u) return null;
+  // Treat /pages/.../X.jpg, X-thumb.jpg, X-full.jpg as the same logical page.
+  return u
+    .replace(/-thumb\.jpg(\?.*)?$/, '.jpg')
+    .replace(/-full\.jpg(\?.*)?$/, '.jpg');
+}
+
+await client.connect();
+try {
+  const db = client.db('bookstore');
+  const match = { visible: true };
+  if (TENANT) {
+    // BPH books are tagged via image_source.provider rather than tenantId slug.
+    if (TENANT === 'bph') match['image_source.provider'] = 'bph';
+    else match.tenantId = TENANT;
+  }
+
+  const cursor = db.collection('books').find(match, {
+    projection: {
+      id: 1, slug: 1, title: 1,
+      image_display: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1,
+      thumbnail_source: 1,
+    },
+  });
+
+  let total = 0;
+  let bothSet = 0;
+  let onlyLegacy = 0;     // thumbnail set, image_display unset
+  let onlyCanonical = 0;  // image_display set, thumbnail unset
+  let neither = 0;
+  let divergentDisplay = 0;
+  const samples = [];
+
+  for await (const b of cursor) {
+    total++;
+    const display = b.image_display || null;
+    const legacy = b.thumbnail || null;
+    if (display && legacy) {
+      bothSet++;
+      if (normalize(display) !== normalize(legacy)) {
+        divergentDisplay++;
+        if (samples.length < SAMPLE) {
+          samples.push({
+            id: b.id, slug: b.slug, title: (b.title || '').slice(0, 70),
+            thumbnail_source: b.thumbnail_source || null,
+            image_display: display,
+            thumbnail: legacy,
+          });
+        }
+      }
+    } else if (legacy) {
+      onlyLegacy++;
+    } else if (display) {
+      onlyCanonical++;
+    } else {
+      neither++;
+    }
+  }
+
+  console.log(JSON.stringify({
+    scope: TENANT ? `tenant=${TENANT}` : 'all visible',
+    total,
+    bothSet,
+    divergentDisplay,
+    onlyLegacy,
+    onlyCanonical,
+    neither,
+    samples,
+  }, null, 2));
+} finally {
+  await client.close();
+}

--- a/scripts/sync-cover-fields.mjs
+++ b/scripts/sync-cover-fields.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Sync legacy cover fields (thumbnail / thumbnail_blob) to agree with the
+ * canonical fields (image_display / image_thumb) for books where they diverge.
+ *
+ * Rationale: `getBookThumbnailUrl()` prefers image_display. When thumbnail
+ * and image_display point to different pages, the book detail page (which reads
+ * thumbnail) and the embed gallery (which reads image_display via the helper)
+ * show different covers. Aligning thumbnail → image_display makes all read
+ * paths agree without changing which image is visible on the gallery.
+ *
+ * Safety rules:
+ *   - Skip books with thumbnail_source === 'manual' (human-curated override).
+ *   - Only touch books where image_display IS set (never blindly clear thumbnail).
+ *   - Dry-run by default; pass --apply to write.
+ *   - Can be scoped with --provider bph (default) or --all.
+ *   - Can target a single book with --id <book_id>.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/sync-cover-fields.mjs --dry-run       # preview (default)
+ *   node scripts/sync-cover-fields.mjs --apply          # write changes
+ *   node scripts/sync-cover-fields.mjs --apply --all    # all visible books
+ *   node scripts/sync-cover-fields.mjs --apply --id 69c85eca6c6f3cc53c8552ec
+ */
+
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const DRY_RUN = !args.includes('--apply');
+const ALL = args.includes('--all');
+const ONLY_ID = (() => {
+  const i = args.indexOf('--id');
+  return i !== -1 ? args[i + 1] : null;
+})();
+const PROVIDER = (() => {
+  const i = args.indexOf('--provider');
+  return i !== -1 ? args[i + 1] : 'bph';
+})();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Source .env.production.local first.');
+  process.exit(1);
+}
+
+function normalize(u) {
+  if (!u) return null;
+  return u
+    .replace(/-thumb\.jpg(\?.*)?$/, '.jpg')
+    .replace(/-full\.jpg(\?.*)?$/, '.jpg');
+}
+
+const client = new MongoClient(MONGODB_URI);
+await client.connect();
+try {
+  const db = client.db('bookstore');
+
+  const baseMatch = { visible: true, image_display: { $exists: true, $ne: null } };
+  if (ONLY_ID) {
+    baseMatch.id = ONLY_ID;
+  } else if (!ALL) {
+    baseMatch['image_source.provider'] = PROVIDER;
+  }
+
+  const cursor = db.collection('books').find(baseMatch, {
+    projection: {
+      id: 1, slug: 1, title: 1,
+      image_display: 1, image_thumb: 1,
+      thumbnail: 1, thumbnail_blob: 1,
+      thumbnail_source: 1,
+    },
+  });
+
+  let checked = 0;
+  let skippedManual = 0;
+  let alreadyInSync = 0;
+  let fixed = 0;
+  let errors = 0;
+
+  for await (const b of cursor) {
+    checked++;
+
+    if (b.thumbnail_source === 'manual') {
+      skippedManual++;
+      continue;
+    }
+
+    const displayNorm = normalize(b.image_display);
+    const thumbNorm = normalize(b.thumbnail);
+
+    if (displayNorm === thumbNorm) {
+      alreadyInSync++;
+      continue;
+    }
+
+    // image_thumb: prefer what's already set if it matches image_display;
+    // otherwise mirror image_display (the thumb variant if available).
+    const newThumb = b.image_thumb || b.image_display;
+
+    console.log(`${DRY_RUN ? '[DRY]' : '[FIX]'} ${b.id} ${(b.slug || '').slice(0, 55)}`);
+    console.log(`  image_display: ${b.image_display}`);
+    console.log(`  thumbnail    : ${b.thumbnail}`);
+
+    if (!DRY_RUN) {
+      try {
+        await db.collection('books').updateOne(
+          { id: b.id },
+          {
+            $set: {
+              thumbnail: b.image_display,
+              thumbnail_blob: newThumb,
+            },
+          },
+        );
+        fixed++;
+      } catch (err) {
+        console.error(`  ERROR: ${err.message}`);
+        errors++;
+      }
+    } else {
+      fixed++;
+    }
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`checked       : ${checked}`);
+  console.log(`already in sync: ${alreadyInSync}`);
+  console.log(`skipped manual : ${skippedManual}`);
+  console.log(`${DRY_RUN ? 'would fix' : 'fixed'}   : ${fixed}`);
+  if (errors) console.log(`errors        : ${errors}`);
+  if (DRY_RUN) console.log('\nDry-run complete. Pass --apply to write changes.');
+} finally {
+  await client.close();
+}

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -39,7 +39,7 @@ import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter'
 import SignUpCTA from '@/components/auth/SignUpCTA';
 import { authorUrl } from '@/lib/slugify';
 import { firstTranslationBadge, firstTranslationDescription } from '@/lib/first-translation-labels';
-import { formatAuthor } from '@/lib/utils';
+import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import { getEffectiveByline } from '@/lib/byline';
 import AuthorName from '@/components/AuthorName';
 import ConditionalSiteHeader from '@/components/layout/ConditionalSiteHeader';
@@ -621,8 +621,8 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
             <div className="flex-shrink-0 flex justify-center sm:justify-start">
               <CoverImagePicker
                 bookId={book.id}
-                currentThumbnail={book.thumbnail}
-                currentThumbnailBlob={book.thumbnail_blob}
+                currentThumbnail={getBookThumbnailUrl(book as Parameters<typeof getBookThumbnailUrl>[0], 'display') ?? undefined}
+                currentThumbnailBlob={getBookThumbnailUrl(book as Parameters<typeof getBookThumbnailUrl>[0], 'thumb') ?? undefined}
                 bookTitle={book.title}
                 pages={pages}
               />


### PR DESCRIPTION
## Summary

- **290 BPH books** had `image_display` and `thumbnail` pointing at different pages. The embed gallery used `getBookThumbnailUrl` (prefers `image_display`) while the book detail page read `thumbnail` raw — resulting in two different cover images for the same book on different surfaces.
- **Data fix**: `scripts/sync-cover-fields.mjs` aligned `thumbnail`/`thumbnail_blob` to match `image_display`/`image_thumb` for all 290 divergent BPH books. 27 manually-curated books skipped (`thumbnail_source === 'manual'`).
- **Code fix**: book detail page now reads covers through `getBookThumbnailUrl(book, 'display')` — same canonical field priority as the gallery, embed API, and catalog. Makes the mismatch impossible even if a future writer only updates one field.
- **Audit script** added (`scripts/audit-cover-field-divergence.mjs`) to catch future divergences.

## Root cause

`smart-ocr-cover-selection` (and some older import scripts) wrote cover URLs to `thumbnail` without updating `image_display`, or vice versa. The R2 migration (PR #1588) introduced `image_display` as the canonical field but didn't backfill all legacy writes.

## Test plan

- [ ] https://bph.sourcelibrary.org/book/allerneuste-geheimnisse-der-freijmaurer-deren-sitten-und-larudan — cover should now match what appears on the grid at https://bph.sourcelibrary.org/embed/bph
- [ ] Spot-check a few other books that were in the divergent set (slugs in dry-run output)
- [ ] Cover picker on detail page should still work (picks a page, updates all fields via existing PATCH flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)