### PR TITLE
Imports: capture full metadata from IA and IIIF (catalog_metadata, dublin_core, publisher, place)

### DIFF
--- a/src/app/api/import/ia/route.ts
+++ b/src/app/api/import/ia/route.ts
@@ -187,6 +187,60 @@ export const POST = withCuratorAuth(async (request, session) => {
     const contributor = typeof iaMetadata.contributor === 'string' ? stripHtml(iaMetadata.contributor) : null;
     const sponsor = typeof iaMetadata.sponsor === 'string' ? stripHtml(iaMetadata.sponsor) : null;
 
+    // Normalise fields that may arrive as string or array. IA frequently
+    // wraps free-text fields (description, notes) in HTML — strip it so the
+    // catalog_metadata holds clean plain text for display/search.
+    const stripText = (s: string) => s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    const firstOf = (v: unknown): string | null => {
+      const raw = Array.isArray(v) ? (typeof v[0] === 'string' ? v[0] : null) : (typeof v === 'string' ? v : null);
+      return raw ? stripText(raw) || null : null;
+    };
+    const arrOf = (v: unknown): string[] => {
+      const raw = Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : (typeof v === 'string' ? [v] : []);
+      return raw.map(stripText).filter(Boolean);
+    };
+
+    // Pull every field we might want downstream into catalog_metadata so the
+    // book page can show provenance, ARK/OCLC/LCCN cross-refs, edition info,
+    // and scanning provenance without re-fetching IA. Drops null/empty after.
+    const iaCatalog: Record<string, unknown> = {
+      source: 'internet_archive',
+      identifier: ia_identifier,
+      ark: iaMetadata['identifier-ark'] || null,
+      mediatype: iaMetadata.mediatype || null,
+      collections: arrOf(iaMetadata.collection),
+      access_restricted: iaMetadata['access-restricted-item'] === 'true' || iaMetadata['access-restricted-item'] === true,
+      publisher: firstOf(iaMetadata.publisher),
+      place: firstOf(iaMetadata.publishplace) || firstOf(iaMetadata.place),
+      creator: firstOf(iaMetadata.creator),
+      edition: firstOf(iaMetadata.edition),
+      volume: firstOf(iaMetadata.volume),
+      description: firstOf(iaMetadata.description),
+      subjects: arrOf(iaMetadata.subject),
+      notes: arrOf(iaMetadata.notes),
+      isbn: arrOf(iaMetadata.isbn),
+      oclc_id: firstOf(iaMetadata['oclc-id']),
+      lccn: firstOf(iaMetadata.lccn),
+      openlibrary_work: firstOf(iaMetadata.openlibrary_work),
+      openlibrary_edition: firstOf(iaMetadata.openlibrary_edition),
+      external_identifiers: arrOf(iaMetadata['external-identifier']),
+      page_progression: firstOf(iaMetadata['page-progression']),
+      ppi: iaMetadata.ppi ? parseInt(String(iaMetadata.ppi), 10) : null,
+      imagecount: iaMetadata.imagecount ? parseInt(String(iaMetadata.imagecount), 10) : null,
+      ocr_detected_lang: firstOf(iaMetadata.ocr_detected_lang),
+      ocr_detected_script: firstOf(iaMetadata.ocr_detected_script),
+      date_iso: firstOf(iaMetadata.date),
+      public_date: firstOf(iaMetadata.publicdate),
+      scan_date: firstOf(iaMetadata.scandate),
+      scanning_center: firstOf(iaMetadata.scanningcenter),
+      scanner: firstOf(iaMetadata.scanner),
+      scraped_at: new Date().toISOString(),
+    };
+    for (const k of Object.keys(iaCatalog)) {
+      const v = iaCatalog[k];
+      if (v === null || v === undefined || (Array.isArray(v) && v.length === 0)) delete iaCatalog[k];
+    }
+
     const slug = await generateUniqueBookSlug(db, title, author, display_title);
 
     const bookDoc = {
@@ -208,9 +262,22 @@ export const POST = withCuratorAuth(async (request, session) => {
       pages_ocr: 0,
       pages_translated: 0,
       dublin_core: dublin_core || {
-        dc_identifier: [`IA:${ia_identifier}`],
-        dc_source: `https://archive.org/details/${ia_identifier}`
+        dc_identifier: [
+          `IA:${ia_identifier}`,
+          ...(iaCatalog.ark ? [String(iaCatalog.ark)] : []),
+          ...(iaCatalog.oclc_id ? [`OCLC:${iaCatalog.oclc_id}`] : []),
+          ...(iaCatalog.lccn ? [`LCCN:${iaCatalog.lccn}`] : []),
+        ],
+        dc_source: `https://archive.org/details/${ia_identifier}`,
+        ...(iaCatalog.publisher ? { dc_publisher: iaCatalog.publisher } : {}),
+        ...(iaCatalog.description ? { dc_description: iaCatalog.description } : {}),
+        ...(iaCatalog.subjects && Array.isArray(iaCatalog.subjects) && iaCatalog.subjects.length
+          ? { dc_subject: iaCatalog.subjects }
+          : {}),
       },
+      catalog_metadata: iaCatalog,
+      ...(iaCatalog.place ? { place_published: String(iaCatalog.place) } : {}),
+      ...(iaCatalog.publisher ? { publisher: String(iaCatalog.publisher) } : {}),
       image_source: {
         provider: 'internet_archive',
         provider_name: 'Internet Archive',

--- a/src/app/api/import/iiif/route.ts
+++ b/src/app/api/import/iiif/route.ts
@@ -72,6 +72,10 @@ interface IIIFManifest {
   attribution?: string | { '@value'?: string; '@language'?: string }[];
   requiredStatement?: { label?: Record<string, string[]>; value?: Record<string, string[]> }; // v3
   logo?: string | { '@id'?: string };
+  metadata?: Array<{ label?: unknown; value?: unknown }>;
+  seeAlso?: unknown | unknown[];
+  navDate?: string;
+  viewingDirection?: string;
   sequences?: Array<{
     canvases?: IIIFv2Canvas[];
   }>;
@@ -363,6 +367,82 @@ export const POST = withCuratorAuth(async (request, session) => {
       if (vals?.[0]) attributionText = vals[0].replace(/<[^>]*>/g, '').trim();
     }
 
+    // Extract the manifest's `metadata` array — IIIF stores publisher,
+    // creator, persistent ID, call number, DOI, etc. as label/value pairs
+    // here. Both v2 and v3 use the same structure but values can be a
+    // string, array, or {language: [strings]} map. Normalise to {label: string,
+    // value: string} for downstream display.
+    const flattenIiifValue = (v: unknown): string => {
+      if (typeof v === 'string') return v.replace(/<[^>]*>/g, '').trim();
+      if (Array.isArray(v)) return v.map(flattenIiifValue).filter(Boolean).join(' / ');
+      if (v && typeof v === 'object') {
+        const obj = v as Record<string, unknown>;
+        // v3 language map: {en: ['…']}
+        const en = obj['en'] || obj['none'] || Object.values(obj)[0];
+        if (Array.isArray(en)) return en.map(flattenIiifValue).filter(Boolean).join(' / ');
+        if (typeof en === 'string') return en;
+      }
+      return '';
+    };
+    const iiifMetadata: Array<{ label: string; value: string }> = [];
+    for (const item of (manifest.metadata || [])) {
+      const label = flattenIiifValue(item.label);
+      const value = flattenIiifValue(item.value);
+      if (label && value) iiifMetadata.push({ label, value });
+    }
+    // Index by common labels for quick access. Labels vary per institution
+    // ("Publisher", "Publication Date", "Author", "Creator", "Call Number",
+    // "DOI", "Persistent ID", "Bibliographic ID") — we collapse a few
+    // synonyms so the catalog_metadata has stable keys.
+    const labelGet = (...needles: string[]): string | null => {
+      for (const n of needles) {
+        const hit = iiifMetadata.find(m => m.label.toLowerCase().includes(n.toLowerCase()));
+        if (hit) return hit.value;
+      }
+      return null;
+    };
+    const iiifPublisher = labelGet('publisher');
+    const iiifPlace = labelGet('publication place', 'place of publication', 'place');
+    const iiifPubDate = labelGet('publication date', 'date issued', 'date');
+    const iiifCreator = labelGet('creator', 'author');
+    const iiifCallNumber = labelGet('call number', 'shelfmark', 'shelf mark');
+    const iiifDoi = labelGet('doi');
+    const iiifBibId = labelGet('bibliographic id', 'bibliographic identifier', 'identifier');
+    const iiifPersistentId = labelGet('persistent id', 'persistent identifier');
+    const iiifDescription = v3
+      ? flattenIiifValue(manifest.summary)
+      : (manifest.description ? flattenIiifValue(manifest.description) : '');
+    const iiifSeeAlso: string[] = [];
+    for (const ref of (Array.isArray(manifest.seeAlso) ? manifest.seeAlso : manifest.seeAlso ? [manifest.seeAlso] : [])) {
+      const id = ref?.id || ref?.['@id'] || ref;
+      if (typeof id === 'string') iiifSeeAlso.push(id);
+    }
+
+    const iiifCatalog: Record<string, unknown> = {
+      source: 'iiif',
+      manifest_url,
+      manifest_version: v3 ? 'v3' : 'v2',
+      publisher: iiifPublisher,
+      place: iiifPlace,
+      publication_date: iiifPubDate,
+      creator: iiifCreator,
+      call_number: iiifCallNumber,
+      doi: iiifDoi,
+      bibliographic_id: iiifBibId,
+      persistent_id: iiifPersistentId,
+      description: iiifDescription,
+      see_also: iiifSeeAlso,
+      metadata_pairs: iiifMetadata,
+      nav_date: manifest.navDate || null,
+      viewing_direction: manifest.viewingDirection || null,
+      attribution: attributionText || null,
+      scraped_at: new Date().toISOString(),
+    };
+    for (const k of Object.keys(iiifCatalog)) {
+      const v = iiifCatalog[k];
+      if (v === null || v === undefined || v === '' || (Array.isArray(v) && v.length === 0)) delete iiifCatalog[k];
+    }
+
     // Determine provider name
     let providerName = provider || 'IIIF Source';
     const manifestId = manifest['@id'] || manifest.id || manifest_url;
@@ -422,9 +502,19 @@ export const POST = withCuratorAuth(async (request, session) => {
       pages_ocr: 0,
       pages_translated: 0,
       dublin_core: {
-        dc_identifier: [`IIIF:${rawManifestId}`],
-        dc_source: rawManifestId
+        dc_identifier: [
+          `IIIF:${rawManifestId}`,
+          ...(iiifCatalog.persistent_id ? [String(iiifCatalog.persistent_id)] : []),
+          ...(iiifCatalog.doi ? [`DOI:${iiifCatalog.doi}`] : []),
+          ...(iiifCatalog.bibliographic_id ? [`BIB:${iiifCatalog.bibliographic_id}`] : []),
+        ],
+        dc_source: rawManifestId,
+        ...(iiifCatalog.publisher ? { dc_publisher: iiifCatalog.publisher } : {}),
+        ...(iiifCatalog.description ? { dc_description: iiifCatalog.description } : {}),
       },
+      catalog_metadata: iiifCatalog,
+      ...(iiifCatalog.place ? { place_published: String(iiifCatalog.place) } : {}),
+      ...(iiifCatalog.publisher ? { publisher: String(iiifCatalog.publisher) } : {}),
       image_source: {
         provider: PROVIDER_NAME_TO_KEY[providerName] || (bodleianMatch ? 'bodleian' : 'iiif'),
         provider_name: providerName,


### PR DESCRIPTION
## Summary
- Both `/api/import/ia` and `/api/import/iiif` now write a complete `catalog_metadata` blob, plus populate `dublin_core` (dc_publisher, dc_description, dc_subject, expanded dc_identifier) and top-level `publisher` + `place_published`.
- Verified against real responses: NDL Japan IIIF v2 manifest (UBN 1183163 *Hatsuyoron*) and IA item (`mooshogorbeh` Mūsh-u-Gurba).

## Why
While planning a curator batch for missing vernacular non-Western erotic literature (al-Tīfāshī, ʿUbayd Zākānī, Ming-Qing fiction, Edo Japanese), we discovered both import routes drop the bulk of their source metadata. IA returns ~50 fields per item; we were keeping ~6. NDL/Bodleian/Gallica IIIF manifests put publisher, call number, DOI, persistent ID, bibliographic ID, etc. into a `metadata` array — we dropped the whole thing.

After this change, an NDL Saikaku import will preserve publisher, call number (e.g. `202-323`), DOI (`10.11501/...`), creator (with translator credit), persistent ID, and bibliographic ID. An IA import will preserve publisher, place, edition, ARK, OCLC/LCCN, IA collection memberships, access-restriction flag, OCR-detected language/script, and scan provenance.

## What stays the same
- No breaking changes to existing book documents or other import callers.
- `catalog_metadata` is additive — the BPH route already uses this shape, so the book reader's existing rendering picks it up for free.

## Test plan
- [ ] Import a known NDL IIIF book and verify `catalog_metadata.publication_date`, `catalog_metadata.call_number`, `catalog_metadata.doi` appear on the book doc
- [ ] Import a known IA book and verify `catalog_metadata.publisher`, `catalog_metadata.collections`, `catalog_metadata.access_restricted` are present
- [ ] Verify `book.publisher` and `book.place_published` are populated where source data has them
- [ ] Verify existing imports continue to work (no breakage in dedup, source_fingerprint, pages, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)