### PR TITLE
Fix /q/[code] shortlinks redirecting to home

### DIFF
--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { decodeShortlink } from '@/lib/shortlinks';
+import { Page } from '@/lib/types';
+
+interface RouteContext {
+  params: Promise<{ code: string }>;
+}
+
+/**
+ * GET /q/[code] — Decode shortlink and redirect to the full page URL.
+ *
+ * The [tenant]/q/[code] route handles tenant-scoped shortlinks (e.g.
+ * bph.sourcelibrary.org/q/ABC after proxy rewrites). This route handles the
+ * canonical sourcelibrary.org/q/ABC form (2-segment path, no tenant prefix).
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { code } = await context.params;
+    const { bookId, pageNumber } = decodeShortlink(code);
+
+    const db = await getReadDb();
+    const page = await db.collection('pages').findOne({
+      book_id: bookId,
+      page_number: pageNumber,
+    }) as unknown as Page | null;
+
+    if (!page) {
+      return NextResponse.redirect(new URL(`/book/${bookId}`, request.url), { status: 302 });
+    }
+
+    return NextResponse.redirect(
+      new URL(`/book/${bookId}/page/${page.id}`, request.url),
+      { status: 302 }
+    );
+  } catch {
+    return NextResponse.redirect(new URL('/', request.url), { status: 302 });
+  }
+}


### PR DESCRIPTION
## Problem

`sourcelibrary.org/q/ABC123` was redirecting to home instead of the target page.

Root cause: the shortlink handler lived at `src/app/[tenant]/q/[code]/route.ts` — a 3-segment path. The canonical shortlink URL `/q/ABC123` is 2 segments, so Next.js had no matching route, fell to the `[tenant]` catch-all (with `tenant="q"`), failed tenant resolution, and redirected home.

## Fix

New `src/app/q/[code]/route.ts` handles the canonical 2-segment form. Logic is identical to the `[tenant]` variant — decode base62 → look up page in MongoDB → redirect to `/book/{id}/page/{pageId}`.

The `[tenant]/q/[code]` variant stays in place for tenant-scoped shortlinks (e.g. after proxy rewrites on subdomain requests).

## Test

Before: `curl -I https://sourcelibrary.org/q/BhDb5QcJxN7hYzMZxKU` → 307 to `/`
After: → 302 to `/book/{id}/page/{pageId}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)