### PR TITLE
Add language/year filters to search_concept; sync to stdio MCP

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -191,6 +191,46 @@ export async function searchPassages(args: {
   };
 }
 
+export async function searchConcept(args: {
+  query: string;
+  language?: string;
+  year_from?: number;
+  year_to?: number;
+  limit?: number;
+}) {
+  const params = new URLSearchParams({
+    q: args.query,
+    level: "page",
+    limit: String(Math.min(args.limit || 15, 50)),
+  });
+  if (args.language) params.set("language", args.language);
+  if (args.year_from) params.set("year_min", String(args.year_from));
+  if (args.year_to) params.set("year_max", String(args.year_to));
+
+  const result = (await apiGet("/search/semantic", params)) as Record<string, unknown>;
+
+  const passages = (result.results as Array<Record<string, unknown>>)?.map((r) => ({
+    book_id: r.book_id,
+    title: r.book_title,
+    author: r.book_author,
+    language: r.book_language,
+    published: r.book_year,
+    page: r.page_number,
+    snippet: r.snippet,
+    snippet_type: "translation",
+    similarity: r.score,
+    url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
+  })) || [];
+
+  return {
+    query: result.query,
+    total_matches: passages.length,
+    returned: passages.length,
+    passages,
+    tip: "Results ranked by conceptual similarity (Gemini embeddings). Treat scores below ~0.45 with skepticism.",
+  };
+}
+
 export async function searchWithinBook(args: {
   book_id: string;
   query: string;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   searchLibrary,
   searchPassages,
+  searchConcept,
   searchWithinBook,
   listBooks,
   getBook,
@@ -139,6 +140,38 @@ const TOOLS: Tool[] = [
         limit: {
           type: "number",
           description: "Maximum results (default 20, max 50)",
+        },
+      },
+      required: ["query"],
+    },
+  },
+
+  {
+    name: "search_concept",
+    description:
+      "Conceptual / semantic passage search. Use when the modern term won't literally appear in historical texts — e.g. \"distributed cognition\" maps to passages about active intellect, art of memory, wax tablet metaphors; \"social contract\" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings, so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Each passage includes a similarity score (0-1); treat scores below ~0.45 with skepticism.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description: "A concept or natural-language description — full sentences are fine. Unlike search_translations, this does NOT require words that appear in the corpus.",
+        },
+        language: {
+          type: "string",
+          description: "Filter by original language (e.g., Latin, German, Greek, Arabic)",
+        },
+        year_from: {
+          type: "number",
+          description: "Filter by publication year (start, inclusive)",
+        },
+        year_to: {
+          type: "number",
+          description: "Filter by publication year (end, inclusive)",
+        },
+        limit: {
+          type: "number",
+          description: "Max passages (default 15, max 50)",
         },
       },
       required: ["query"],
@@ -410,6 +443,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "search_passages":
         result = await searchPassages(args as Parameters<typeof searchPassages>[0]);
         break;
+      case "search_concept":
+        result = await searchConcept(args as Parameters<typeof searchConcept>[0]);
+        break;
       case "search_within_book":
         result = await searchWithinBook(args as Parameters<typeof searchWithinBook>[0]);
         break;
