### PR TITLE
Fix shortlinks: add 'q' to NON_TENANT_PATHS in proxy

### DIFF
--- a/src/app/q/[code]/route.ts
+++ b/src/app/q/[code]/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReadDb } from '@/lib/mongodb';
+import { decodeShortlink } from '@/lib/shortlinks';
+import { Page } from '@/lib/types';
+
+interface RouteContext {
+  params: Promise<{ code: string }>;
+}
+
+/**
+ * GET /q/[code] — Decode shortlink and redirect to the full page URL.
+ *
+ * The [tenant]/q/[code] route handles tenant-scoped shortlinks (e.g.
+ * bph.sourcelibrary.org/q/ABC after proxy rewrites). This route handles the
+ * canonical sourcelibrary.org/q/ABC form (2-segment path, no tenant prefix).
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const { code } = await context.params;
+    const { bookId, pageNumber } = decodeShortlink(code);
+
+    const db = await getReadDb();
+    const page = await db.collection('pages').findOne({
+      book_id: bookId,
+      page_number: pageNumber,
+    }) as unknown as Page | null;
+
+    if (!page) {
+      return NextResponse.redirect(new URL(`/book/${bookId}`, request.url), { status: 302 });
+    }
+
+    return NextResponse.redirect(
+      new URL(`/book/${bookId}/page/${page.id}`, request.url),
+      { status: 302 }
+    );
+  } catch {
+    return NextResponse.redirect(new URL('/', request.url), { status: 302 });
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,6 +24,8 @@ const NON_TENANT_PATHS = new Set([
   'research', 'embed', 'shwep', 'for-researchers', 'identify',
   // Welcome flow (post-signup interstitial + temporary preview route)
   'welcome', 'welcome-preview',
+  // Shortlinks — /q/[code] must pass through to src/app/q/[code]/route.ts
+  'q',
 ]);
 
 // Domains that enable the Ficino Society social layer


### PR DESCRIPTION
## Problem

`sourcelibrary.org/q/ABC123` was still redirecting home even after #1790 added `src/app/q/[code]/route.ts`.

Root cause: `src/proxy.ts` has a catch-all guard (lines 568-575) that redirects any unknown first-path-segment to home **before Next.js routing runs**. `q` wasn't in `NON_TENANT_PATHS`, so the proxy intercepted `/q/ABC123`, found no tenant named "q", and redirected home.

## Fix

Add `'q'` to `NON_TENANT_PATHS`. The proxy now passes `/q/*` through to Next.js routing, where `src/app/q/[code]/route.ts` handles it.

## Test

Before: `curl -I https://sourcelibrary.org/q/BhDb5QcJxN7hYzMZxKU` → 307 `/`
After: → 302 `/book/{id}/page/{pageId}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)