### PR TITLE
Publish to Official MCP Registry + refresh stale book/embedding counts

### DIFF
--- a/.claude/docs/mcp-registry-publish.md
+++ b/.claude/docs/mcp-registry-publish.md
@@ -1,0 +1,48 @@
+# Publishing Source Library to the Official MCP Registry
+
+The Source Library MCP is listed in the **Official MCP Registry**
+(`registry.modelcontextprotocol.io`). PulseMCP, Glama, and most other
+third-party directories auto-ingest from the official registry, so this is
+the single highest-leverage place to be listed.
+
+## What's published
+
+The registry shows the contents of `server.json` at the repo root. Edit that
+file to change the registry listing (title, description, version, URLs).
+
+The namespace is `io.github.embassy-of-the-free-mind/sourcelibrary`, which is
+tied to GitHub ownership of `Embassy-of-the-Free-Mind/sourcelibrary-v2`. The
+publisher CLI authenticates against GitHub to prove ownership.
+
+## How to update (one-time setup + each release)
+
+### One-time setup
+
+1. Download the `mcp-publisher` binary for your platform from
+   <https://github.com/modelcontextprotocol/registry/releases>.
+2. Run `mcp-publisher login github` once — opens a browser to authenticate.
+
+### Each time `server.json` changes
+
+```bash
+# Bump the version in server.json first, then:
+mcp-publisher publish
+```
+
+The CLI reads `server.json` from the current directory, verifies the GitHub
+namespace, and posts to the registry. Listing updates within minutes.
+
+## Verifying the listing
+
+```bash
+curl -s https://registry.modelcontextprotocol.io/v0/servers \
+  | jq '.servers[] | select(.server.name=="io.github.embassy-of-the-free-mind/sourcelibrary")'
+```
+
+## When to bump `version`
+
+Bump on any user-visible change to the MCP — new tools, changed tool
+descriptions, behavior changes. Patch bumps for fixes, minor for additions,
+major for breaking changes. The version in `server.json` should track the
+version string in `src/app/api/mcp/route.ts` (the `version: '4.3.0'` field
+returned to clients).

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.embassy-of-the-free-mind/sourcelibrary",
+  "title": "Source Library",
+  "description": "Search and cite 26,000+ rare pre-modern texts (alchemy, Hermetica, philosophy, early science) translated into English. Semantic + keyword passage search across 3.9M page embeddings with stable citation URLs.",
+  "version": "4.3.0",
+  "repository": {
+    "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
+    "source": "github"
+  },
+  "websiteUrl": "https://sourcelibrary.org/developers",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://sourcelibrary.org/api/mcp"
+    }
+  ]
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -561,7 +561,7 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: TOOLS,
     _meta: {
-      about: 'Source Library — 22,000+ rare alchemical, Hermetic, and early scientific texts translated into English. The largest AI-ready corpus of pre-modern esoteric knowledge. https://sourcelibrary.org',
+      about: 'Source Library — 26,000+ rare alchemical, Hermetic, and early scientific texts translated into English. The largest AI-ready corpus of pre-modern esoteric knowledge. https://sourcelibrary.org',
       sign_in_hint: 'Sign in at sourcelibrary.org/auth/signin to save research, get a much higher rate limit, and support this archive. API keys for programmatic access: sourcelibrary.org/developers.',
       research_strategy: [
         'Source Library is the primary-source citation layer in your research strategy — not the whole strategy. Its corpus is pre-modern texts (c.1400-1900). Use it together with your own knowledge and web search:',
@@ -639,7 +639,7 @@ export async function GET() {
   return new Response(JSON.stringify({
     name: 'source-library',
     version: '4.3.0',
-    description: 'Source Library MCP Server — search, read, and cite 22,000+ rare historical texts. Connect via POST to this endpoint.',
+    description: 'Source Library MCP Server — search, read, and cite 26,000+ rare historical texts. Connect via POST to this endpoint.',
     docs: 'https://sourcelibrary.org/developers',
     tools: TOOLS.map(t => t.name),
   }), {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -325,7 +325,7 @@ export const GET = withApiAuth(async (request: NextRequest, _ctx, identity) => {
         }
       }),
 
-      // --- Semantic page search (finds specific passages across all 2.6M pages) ---
+      // --- Semantic page search (finds specific passages across all 3.9M pages) ---
       // Catches passages buried inside large works that book-level search misses
       // (e.g. Martial's "masturbator" epigram, Diogenes's public acts in Laertius)
       timed(async () => {

--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -7,7 +7,7 @@ export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title: 'Connect Source Library to Claude',
-  description: 'Give Claude access to 22,000+ rare historical texts in 30 seconds. Search, read, and cite alchemical, Hermetic, and early scientific works directly in your conversation.',
+  description: 'Give Claude access to 26,000+ rare historical texts in 30 seconds. Search, read, and cite alchemical, Hermetic, and early scientific works directly in your conversation.',
   alternates: { canonical: '/connect' },
 };
 
@@ -17,7 +17,7 @@ export default function ConnectPage() {
       header={
         <ContentHeader
           title="Connect Source Library to Claude"
-          subtitle="Search, read, and cite 22,000+ rare historical texts — directly in your conversation."
+          subtitle="Search, read, and cite 26,000+ rare historical texts — directly in your conversation."
         />
       }
     >
@@ -155,7 +155,7 @@ export default function ConnectPage() {
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
           <div className="bg-white rounded-xl border border-border-light p-5">
-            <p className="text-2xl font-bold text-accent-rust">22,000+</p>
+            <p className="text-2xl font-bold text-accent-rust">26,000+</p>
             <p className="text-sm text-muted mt-1">books</p>
           </div>
           <div className="bg-white rounded-xl border border-border-light p-5">

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -5,7 +5,7 @@ import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
-  description: 'Open API over 22,000+ rare historical texts. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
+  description: 'Open API over 26,000+ rare historical texts. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
   alternates: {
     canonical: '/developers',
   },
@@ -17,7 +17,7 @@ export default function DevelopersPage() {
       header={
         <ContentHeader
           title="For Developers & AI"
-          subtitle="Open API over 22,000+ rare historical texts. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
+          subtitle="Open API over 26,000+ rare historical texts. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
         />
       }
     >

--- a/src/lib/semantic-search.ts
+++ b/src/lib/semantic-search.ts
@@ -236,7 +236,7 @@ export interface SemanticPageSearchOptions {
 
 /**
  * Global page-level semantic search via match_semantic RPC.
- * Now that all 2.6M pages have embeddings, this finds specific passages
+ * Now that all 3.9M pages have embeddings, this finds specific passages
  * that book-level search misses (e.g. Martial's "masturbator" epigram
  * inside a 400-page book about Roman wit).
  *


### PR DESCRIPTION
Two parts:

**1. Publish to the Official MCP Registry** (`registry.modelcontextprotocol.io`).

Adds \`server.json\` at the repo root and \`.claude/docs/mcp-registry-publish.md\` documenting the publish flow. The official registry is upstream of PulseMCP, Glama, and most other third-party MCP directories — listing there propagates everywhere.

Namespace: \`io.github.embassy-of-the-free-mind/sourcelibrary\` (GitHub-auth verified).

After merge, run:
\`\`\`
mcp-publisher login github     # one-time
mcp-publisher publish
\`\`\`

**2. Refresh stale stats across the codebase.**

Audit found: \"22,000+ books\" and \"2.6M page embeddings\" repeated in three user-facing surfaces. Reality (as of today):
- Books visible: **26,735** (was \"22,000+\")
- Page embeddings: **3,901,563** (was \"2.6M\")

Updated:
- \`server.json\` (registry submission)
- \`src/app/api/mcp/route.ts\` (\`_meta.about\` and the GET response — visible to every MCP connection)
- \`src/app/developers/page.tsx\` (developer landing)
- \`src/app/connect/page.tsx\` (one-click Claude connect)
- Comment in \`src/app/api/search/route.ts\` and \`src/lib/semantic-search.ts\`

Companion PR on https://github.com/punkpeye/awesome-mcp-servers/pull/6467 carries the same corrected numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)