### PR TITLE
/developers: lead with openness, soften the API-key ask

### DIFF
--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -5,7 +5,7 @@ import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
-  description: 'Search, read, and cite 1,200+ rare historical texts from the terminal or via MCP. 8 research tools, CLI + MCP server, no API key needed.',
+  description: 'Open API over 22,000+ rare historical texts. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
   alternates: {
     canonical: '/developers',
   },
@@ -17,16 +17,69 @@ export default function DevelopersPage() {
       header={
         <ContentHeader
           title="For Developers & AI"
-          subtitle="Search, read, and cite rare historical texts via MCP, CLI, or REST. Sign in for a free API key — generous limits and attributed usage."
+          subtitle="Open API over 22,000+ rare historical texts. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
         />
       }
     >
-      {/* Get an API Key */}
+      {/* 30-second start */}
+      <section className="mb-16">
+        <h2 className="text-2xl font-semibold text-primary mb-2">30-second start</h2>
+        <p className="text-secondary mb-6 max-w-2xl">
+          One endpoint, no key required to begin. It speaks JSON-RPC over HTTP, so anything that can POST JSON can talk to it.
+        </p>
+
+        <div className="space-y-4">
+          <div className="bg-white rounded-xl border border-border-light overflow-hidden">
+            <div className="bg-stone-100 px-4 py-2 border-b border-border-light">
+              <span className="text-sm font-medium text-stone-700">curl</span>
+            </div>
+            <pre className="p-4 text-sm overflow-x-auto bg-stone-900 text-stone-100">
+{`curl -X POST https://sourcelibrary.org/api/mcp \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "jsonrpc": "2.0", "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "search_concept",
+      "arguments": { "query": "prima materia", "limit": 5 }
+    }
+  }'`}
+            </pre>
+          </div>
+
+          <div className="bg-white rounded-xl border border-border-light overflow-hidden">
+            <div className="bg-stone-100 px-4 py-2 border-b border-border-light">
+              <span className="text-sm font-medium text-stone-700">Browser (fetch)</span>
+            </div>
+            <pre className="p-4 text-sm overflow-x-auto bg-stone-900 text-stone-100">
+{`fetch('https://sourcelibrary.org/api/mcp', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    jsonrpc: '2.0', id: 1,
+    method: 'tools/call',
+    params: {
+      name: 'search_concept',
+      arguments: { query: 'prima materia', limit: 5 }
+    }
+  })
+}).then(r => r.json()).then(console.log)`}
+            </pre>
+          </div>
+        </div>
+
+        <p className="text-muted text-sm mt-4 max-w-2xl">
+          CORS is open (<code className="text-accent-rust">Access-Control-Allow-Origin: *</code>) — paste the snippet above into any browser console and it works.
+        </p>
+      </section>
+
+      {/* Free API key — soft CTA */}
       <section className="mb-16">
         <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
-          <h2 className="text-lg font-semibold text-primary mb-2">Get an API Key</h2>
+          <h2 className="text-lg font-semibold text-primary mb-2">Building something? Grab a free key.</h2>
           <p className="text-secondary mb-6">
-            Free for individual use. Higher limits for signed-in callers and partner-tier access available on request.
+            The endpoints work without one — keys lift rate limits, give your traffic attribution, and help us learn what
+            people are building so we can keep this open and free. Takes a minute.
           </p>
           <ApiKeyRequestForm />
         </div>
@@ -56,7 +109,9 @@ export default function DevelopersPage() {
         <h2 className="text-2xl font-semibold text-primary mb-2">MCP Server</h2>
         <p className="text-secondary mb-6 max-w-2xl">
           Gives Claude (and any MCP client) direct access to the full collection &mdash;
-          search, read, quote, and browse 90,000+ illustrations. One command to install.
+          search, read, quote, and browse 90,000+ illustrations. The endpoint is plain JSON-RPC
+          over HTTP, so you can also call it from any HTTP client without an MCP library
+          (see the snippets above). Pick whichever path fits.
         </p>
 
         {/* Remote MCP URL */}
@@ -344,18 +399,13 @@ source-library search "alchemy" --json | jq .results`}
         </div>
       </section>
 
-      {/* Dataset API */}
+      {/* Bulk dataset access */}
       <section className="mb-16">
-        <h2 className="text-2xl font-semibold text-primary mb-2">Dataset API</h2>
+        <h2 className="text-2xl font-semibold text-primary mb-2">Bulk dataset access</h2>
         <p className="text-secondary mb-6 max-w-2xl">
-          For bulk access to OCR text, translations, and page-level data, request an API key.
-          Keys are reviewed within 24 hours.
+          Pulling OCR text, translations, or page-level data in bulk? That tier is keyed — use the
+          form above to request one, or email us with what you&apos;re building. Reviewed within 24 hours.
         </p>
-
-        <div className="bg-white rounded-xl border border-border-light p-6 md:p-8">
-          <h3 className="text-lg font-semibold text-primary mb-4">Request an API Key</h3>
-          <ApiKeyRequestForm />
-        </div>
       </section>
 
       {/* Citations */}


### PR DESCRIPTION
## Why
The /developers page was making the API sound harder to use than it is. The hero pushed \"Sign in for a free API key\" front and center, and the first concrete section on the page was a key-request form — implying the whole thing is gated.

It isn't. The MCP endpoint, all 9 research tools, and the entire REST surface are open with no auth. The API key is only required for **bulk dataset access** (OCR/translation pulls). And there was no \`fetch()\` / curl example anywhere — so a browser dev had no proof they could just call it.

We still want sign-ins (rate limits, attribution, signal on what's being built) — just framed as a soft benefit, not a gate.

## Changes
- **Hero**: \"Open API … no auth needed to start — sign in for a free key to lift rate limits and help us see what you're building.\"
- **New \"30-second start\" section** at the top with copy-pastable **curl** and **browser fetch** snippets calling \`/api/mcp\` directly, plus a one-liner noting CORS is wide open.
- **API-key form** moved into a friendlier \"Building something? Grab a free key.\" card right after the snippets — keeps the sign-in CTA prominent without making it the first thing you have to do.
- **MCP section** gains one clarifying line: the endpoint is plain JSON-RPC, so any HTTP client works (no MCP library required).
- **Dataset section deduplicated** (the form lived twice) and reframed around bulk pulls, which is what actually needs a key.
- **Meta description** updated.

## Net effect
A new dev landing on the page can paste a curl/fetch snippet and have a working call in 30 seconds, then opt into a key when they want higher limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)