### PR TITLE
Archive: broaden IA-bulk script + fix archive-ocr 403s (no User-Agent)

### DIFF
--- a/scripts/maintenance/archive-ia-bulk.mjs
+++ b/scripts/maintenance/archive-ia-bulk.mjs
@@ -216,11 +216,13 @@ async function jp2ToJpeg(jp2Path) {
  * Handles full-res IIIF URLs by requesting a capped size.
  */
 async function fetchPageImage(photoUrl, iaId) {
-  // For IA IIIF URLs, request a capped size instead of full resolution
-  // Original: /page/n0/full/pct:50/0/default.jpg
-  // Capped:   /page/n0/full/!3000,3000/0/default.jpg
+  // Cap any IIIF URL (IA, NDL, Bodleian, Gallica, MDZ, Vatican, e-rara,
+  // Allard Pierson, etc.) to a sane max dimension. The shared shape is
+  // `…/full/<size>/<rotation>/<quality>.<format>` so a regex on the
+  // `/full/<size>/` segment is portable across providers.
   let url = photoUrl;
-  if (url.includes('archive.org') && url.includes('/page/')) {
+  if (/\/full\/[^/]+\/[0-9]+\/[a-z]+\.(jpe?g|png|tif)/i.test(url) ||
+      (url.includes('archive.org') && url.includes('/page/'))) {
     url = url.replace(/\/full\/[^/]+\//, `/full/!${MAX_DIMENSION},${MAX_DIMENSION}/`);
   }
 
@@ -260,8 +262,12 @@ async function fetchPageImage(photoUrl, iaId) {
  * Correct by construction — no mapping needed.
  */
 async function processBook(book, db) {
-  const iaId = book.ia_identifier || book.image_source?.identifier;
-  if (!iaId) { stats.booksSkipped++; return; }
+  // For provenance/logging only. IIIF books from NDL/Bodleian/etc. won't
+  // have ia_identifier; that's fine — the actual fetch uses each page's
+  // own photo_original URL.
+  const sourceId = book.ia_identifier
+    || book.image_source?.identifier
+    || (book.image_source?.iiif_manifest ? book.image_source.iiif_manifest.split('/').slice(-2, -1)[0] : null);
 
   // Get pages needing archiving for this book
   const pages = await db.collection('pages')
@@ -277,14 +283,17 @@ async function processBook(book, db) {
   const totalPages = book.pages_count || pages.length;
   console.log(`  [IIIF] ${book.title?.slice(0, 50)} — ${pages.length}/${totalPages} pages to archive`);
 
-  // Filter to pages with valid IA IIIF URLs
+  // Accept any IIIF-shaped page URL (any provider) plus IA's /page/ legacy
+  // shape. Reject pages that already point at our own R2 (images.sourcelibrary.org).
   const workItems = pages.filter(p => {
     const url = p.photo_original || p.photo || '';
-    return url.includes('archive.org') || url.includes('/page/');
+    if (!url || url.includes('images.sourcelibrary.org')) return false;
+    return url.includes('/page/')                                  // IA legacy
+      || /\/full\/[^/]+\/[0-9]+\/[a-z]+\.(jpe?g|png|tif)/i.test(url); // IIIF
   });
 
   if (workItems.length === 0) {
-    console.log(`    [SKIP] No IA IIIF URLs found`);
+    console.log(`    [SKIP] No fetchable image URLs found`);
     stats.booksSkipped++;
     return;
   }
@@ -352,14 +361,16 @@ async function main() {
   await client.connect();
   const db = client.db('bookstore');
 
-  // Find IA books with unarchived pages
-  // Query books collection (indexed, fast) instead of scanning pages
-  const bookQuery = {
-    $or: [
-      { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
-      { 'image_source.provider': 'ia' },
-    ],
-  };
+  // Find books with unarchived pages. By default include any provider
+  // whose pages hotlink to an external IIIF/IA URL. --ia-only restores
+  // the original IA-only behaviour for callers who want it.
+  const IA_ONLY = hasFlag('ia-only');
+  const bookQuery = IA_ONLY
+    ? { $or: [
+        { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
+        { 'image_source.provider': { $in: ['ia', 'internet_archive'] } },
+      ]}
+    : { 'image_source.provider': { $exists: true, $ne: null, $nin: ['wikimedia_commons', 'rijksmuseum', 'met', 'nga'] } };
   if (BOOK_ID) bookQuery._id = BOOK_ID;
 
   const iaBooks = await db.collection('books')
@@ -368,7 +379,7 @@ async function main() {
     .limit(BOOK_LIMIT || 0)
     .toArray();
 
-  console.log(`Found ${iaBooks.length} IA books`);
+  console.log(`Found ${iaBooks.length} candidate books (${IA_ONLY ? 'IA-only' : 'all IIIF providers'})`);
 
   if (DRY_RUN) {
     console.log('Dry run — not processing.');

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -96,12 +96,20 @@ const r2 = new S3Client({
 const BUCKET = process.env.R2_BUCKET_NAME || 'sourcelibrary-images';
 const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
 
+// Many archives (e-rara, some Bodleian endpoints, Wellcome, Vatican) reject
+// requests without a User-Agent — Node's default UA gets blocked. Match the
+// UA the IA bulk archiver uses so per-provider policies are consistent.
+const USER_AGENT = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)';
+
 async function downloadImage(url, retries = 2) {
   for (let attempt = 0; attempt <= retries; attempt++) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 60_000); // 60s for full-res images
     try {
-      const res = await fetch(url, { signal: controller.signal });
+      const res = await fetch(url, {
+        signal: controller.signal,
+        headers: { 'User-Agent': USER_AGENT, Accept: 'image/jpeg,image/png,image/*;q=0.9,*/*;q=0.1' },
+      });
       if (res.status === 429 || res.status === 503) {
         clearTimeout(timeout);
         if (attempt < retries) {


### PR DESCRIPTION
## Summary
- **`scripts/maintenance/archive-ia-bulk.mjs`**: was IA-only (book query + page-URL filter both hard-coded to `archive.org`). Broadened the query and URL pattern to handle any IIIF-shaped page. `--ia-only` opts back in to the old behaviour.
- **`scripts/workers/archive-ocr.mjs`**: bare `fetch(url)` had no User-Agent, so e-rara was 403ing every request. Added the same UA the IA bulk worker uses + an Accept header.

## Why
While investigating what looked like an archive backlog (175 books, 67K pages with no `archived_photo`), I found that the system already runs `archive-bulk.mjs` (IA) and `archive-ocr.mjs` (IIIF) every 10 min via the unified scheduler — the "backlog" is normal churn. But:

1. The *maintenance* `archive-ia-bulk.mjs` script (used for manual drains, not the scheduled worker) couldn't help with NDL/MDZ/Gallica/Bodleian books because its filters were IA-shaped.
2. Looking at `archive-ocr.log` revealed a pattern of `e-rara.ch: HTTP 403` errors — the worker was being blocked by Node's default UA.

## Not fixed here
- MDZ HTTP 404s — likely URL pattern drift; needs a separate look at whether `digitale-sammlungen.de` changed its image endpoint
- NDL HTTP 500s — likely malformed IIIF tile request; needs deeper debug

## Test plan
- [ ] Run `node scripts/maintenance/archive-ia-bulk.mjs --limit=20 --dry-run` and verify it now finds non-IA candidates
- [ ] After this merges, check `/var/log/sourcelibrary/archive-ocr.log` over the next hour for the e-rara 403s to drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)