### PR TITLE
Log search queries; add unified MCP+search usage analyzer

### DIFF
--- a/scripts/analyze-search-usage.mjs
+++ b/scripts/analyze-search-usage.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Unified search / MCP usage report.
+ *
+ * Reads two collections:
+ *   - mcp_tool_calls: every MCP tool invocation (incl. search_concept,
+ *     search_library, search_translations, search_within_book, etc.)
+ *   - search_queries: direct hits on /api/search and /api/search/semantic
+ *     (filled by lib/search-log.ts — only data from after that deploy)
+ *
+ * Reports:
+ *   1. MCP tool mix + latency + error rates
+ *   2. Top search queries (MCP + web, merged)
+ *   3. Top queries by route (search_concept vs search.semantic.page etc.)
+ *   4. Top user-agents
+ *   5. Daily volume trend
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/analyze-search-usage.mjs [--days N] [--top N]
+ */
+
+import { MongoClient } from 'mongodb';
+
+const args = {};
+for (let i = 0; i < process.argv.length - 2; i++) {
+  const arg = process.argv[i + 2];
+  const eq = arg.match(/^--([^=]+)=(.*)$/);
+  if (eq) { args[eq[1]] = eq[2]; continue; }
+  if (arg.startsWith('--')) {
+    const key = arg.slice(2);
+    const next = process.argv[i + 3];
+    if (next && !next.startsWith('--')) { args[key] = next; i++; }
+    else { args[key] = 'true'; }
+  }
+}
+
+const DAYS = Number(args.days || 7);
+const TOP = Number(args.top || 30);
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI is not set. Source .env.production.local first.'); process.exit(1); }
+
+function fmtNum(n) { return n.toLocaleString(); }
+function pad(s, n) { return String(s).padEnd(n); }
+function rpad(s, n) { return String(s).padStart(n); }
+
+async function main() {
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db('bookstore');
+  const since = new Date(Date.now() - DAYS * 24 * 3600 * 1000);
+
+  console.log(`Source Library — search & MCP usage report`);
+  console.log(`Window: ${since.toISOString()} → now (${DAYS} days)`);
+  console.log('='.repeat(76));
+
+  // --- 1. MCP tool mix + latency + errors ---
+  const mcpCol = db.collection('mcp_tool_calls');
+  const mcpTotal = await mcpCol.countDocuments({ ts: { $gte: since } });
+  const byTool = await mcpCol.aggregate([
+    { $match: { ts: { $gte: since } } },
+    {
+      $group: {
+        _id: '$tool',
+        n: { $sum: 1 },
+        errs: { $sum: { $cond: ['$ok', 0, 1] } },
+        ms_all: { $push: '$ms' },
+      },
+    },
+    { $sort: { n: -1 } },
+  ]).toArray();
+
+  console.log(`\n[1] MCP tool calls: ${fmtNum(mcpTotal)} total\n`);
+  console.log(`  ${pad('tool', 22)} ${rpad('calls', 6)}  ${rpad('errs', 5)}  ${rpad('p50ms', 7)} ${rpad('p95ms', 7)} ${rpad('p99ms', 7)}`);
+  for (const t of byTool) {
+    const sorted = t.ms_all.sort((a, b) => a - b);
+    const p = (q) => sorted[Math.min(sorted.length - 1, Math.floor((q / 100) * sorted.length))];
+    console.log(`  ${pad(t._id || '?', 22)} ${rpad(t.n, 6)}  ${rpad(t.errs, 5)}  ${rpad(p(50), 7)} ${rpad(p(95), 7)} ${rpad(p(99), 7)}`);
+  }
+
+  // --- 2. Web search queries (search_queries collection) ---
+  const sqCol = db.collection('search_queries');
+  const sqExists = await db.listCollections({ name: 'search_queries' }).hasNext();
+  let webTotal = 0;
+  let byRouteWeb = [];
+  if (sqExists) {
+    webTotal = await sqCol.countDocuments({ ts: { $gte: since } });
+    byRouteWeb = await sqCol.aggregate([
+      { $match: { ts: { $gte: since } } },
+      {
+        $group: {
+          _id: '$route',
+          n: { $sum: 1 },
+          errs: { $sum: { $cond: ['$ok', 0, 1] } },
+          mean_total: { $avg: '$total' },
+        },
+      },
+      { $sort: { n: -1 } },
+    ]).toArray();
+    console.log(`\n[2] Direct (non-MCP) search calls: ${fmtNum(webTotal)} total\n`);
+    console.log(`  ${pad('route', 28)} ${rpad('calls', 6)}  ${rpad('errs', 5)}  ${rpad('mean_total', 11)}`);
+    for (const r of byRouteWeb) {
+      console.log(`  ${pad(r._id || '?', 28)} ${rpad(r.n, 6)}  ${rpad(r.errs, 5)}  ${rpad(Math.round(r.mean_total || 0), 11)}`);
+    }
+  } else {
+    console.log(`\n[2] Direct (non-MCP) search calls: collection does not exist yet`);
+    console.log(`    (the search_queries collection is created on first write — wait for one /api/search hit after deploy)`);
+  }
+
+  // --- 3. Top queries (MCP + web, merged) ---
+  // From MCP: tools whose args contain a 'query' field (all search_* + get_quote-ish)
+  const mcpQueries = await mcpCol.aggregate([
+    { $match: { ts: { $gte: since }, 'args.query': { $exists: true, $type: 'string', $ne: '' } } },
+    { $group: { _id: { q: '$args.query', src: 'mcp' }, n: { $sum: 1 }, tools: { $addToSet: '$tool' } } },
+  ]).toArray();
+  let webQueries = [];
+  if (sqExists) {
+    webQueries = await sqCol.aggregate([
+      { $match: { ts: { $gte: since }, query: { $ne: '' } } },
+      { $group: { _id: { q: '$query', src: 'web' }, n: { $sum: 1 }, tools: { $addToSet: '$route' } } },
+    ]).toArray();
+  }
+
+  // Merge by query string
+  const merged = new Map();
+  for (const r of [...mcpQueries, ...webQueries]) {
+    const key = r._id.q;
+    const existing = merged.get(key) || { q: key, n: 0, sources: new Set(), tools: new Set() };
+    existing.n += r.n;
+    existing.sources.add(r._id.src);
+    for (const t of r.tools || []) existing.tools.add(t);
+    merged.set(key, existing);
+  }
+  const sortedQueries = [...merged.values()].sort((a, b) => b.n - a.n).slice(0, TOP);
+
+  console.log(`\n[3] Top ${TOP} queries (MCP + web merged, ${fmtNum(merged.size)} unique queries total):\n`);
+  console.log(`  ${rpad('n', 4)}  ${pad('src', 8)} ${pad('routes/tools', 32)} query`);
+  for (const q of sortedQueries) {
+    const src = [...q.sources].join(',');
+    const tools = [...q.tools].slice(0, 3).join(',');
+    const qstr = JSON.stringify(q.q).slice(0, 80);
+    console.log(`  ${rpad(q.n, 4)}  ${pad(src, 8)} ${pad(tools, 32)} ${qstr}`);
+  }
+
+  // --- 4. User-agent mix (MCP only — web side has it too but we keep this terse) ---
+  const byUa = await mcpCol.aggregate([
+    { $match: { ts: { $gte: since } } },
+    { $project: { ua_stem: { $substr: ['$user_agent', 0, 40] } } },
+    { $group: { _id: '$ua_stem', n: { $sum: 1 } } },
+    { $sort: { n: -1 } },
+    { $limit: 10 },
+  ]).toArray();
+  console.log(`\n[4] Top MCP user-agent prefixes (first 40 chars):\n`);
+  for (const r of byUa) {
+    console.log(`  ${pad(r._id || '(none)', 42)} ${rpad(r.n, 6)}`);
+  }
+
+  // --- 5. Daily volume trend ---
+  const daily = await mcpCol.aggregate([
+    { $match: { ts: { $gte: since } } },
+    {
+      $group: {
+        _id: { $dateToString: { date: '$ts', format: '%Y-%m-%d' } },
+        n: { $sum: 1 },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ]).toArray();
+  console.log(`\n[5] Daily MCP call volume:\n`);
+  for (const d of daily) {
+    const bar = '█'.repeat(Math.min(60, Math.ceil(d.n / Math.max(1, mcpTotal / DAYS / 10))));
+    console.log(`  ${d._id}  ${rpad(d.n, 5)} ${bar}`);
+  }
+
+  console.log('\n' + '='.repeat(76));
+
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -8,6 +8,7 @@ import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-sea
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { withApiAuth } from '@/lib/api-auth';
 import { expandLanguages } from '@/lib/language-utils';
+import { logSearchQuery } from '@/lib/search-log';
 
 export const preferredRegion = 'fra1';
 
@@ -44,7 +45,8 @@ function extractSnippet(text: string, query: string, contextChars = 150): string
 }
 
 // GET /api/search - Search across books and translations
-export const GET = withApiAuth(async (request: NextRequest) => {
+export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
+  const _searchStart = Date.now();
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q') || '';
@@ -656,6 +658,16 @@ export const GET = withApiAuth(async (request: NextRequest) => {
       created_at: new Date(),
     }).catch(() => {});
 
+    logSearchQuery({
+      request, identity, route: 'search', query,
+      total: dedupedResults.length, ms: Date.now() - _searchStart, ok: true,
+      filters: {
+        language, category, year, year_from: yearFrom, year_to: yearTo,
+        languages, exclude_languages: excludeLanguages,
+        has_doi: hasDoi, has_translation: hasTranslation, book_id: bookId,
+        pages_only: pagesOnly, sort: sortBy,
+      },
+    });
     return NextResponse.json({
       query,
       total: dedupedResults.length,
@@ -689,6 +701,11 @@ export const GET = withApiAuth(async (request: NextRequest) => {
     });
   } catch (error) {
     console.error('Search error:', error);
+    logSearchQuery({
+      request, identity, route: 'search',
+      query: new URL(request.url).searchParams.get('q') || '',
+      ms: Date.now() - _searchStart, ok: false,
+    });
     return NextResponse.json({
       error: 'Search failed',
       message: error instanceof Error ? error.message : String(error),

--- a/src/app/api/search/semantic/route.ts
+++ b/src/app/api/search/semantic/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { semanticBookSearch, semanticPageSearchGlobal } from '@/lib/semantic-search';
 import { getDb } from '@/lib/mongodb';
+import { logSearchQuery } from '@/lib/search-log';
 
 export const dynamic = 'force-dynamic';
 
@@ -25,6 +26,7 @@ export const dynamic = 'force-dynamic';
  *   max_per_book  — page-level only: cap on passages from any single book
  */
 export async function GET(request: NextRequest) {
+  const _searchStart = Date.now();
   const { searchParams } = new URL(request.url);
   const query = searchParams.get('q')?.trim();
   const level = searchParams.get('level') === 'page' ? 'page' : 'book';
@@ -64,6 +66,11 @@ export async function GET(request: NextRequest) {
         ...p,
         slug: slugMap[p.book_id] || null,
       }));
+      logSearchQuery({
+        request, route: 'search.semantic.page', query: query!,
+        total: enriched.length, ms: Date.now() - _searchStart, ok: true,
+        filters: { language, languages, exclude_languages: excludeLanguages, year_min: yearMin, year_max: yearMax, max_per_book: maxPerBook },
+      });
       return NextResponse.json({
         results: enriched,
         query,
@@ -75,6 +82,10 @@ export async function GET(request: NextRequest) {
       });
     } catch (error) {
       console.error('[semantic-search] page-level error:', error);
+      logSearchQuery({
+        request, route: 'search.semantic.page', query: query!,
+        ms: Date.now() - _searchStart, ok: false,
+      });
       return NextResponse.json(
         { error: 'Search failed', results: [], query },
         { status: 500 }
@@ -122,6 +133,11 @@ export async function GET(request: NextRequest) {
         slug: thumbnailMap[b.book_id]?.slug || b.book_id,
       }));
 
+    logSearchQuery({
+      request, route: 'search.semantic.book', query: query!,
+      total: enriched.length, ms: Date.now() - _searchStart, ok: true,
+      filters: { language, year_min: yearMin, year_max: yearMax },
+    });
     return NextResponse.json({
       results: enriched,
       query,
@@ -132,6 +148,10 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('[semantic-search] Error:', error);
+    logSearchQuery({
+      request, route: 'search.semantic.book', query: query!,
+      ms: Date.now() - _searchStart, ok: false,
+    });
     return NextResponse.json(
       { error: 'Search failed', results: [], query },
       { status: 500 }

--- a/src/lib/search-log.ts
+++ b/src/lib/search-log.ts
@@ -1,0 +1,96 @@
+/**
+ * Append-only query log for direct (non-MCP) search endpoints.
+ *
+ * The MCP path already logs to `mcp_tool_calls` (one doc per tool call, with
+ * args.query). This collection fills the gap for callers that hit /api/search
+ * and /api/search/semantic directly — browser users, scrapers, partner sites.
+ *
+ * Indexes (created lazily, idempotent):
+ *   - { ts: 1 } TTL 90 days
+ *   - { route: 1, ts: -1 }
+ *   - { ip_hash: 1, ts: -1 }
+ *
+ * Fire-and-forget — logging failures never affect the response.
+ * IPs are hashed (SHA-256, 16 hex chars) to keep the collection PII-light.
+ */
+import { createHash } from 'crypto';
+import type { NextRequest } from 'next/server';
+import { getDb } from '@/lib/mongodb';
+import { getClientIp } from '@/lib/rate-limit';
+import type { ApiIdentity } from '@/lib/api-auth';
+
+const COLLECTION = 'search_queries';
+const MAX_QUERY_LEN = 500;
+
+let indexesEnsured = false;
+async function ensureIndexes() {
+  if (indexesEnsured) return;
+  indexesEnsured = true;
+  try {
+    const db = await getDb();
+    const col = db.collection(COLLECTION);
+    await Promise.all([
+      col.createIndex({ ts: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 90 }),
+      col.createIndex({ route: 1, ts: -1 }),
+      col.createIndex({ ip_hash: 1, ts: -1 }),
+    ]);
+  } catch {
+    indexesEnsured = false;
+  }
+}
+
+function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+export interface LogSearchQueryInput {
+  request: NextRequest;
+  identity?: ApiIdentity;
+  /** Logical route name, e.g. 'search', 'search.semantic.book', 'search.semantic.page' */
+  route: string;
+  /** The user-supplied query string (will be truncated to MAX_QUERY_LEN). */
+  query: string;
+  /** Total result count returned to the caller, if available. */
+  total?: number;
+  /** Wall-clock duration in ms. */
+  ms: number;
+  /** False if the request errored. */
+  ok: boolean;
+  /** Free-form bag of filter params (language, year range, etc.). Values
+   *  are coerced to primitives; arrays of strings preserved. */
+  filters?: Record<string, unknown>;
+}
+
+export function logSearchQuery(input: LogSearchQueryInput): void {
+  void writeEntry(input).catch(() => {});
+}
+
+async function writeEntry(input: LogSearchQueryInput) {
+  if (!input.query || input.query.trim().length < 1) return; // skip empty
+  await ensureIndexes();
+  const db = await getDb();
+  const ip = getClientIp(input.request);
+
+  const filters: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input.filters || {})) {
+    if (v == null) continue;
+    if (typeof v === 'string') filters[k] = v.slice(0, 100);
+    else if (typeof v === 'number' || typeof v === 'boolean') filters[k] = v;
+    else if (Array.isArray(v)) filters[k] = v.slice(0, 10).map(x => String(x).slice(0, 100));
+  }
+
+  await db.collection(COLLECTION).insertOne({
+    ts: new Date(),
+    route: input.route,
+    query: input.query.slice(0, MAX_QUERY_LEN),
+    total: input.total ?? null,
+    ms: input.ms,
+    ok: input.ok,
+    identity_kind: input.identity?.kind || 'anon',
+    user_id: input.identity?.userId || null,
+    api_key_id: input.identity?.apiKeyId || null,
+    ip_hash: hashIp(ip),
+    user_agent: (input.request.headers.get('user-agent') || '').slice(0, 200),
+    filters,
+  });
+}


### PR DESCRIPTION
## Summary

Two pieces of search-side observability:

1. **`search_queries` collection** — fire-and-forget log of every query hit on `/api/search` and `/api/search/semantic`. Fills the gap between `api_usage` (logs the request but not the query text) and `mcp_tool_calls` (MCP only).
2. **`scripts/analyze-search-usage.mjs`** — unified report across both collections. Top tools by call/latency/error, top queries merged across MCP + web, user-agent mix, daily trend.

Schema: query (truncated to 500 chars), route, total results, ms, ok, identity_kind, user_id, api_key_id, ip_hash (sha256, 16 hex), user_agent, filters (sanitized). 90-day TTL, indexes on ts/route/ip_hash.

## Sample current output (7 days, MCP-only since search_queries is new)

```
[1] MCP tool calls: 122 total
  search_concept             42      0     1085    1920    2823
  get_quote                  32      1      275     474     730
  search_library             22      0     8174    8389    8470
  search_translations        21      0     8267    8751    8964
```

Some notable findings:
- `search_library` / `search_translations` are slow (p50 ~8s) — worth a separate perf pass
- `Claude-User` dominates user agents (90% of MCP traffic), confirming the value of the sign-in nudges shipped in #1784
- 76 unique queries across 122 calls — heavy "long natural-language LLM prompt" pattern from Claude.ai users

## Verification

- `npx tsc --noEmit` clean
- Logger is fire-and-forget; failures never affect responses
- Empty queries are skipped before write
- Analyzer gracefully handles missing `search_queries` collection (printed message instead of crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)