### PR TITLE
MCP: sign-in hint in tools/list, quota-approaching nudge on tool calls

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from 'next/server';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { withApiAuth } from '@/lib/api-auth';
+import { withApiAuth, type ApiIdentity } from '@/lib/api-auth';
 import { logMcpToolCall } from '@/lib/mcp-usage';
-import { getClientIp } from '@/lib/rate-limit';
+import { getClientIp, peekRateLimit } from '@/lib/rate-limit';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -468,7 +468,39 @@ async function fetchImageBase64(url: string): Promise<{ data: string; mimeType: 
 
 // ── Create a fresh MCP server instance (stateless per-request) ─────
 
-function createServer(reqContext: { ip: string; userAgent: string | null }) {
+const ANON_LIMIT_PER_HOUR = Number(process.env.API_ANON_LIMIT_PER_HOUR || 60);
+
+/**
+ * Build a `_meta.upgrade_hint` payload for anonymous callers approaching their
+ * rate-limit ceiling. Returns null for signed-in / API-key / bot identities —
+ * they don't need to upgrade. Returns null for anonymous callers under 80% of
+ * quota to keep responses noise-free.
+ *
+ * The hint is structured rather than a string so MCP clients can present it
+ * however they like (banner, inline note, or ignore). Agents reading it can
+ * decide whether to surface the message to the human user.
+ */
+function buildUpgradeHint(identity: ApiIdentity, ip: string) {
+  if (identity.kind !== 'anon') return null;
+  const usage = peekRateLimit(
+    { name: 'api:anon', limit: ANON_LIMIT_PER_HOUR, windowSeconds: 3600 },
+    ip,
+  );
+  if (usage.count < usage.limit * 0.8) return null;
+  return {
+    type: 'rate_limit_approaching',
+    usage: { count: usage.count, limit: usage.limit, remaining: usage.remaining },
+    reset_at_unix_ms: usage.resetAt,
+    message:
+      `You've used ${usage.count} of ${usage.limit} anonymous requests this hour. ` +
+      `Sign in at sourcelibrary.org/auth/signin for a much higher limit, ` +
+      `or get an API key at sourcelibrary.org/developers.`,
+    sign_in_url: 'https://sourcelibrary.org/auth/signin',
+    api_key_url: 'https://sourcelibrary.org/developers',
+  };
+}
+
+function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
     { name: 'source-library', version: '4.2.0' },
     { capabilities: { tools: {} } },
@@ -478,6 +510,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null }) {
     tools: TOOLS,
     _meta: {
       about: 'Source Library — 22,000+ rare alchemical, Hermetic, and early scientific texts translated into English. The largest AI-ready corpus of pre-modern esoteric knowledge. https://sourcelibrary.org',
+      sign_in_hint: 'Sign in at sourcelibrary.org/auth/signin to save research, get a much higher rate limit, and support this archive. API keys for programmatic access: sourcelibrary.org/developers.',
     },
   }));
 
@@ -491,6 +524,9 @@ function createServer(reqContext: { ip: string; userAgent: string | null }) {
         tool: name, args: argsObj, ms: Date.now() - started,
         ip: reqContext.ip, userAgent: reqContext.userAgent,
       });
+
+      const upgradeHint = buildUpgradeHint(reqContext.identity, reqContext.ip);
+      const meta = upgradeHint ? { _meta: { upgrade_hint: upgradeHint } } : {};
 
       // search_images: return image content blocks alongside text metadata
       if (name === 'search_images' && result && typeof result === 'object' && 'images' in result) {
@@ -511,11 +547,11 @@ function createServer(reqContext: { ip: string; userAgent: string | null }) {
           }
         }
 
-        return { content };
+        return { content, ...meta };
       }
 
       const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-      return { content: [{ type: 'text' as const, text }] };
+      return { content: [{ type: 'text' as const, text }], ...meta };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       logMcpToolCall({
@@ -550,7 +586,7 @@ export async function GET() {
   });
 }
 
