### PR TITLE
Drop orphan 4-arg match_semantic from Supabase

### DIFF
--- a/scripts/migration/drop-match-semantic-4arg-orphan.sql
+++ b/scripts/migration/drop-match-semantic-4arg-orphan.sql
@@ -1,0 +1,33 @@
+-- Drop the orphaned 4-arg match_semantic from Supabase.
+--
+-- Background: the original match_semantic was deployed with 4 args
+-- (query_embedding, match_threshold, match_count, filter_tenant_id) in PR #1769.
+-- PR #1776 added language and year filters by extending the signature to 7 args.
+-- Postgres treats different-arity functions as separate definitions, so the
+-- CREATE OR REPLACE in PR #1776 *added* the 7-arg version without removing the
+-- 4-arg one. Both versions coexisted for ~30 minutes on 2026-05-16, breaking
+-- all calls that didn't pass every arg by name — supabase.rpc() reported:
+--
+--   "Could not choose the best candidate function between:
+--      public.match_semantic(vector, double precision, integer, text),
+--      public.match_semantic(vector, double precision, integer, text, text, integer, integer)"
+--
+-- The lib was updated to always pass all 7 named args, which restored service.
+-- This migration removes the now-orphan 4-arg version so future callers can
+-- safely use defaults again.
+--
+-- Safe to run: no current caller passes exactly 4 args (verified in
+-- src/lib/semantic-search.ts after PR #1776).
+
+DROP FUNCTION IF EXISTS match_semantic(
+  vector(768),
+  FLOAT,
+  INT,
+  TEXT
+);
+
+-- Verify only the 7-arg version remains:
+--   SELECT pg_get_function_identity_arguments(oid)
+--   FROM pg_proc
+--   WHERE proname = 'match_semantic';
+-- Should return one row.


### PR DESCRIPTION
## Summary

After PR #1776 added language/year filters to `match_semantic` (extending it to 7 args), the original 4-arg version from PR #1769 was left orphaned in Supabase. Postgres treats different-arity functions as distinct definitions, so `CREATE OR REPLACE FUNCTION` in #1776 created the new variant alongside the old rather than replacing it.

Both versions coexisted for ~30 minutes today and broke every `supabase.rpc('match_semantic', ...)` call that didn't pass every argument by name — the error was *"Could not choose the best candidate function"*. The lib was hot-patched in #1776 to always pass 7 named args, restoring service, but the orphan is still in the database and would re-bite the next dev who uses defaults.

This PR adds a migration that drops the 4-arg variant.

## Verification before drop

```
$ supabase.rpc('match_semantic', { ...4 args }) → ERROR (still conflicts)
$ supabase.rpc('match_semantic', { ...7 args }) → OK
```

After running the migration, the 4-arg call should resolve to the 7-arg version via defaults.

## Test plan

- [ ] Apply migration via Supabase Studio SQL editor (or psql)
- [ ] Confirm `SELECT pg_get_function_identity_arguments(oid) FROM pg_proc WHERE proname='match_semantic'` returns exactly one row (the 7-arg signature)
- [ ] Confirm `https://sourcelibrary.org/api/search/semantic?level=page&q=art%20of%20memory` still returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)