### PR TITLE
MCP: split language into original_language + snippet_language for passage results

### DIFF
--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -171,17 +171,22 @@ export async function searchPassages(args: {
 
   const passages = (
     result.results as Array<Record<string, unknown>>
-  )?.map((r) => ({
-    book_id: r.book_id,
-    title: r.display_title || r.title,
-    author: r.author,
-    language: r.language,
-    published: r.published,
-    page: r.page_number,
-    snippet: r.snippet,
-    snippet_source: r.snippet_type,
-    url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
-  }));
+  )?.map((r) => {
+    const snippetType = r.snippet_type as string | undefined;
+    const snippetLanguage = snippetType === 'ocr' ? r.language : 'English';
+    return {
+      book_id: r.book_id,
+      title: r.display_title || r.title,
+      author: r.author,
+      original_language: r.language,
+      snippet_language: snippetLanguage,
+      published: r.published,
+      page: r.page_number,
+      snippet: r.snippet,
+      snippet_source: snippetType,
+      url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
+    };
+  }).filter((p) => !!(p.snippet as string | undefined)?.trim());
 
   return {
     query: result.query,
@@ -213,14 +218,15 @@ export async function searchConcept(args: {
     book_id: r.book_id,
     title: r.book_title,
     author: r.book_author,
-    language: r.book_language,
+    original_language: r.book_language,
+    snippet_language: 'English',
     published: r.book_year,
     page: r.page_number,
     snippet: r.snippet,
     snippet_type: "translation",
     similarity: r.score,
     url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
-  })) || [];
+  })).filter((p) => !!(p.snippet as string | undefined)?.trim()) || [];
 
   return {
     query: result.query,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -92,28 +92,33 @@ async function searchPassages(args: Record<string, unknown>) {
   if (args.book_id) params.set('book_id', String(args.book_id));
 
   const result = await apiGet('/search', params) as Record<string, unknown>;
-  const passages = (result.results as Array<Record<string, unknown>>)?.map((r) => ({
-    book_id: r.book_id,
-    title: r.display_title || r.title,
-    author: r.author,
-    language: r.language,
-    published: r.published,
-    page: r.page_number,
-    snippet: r.snippet,
-    // snippet_type:
-    //   'translation' / 'ocr' = verbatim extract from source text (safe to quote)
-    //   'summary'             = AI-generated description (do NOT quote as the author's words)
-    snippet_type: r.snippet_type,
-    url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
-    short_url: r.book_id && r.page_number ? getShortUrl(String(r.book_id), Number(r.page_number)) : undefined,
-  })).filter(p => !!(p.snippet as string | undefined)?.trim()) || [];
+  const passages = (result.results as Array<Record<string, unknown>>)?.map((r) => {
+    const snippetType = r.snippet_type as string | undefined;
+    const snippetLanguage = snippetType === 'ocr' ? r.language : 'English';
+    return {
+      book_id: r.book_id,
+      title: r.display_title || r.title,
+      author: r.author,
+      original_language: r.language,
+      snippet_language: snippetLanguage,
+      published: r.published,
+      page: r.page_number,
+      snippet: r.snippet,
+      // snippet_type:
+      //   'translation' / 'ocr' = verbatim extract from source text (safe to quote)
+      //   'summary'             = AI-generated description (do NOT quote as the author's words)
+      snippet_type: snippetType,
+      url: `https://sourcelibrary.org/book/${r.slug || r.book_id}?page=${r.page_number || 1}`,
+      short_url: r.book_id && r.page_number ? getShortUrl(String(r.book_id), Number(r.page_number)) : undefined,
+    };
+  }).filter(p => !!(p.snippet as string | undefined)?.trim()) || [];
   return {
     query: result.query,
     total_matches: result.total,
     returned: passages.length,
     offset,
     passages,
-    tip: 'Only quote snippets where snippet_type is "translation" or "ocr". Always cite using short_url when presenting passages to users.',
+    tip: 'original_language is the book\'s source language; snippet_language is the language of the snippet text (English for translations/summaries, source language for ocr). Only quote snippets where snippet_type is "translation" or "ocr". Always cite using short_url when presenting passages to users.',
   };
 }
 
@@ -132,7 +137,8 @@ async function searchConcept(args: Record<string, unknown>) {
     book_id: r.book_id,
     title: r.book_title,
     author: r.book_author,
-    language: r.book_language,
+    original_language: r.book_language,
+    snippet_language: 'English',
     published: r.book_year,
     page: r.page_number,
     snippet: r.snippet,
@@ -149,7 +155,7 @@ async function searchConcept(args: Record<string, unknown>) {
     total_matches: passages.length,
     returned: passages.length,
     passages,
-    tip: 'Similarity calibration: 0.70+ strong match (quote with confidence); 0.55–0.70 worth reading but verify; below 0.55 mostly conceptual drift. Snippets tagged snippet_type:"summary" are AI continuity notes — paraphrase only, never quote. Always cite using short_url when presenting passages to users.',
+    tip: 'original_language is the book\'s source language; semantic search always returns English translation text (snippet_language: "English"). Similarity calibration: 0.70+ strong match (quote with confidence); 0.55–0.70 worth reading but verify; below 0.55 mostly conceptual drift. Snippets tagged snippet_type:"summary" are AI continuity notes — paraphrase only, never quote. Always cite using short_url when presenting passages to users.',
   };
 }
 


### PR DESCRIPTION
## Summary
In passage-level MCP results, `language` was the **book's** source language — but the snippet itself was often an English translation. LLMs seeing `language: "Latin"` with English snippet text had no way to know the snippet had been translated.

## Change
Passage results in `search_translations` and `search_concept` now expose both:
- `original_language` — the book's source language (was: `language`)
- `snippet_language` — the language of the snippet text:
  - `English` when `snippet_type` is `translation` or `summary`
  - source language when `snippet_type` is `ocr`

Synced across both the HTTP MCP route (`src/app/api/mcp/route.ts`) and the stdio mcp-server (`mcp-server/src/api.ts`).

## Note on compatibility
Book-list responses (`list_books`, `get_book`, `search_within_book`) still use the plain `language` field — those refer unambiguously to the book itself, not to a snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)