### PR TITLE
MCP: sign-in hint in tools/list, quota-approaching nudge on tool calls

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from 'next/server';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { withApiAuth } from '@/lib/api-auth';
+import { withApiAuth, type ApiIdentity } from '@/lib/api-auth';
 import { logMcpToolCall } from '@/lib/mcp-usage';
-import { getClientIp } from '@/lib/rate-limit';
+import { getClientIp, peekRateLimit } from '@/lib/rate-limit';
 import { getShortUrl } from '@/lib/shortlinks';
 import {
   CallToolRequestSchema,
@@ -473,7 +473,39 @@ async function fetchImageBase64(url: string): Promise<{ data: string; mimeType: 
 
 // ── Create a fresh MCP server instance (stateless per-request) ─────
 
-function createServer(reqContext: { ip: string; userAgent: string | null }) {
+const ANON_LIMIT_PER_HOUR = Number(process.env.API_ANON_LIMIT_PER_HOUR || 60);
+
+/**
+ * Build a `_meta.upgrade_hint` payload for anonymous callers approaching their
+ * rate-limit ceiling. Returns null for signed-in / API-key / bot identities —
+ * they don't need to upgrade. Returns null for anonymous callers under 80% of
+ * quota to keep responses noise-free.
+ *
+ * The hint is structured rather than a string so MCP clients can present it
+ * however they like (banner, inline note, or ignore). Agents reading it can
+ * decide whether to surface the message to the human user.
+ */
+function buildUpgradeHint(identity: ApiIdentity, ip: string) {
+  if (identity.kind !== 'anon') return null;
+  const usage = peekRateLimit(
+    { name: 'api:anon', limit: ANON_LIMIT_PER_HOUR, windowSeconds: 3600 },
+    ip,
+  );
+  if (usage.count < usage.limit * 0.8) return null;
+  return {
+    type: 'rate_limit_approaching',
+    usage: { count: usage.count, limit: usage.limit, remaining: usage.remaining },
+    reset_at_unix_ms: usage.resetAt,
+    message:
+      `You've used ${usage.count} of ${usage.limit} anonymous requests this hour. ` +
+      `Sign in at sourcelibrary.org/auth/signin for a much higher limit, ` +
+      `or get an API key at sourcelibrary.org/developers.`,
+    sign_in_url: 'https://sourcelibrary.org/auth/signin',
+    api_key_url: 'https://sourcelibrary.org/developers',
+  };
+}
+
+function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
     { name: 'source-library', version: '4.2.0' },
     { capabilities: { tools: {} } },
@@ -483,6 +515,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null }) {
     tools: TOOLS,
     _meta: {
       about: 'Source Library — 22,000+ rare alchemical, Hermetic, and early scientific texts translated into English. The largest AI-ready corpus of pre-modern esoteric knowledge. https://sourcelibrary.org',
+      sign_in_hint: 'Sign in at sourcelibrary.org/auth/signin to save research, get a much higher rate limit, and support this archive. API keys for programmatic access: sourcelibrary.org/developers.',
     },
   }));
 
@@ -496,6 +529,9 @@ function createServer(reqContext: { ip: string; userAgent: string | null }) {
         tool: name, args: argsObj, ms: Date.now() - started,
         ip: reqContext.ip, userAgent: reqContext.userAgent,
       });
+
+      const upgradeHint = buildUpgradeHint(reqContext.identity, reqContext.ip);
+      const meta = upgradeHint ? { _meta: { upgrade_hint: upgradeHint } } : {};
 
       // search_images: return image content blocks alongside text metadata
       if (name === 'search_images' && result && typeof result === 'object' && 'images' in result) {
@@ -516,11 +552,11 @@ function createServer(reqContext: { ip: string; userAgent: string | null }) {
           }
         }
 
-        return { content };
+        return { content, ...meta };
       }
 
       const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-      return { content: [{ type: 'text' as const, text }] };
+      return { content: [{ type: 'text' as const, text }], ...meta };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       logMcpToolCall({
@@ -555,7 +591,7 @@ export async function GET() {
   });
 }
 
-export const POST = withApiAuth(async (req: NextRequest) => {
+export const POST = withApiAuth(async (req: NextRequest, _ctx, identity) => {
   try {
     const body = await req.json();
 
@@ -572,6 +608,7 @@ export const POST = withApiAuth(async (req: NextRequest) => {
     const server = createServer({
       ip: getClientIp(req),
       userAgent: req.headers.get('user-agent'),
+      identity,
     });
     await server.connect(transport);
     try {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -62,6 +62,32 @@ export function checkRateLimit(
 }
 
 /**
+ * Read-only sibling of checkRateLimit — returns the current usage state for an
+ * IP without incrementing the counter. Used to surface "you're at N% of your
+ * quota" hints in responses before the hard 401 ever fires.
+ *
+ * Returns { count: 0, ... } when no entry exists yet for this IP (i.e. the
+ * counter was pruned or the user is on a fresh instance — usage looks low).
+ */
+export function peekRateLimit(
+  config: RateLimitConfig,
+  ip: string,
+): { count: number; limit: number; remaining: number; resetAt: number } {
+  const store = limiters.get(config.name);
+  const now = Date.now();
+  const entry = store?.get(ip);
+  if (!entry || entry.resetAt < now) {
+    return { count: 0, limit: config.limit, remaining: config.limit, resetAt: now + config.windowSeconds * 1000 };
+  }
+  return {
+    count: entry.count,
+    limit: config.limit,
+    remaining: Math.max(0, config.limit - entry.count),
+    resetAt: entry.resetAt,
+  };
+}
+
+/**
  * Extract client IP from request headers.
  * Vercel sets x-forwarded-for; Cloudflare sets cf-connecting-ip.
  */


### PR DESCRIPTION
## Summary

Reopen of #1781 after rebase onto main (PR #1783 had landed and touched the same import line in `src/app/api/mcp/route.ts`).

Two small additions to make the existing rate-limit infrastructure more discoverable to MCP clients before the hard 401 ever fires:

1. **`tools/list._meta.sign_in_hint`** — every new client sees the value prop at connection.
2. **`tools/call._meta.upgrade_hint`** — structured payload (usage counts, reset timestamp, URLs) when anon callers cross 80% of hourly quota. Silent for signed-in/key/bot identities. Silent below threshold.

New `peekRateLimit(config, ip)` in `src/lib/rate-limit.ts` — read-only sibling of `checkRateLimit` for any consumer that wants quota-aware UX.

## Verification

Verified locally with `API_ANON_LIMIT_PER_HOUR=5`: silent on calls 1–3, fires from call 4 (80%), persists past the limit. Verified on the previous PR's Vercel preview (before it was closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)