@@ -466,7 +502,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Source Library MCP server v4.2.0 running (9 tools)");
+  console.error("Source Library MCP server v4.3.0 running (10 tools)");
 }
 
 main().catch((error) => {

--- a/scripts/migration/add-match-semantic-rpc.sql
+++ b/scripts/migration/add-match-semantic-rpc.sql
@@ -16,7 +16,10 @@ CREATE OR REPLACE FUNCTION match_semantic(
   query_embedding vector(768),
   match_threshold FLOAT DEFAULT 0.3,
   match_count INT DEFAULT 15,
-  filter_tenant_id TEXT DEFAULT NULL
+  filter_tenant_id TEXT DEFAULT NULL,
+  filter_language TEXT DEFAULT NULL,
+  filter_year_min INT DEFAULT NULL,
+  filter_year_max INT DEFAULT NULL
 )
 RETURNS TABLE (
   page_id TEXT,
@@ -46,8 +49,11 @@ BEGIN
   FROM page_translations p
   WHERE p.embedding IS NOT NULL
     AND 1 - (p.embedding <=> query_embedding) > match_threshold
-    -- filter_tenant_id is accepted for API parity with match_books_semantic but
-    -- is currently a no-op: page_translations has no tenant_id column.
+    -- filter_tenant_id is accepted for API parity but is a no-op:
+    -- page_translations has no tenant_id column yet.
+    AND (filter_language IS NULL OR p.book_language = filter_language)
+    AND (filter_year_min IS NULL OR p.book_year >= filter_year_min)
+    AND (filter_year_max IS NULL OR p.book_year <= filter_year_max)
   ORDER BY p.embedding <=> query_embedding
   LIMIT match_count;
 END;

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -116,6 +116,9 @@ async function searchPassages(args: Record<string, unknown>) {
 async function searchConcept(args: Record<string, unknown>) {
   const limit = Math.min(Number(args.limit) || 15, 50);
   const params = new URLSearchParams({ q: String(args.query), level: 'page', limit: String(limit) });
+  if (args.language) params.set('language', String(args.language));
+  if (args.year_from) params.set('year_min', String(args.year_from));
+  if (args.year_to) params.set('year_max', String(args.year_to));
 
   const result = await apiGet('/search/semantic', params) as Record<string, unknown>;
   const passages = (result.results as Array<Record<string, unknown>>)?.map((r) => ({
@@ -315,6 +318,9 @@ const TOOLS: Tool[] = [
       type: 'object' as const,
       properties: {
         query: { type: 'string', description: 'A concept or natural-language description — full sentences are fine (e.g. "tools that extend the mind beyond the body"). Unlike search_translations, this does NOT require words that appear in the corpus.' },
+        language: { type: 'string', description: 'Filter by original language (e.g., Latin, German, Greek, Arabic)' },
+        year_from: { type: 'number', description: 'Filter by publication year (start, inclusive)' },
+        year_to: { type: 'number', description: 'Filter by publication year (end, inclusive)' },
         limit: { type: 'number', description: 'Max passages (default 15, max 50)' },
       },
       required: ['query'],

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -311,7 +311,7 @@ export const GET = withApiAuth(async (request: NextRequest) => {
       (async () => {
         if (bookId || !searchContent) return [];
         try {
-          return await semanticPageSearchGlobal(matchQuery, 15, tenantId || undefined);
+          return await semanticPageSearchGlobal(matchQuery, 15, { tenantId: tenantId || undefined });
         } catch {
           return [];
         }

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
 
   if (level === 'page') {
     try {
-      const pages = await semanticPageSearchGlobal(searchQuery, limit);
+      const pages = await semanticPageSearchGlobal(searchQuery, limit, { language, yearMin, yearMax });
       const bookIds = [...new Set(pages.map(p => p.book_id))];
       let slugMap: Record<string, string> = {};
       if (bookIds.length > 0) {

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -202,7 +202,7 @@ export async function semanticArtworkSearch(
 export async function semanticPageSearchGlobal(
   query: string,
   limit: number = 15,
-  tenantId?: string,
+  opts?: { tenantId?: string; language?: string; yearMin?: number; yearMax?: number },
 ): Promise<SemanticPageResult[]> {
   const queryEmbedding = await getQueryEmbedding(query);
   if (!queryEmbedding) return [];
@@ -211,7 +211,10 @@ export async function semanticPageSearchGlobal(
     query_embedding: JSON.stringify(queryEmbedding),
     match_threshold: 0.3,
     match_count: limit,
-    filter_tenant_id: tenantId ?? null,
+    filter_tenant_id: opts?.tenantId ?? null,
+    filter_language: opts?.language ?? null,
+    filter_year_min: opts?.yearMin ?? null,
+    filter_year_max: opts?.yearMax ?? null,
   });
 
   if (error) {


### PR DESCRIPTION
## Summary
- `search_concept` now accepts `language`, `year_from`, `year_to` filters — works in both the HTTP MCP (Claude.ai) and the stdio server (CLI)
- `match_semantic` SQL RPC updated to accept `filter_language`, `filter_year_min`, `filter_year_max` — filters applied at the pgvector query level
- `semanticPageSearchGlobal` signature changed from positional `tenantId` arg to an opts object for consistency with `semanticBookSearch`
- `search_concept` added to the stdio MCP server (`mcp-server/`) — was completely missing from the CLI version

## Deploy note
The updated `match_semantic` SQL needs to be re-run in Supabase (`scripts/migration/add-match-semantic-rpc.sql`) before the language/year filters take effect. The old signature is backward-compatible (new params default to NULL = no filter), so deploying the code first is safe.

## Test plan
- [ ] Deploy SQL migration to Supabase
- [ ] `search_concept` with `language: "Latin"` returns only Latin-language passages
- [ ] `search_concept` with `year_from: 1400, year_to: 1600` returns only 15th–16th c. passages
- [ ] CLI MCP: `search_concept` tool appears in tool list
- [ ] No regression on unfiltered `search_concept` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)