### PR TITLE
MCP search_concept: max_per_book, year filters, strip Continuity preamble

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -116,6 +116,9 @@ async function searchPassages(args: Record<string, unknown>) {
 async function searchConcept(args: Record<string, unknown>) {
   const limit = Math.min(Number(args.limit) || 15, 50);
   const params = new URLSearchParams({ q: String(args.query), level: 'page', limit: String(limit) });
+  if (args.year_from) params.set('year_min', String(args.year_from));
+  if (args.year_to) params.set('year_max', String(args.year_to));
+  if (args.max_per_book) params.set('max_per_book', String(args.max_per_book));
 
   const result = await apiGet('/search/semantic', params) as Record<string, unknown>;
   const passages = (result.results as Array<Record<string, unknown>>)?.map((r) => ({
@@ -126,9 +129,10 @@ async function searchConcept(args: Record<string, unknown>) {
     published: r.book_year,
     page: r.page_number,
     snippet: r.snippet,
-    // Semantic-page snippets are verbatim translation excerpts, not AI summaries —
-    // always safe to quote (the AI step is upstream in the embedding, not the snippet).
-    snippet_type: 'translation',
+    // 'translation' = verbatim source text (safe to quote).
+    // 'summary'     = AI-written page-continuity preamble we couldn't cleanly strip —
+    //                 useful as topical evidence but DO NOT quote as the author's words.
+    snippet_type: r.snippet_type || 'translation',
     similarity: r.score,
     url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
   })) || [];
@@ -137,7 +141,7 @@ async function searchConcept(args: Record<string, unknown>) {
     total_matches: passages.length,
     returned: passages.length,
     passages,
-    tip: 'These results are ranked by conceptual similarity (cosine distance on Gemini embeddings), not literal keyword match. Lower similarity scores mean weaker matches — be skeptical below ~0.45.',
+    tip: 'Similarity calibration: 0.70+ strong match (quote with confidence); 0.55–0.70 worth reading but verify; below 0.55 mostly conceptual drift. Snippets tagged snippet_type:"summary" are AI continuity notes — paraphrase only, never quote.',
   };
 }
 
@@ -309,13 +313,16 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'search_concept',
-    description: 'Conceptual / semantic passage search. Use when the modern term won\'t literally appear in historical texts — e.g. "distributed cognition" maps to passages about active intellect, art of memory, wax tablet metaphors; "social contract" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings (768d), so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Each passage includes a similarity score (0-1); treat scores below ~0.45 with skepticism.',
+    description: 'Conceptual / semantic passage search. Use when the modern term won\'t literally appear in historical texts — e.g. "distributed cognition" maps to passages about active intellect, art of memory, wax tablet metaphors; "social contract" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings (768d), so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Similarity calibration: 0.70+ is a strong match, 0.55–0.70 is worth reading but verify, below 0.55 is mostly conceptual drift. Set max_per_book to diversify results across many books rather than cluster on one source. Each passage carries a snippet_type — quote only "translation" snippets, never "summary".',
     annotations: { title: 'Search by Concept', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
       properties: {
         query: { type: 'string', description: 'A concept or natural-language description — full sentences are fine (e.g. "tools that extend the mind beyond the body"). Unlike search_translations, this does NOT require words that appear in the corpus.' },
         limit: { type: 'number', description: 'Max passages (default 15, max 50)' },
+        year_from: { type: 'number', description: 'Restrict to books published in or after this year (filters out modern editions and translations).' },
+        year_to: { type: 'number', description: 'Restrict to books published in or before this year.' },
+        max_per_book: { type: 'number', description: 'Cap on passages from any single book. Useful when one book dominates the conceptual neighborhood; set to 1–2 for diverse author/work coverage.' },
       },
       required: ['query'],
     },

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -16,12 +16,13 @@ export const dynamic = 'force-dynamic';
  * Replaces the broken hybrid_search on 3M+ page_translations (issue #1158).
  *
  * Query params:
- *   q        — search query (required)
- *   level    — 'book' (default) or 'page'
- *   limit    — max results (default 20, max 50)
- *   language — filter by language (book-level only)
- *   year_min — filter by minimum year (book-level only)
- *   year_max — filter by maximum year (book-level only)
+ *   q             — search query (required)
+ *   level         — 'book' (default) or 'page'
+ *   limit         — max results (default 20, max 50)
+ *   language      — filter by language (book-level only)
+ *   year_min      — filter by minimum year (book + page level)
+ *   year_max      — filter by maximum year (book + page level)
+ *   max_per_book  — page-level only: cap on passages from any single book
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -31,6 +32,7 @@ export async function GET(request: NextRequest) {
   const language = searchParams.get('language') || undefined;
   const yearMin = searchParams.get('year_min') ? parseInt(searchParams.get('year_min')!, 10) : undefined;
   const yearMax = searchParams.get('year_max') ? parseInt(searchParams.get('year_max')!, 10) : undefined;
+  const maxPerBook = searchParams.get('max_per_book') ? parseInt(searchParams.get('max_per_book')!, 10) : undefined;
 
   if (!query || query.length < 2) {
     return NextResponse.json({ results: [], query: '' });
@@ -41,7 +43,11 @@ export async function GET(request: NextRequest) {
 
   if (level === 'page') {
     try {
-      const pages = await semanticPageSearchGlobal(searchQuery, limit);
+      const pages = await semanticPageSearchGlobal(searchQuery, limit, {
+        yearMin,
+        yearMax,
+        maxPerBook,
+      });
       const bookIds = [...new Set(pages.map(p => p.book_id))];
       let slugMap: Record<string, string> = {};
       if (bookIds.length > 0) {

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -194,24 +194,75 @@ export async function semanticArtworkSearch(
 // ── Global page-level semantic search ────────────────────────────────
 
 /**
+ * Translations from books processed through the multi-page pipeline can begin
+ * with an AI-written "Continuity:" preamble — a 1-3 sentence summary of what
+ * came before, separated from the real verbatim translation by a markdown
+ * heading. Snippets that lead with this preamble look quotable but aren't;
+ * worse, the slice(0, 300) often truncates entirely inside the preamble so
+ * the actual source text never surfaces.
+ *
+ * We try to detect the boundary (a heading marker like `. # `, `. -># `, or
+ * an ALL-CAPS chapter title) and trim past it. When detected the snippet is
+ * still verbatim translation. When not detected we keep the original text but
+ * tag the snippet as 'summary' so consumers don't quote AI prose as source.
+ */
+function stripContinuityPrefix(text: string): { snippet: string; type: 'translation' | 'summary' } {
+  if (!text) return { snippet: '', type: 'translation' };
+  if (!/^Continuity:\s/i.test(text)) return { snippet: text.slice(0, 300), type: 'translation' };
+
+  const head = text.slice(0, 1000);
+  // Heading markers, in order of specificity:
+  //   . # Heading  /  . ## Heading  /  . ### Heading
+  //   . ->#  Heading  (arrow-prefixed markdown heading)
+  //   . PART ONE.  /  . CHAPTER XII.  (ALL-CAPS chapter title)
+  //   . 1.  /  . 23.  (numbered section)
+  const headingMatch = head.match(/\.\s+(?:->#{1,4}\s|#{1,4}\s|[A-Z][A-Z\s']{3,}\.\s|\d+\.\s)/);
+  if (headingMatch && headingMatch.index !== undefined) {
+    const stripped = text.slice(headingMatch.index + 1).trimStart();
+    return { snippet: stripped.slice(0, 300), type: 'translation' };
+  }
+  return { snippet: text.slice(0, 300), type: 'summary' };
+}
+
+export interface SemanticPageSearchOptions {
+  yearMin?: number;
+  yearMax?: number;
+  maxPerBook?: number;
+  tenantId?: string;
+}
+
+/**
  * Global page-level semantic search via match_semantic RPC.
  * Now that all 2.6M pages have embeddings, this finds specific passages
  * that book-level search misses (e.g. Martial's "masturbator" epigram
  * inside a 400-page book about Roman wit).
+ *
+ * yearMin / yearMax / maxPerBook are applied post-hoc in JS because the
+ * underlying RPC doesn't accept these filters. We over-request from Supabase
+ * (3x the requested limit, capped at 50 — the RPC's hard ceiling) so that
+ * filtering still yields close to the requested count when filters are tight.
+ *
+ * The `tenantId` parameter is accepted as the 2nd positional arg for backward
+ * compatibility with earlier callers that passed (query, limit, tenantId).
  */
 export async function semanticPageSearchGlobal(
   query: string,
   limit: number = 15,
-  tenantId?: string,
+  optsOrTenantId?: SemanticPageSearchOptions | string,
 ): Promise<SemanticPageResult[]> {
+  const opts: SemanticPageSearchOptions =
+    typeof optsOrTenantId === 'string' ? { tenantId: optsOrTenantId } : (optsOrTenantId || {});
   const queryEmbedding = await getQueryEmbedding(query);
   if (!queryEmbedding) return [];
+
+  const filtering = opts.yearMin !== undefined || opts.yearMax !== undefined || (opts.maxPerBook ?? 0) > 0;
+  const overRequest = filtering ? Math.min(limit * 3, 50) : limit;
 
   const { data, error } = await supabase.rpc('match_semantic', {
     query_embedding: JSON.stringify(queryEmbedding),
     match_threshold: 0.3,
-    match_count: limit,
-    filter_tenant_id: tenantId ?? null,
+    match_count: overRequest,
+    filter_tenant_id: opts.tenantId ?? null,
   });
 
   if (error) {
@@ -219,17 +270,35 @@ export async function semanticPageSearchGlobal(
     return [];
   }
 
-  return (data || []).map((row: any) => ({
-    page_id: row.page_id,
-    book_id: row.book_id,
-    page_number: row.page_number,
-    snippet: (row.translation || '').slice(0, 300),
-    score: Number(row.similarity) || 0,
-    book_title: row.book_title,
-    book_author: row.book_author,
-    book_language: row.book_language,
-    book_year: row.book_year,
-  }));
+  let rows = (data || []) as any[];
+
+  if (opts.yearMin !== undefined) rows = rows.filter(r => (r.book_year ?? null) !== null && r.book_year >= opts.yearMin!);
+  if (opts.yearMax !== undefined) rows = rows.filter(r => (r.book_year ?? null) !== null && r.book_year <= opts.yearMax!);
+
+  if ((opts.maxPerBook ?? 0) > 0) {
+    const perBook = new Map<string, number>();
+    rows = rows.filter(r => {
+      const n = (perBook.get(r.book_id) || 0) + 1;
+      perBook.set(r.book_id, n);
+      return n <= opts.maxPerBook!;
+    });
+  }
+
+  return rows.slice(0, limit).map((row) => {
+    const { snippet, type } = stripContinuityPrefix(row.translation || '');
+    return {
+      page_id: row.page_id,
+      book_id: row.book_id,
+      page_number: row.page_number,
+      snippet,
+      snippet_type: type,
+      score: Number(row.similarity) || 0,
+      book_title: row.book_title,
+      book_author: row.book_author,
+      book_language: row.book_language,
+      book_year: row.book_year,
+    };
+  });
 }
 
 // ── Page-level scoped search (step 2: within specific books) ────────
@@ -239,6 +308,9 @@ export interface SemanticPageResult {
   book_id: string;
   page_number: number;
   snippet: string;
+  // 'translation' = verbatim source text (safe to quote)
+  // 'summary'     = AI-written continuity preamble that we could not cleanly strip
+  snippet_type?: 'translation' | 'summary';
   score: number;
   book_title: string;
   book_author: string | null;
@@ -275,15 +347,19 @@ export async function semanticPageSearchScoped(
     return [];
   }
 
-  return (data || []).map((row: any) => ({
-    page_id: row.page_id,
-    book_id: row.book_id,
-    page_number: row.page_number,
-    snippet: (row.translation || '').slice(0, 300),
-    score: Number(row.similarity) || 0,
-    book_title: row.book_title,
-    book_author: row.book_author,
-    book_language: row.book_language,
-    book_year: row.book_year,
-  }));
+  return (data || []).map((row: any) => {
+    const { snippet, type } = stripContinuityPrefix(row.translation || '');
+    return {
+      page_id: row.page_id,
+      book_id: row.book_id,
+      page_number: row.page_number,
+      snippet,
+      snippet_type: type,
+      score: Number(row.similarity) || 0,
+      book_title: row.book_title,
+      book_author: row.book_author,
+      book_language: row.book_language,
+      book_year: row.book_year,
+    };
+  });
 }


### PR DESCRIPTION
## Summary
Three ergonomics fixes to the MCP `search_concept` tool, surfaced while using it to compile a literature brief on distributed cognition.

- **`max_per_book`** — caps passages from any single book. Without it, a single dominant source (Bruno's *De Umbris*, Atkinson's memory manual) was returning 4-6 of every 15 hits on conceptual queries.
- **`year_from` / `year_to`** — parity with `search_translations`. Lets conceptual queries restrict to a historical window. Implemented as post-hoc filtering with 3x over-request (capped at the `match_semantic` RPC ceiling of 50).
- **Continuity preamble stripping** — AI-written page-continuity notes were leading snippets, so the actual translation never surfaced inside the 300-char window. Heuristic detects heading markers (`#`, `->#`, ALL-CAPS chapter titles, numbered sections) and trims past them. When no clean boundary is found, `snippet_type` drops from `translation` to `summary` so callers don't quote AI prose as the author's words.

Also updates the tool description with a calibrated similarity scale (0.70+ strong / 0.55–0.70 verify / <0.55 drift) and documents the `snippet_type` semantics.

## Verification
Verified via direct calls to `semanticPageSearchGlobal`:
- `maxPerBook: 1` on "art of memory" → 6 unique books in 6 results (no clustering)
- `yearMax: 1700` on "art of memory" → 10 results, max year 1612
- `yearMin: 1500, yearMax: 1600` → 10 results, all 1514-1584
- Snippets across the run lead with `# THE ART OF MEMORY`, `# DE ORATORE`, `# ON THE ART OF MEMORY` — Continuity prefix cleanly stripped

Also verified `max_per_book=2` end-to-end through the `/api/search/semantic` route (Bruno's 4-hit cluster on baseline drops to 2 in the same query).

## Test plan
- [ ] Vercel preview deploy succeeds
- [ ] `curl preview/api/search/semantic?level=page&q=art%20of%20memory&max_per_book=2` returns ≤2 hits per book
- [ ] `curl preview/api/search/semantic?level=page&q=art%20of%20memory&year_max=1700` returns only pre-1700 results
- [ ] MCP `search_concept` tool list shows `year_from`, `year_to`, `max_per_book` params
- [ ] Existing `semanticPageSearchGlobal(query, limit, tenantId)` callers (search/route.ts) still work — backward-compat preserved

## Risk
- Continuity heuristic is best-effort. It strips ~18% of affected pages cleanly (those with `. # heading`) and another ~20% via the ALLCAPS/arrow patterns; the rest get `snippet_type: 'summary'` instead. Worst case is unchanged behavior plus a more honest type label.
- Filter over-request is 3x capped at 50 (the RPC ceiling). Narrow year ranges on dominantly-modern queries (e.g. "distributed cognition" + yearMax 1700) can return empty rather than fall back. Acceptable for now; a deeper fix would push the year filter into the SQL RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)