### PR TITLE
Fix language filter: expand ISO codes↔full names in exclude_languages/languages

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -7,6 +7,7 @@ import { searchBookIds } from '@/lib/books-catalog';
 import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-search';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { withApiAuth } from '@/lib/api-auth';
+import { expandLanguages } from '@/lib/language-utils';
 
 export const preferredRegion = 'fra1';
 
@@ -50,8 +51,8 @@ export const GET = withApiAuth(async (request: NextRequest) => {
     const language = searchParams.get('language');
     const languagesParam = searchParams.get('languages');
     const excludeLanguagesParam = searchParams.get('exclude_languages');
-    const languages = languagesParam ? languagesParam.split(',').map(l => l.trim()).filter(Boolean) : [];
-    const excludeLanguages = excludeLanguagesParam ? excludeLanguagesParam.split(',').map(l => l.trim()).filter(Boolean) : [];
+    const languages = expandLanguages(languagesParam ? languagesParam.split(',').map(l => l.trim()).filter(Boolean) : []);
+    const excludeLanguages = expandLanguages(excludeLanguagesParam ? excludeLanguagesParam.split(',').map(l => l.trim()).filter(Boolean) : []);
     const category = searchParams.get('category'); // Category filter
     const dateFrom = searchParams.get('date_from');
     const dateTo = searchParams.get('date_to');

--- a/src/lib/language-utils.ts
+++ b/src/lib/language-utils.ts
@@ -1,0 +1,34 @@
+/** ISO-639-1 code → canonical English name */
+const CODE_TO_NAME: Record<string, string> = {
+  ar: 'Arabic', cs: 'Czech', da: 'Danish', de: 'German', el: 'Greek',
+  en: 'English', es: 'Spanish', fa: 'Persian', fr: 'French', he: 'Hebrew',
+  hu: 'Hungarian', it: 'Italian', ja: 'Japanese', la: 'Latin', nl: 'Dutch',
+  no: 'Norwegian', pl: 'Polish', pt: 'Portuguese', ru: 'Russian', sa: 'Sanskrit',
+  sv: 'Swedish', tr: 'Turkish', zh: 'Chinese',
+};
+
+/** Canonical English name → ISO-639-1 code */
+const NAME_TO_CODE: Record<string, string> = Object.fromEntries(
+  Object.entries(CODE_TO_NAME).map(([code, name]) => [name.toLowerCase(), code])
+);
+
+/**
+ * Expand a language list to include both ISO codes and English names.
+ * e.g. ["French", "la"] → ["French", "fr", "Latin", "la"]
+ *
+ * Source Library books use either form depending on import source.
+ * This lets filters like exclude_languages=["French"] also catch books
+ * stored as "fr", and vice-versa.
+ */
+export function expandLanguages(langs: string[]): string[] {
+  const result = new Set<string>();
+  for (const lang of langs) {
+    result.add(lang);
+    const lower = lang.toLowerCase();
+    const code = NAME_TO_CODE[lower];
+    if (code) result.add(code);
+    const name = CODE_TO_NAME[lower];
+    if (name) result.add(name);
+  }
+  return [...result];
+}

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase';
+import { expandLanguages } from '@/lib/language-utils';
 
 /**
  * Generate query embedding via Gemini embedding-2-preview.
@@ -279,11 +280,11 @@ export async function semanticPageSearchGlobal(
   let rows = (data || []) as any[];
 
   if ((opts.languages?.length ?? 0) > 0) {
-    const set = new Set(opts.languages!.map(l => l.toLowerCase()));
+    const set = new Set(expandLanguages(opts.languages!).map(l => l.toLowerCase()));
     rows = rows.filter(r => r.book_language && set.has(String(r.book_language).toLowerCase()));
   }
   if ((opts.excludeLanguages?.length ?? 0) > 0) {
-    const set = new Set(opts.excludeLanguages!.map(l => l.toLowerCase()));
+    const set = new Set(expandLanguages(opts.excludeLanguages!).map(l => l.toLowerCase()));
     rows = rows.filter(r => !r.book_language || !set.has(String(r.book_language).toLowerCase()));
   }
   if ((opts.maxPerBook ?? 0) > 0) {


### PR DESCRIPTION
## Problem

`search_translations` with `exclude_languages: ["French"]` still returned Tissot's *L'Onanisme* because his book is stored as `language: "fr"` (ISO code), not `"French"`. Same issue with `languages` include filter and the semantic post-hoc JS filter.

## Fix

New shared utility `src/lib/language-utils.ts` — `expandLanguages()` resolves both directions:
- `"French"` → `["French", "fr"]`
- `"fr"` → `["fr", "French"]`

Applied in two places:
- `src/app/api/search/route.ts`: MongoDB `\$in`/`\$nin` now includes both forms
- `src/lib/semantic-search.ts`: post-hoc JS Set includes both forms

Covers 23 languages (all common ISO-639-1 codes + English names).

## Test
Before: `exclude_languages=["French"]` matches only exact `"French"`, misses `"fr"` books.
After: matches both — Tissot and other `"fr"` books are correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)