### PR TITLE
MCP: bump version to 4.3.0

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -15,7 +15,7 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 // ── API helpers (same as mcp-server/src/api.ts, self-calling) ──────
 
 const API_BASE = 'https://sourcelibrary.org/api';
-const MCP_HEADERS = { 'User-Agent': 'SourceLibrary-MCP/4.2', 'Accept-Language': 'en' };
+const MCP_HEADERS = { 'User-Agent': 'SourceLibrary-MCP/4.3', 'Accept-Language': 'en' };
 
 async function apiGet(path: string, params?: URLSearchParams) {
   const url = params ? `${API_BASE}${path}?${params}` : `${API_BASE}${path}`;
@@ -507,7 +507,7 @@ function buildUpgradeHint(identity: ApiIdentity, ip: string) {
 
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
-    { name: 'source-library', version: '4.2.0' },
+    { name: 'source-library', version: '4.3.0' },
     { capabilities: { tools: {} } },
   );
 
@@ -578,7 +578,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
 export async function GET() {
   return new Response(JSON.stringify({
     name: 'source-library',
-    version: '4.2.0',
+    version: '4.3.0',
     description: 'Source Library MCP Server — search, read, and cite 22,000+ rare historical texts. Connect via POST to this endpoint.',
     docs: 'https://sourcelibrary.org/developers',
     tools: TOOLS.map(t => t.name),


### PR DESCRIPTION
## Summary

Bump MCP server version string from 4.2.0 → 4.3.0 to reflect this week's additions:

- #1775 — max_per_book + year filters + Continuity preamble stripping on `search_concept`
- #1776 — SQL-level language/year filters in `match_semantic`
- #1783 — `short_url` on all passage results
- #1784 — `sign_in_hint` in tools/list and `upgrade_hint` quota nudge in tool/call responses
- (out-of-band) `API_AUTH_ENFORCE=1`, `API_ANON_LIMIT_PER_HOUR=120` set in Vercel production env

Also serves as the source diff Vercel needs to actually rebuild — without a change under `src/`, the deploy is skipped by the ignore step and the new env vars don't propagate to all serverless instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)