### PR TITLE
BPH catalogue: show cross-provider scans separately from BPH-native digitisations

### DIFF
--- a/scripts/migration/add-bph-external-links.sql
+++ b/scripts/migration/add-bph-external-links.sql
@@ -1,0 +1,25 @@
+-- Add external-link columns to bph_works so the catalogue can surface BPH-held
+-- works that were digitised by another archive (Internet Archive, CMC Kloss,
+-- MDZ, Gallica, e-rara, etc.) without conflating them with BPH-native scans.
+--
+-- Invariant: sl_book_id continues to mean "BPH digitised this work and we host
+-- the scans on Source Library." The new sl_external_* columns mean "BPH holds
+-- this work physically and a scan is available on Source Library, sourced from
+-- another provider." A row may have both filled (rare but possible — same UBN
+-- has both a BPH scan and a cross-provider match), or neither, or only one.
+--
+-- Run via Supabase SQL editor or psql:
+--   psql "$DATABASE_URL" -f scripts/migration/add-bph-external-links.sql
+
+ALTER TABLE bph_works
+  ADD COLUMN IF NOT EXISTS sl_external_book_id TEXT,
+  ADD COLUMN IF NOT EXISTS sl_external_slug    TEXT,
+  ADD COLUMN IF NOT EXISTS sl_external_source  TEXT;
+  -- sl_external_source mirrors the source Mongo book's image_source.provider
+  -- (e.g. 'internet_archive', 'cmc_kloss', 'mdz', 'gallica', 'e-rara',
+  -- 'google_books', 'allard_pierson', 'bodleian', 'vatican', 'cambridge',
+  -- 'laurenziana'). Free-text rather than enum because new providers get
+  -- added periodically and we don't want an ALTER per provider.
+
+CREATE INDEX IF NOT EXISTS bph_works_sl_external_book_id_idx
+  ON bph_works (sl_external_book_id) WHERE sl_external_book_id IS NOT NULL;

