### PR TITLE
MCP: add languages[] and exclude_languages[] filters to passage search

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -85,6 +85,8 @@ async function searchPassages(args: Record<string, unknown>) {
   const offset = Number(args.offset) || 0;
   const params = new URLSearchParams({ q: String(args.query), pages_only: 'true', limit: String(limit), offset: String(offset) });
   if (args.language) params.set('language', String(args.language));
+  if (Array.isArray(args.languages) && args.languages.length > 0) params.set('languages', args.languages.join(','));
+  if (Array.isArray(args.exclude_languages) && args.exclude_languages.length > 0) params.set('exclude_languages', args.exclude_languages.join(','));
   if (args.year_from) params.set('year_from', String(args.year_from));
   if (args.year_to) params.set('year_to', String(args.year_to));
   if (args.book_id) params.set('book_id', String(args.book_id));
@@ -119,6 +121,8 @@ async function searchConcept(args: Record<string, unknown>) {
   const limit = Math.min(Number(args.limit) || 15, 50);
   const params = new URLSearchParams({ q: String(args.query), level: 'page', limit: String(limit) });
   if (args.language) params.set('language', String(args.language));
+  if (Array.isArray(args.languages) && args.languages.length > 0) params.set('languages', args.languages.join(','));
+  if (Array.isArray(args.exclude_languages) && args.exclude_languages.length > 0) params.set('exclude_languages', args.exclude_languages.join(','));
   if (args.year_from) params.set('year_min', String(args.year_from));
   if (args.year_to) params.set('year_max', String(args.year_to));
   if (args.max_per_book) params.set('max_per_book', String(args.max_per_book));
@@ -308,7 +312,9 @@ const TOOLS: Tool[] = [
       type: 'object' as const,
       properties: {
         query: { type: 'string', description: 'Search term — prefer single distinctive concepts ("harmony of the spheres", "active intellect") over long natural-language phrases. Multi-word queries match all terms (not phrase); wrap in "double quotes" for exact phrase.' },
-        language: { type: 'string', description: 'Filter by book\'s original language' },
+        language: { type: 'string', description: 'Filter by a single original language' },
+        languages: { type: 'array', items: { type: 'string' }, description: 'Filter to any of these languages, e.g. ["Sanskrit", "Arabic", "Chinese"]. Use instead of language when targeting multiple traditions.' },
+        exclude_languages: { type: 'array', items: { type: 'string' }, description: 'Exclude these languages, e.g. ["Latin", "French", "German", "English"] to surface non-Western sources.' },
         year_from: { type: 'number' }, year_to: { type: 'number' },
         book_id: { type: 'string', description: 'Search within a specific book' },
         limit: { type: 'number', description: 'Max results per page (default 20, max 50)' },
@@ -325,7 +331,9 @@ const TOOLS: Tool[] = [
       type: 'object' as const,
       properties: {
         query: { type: 'string', description: 'A concept or natural-language description — full sentences are fine (e.g. "tools that extend the mind beyond the body"). Unlike search_translations, this does NOT require words that appear in the corpus.' },
-        language: { type: 'string', description: 'Filter by original language (e.g., Latin, German, Greek, Arabic)' },
+        language: { type: 'string', description: 'Filter by a single original language' },
+        languages: { type: 'array', items: { type: 'string' }, description: 'Filter to any of these languages, e.g. ["Sanskrit", "Arabic", "Chinese"]. Use instead of language when targeting multiple traditions.' },
+        exclude_languages: { type: 'array', items: { type: 'string' }, description: 'Exclude these languages, e.g. ["Latin", "French", "German", "English"] to surface non-Western sources.' },
         year_from: { type: 'number', description: 'Restrict to books published in or after this year (filters out modern editions and translations).' },
         year_to: { type: 'number', description: 'Restrict to books published in or before this year.' },
         max_per_book: { type: 'number', description: 'Cap on passages from any single book. Useful when one book dominates the conceptual neighborhood; set to 1–2 for diverse author/work coverage.' },

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -48,6 +48,10 @@ export const GET = withApiAuth(async (request: NextRequest) => {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') || '';
     const language = searchParams.get('language');
+    const languagesParam = searchParams.get('languages');
+    const excludeLanguagesParam = searchParams.get('exclude_languages');
+    const languages = languagesParam ? languagesParam.split(',').map(l => l.trim()).filter(Boolean) : [];
+    const excludeLanguages = excludeLanguagesParam ? excludeLanguagesParam.split(',').map(l => l.trim()).filter(Boolean) : [];
     const category = searchParams.get('category'); // Category filter
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');
@@ -91,7 +95,9 @@ export const GET = withApiAuth(async (request: NextRequest) => {
     function buildBookFilters(): Record<string, unknown> {
       const filters: Record<string, unknown> = { visible: true, pages_count: { $gt: 0 } };
       if (tenantId) filters.tenantId = tenantId;
-      if (language) filters.language = language;
+      if (languages.length > 0) filters.language = { $in: languages };
+      else if (excludeLanguages.length > 0) filters.language = { $nin: excludeLanguages };
+      else if (language) filters.language = language;
       if (category) filters.categories = category;
       if (dateFrom || dateTo) {
         filters.published = {};
@@ -155,7 +161,7 @@ export const GET = withApiAuth(async (request: NextRequest) => {
     }
 
     // Run book search and page content search in parallel
-    const hasBookLevelFilters = !!(language || category || dateFrom || dateTo || hasDoi === 'true' || hasTranslation === 'true' || firstTranslation === 'true' || year || yearFrom || yearTo || library);
+    const hasBookLevelFilters = !!(language || languages.length > 0 || excludeLanguages.length > 0 || category || dateFrom || dateTo || hasDoi === 'true' || hasTranslation === 'true' || firstTranslation === 'true' || year || yearFrom || yearTo || library);
 
     const [bookDocs, pageDocs, semanticDocs, semanticPageDocs] = await Promise.all([
       // --- Book search via Supabase trigram (fast, no cold-start penalty) ---
@@ -223,7 +229,9 @@ export const GET = withApiAuth(async (request: NextRequest) => {
           } else if (hasBookLevelFilters) {
             const bookIdFilter: Record<string, unknown> = { visible: true };
             if (tenantId) bookIdFilter.tenantId = tenantId;
-            if (language) bookIdFilter.language = language;
+            if (languages.length > 0) bookIdFilter.language = { $in: languages };
+            else if (excludeLanguages.length > 0) bookIdFilter.language = { $nin: excludeLanguages };
+            else if (language) bookIdFilter.language = language;
             if (category) bookIdFilter.categories = category;
             if (dateFrom || dateTo) {
               bookIdFilter.published = {};

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -30,6 +30,10 @@ export async function GET(request: NextRequest) {
   const level = searchParams.get('level') === 'page' ? 'page' : 'book';
   const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10), 50);
   const language = searchParams.get('language') || undefined;
+  const languagesParam = searchParams.get('languages');
+  const excludeLanguagesParam = searchParams.get('exclude_languages');
+  const languages = languagesParam ? languagesParam.split(',').map(l => l.trim()).filter(Boolean) : undefined;
+  const excludeLanguages = excludeLanguagesParam ? excludeLanguagesParam.split(',').map(l => l.trim()).filter(Boolean) : undefined;
   const yearMin = searchParams.get('year_min') ? parseInt(searchParams.get('year_min')!, 10) : undefined;
   const yearMax = searchParams.get('year_max') ? parseInt(searchParams.get('year_max')!, 10) : undefined;
   const maxPerBook = searchParams.get('max_per_book') ? parseInt(searchParams.get('max_per_book')!, 10) : undefined;
@@ -43,7 +47,7 @@ export async function GET(request: NextRequest) {
 
   if (level === 'page') {
     try {
-      const pages = await semanticPageSearchGlobal(searchQuery, limit, { language, yearMin, yearMax, maxPerBook });
+      const pages = await semanticPageSearchGlobal(searchQuery, limit, { language, languages, excludeLanguages, yearMin, yearMax, maxPerBook });
       const bookIds = [...new Set(pages.map(p => p.book_id))];
       let slugMap: Record<string, string> = {};
       if (bookIds.length > 0) {

--- a/src/lib/atlas-search.ts
+++ b/src/lib/atlas-search.ts
@@ -6,6 +6,8 @@ export const PAGE_SEARCH_INDEX = 'pages_search';
 export interface BookSearchFilters {
   tenantId?: string;
   language?: string;
+  languages?: string[];
+  excludeLanguages?: string[];
   category?: string;
   yearExact?: number;
   yearFrom?: number;
@@ -59,8 +61,13 @@ export function buildBookSearchStage(query: string, filters: BookSearchFilters =
   // Exclude empty shell books (0 pages from failed imports)
   filter.push({ range: { path: 'pages_count', gt: 0 } });
 
-  if (filters.language) {
+  if (filters.languages && filters.languages.length > 0) {
+    filter.push({ in: { path: 'language', value: filters.languages } });
+  } else if (filters.language) {
     filter.push({ equals: { path: 'language', value: filters.language } });
+  }
+  if (filters.excludeLanguages && filters.excludeLanguages.length > 0) {
+    mustNot.push({ in: { path: 'language', value: filters.excludeLanguages } });
   }
   if (filters.category) {
     filter.push({ equals: { path: 'categories', value: filters.category } });

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -229,6 +229,8 @@ export interface SemanticPageSearchOptions {
   maxPerBook?: number;
   tenantId?: string;
   language?: string;
+  languages?: string[];
+  excludeLanguages?: string[];
 }
 
 /**
@@ -255,9 +257,9 @@ export async function semanticPageSearchGlobal(
   const queryEmbedding = await getQueryEmbedding(query);
   if (!queryEmbedding) return [];
 
-  // Over-request only when maxPerBook filtering is needed (JS post-hoc).
-  // language/year are filtered at the RPC level so no over-requesting needed for those.
-  const overRequest = (opts.maxPerBook ?? 0) > 0 ? Math.min(limit * 3, 50) : limit;
+  // Over-request when post-hoc JS filtering is needed (maxPerBook, languages, excludeLanguages).
+  const needsPostHocFilter = (opts.maxPerBook ?? 0) > 0 || (opts.languages?.length ?? 0) > 0 || (opts.excludeLanguages?.length ?? 0) > 0;
+  const overRequest = needsPostHocFilter ? Math.min(limit * 3, 50) : limit;
 
   const { data, error } = await supabase.rpc('match_semantic', {
     query_embedding: JSON.stringify(queryEmbedding),
@@ -276,6 +278,14 @@ export async function semanticPageSearchGlobal(
 
   let rows = (data || []) as any[];
 
+  if ((opts.languages?.length ?? 0) > 0) {
+    const set = new Set(opts.languages!.map(l => l.toLowerCase()));
+    rows = rows.filter(r => r.book_language && set.has(String(r.book_language).toLowerCase()));
+  }
+  if ((opts.excludeLanguages?.length ?? 0) > 0) {
+    const set = new Set(opts.excludeLanguages!.map(l => l.toLowerCase()));
+    rows = rows.filter(r => !r.book_language || !set.has(String(r.book_language).toLowerCase()));
+  }
   if ((opts.maxPerBook ?? 0) > 0) {
     const perBook = new Map<string, number>();
     rows = rows.filter(r => {


### PR DESCRIPTION
## Summary
- Adds `languages` (array) and `exclude_languages` (array) params to `search_translations` and `search_concept` MCP tools
- `languages: ["Sanskrit", "Arabic", "Chinese"]` — include any of these in one query
- `exclude_languages: ["Latin", "French", "English"]` — exclude Western-language sources to surface non-Western results
- Threads the filters through the full stack: atlas-search.ts (Atlas `$in`/`$nin`), semantic-search.ts (post-hoc JS with 3x over-request), and both search API routes

## How it works
- **Keyword search** (`search_translations`): uses MongoDB `$in`/`$nin` for book-level filtering; Atlas Search uses the `in` operator in the filter clause
- **Semantic search** (`search_concept`): Supabase RPC only accepts a single `filter_language`, so `languages`/`exclude_languages` are applied post-hoc in JS. Over-requests 3x from the RPC to compensate for filtering losses

🤖 Generated with [Claude Code](https://claude.com/claude-code)