-export const POST = withApiAuth(async (req: NextRequest) => {
+export const POST = withApiAuth(async (req: NextRequest, _ctx, identity) => {
   try {
     const body = await req.json();
 
@@ -567,6 +603,7 @@ export const POST = withApiAuth(async (req: NextRequest) => {
     const server = createServer({
       ip: getClientIp(req),
       userAgent: req.headers.get('user-agent'),
+      identity,
     });
     await server.connect(transport);
     try {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -62,6 +62,32 @@ export function checkRateLimit(
 }
 
 /**
+ * Read-only sibling of checkRateLimit — returns the current usage state for an
+ * IP without incrementing the counter. Used to surface "you're at N% of your
+ * quota" hints in responses before the hard 401 ever fires.
+ *
+ * Returns { count: 0, ... } when no entry exists yet for this IP (i.e. the
+ * counter was pruned or the user is on a fresh instance — usage looks low).
+ */
+export function peekRateLimit(
+  config: RateLimitConfig,
+  ip: string,
+): { count: number; limit: number; remaining: number; resetAt: number } {
+  const store = limiters.get(config.name);
+  const now = Date.now();
+  const entry = store?.get(ip);
+  if (!entry || entry.resetAt < now) {
+    return { count: 0, limit: config.limit, remaining: config.limit, resetAt: now + config.windowSeconds * 1000 };
+  }
+  return {
+    count: entry.count,
+    limit: config.limit,
+    remaining: Math.max(0, config.limit - entry.count),
+    resetAt: entry.resetAt,
+  };
+}
+
+/**
  * Extract client IP from request headers.
  * Vercel sets x-forwarded-for; Cloudflare sets cf-connecting-ip.
  */


### PR DESCRIPTION
## Summary

Two small additions that make the existing public-API rate-limit infrastructure more discoverable to MCP clients before the hard 401 ever fires. No behavior change for the auth gate itself — those CTAs are already in place — this surfaces them earlier and in a structured form.

1. **`tools/list._meta.sign_in_hint`** — reaches every new client at connection time with the value proposition (save research, higher rate limit, support archive). One line, no schema cost.

2. **`tools/call._meta.upgrade_hint`** — fires when an anonymous caller crosses 80% of their hourly quota. Structured payload (usage counts, reset timestamp, URLs) so clients can render it as a banner, inline note, or skip it. Silent for signed-in / API-key / bot identities. Silent below 80%.

The nudge is useful in both rollout phases: while `API_AUTH_ENFORCE` is off (observe-only) it still tells active anon users their quota is filling up; once flipped, it gives them a chance to upgrade before they get a 401.

## What changed

- New `peekRateLimit(config, ip)` in `src/lib/rate-limit.ts` — read-only sibling of `checkRateLimit` that returns `{ count, limit, remaining, resetAt }` without incrementing the counter.
- `src/app/api/mcp/route.ts`: imports `ApiIdentity` + `peekRateLimit`, wires the existing-but-ignored `identity` arg from `withApiAuth` through to `createServer`, and attaches `_meta.upgrade_hint` to both the JSON tool response and the `search_images` content-block response when anon usage ≥ 80%.

## Verification

Local dev with `API_ANON_LIMIT_PER_HOUR=5`:

| call | count | _meta.upgrade_hint? |
|------|-------|---------------------|
| 1    | 1     | no |
| 2    | 2     | no |
| 3    | 3     | no |
| 4    | 4     | **yes** (80%) |
| 5    | 5     | yes (100%) |
| 6    | 6     | yes (would be 401 if enforce flipped) |

Tools/list `_meta` keys: `['about', 'sign_in_hint']`, sign_in_hint text confirmed.

## Test plan

- [ ] Vercel preview deploy succeeds
- [ ] `curl preview/api/mcp -d '{"method":"tools/list"}'` returns `_meta.sign_in_hint`
- [ ] `curl preview/api/mcp` repeatedly until 80% of `API_ANON_LIMIT_PER_HOUR` — `_meta.upgrade_hint` appears, persists past the limit
- [ ] Signed-in session calls do NOT carry the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)