### PR TITLE
/api/search: per-stage timing in search_queries log

### DIFF
--- a/scripts/analyze-search-usage.mjs
+++ b/scripts/analyze-search-usage.mjs
@@ -142,7 +142,45 @@ async function main() {
     console.log(`  ${rpad(q.n, 4)}  ${pad(src, 8)} ${pad(tools, 32)} ${qstr}`);
   }
 
-  // --- 4. User-agent mix (MCP only — web side has it too but we keep this terse) ---
+  // --- 4. /api/search per-stage latency breakdown ---
+  if (sqExists) {
+    const stageRows = await sqCol.aggregate([
+      { $match: { ts: { $gte: since }, route: 'search', stage_ms: { $exists: true } } },
+      { $group: {
+          _id: null,
+          n: { $sum: 1 },
+          timeouts: { $sum: { $cond: ['$page_search_timed_out', 1, 0] } },
+          all_book: { $push: '$stage_ms.book' },
+          all_page: { $push: '$stage_ms.page' },
+          all_sem_book: { $push: '$stage_ms.semantic_book' },
+          all_sem_page: { $push: '$stage_ms.semantic_page' },
+          all_total: { $push: '$ms' },
+      } },
+    ]).toArray();
+    if (stageRows[0]?.n) {
+      const r = stageRows[0];
+      const pcts = (arr) => {
+        const s = arr.filter(x => typeof x === 'number').sort((a, b) => a - b);
+        const p = (q) => s.length ? s[Math.min(s.length - 1, Math.floor((q / 100) * s.length))] : 0;
+        return { p50: p(50), p95: p(95), p99: p(99) };
+      };
+      console.log(`\n[4] /api/search stage latencies (${fmtNum(r.n)} samples, ${r.timeouts} page-search timeouts):\n`);
+      console.log(`  ${pad('stage', 18)} ${rpad('p50', 7)} ${rpad('p95', 7)} ${rpad('p99', 7)}`);
+      const stages = [
+        ['book', r.all_book], ['page (Atlas)', r.all_page],
+        ['semantic_book', r.all_sem_book], ['semantic_page', r.all_sem_page],
+        ['TOTAL wall', r.all_total],
+      ];
+      for (const [name, arr] of stages) {
+        const p = pcts(arr);
+        console.log(`  ${pad(name, 18)} ${rpad(p.p50, 7)} ${rpad(p.p95, 7)} ${rpad(p.p99, 7)}`);
+      }
+    } else {
+      console.log(`\n[4] /api/search stage latencies: no stage_ms data yet (waiting for traffic after stage-timing deploy)`);
+    }
+  }
+
+  // --- 5. User-agent mix (MCP only — web side has it too but we keep this terse) ---
   const byUa = await mcpCol.aggregate([
     { $match: { ts: { $gte: since } } },
     { $project: { ua_stem: { $substr: ['$user_agent', 0, 40] } } },
@@ -150,12 +188,12 @@ async function main() {
     { $sort: { n: -1 } },
     { $limit: 10 },
   ]).toArray();
-  console.log(`\n[4] Top MCP user-agent prefixes (first 40 chars):\n`);
+  console.log(`\n[5] Top MCP user-agent prefixes (first 40 chars):\n`);
   for (const r of byUa) {
     console.log(`  ${pad(r._id || '(none)', 42)} ${rpad(r.n, 6)}`);
   }
 
-  // --- 5. Daily volume trend ---
+  // --- 6. Daily volume trend ---
   const daily = await mcpCol.aggregate([
     { $match: { ts: { $gte: since } } },
     {
@@ -166,7 +204,7 @@ async function main() {
     },
     { $sort: { _id: 1 } },
   ]).toArray();
-  console.log(`\n[5] Daily MCP call volume:\n`);
+  console.log(`\n[6] Daily MCP call volume:\n`);
   for (const d of daily) {
     const bar = '█'.repeat(Math.min(60, Math.ceil(d.n / Math.max(1, mcpTotal / DAYS / 10))));
     console.log(`  ${d._id}  ${rpad(d.n, 5)} ${bar}`);

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -166,9 +166,18 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     // Run book search and page content search in parallel
     const hasBookLevelFilters = !!(language || languages.length > 0 || excludeLanguages.length > 0 || category || dateFrom || dateTo || hasDoi === 'true' || hasTranslation === 'true' || firstTranslation === 'true' || year || yearFrom || yearTo || library);
 
-    const [bookDocs, pageDocs, semanticDocs, semanticPageDocs] = await Promise.all([
+    // Per-stage timing so we can see which lane is dragging the total wall-clock.
+    // Total latency = max(stages) since they run in parallel; recording each
+    // individually tells us where to optimize.
+    async function timed<T>(fn: () => Promise<T>): Promise<{ value: T; ms: number }> {
+      const start = Date.now();
+      const value = await fn();
+      return { value, ms: Date.now() - start };
+    }
+
+    const [bookResult, pageResult, semanticResult, semanticPageResult] = await Promise.all([
       // --- Book search via Supabase trigram (fast, no cold-start penalty) ---
-      (async () => {
+      timed(async () => {
         if (bookId || pagesOnly) return [];
         try {
           const matchingIds = await searchBookIds(query, { limit: limit * 2 });
@@ -218,11 +227,11 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
           console.warn('[search] Book lane failed:', err instanceof Error ? err.message : String(err));
           return [];
         }
-      })(),
+      }),
 
       // --- Page content search (aggregation pipeline truncates text for snippets) ---
       // Wrapped in a timeout race to prevent Atlas Search from blocking the response
-      (async () => {
+      timed(async () => {
         if (!searchContent && !pagesOnly) return [];
 
         const pageSearchPromise = (async () => {
@@ -290,10 +299,10 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
             resolve([]);
           }, 8000)),
         ]).catch(() => []);
-      })(),
+      }),
 
       // --- Semantic book search (finds conceptually related books) ---
-      (async () => {
+      timed(async () => {
         if (bookId || !searchContent) return [];
         try {
           const books = await semanticBookSearch(matchQuery, MAX_PAGE_RESULTS, {
@@ -314,20 +323,33 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         } catch {
           return [];
         }
-      })(),
+      }),
 
       // --- Semantic page search (finds specific passages across all 2.6M pages) ---
       // Catches passages buried inside large works that book-level search misses
       // (e.g. Martial's "masturbator" epigram, Diogenes's public acts in Laertius)
-      (async () => {
+      timed(async () => {
         if (bookId || !searchContent) return [];
         try {
           return await semanticPageSearchGlobal(matchQuery, 15, { tenantId: tenantId || undefined });
         } catch {
           return [];
         }
-      })(),
+      }),
     ]);
+
+    const bookDocs = bookResult.value;
+    const pageDocs = pageResult.value;
+    const semanticDocs = semanticResult.value;
+    const semanticPageDocs = semanticPageResult.value;
+    const stageMs = {
+      book: bookResult.ms,
+      page: pageResult.ms,
+      semantic_book: semanticResult.ms,
+      semantic_page: semanticPageResult.ms,
+    };
+    // Surface if the page lane hit its 8s ceiling — likely degraded results.
+    const pageSearchHitTimeout = pageResult.ms >= 8000 && pageDocs.length === 0;
 
     // Process book results
     for (const book of bookDocs) {
@@ -661,6 +683,8 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
     logSearchQuery({
       request, identity, route: 'search', query,
       total: dedupedResults.length, ms: Date.now() - _searchStart, ok: true,
+      stage_ms: stageMs,
+      page_search_timed_out: pageSearchHitTimeout,
       filters: {
         language, category, year, year_from: yearFrom, year_to: yearTo,
         languages, exclude_languages: excludeLanguages,

--- a/src/lib/search-log.ts
+++ b/src/lib/search-log.ts
@@ -59,6 +59,13 @@ export interface LogSearchQueryInput {
   /** Free-form bag of filter params (language, year range, etc.). Values
    *  are coerced to primitives; arrays of strings preserved. */
   filters?: Record<string, unknown>;
+  /** Per-lane latency breakdown for `/api/search` (book / page / semantic_book /
+   *  semantic_page). Total wall-clock = max(lanes) since they run in parallel.
+   *  Lets us correlate slow queries with which lane stalled. */
+  stage_ms?: Record<string, number>;
+  /** True if the page-content Atlas Search lane hit its hardcoded timeout and
+   *  returned empty results. Used to size the quality-vs-latency tradeoff. */
+  page_search_timed_out?: boolean;
 }
 
 export function logSearchQuery(input: LogSearchQueryInput): void {
@@ -92,5 +99,7 @@ async function writeEntry(input: LogSearchQueryInput) {
     ip_hash: hashIp(ip),
     user_agent: (input.request.headers.get('user-agent') || '').slice(0, 200),
     filters,
+    ...(input.stage_ms ? { stage_ms: input.stage_ms } : {}),
+    ...(input.page_search_timed_out ? { page_search_timed_out: true } : {}),
   });
 }


### PR DESCRIPTION
## Summary

Adds per-lane wall-clock timing to the search log so we can see *which* lane (book / page-Atlas / semantic-book / semantic-page) is dragging slow queries — before committing to any quality-sensitive optimization.

Tiny `timed()` helper wraps each of the four parallel lanes. Their durations land in `search_queries.stage_ms.{book, page, semantic_book, semantic_page}`. Also flags `page_search_timed_out: true` when the page-Atlas lane hits its hardcoded 8s race timer.

## Why this and not the quick fix

In the prior thread I floated dropping \`maxCharsToExamine\` 100K→8K and the timeout 8s→4s. Both would speed things up at real quality cost — long pages would lose highlight context, and queries between p50 and p95 would return empty instead of slow. We don't have to choose: with stage_ms data, we can see whether the win comes from the page-Atlas lane specifically (and how often it hits the timeout vs returns real but slow results) and route accordingly.

## Local sample

\`\`\`
GET /api/search?q=alchemy&limit=3
TOTAL wall:    3702ms
book:           423ms
page (Atlas): 3202ms   ← bottleneck
semantic_book: 2347ms
semantic_page: 2476ms
\`\`\`

## Verification

- `npx tsc --noEmit` clean
- Local hit on `/api/search?q=alchemy` produced the doc above with all four stage_ms values populated
- Schema is append-only optional fields; existing search_queries docs still readable

## Test plan

- [ ] Vercel preview deploys
- [ ] Run a few /api/search queries against the preview; verify search_queries collection gets new docs with stage_ms
- [ ] After a day of production traffic, run `node scripts/analyze-search-usage.mjs --days 1` — should show the new "stage latencies" section with p50/p95/p99 per lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)