--- a/scripts/migration/backfill-bph-external-links.mjs
+++ b/scripts/migration/backfill-bph-external-links.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+/**
+ * Backfill bph_works.sl_external_book_id / sl_external_slug / sl_external_source
+ * for BPH-held works that were digitised by another archive (IA, CMC Kloss,
+ * MDZ, Gallica, e-rara, etc.) — i.e. Mongo books with held_by:'bph' AND
+ * image_source.provider !== 'bph'.
+ *
+ * The catalogue UI uses these columns to surface a "Read at [Source]" link
+ * on rows where BPH has no native digitisation. They are deliberately kept
+ * separate from sl_book_id so existing "BPH digitised" counters and filters
+ * don't change.
+ *
+ * Match logic: title+author+year fuzzy match, ported from
+ * scripts/migration/backfill-held-by-fuzzy.mjs (PR #1324). The threshold and
+ * short-title guards are intentionally identical, so the set of rows that
+ * gain an external link mirrors the set of Mongo books that gained held_by:'bph'.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/migration/backfill-bph-external-links.mjs            # Dry run
+ *   node scripts/migration/backfill-bph-external-links.mjs --apply    # Write
+ *   node scripts/migration/backfill-bph-external-links.mjs --threshold 0.7
+ */
+
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = !process.argv.includes('--apply');
+const thresholdIdx = process.argv.indexOf('--threshold');
+const THRESHOLD = thresholdIdx >= 0 ? parseFloat(process.argv[thresholdIdx + 1]) : 0.6;
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!MONGODB_URI || !SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing MONGODB_URI / SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+// ── Fuzzy matching (lifted from backfill-held-by-fuzzy.mjs) ─────────
+function normalize(str) {
+  return (str || '')
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function titleSimilarity(a, b) {
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (!na || !nb) return 0;
+  if (na === nb) return 1.0;
+  if (na.includes(nb) || nb.includes(na)) return 0.85;
+  const wordsA = new Set(na.split(' ').filter(w => w.length > 2));
+  const wordsB = new Set(nb.split(' ').filter(w => w.length > 2));
+  if (wordsA.size === 0 || wordsB.size === 0) return 0;
+  let overlap = 0;
+  for (const w of wordsA) if (wordsB.has(w)) overlap++;
+  return overlap / (wordsA.size + wordsB.size - overlap);
+}
+
+function authorMatch(bookAuthor, bphAuthor) {
+  if (!bookAuthor || !bphAuthor) return true;
+  const na = normalize(bookAuthor);
+  const nb = normalize(bphAuthor);
+  if (na.includes(nb) || nb.includes(na)) return true;
+  const lastA = na.split(' ').pop();
+  const lastB = nb.split(' ').pop();
+  return lastA === lastB;
+}
+
+function findBestMatch(book, bphResults) {
+  let bestMatch = null;
+  let bestScore = 0;
+  for (const bph of bphResults) {
+    let score = titleSimilarity(book.title, bph.title);
+    if (authorMatch(book.author, bph.author)) score += 0.1;
+    else score -= 0.3;
+    const bookYear = book.year ?? parseYear(book.published);
+    if (bookYear && bph.year) {
+      const yearDiff = Math.abs(bookYear - bph.year);
+      if (yearDiff === 0) score += 0.1;
+      else if (yearDiff <= 5) score += 0.05;
+      else if (yearDiff > 20) score -= 0.2;
+    }
+    if (score > bestScore) { bestScore = score; bestMatch = { bph, score }; }
+  }
+  if (!bestMatch || bestScore < THRESHOLD) return null;
+  const minLen = Math.min(normalize(book.title).length, normalize(bestMatch.bph.title).length);
+  if (bestScore < 0.9 && minLen < 15) return null;
+  if (bestScore < 1.0 && minLen < 10) return null;
+  return bestMatch;
+}
+
+function parseYear(s) {
+  if (!s) return null;
+  const m = String(s).match(/\d{4}/);
+  return m ? parseInt(m[0], 10) : null;
+}
+
+function buildIndex(bphWorks) {
+  const index = new Map();
+  for (const bph of bphWorks) {
+    const words = normalize(bph.title).split(' ').filter(w => w.length > 3);
+    for (const w of words) {
+      if (!index.has(w)) index.set(w, []);
+      index.get(w).push(bph);
+    }
+  }
+  return index;
+}
+
+function getCandidates(book, index) {
+  const words = normalize(book.title).split(' ').filter(w => w.length > 3).slice(0, 4);
+  const seen = new Set();
+  const candidates = [];
+  for (const w of words) {
+    for (const e of index.get(w) || []) {
+      if (!seen.has(e.ubn)) { seen.add(e.ubn); candidates.push(e); }
+    }
+  }
+  return candidates;
+}
+
+// ── Supabase helpers ────────────────────────────────────────────────
+const sbHeaders = {
+  apikey: SUPABASE_KEY,
+  Authorization: `Bearer ${SUPABASE_KEY}`,
+  'Content-Type': 'application/json',
+};
+
+async function loadCatalog() {
+  const all = [];
+  let offset = 0;
+  while (true) {
+    const url = `${SUPABASE_URL}/rest/v1/bph_works?select=ubn,title,author,year,sl_book_id,sl_external_book_id&order=ubn&offset=${offset}&limit=1000`;
+    const res = await fetch(url, { headers: sbHeaders });
+    if (!res.ok) {
+      const body = await res.text();
+      if (body.includes('sl_external_book_id') && body.includes('does not exist')) {
+        console.error('\nERROR: sl_external_book_id column missing.');
+        console.error('Apply scripts/migration/add-bph-external-links.sql first.\n');
+        process.exit(2);
+      }
+      throw new Error(`Supabase load failed: ${res.status} ${body}`);
+    }
+    const data = await res.json();
+    if (!data.length) break;
+    all.push(...data);
+    offset += 1000;
+    if (data.length < 1000) break;
+  }
+  return all;
+}
+
+async function patchExternalLink(ubn, payload) {
+  const url = `${SUPABASE_URL}/rest/v1/bph_works?ubn=eq.${encodeURIComponent(ubn)}`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: { ...sbHeaders, Prefer: 'return=minimal' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`PATCH ubn=${ubn}: ${res.status} ${await res.text()}`);
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+async function main() {
+  console.log('=== BPH cross-provider external link backfill ===');
+  console.log(`Mode      : ${DRY_RUN ? 'DRY RUN' : 'APPLY'}`);
+  console.log(`Threshold : ${THRESHOLD}`);
+
+  console.log('\nLoading BPH catalog from Supabase...');
+  const catalog = await loadCatalog();
+  console.log(`Loaded ${catalog.length} catalog rows`);
+
+  const index = buildIndex(catalog);
+  console.log(`Built word index: ${index.size} words`);
+
+  const mongo = new MongoClient(MONGODB_URI);
+  await mongo.connect();
+  const db = mongo.db('bookstore');
+
+  // The candidate set: books we've already classified as BPH-held but that
+  // came from another archive's scans. These are the rows produced by PR #1324.
+  // We deliberately skip image_source.provider:'bph' here — those go through
+  // the existing sync-bph-sl-book-ids cron via UBN match.
+  const candidates = await db.collection('books').find(
+    {
+      held_by: 'bph',
+      'image_source.provider': { $ne: 'bph' },
+      visible: true,
+      pages_count: { $gt: 0 },
+      bph_catalog_link: { $ne: false },
+    },
+    {
+      projection: {
+        id: 1, _id: 1, slug: 1, title: 1, author: 1, year: 1, published: 1,
+        'image_source.provider': 1,
+      },
+    },
+  ).toArray();
+  console.log(`\nCandidate Mongo books (cross-provider, BPH-held): ${candidates.length}`);
+
+  const matches = [];
+  let collidesWithBphScan = 0;
+  let alreadyLinked = 0;
+  for (const book of candidates) {
+    const cands = getCandidates(book, index);
+    if (!cands.length) continue;
+    const match = findBestMatch(book, cands);
+    if (!match) continue;
+    // Don't overwrite a row that already has a BPH-native scan — that's a
+    // stronger claim than "also held by BPH." Leave sl_book_id alone.
+    if (match.bph.sl_book_id) { collidesWithBphScan++; continue; }
+    // Skip rows where this exact external link is already set.
+    if (match.bph.sl_external_book_id === book.id) { alreadyLinked++; continue; }
+    matches.push({
+      ubn: match.bph.ubn,
+      bphTitle: match.bph.title,
+      bphYear: match.bph.year,
+      book,
+      source: book.image_source?.provider || 'unknown',
+      score: match.score,
+    });
+  }
+
+  // Volume-mismatch guard: many works in the BPH catalog are multi-volume,
+  // and a Mongo book labelled "Vol II" / "II" / "Band 2" / "Teil 3" should
+  // NOT be linked to the catalog row for volume I. We strip volume markers
+  // when comparing the *base* title (so volumes still match each other when
+  // both sides carry the marker), then reject the match if exactly one side
+  // claims a volume number and the other doesn't, or if both do but differ.
+  function extractVolume(t) {
+    if (!t) return null;
+    const s = String(t);
+    // Arabic: "Vol 2", "Volume 3", "Band 4", "Teil 5", "Part 6", "Deel 7"
+    let m = s.match(/\b(?:vol|volume|band|teil|part|deel|tome|tomo|tom)\.?\s*(\d{1,3})\b/i);
+    if (m) return parseInt(m[1], 10);
+    // Roman at end after a dot/space: "... II", "... III", "... IV"
+    m = s.match(/(?:[.\s])(I{2,3}|IV|VI{0,3}|IX|XI{0,3}|XIV?|XV)\.?\s*$/);
+    if (m) return romanToInt(m[1]);
+    // Bare arabic at end: "... 2" — only if title has multiple words to
+    // avoid catching years (already filtered by length) and identifier rows.
+    m = s.match(/[^\d]\s+(\d{1,2})\.?\s*$/);
+    if (m && s.split(/\s+/).length > 2) return parseInt(m[1], 10);
+    return null;
+  }
+  function romanToInt(r) {
+    const map = { I: 1, V: 5, X: 10, L: 50 };
+    let n = 0, prev = 0;
+    for (let i = r.length - 1; i >= 0; i--) {
+      const v = map[r[i]];
+      if (!v) return null;
+      n += v < prev ? -v : v;
+      prev = v;
+    }
+    return n;
+  }
+
+  // Strip volume markers + tail punctuation so two volumes of the same work
+  // share a base key. Used to look up a sibling catalog row at the right volume.
+  function baseTitle(t) {
+    if (!t) return '';
+    return normalize(String(t)
+      .replace(/\b(?:vol|volume|band|teil|part|deel|tome|tomo|tom)\.?\s*\d{1,3}\b/gi, '')
+      .replace(/(?:[.\s])(I{2,3}|IV|VI{0,3}|IX|XI{0,3}|XIV?|XV)\.?\s*$/i, '')
+      .replace(/[^\d]\s+\d{1,2}\.?\s*$/, ''));
+  }
+
+  // Group catalog rows by base title so we can hop between volumes.
+  const catalogByBase = new Map();
+  for (const c of catalog) {
+    const base = baseTitle(c.title);
+    if (!base) continue;
+    if (!catalogByBase.has(base)) catalogByBase.set(base, []);
+    catalogByBase.get(base).push(c);
+  }
+
+  function findSiblingVolume(bookTitle, bookAuthor, wantVol) {
+    const base = baseTitle(bookTitle);
+    const siblings = catalogByBase.get(base);
+    if (!siblings) return null;
+    // Look for a sibling whose extracted volume matches wantVol AND author lines up.
+    for (const s of siblings) {
+      if (extractVolume(s.title) !== wantVol) continue;
+      if (!authorMatch(bookAuthor, s.author)) continue;
+      return s;
+    }
+    return null;
+  }
+
+  const volumeMismatches = [];
+  const volumeRepairs = [];
+  const filtered = [];
+  for (const m of matches) {
+    const bookVol = extractVolume(m.book.title);
+    const bphVol = extractVolume(m.bphTitle);
+    const reasonIf = (r) => ({ ...m, reason: r });
+    let mismatch = null;
+    if (bookVol != null && bphVol == null) mismatch = `book is vol ${bookVol}, catalog is base/vol I`;
+    else if (bphVol != null && bookVol == null) mismatch = `catalog is vol ${bphVol}, book is base/vol I`;
+    else if (bookVol != null && bphVol != null && bookVol !== bphVol) mismatch = `book vol ${bookVol} ≠ catalog vol ${bphVol}`;
+
+    if (!mismatch) { filtered.push(m); continue; }
+
+    // Volume mismatch — try to find the correct sibling volume in the catalog.
+    const want = bookVol; // null only when bphVol is set; in that case skip (book has no volume marker)
+    if (want != null) {
+      const sibling = findSiblingVolume(m.book.title, m.book.author, want);
+      if (sibling && !sibling.sl_book_id && !sibling.sl_external_book_id) {
+        volumeRepairs.push({
+          oldUbn: m.ubn,
+          ubn: sibling.ubn,
+          bphTitle: sibling.title,
+          bphYear: sibling.year,
+          book: m.book,
+          source: m.source,
+          score: m.score,
+        });
+        continue;
+      }
+    }
+    volumeMismatches.push(reasonIf(mismatch));
+  }
+
+  console.log(`\n=== Matches ===`);
+  console.log(`Match candidates                                : ${matches.length}`);
+  console.log(`Skipped (UBN already has BPH-native scan)       : ${collidesWithBphScan}`);
+  console.log(`Skipped (external link already set to this book): ${alreadyLinked}`);
+  console.log(`Volume mismatch → re-pointed to sibling UBN     : ${volumeRepairs.length}`);
+  console.log(`Volume mismatch → no sibling found, skipped     : ${volumeMismatches.length}`);
+  console.log(`Will apply                                      : ${filtered.length + volumeRepairs.length}`);
+
+  if (volumeRepairs.length > 0) {
+    console.log(`\nVolume repairs (re-pointed to correct vol):`);
+    for (const r of volumeRepairs) {
+      console.log(`  ${r.oldUbn} → ${r.ubn}  "${(r.book.title || '').slice(0, 60)}" → "${(r.bphTitle || '').slice(0, 60)}"`);
+    }
+  }
+  if (volumeMismatches.length > 0) {
+    console.log(`\nVolume mismatches (no sibling, skipped):`);
+    for (const m of volumeMismatches) {
+      console.log(`  UBN ${m.ubn}  ${m.reason}`);
+      console.log(`    Mongo : "${(m.book.title || '').slice(0, 70)}"`);
+      console.log(`    BPH   : "${(m.bphTitle || '').slice(0, 70)}"`);
+    }
+  }
+
+  // Replace `matches` with the post-volume-filter set (clean + repaired) for the rest of the run.
+  matches.length = 0;
+  matches.push(...filtered, ...volumeRepairs);
+
+  const high = matches.filter(m => m.score >= 0.9).length;
+  const med = matches.filter(m => m.score >= 0.7 && m.score < 0.9).length;
+  const low = matches.filter(m => m.score < 0.7).length;
+  console.log(`Score distribution: ≥0.9 ${high}  |  0.7-0.9 ${med}  |  <0.7 ${low}`);
+
+  const bySource = {};
+  for (const m of matches) bySource[m.source] = (bySource[m.source] || 0) + 1;
+  console.log('\nMatches by source provider:');
+  Object.entries(bySource).sort((a, b) => b[1] - a[1])
+    .forEach(([s, n]) => console.log(`  ${s.padEnd(20)} ${n}`));
+
+  console.log('\nSample (first 10):');
+  for (const m of matches.slice(0, 10)) {
+    console.log(`  UBN ${m.ubn}  score=${m.score.toFixed(2)}  src=${m.source}`);
+    console.log(`    Mongo: "${(m.book.title || '').slice(0, 60)}"`);
+    console.log(`    BPH  : "${(m.bphTitle || '').slice(0, 60)}" (${m.bphYear || '—'})`);
+  }
+
+  if (DRY_RUN) {
+    console.log('\nDRY RUN — no writes. Re-run with --apply to PATCH bph_works.');
+    await mongo.close();
+    return;
+  }
+
+  console.log(`\nApplying ${matches.length} PATCHes...`);
+  let updated = 0, failed = 0;
+  const errs = [];
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    try {
+      await patchExternalLink(m.ubn, {
+        sl_external_book_id: m.book.id,
+        sl_external_slug: m.book.slug || m.book.id,
+        sl_external_source: m.source,
+      });
+      updated++;
+      if (updated % 100 === 0) console.log(`  ${updated}/${matches.length}…`);
+    } catch (e) {
+      failed++;
+      if (errs.length < 10) errs.push(String(e.message || e));
+    }
+  }
+  console.log(`\nDone. updated=${updated} failed=${failed}`);
+  if (errs.length) {
+    console.log('First errors:');
+    errs.forEach(e => console.log(`  ${e}`));
+  }
+  await mongo.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic';
 const PER_PAGE = 50;
 
 // New (expanded) field set — requires expand-bph-works-schema.sql to have been run.
-const FIELDS_NEW = [
+const FIELDS_NEW_CORE = [
   'ubn',
   'title', 'parallel_title', 'uniform_title',
   'author', 'variant_author', 'pseudonym',
@@ -25,7 +25,14 @@ const FIELDS_NEW = [
   'thumbnail', 'file_count',
   'sl_book_id', 'sl_book_slug',
   'ia_identifier', 'ustc_sn',
-].join(', ');
+];
+// Cross-provider link (BPH holds the work physically, scans live at another
+// archive — IA, CMC Kloss, MDZ, Gallica, e-rara, etc.). Surfaced as a
+// secondary "Read at [source]" link in the catalogue UI. Deliberately kept
+// separate from sl_book_id so existing "BPH digitised" counters stay accurate.
+// Added by add-bph-external-links.sql; gated by hasExternalLinks so the
+// route degrades gracefully on a runtime that boots before the migration runs.
+const FIELDS_EXTERNAL = ['sl_external_book_id', 'sl_external_slug', 'sl_external_source'];
 
 // Legacy field set — works against the original 11-column bph_works schema.
 const FIELDS_LEGACY = 'ubn, title, author, year, shelf_mark, keywords, ia_identifier, ustc_sn, place, publisher, printer';
@@ -37,6 +44,10 @@ let schemaMode: 'new' | 'legacy' | null = null;
 // the first query that uses them; falls back to plain ilike on the original
 // columns if they don't exist yet.
 let hasNormalizedColumns: boolean | null = null;
+// Tracks whether the sl_external_* columns from add-bph-external-links.sql
+// have been applied. Auto-detected on first error; degrades gracefully so
+// pre-migration runtimes still serve the rest of the v2 schema.
+let hasExternalLinks: boolean | null = null;
 
 function isMissingColumnError(err: { message?: string; code?: string }): boolean {
   if (!err) return false;
@@ -79,7 +90,15 @@ export async function GET(req: NextRequest) {
 
   // Run the query in the requested mode. Returns the supabase result object.
   async function runQuery(mode: 'new' | 'legacy') {
-    const fields = mode === 'new' ? FIELDS_NEW : FIELDS_LEGACY;
+    let fields: string;
+    if (mode === 'legacy') {
+      fields = FIELDS_LEGACY;
+    } else {
+      const cols = hasExternalLinks === false
+        ? FIELDS_NEW_CORE
+        : [...FIELDS_NEW_CORE, ...FIELDS_EXTERNAL];
+      fields = cols.join(', ');
+    }
     let query = supabase.from('bph_works').select(fields, { count: 'exact' });
 
     // Simple search. When the diacritic-normalised `search_norm` column
@@ -193,9 +212,18 @@ export async function GET(req: NextRequest) {
   }
 
   // Try the cached mode; on missing-column error, retry — first by
-  // disabling the diacritic-norm columns (the most recent addition), then
-  // by falling back to the legacy schema.
+  // disabling the external-link columns (the most recent addition), then
+  // the diacritic-norm columns, then by falling back to the legacy schema.
   let result = await runQuery(schemaMode || 'new');
+  if (
+    result.error &&
+    isMissingColumnError(result.error) &&
+    (schemaMode || 'new') === 'new' &&
+    hasExternalLinks !== false
+  ) {
+    hasExternalLinks = false;
+    result = await runQuery('new');
+  }
   if (
     result.error &&
     isMissingColumnError(result.error) &&
@@ -213,6 +241,7 @@ export async function GET(req: NextRequest) {
   } else if (!result.error && schemaMode === null) {
     schemaMode = 'new';
     if (hasNormalizedColumns === null) hasNormalizedColumns = true;
+    if (hasExternalLinks === null) hasExternalLinks = true;
   }
 
   if (result.error) {

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -51,6 +51,13 @@ interface BphWorkRow {
   ustc_sn: string | null;
   sl_book_id: string | null;
   sl_book_slug: string | null;
+  // Cross-provider link (see add-bph-external-links.sql): work is BPH-held but
+  // the scan lives at another archive (IA / CMC Kloss / MDZ / etc.). Surfaced
+  // as a secondary "Read at [source]" panel only when there's no BPH-native
+  // sl_book_id — when both exist, the BPH-native digitisation takes priority.
+  sl_external_book_id: string | null;
+  sl_external_slug: string | null;
+  sl_external_source: string | null;
   field_provenance: Record<string, FieldProvenance> | null;
 }
 
@@ -79,9 +86,10 @@ interface SlBook {
 }
 
 async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
-  const { data } = await supabase
-    .from('bph_works')
-    .select(`
+  // Try with the external-link columns first; if the column doesn't exist yet
+  // (migration not applied on this environment), retry without them so the
+  // page still renders.
+  const select = `
       ubn, title, parallel_title, uniform_title,
       author, variant_author, pseudonym, editor, variant_editor,
       place, printer, publisher, variant_printer, variant_publisher,
@@ -90,11 +98,90 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
       bibliography, remarks, number_of_copies, object_size_cm, bibliographic_format,
       binding, bound_with,
       provenance, ia_identifier, ustc_sn, sl_book_id, sl_book_slug,
+      sl_external_book_id, sl_external_slug, sl_external_source,
       field_provenance
-    `)
-    .eq('ubn', ubn)
-    .maybeSingle();
-  return (data as BphWorkRow | null) ?? null;
+    `;
+  const fallbackSelect = select.replace(
+    'sl_external_book_id, sl_external_slug, sl_external_source,\n      ',
+    '',
+  );
+  const first = await supabase.from('bph_works').select(select).eq('ubn', ubn).maybeSingle();
+  if (first.error) {
+    const msg = (first.error.message || '').toLowerCase();
+    if (msg.includes('does not exist') || msg.includes('could not find')) {
+      const retry = await supabase.from('bph_works').select(fallbackSelect).eq('ubn', ubn).maybeSingle();
+      return (retry.data as BphWorkRow | null) ?? null;
+    }
+    return null;
+  }
+  return (first.data as BphWorkRow | null) ?? null;
+}
+
+/** Look up a Source Library book by Mongo id — used for cross-provider
+    scans where the catalogue row points at a non-BPH-hosted book. */
+async function fetchExternalBook(id: string): Promise<SlBook | null> {
+  try {
+    const db = await getReadDb();
+    const book = await db.collection('books').findOne(
+      { id },
+      {
+        projection: {
+          id: 1, slug: 1, title: 1, display_title: 1, english_title: 1,
+          author: 1, language: 1, published: 1, place_published: 1, publisher: 1,
+          pages_count: 1, pages_ocr: 1, pages_translated: 1,
+          categories: 1, is_first_translation: 1, doi: 1,
+          'reading_summary.overview': 1,
+          image_display: 1, image_thumb: 1, thumbnail: 1, thumbnail_blob: 1,
+        },
+        maxTimeMS: 8_000,
+      },
+    );
+    if (!book) return null;
+    return {
+      id: book.id as string,
+      slug: (book.slug as string) || (book.id as string),
+      title: book.title as string | undefined,
+      display_title: book.display_title as string | undefined,
+      english_title: book.english_title as string | undefined,
+      author: book.author as string | undefined,
+      language: book.language as string | undefined,
+      published: book.published as string | undefined,
+      place_published: book.place_published as string | undefined,
+      publisher: book.publisher as string | undefined,
+      pages_count: book.pages_count as number | undefined,
+      pages_ocr: book.pages_ocr as number | undefined,
+      pages_translated: book.pages_translated as number | undefined,
+      categories: book.categories as string[] | undefined,
+      is_first_translation: book.is_first_translation as boolean | undefined,
+      doi: book.doi as string | undefined,
+      reading_summary: book.reading_summary as { overview?: string } | undefined,
+      image_display: book.image_display as string | null | undefined,
+      image_thumb: book.image_thumb as string | null | undefined,
+      thumbnail: book.thumbnail as string | null | undefined,
+      thumbnail_blob: book.thumbnail_blob as string | null | undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function externalSourceLabel(source: string | null | undefined): string {
+  if (!source) return 'another archive';
+  const map: Record<string, string> = {
+    internet_archive: 'Internet Archive',
+    cmc_kloss: 'CMC (Kloss collection)',
+    mdz: 'MDZ',
+    gallica: 'Gallica',
+    'e-rara': 'e-rara',
+    google_books: 'Google Books',
+    allard_pierson: 'Allard Pierson',
+    bodleian: 'Bodleian',
+    vatican: 'Vatican',
+    cambridge: 'Cambridge',
+    laurenziana: 'Laurenziana',
+  };
+  if (map[source]) return map[source];
+  return source.replace(/[_-]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
 /** Look up the live Source Library book matching this UBN, if any. */
@@ -164,9 +251,19 @@ export default async function CatalogEntryPage({ params }: Props) {
   ]);
   if (!work) notFound();
 
+  // If the work has no BPH-native digitisation but does have a cross-provider
+  // scan recorded, fetch that book so we can offer a "Read at [source]" panel.
+  const externalBook = !slBook && work.sl_external_book_id
+    ? await fetchExternalBook(work.sl_external_book_id)
+    : null;
+
   const displayTitle = work.title || work.parallel_title || work.uniform_title || `(untitled — UBN ${work.ubn})`;
   const slBookHref = slBook ? tenantBookUrl({ id: slBook.id, slug: slBook.slug }, tenant) : null;
   const slCoverUrl = slBook ? getBookThumbnailUrl(slBook, 'display') : null;
+  const externalBookHref = externalBook
+    ? tenantBookUrl({ id: externalBook.id, slug: externalBook.slug }, tenant)
+    : null;
+  const externalCoverUrl = externalBook ? getBookThumbnailUrl(externalBook, 'display') : null;
   const canonicalAuthor = slBook?.author ? formatAuthor(slBook.author).name : null;
   const translationPct = slBook && slBook.pages_translated && slBook.pages_ocr
     ? Math.round((slBook.pages_translated / Math.max(slBook.pages_ocr, 1)) * 100)
@@ -283,6 +380,64 @@ export default async function CatalogEntryPage({ params }: Props) {
               <BookOpen className="w-4 h-4" />
               Read the digitised copy
             </a>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Cross-provider scan — BPH holds the work, but the digitisation
+            lives at another archive. Visually distinct from the BPH-native
+            panel above so users (and EFM) can see at a glance which scan
+            they're looking at. Only renders when the row has no BPH-native
+            link AND we successfully resolved the external book. */}
+        {externalBook && externalBookHref && (
+          <section className="mb-8 p-5 rounded-lg border border-border-light bg-white">
+            <div className="flex items-center gap-2 mb-3">
+              <BookMarked className="w-4 h-4 text-secondary" />
+              <h2 className="text-sm font-medium text-secondary uppercase tracking-wide">
+                Scan via {externalSourceLabel(work.sl_external_source)}
+              </h2>
+            </div>
+            <p className="text-xs text-muted mb-3 leading-relaxed">
+              BPH holds this work; the digitisation shown here was produced by{' '}
+              {externalSourceLabel(work.sl_external_source)} and is read through Source Library.
+            </p>
+            <div className="flex gap-4">
+              {externalCoverUrl && (
+                <a href={externalBookHref} className="shrink-0">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={externalCoverUrl}
+                    alt={externalBook.display_title || externalBook.title || displayTitle}
+                    className="w-28 sm:w-32 rounded shadow-sm border border-border-light bg-cream object-cover"
+                    loading="lazy"
+                  />
+                </a>
+              )}
+              <div className="flex-1 min-w-0">
+                {externalBook.display_title && externalBook.display_title !== work.title && (
+                  <p className="text-lg text-primary font-display leading-snug mb-1">
+                    {externalBook.display_title}
+                  </p>
+                )}
+                <dl className="space-y-1.5 text-sm mb-4">
+                  {externalBook.author && (
+                    <Field label="Author" value={externalBook.author} />
+                  )}
+                  {externalBook.published && (
+                    <Field label="Published" value={externalBook.published} />
+                  )}
+                  {externalBook.pages_count != null && (
+                    <Field label="Pages" value={String(externalBook.pages_count)} />
+                  )}
+                </dl>
+                <a
+                  href={externalBookHref}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-secondary/40 text-secondary hover:bg-warm transition-colors"
+                >
+                  <BookOpen className="w-4 h-4" />
+                  Read the {externalSourceLabel(work.sl_external_source)} scan
+                </a>
               </div>
             </div>
           </section>

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -40,11 +40,39 @@ interface BphWork {
   file_count: number | null;
   sl_book_id: string | null;
   sl_book_slug: string | null;
+  /** Cross-provider link: BPH holds this work physically, but the scan
+      lives at another archive (IA, CMC Kloss, MDZ, Gallica, e-rara, etc.)
+      and is readable through Source Library. Kept separate from sl_book_id
+      so "BPH digitised" counters don't conflate the two. */
+  sl_external_book_id?: string | null;
+  sl_external_slug?: string | null;
+  sl_external_source?: string | null;
   ia_identifier: string | null;
   ustc_sn: string | null;
   /** Source Library cover URL, attached server-side by /api/catalog/bph
       when the row is linked to a digitised SL book. Powers the grid view. */
   sl_cover?: string | null;
+}
+
+/** Human-readable label for an external scan source. Defaults to a Title-Cased
+    fallback when we don't have a curated label for a provider yet. */
+function externalSourceLabel(source: string | null | undefined): string {
+  if (!source) return 'another archive';
+  const map: Record<string, string> = {
+    internet_archive: 'Internet Archive',
+    cmc_kloss: 'CMC (Kloss collection)',
+    mdz: 'MDZ',
+    gallica: 'Gallica',
+    'e-rara': 'e-rara',
+    google_books: 'Google Books',
+    allard_pierson: 'Allard Pierson',
+    bodleian: 'Bodleian',
+    vatican: 'Vatican',
+    cambridge: 'Cambridge',
+    laurenziana: 'Laurenziana',
+  };
+  if (map[source]) return map[source];
+  return source.replace(/[_-]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
 interface AdvancedFilters {
@@ -366,6 +394,19 @@ export default function BphCatalogBrowser({
     return null;
   };
 
+  // External scan: BPH-held work whose digitisation lives at another archive
+  // (IA, CMC Kloss, MDZ, etc.) and is readable on Source Library. Surfaced
+  // as a secondary "Read at [source]" link only when the row has no BPH-native
+  // scan — when both exist, BPH-native wins.
+  const resolveExternal = (w: BphWork, hasDigitized: boolean) => {
+    if (hasDigitized || !w.sl_external_book_id) return null;
+    return {
+      id: w.sl_external_book_id,
+      slug: w.sl_external_slug || w.sl_external_book_id,
+      source: w.sl_external_source || null,
+    };
+  };
+
   // Detail-page URL for a catalog entry. Always nest under basePath so the
   // link works in every host context: bph.sourcelibrary.org (where the proxy
   // serves /embed/bph/catalog/{ubn} directly), sourcelibrary.org/embed/bph
@@ -592,6 +633,7 @@ export default function BphCatalogBrowser({
               )}
               {works.map((w) => {
                 const digitized = resolveDigitized(w);
+                const external = resolveExternal(w, !!digitized);
                 const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
                 const displayAuthor = w.author || w.variant_author || w.pseudonym;
                 return (
@@ -615,6 +657,15 @@ export default function BphCatalogBrowser({
                         >
                           <BookMarked className="w-3 h-3" />
                           Digitised copy
+                        </a>
+                      )}
+                      {external && (
+                        <a
+                          href={tenantBookUrl({ id: external.id, slug: external.slug }, tenantSlug)}
+                          className="inline-flex items-center gap-1 mt-1 text-xs text-secondary hover:text-accent-rust hover:underline"
+                        >
+                          <BookMarked className="w-3 h-3 opacity-60" />
+                          Read at {externalSourceLabel(external.source)}
                         </a>
                       )}
                       {/* Mobile: show author + place inline */}
@@ -684,11 +735,14 @@ export default function BphCatalogBrowser({
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               {works.map((w) => {
                 const digitized = resolveDigitized(w);
+                const external = resolveExternal(w, !!digitized);
                 const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
                 const displayAuthor = w.author || w.variant_author || w.pseudonym;
                 const href = digitized
                   ? tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug)
-                  : detailUrl(w.ubn);
+                  : external
+                    ? tenantBookUrl({ id: external.id, slug: external.slug }, tenantSlug)
+                    : detailUrl(w.ubn);
                 return (
                   <a
                     key={w.ubn}
@@ -707,6 +761,11 @@ export default function BphCatalogBrowser({
                       ) : (
                         <div className="absolute inset-0 flex items-center justify-center text-muted">
                           <BookMarked className="w-8 h-8 opacity-40" />
+                        </div>
+                      )}
+                      {external && (
+                        <div className="absolute bottom-1 left-1 right-1 px-1.5 py-0.5 text-[10px] leading-tight text-white bg-black/55 rounded-sm text-center">
+                          via {externalSourceLabel(external.source)}
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- Adds `sl_external_book_id` / `sl_external_slug` / `sl_external_source` columns to `bph_works` so the BPH catalogue can surface scans hosted by other archives (Internet Archive, MDZ, Gallica, e-rara, Allard Pierson, etc.) as a *secondary* link, without conflating them with BPH-native digitisations.
- Backfilled **267 catalogue rows** with cross-provider links. By source: IA 166, MDZ 57, Gallica 16, Google Books 10, Allard Pierson 5, e-rara/Bodleian/Vatican 3 each, plus one-offs (Cambridge, Laurenziana, CMC Kloss).
- UI: list-view secondary link, grid-view "via [Source]" pill, catalogue detail page gets a new "Scan via [Source]" panel that only appears when there's no BPH-native scan.

## Why
The "digitised" badge on `bph.sourcelibrary.org/catalog` previously meant *only* "BPH scanned it themselves." But BPH physically holds another ~1,200 works whose scans live at other archives — those rows showed as not-digitised even though a user could read them via Source Library through the other archive's import.

Keeping the two concepts visually distinct preserves the existing meaning of every "X BPH digitised" counter while still giving catalogue browsers a way to read these works.

## What's NOT changed
- `sl_book_id` semantics — still strictly "BPH digitised this".
- The "Show digitised" filter — still BPH-native only.
- The home page "X digitised" counter — unchanged.
- The existing `sync-bph-sl-book-ids` cron — still does what it always did.

## Multi-volume gap (left for follow-up)
35 multi-volume Mongo books (Theatrum Chemicum, Works of Plato, Sacred Books of the East, etc.) were deliberately *not* linked. The BPH catalogue holds one row per work while IA has one row per volume, so a single `sl_external_book_id` column can't represent all the volumes. Schema would need to become `sl_external_book_ids JSONB[]` to handle this — out of scope for this PR.

## Migration
Already applied in production (`scripts/migration/add-bph-external-links.sql`). The API route degrades gracefully if the column is missing on a runtime that boots first.

## Test plan
- [ ] Visit `bph.sourcelibrary.org/catalog`, find a UBN with `sl_external_book_id` populated (e.g., UBN 9373 "Monas hieroglyphica", UBN 4671 "Evangelium Nicodemi") — verify secondary "Read at [Source]" link appears under the title in list view
- [ ] Switch to grid view — verify "via [Source]" pill on the cover
- [ ] Click through to `bph.sourcelibrary.org/catalog/9373` — verify "Scan via Gallica" panel renders (not "Digitised copy")
- [ ] Verify the home-page "X digitised" counter is unchanged
- [ ] Verify "Show digitised & translated" filter still returns only BPH-native scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)