### PR TITLE
MCP: add orientation hints — prefer get_book when an author/work is named

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -29,7 +29,7 @@ const TOOLS: Tool[] = [
   {
     name: "search_library",
     description:
-      "Full-text search across Source Library's 1,200+ rare historical books. Searches titles, authors, translations, and OCR text. Returns matching books and page snippets with citation URLs.",
+      "Full-text search across Source Library's 22,000+ rare historical books. Searches titles, authors, translations, and OCR text. Returns matching books and page snippets with citation URLs. ORIENTATION HINT: when the user has named a specific author or work, call get_book directly (or list_books to find the ID first) — the AI-generated book summary is usually the right first answer and saves repeated passage hunting.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -77,7 +77,7 @@ const TOOLS: Tool[] = [
   {
     name: "list_books",
     description:
-      "Browse the full collection with filters. Returns books with title, author, language, year, page counts, and translation progress. Unlike search_library (full-text search), this returns a filtered list. Use for browsing by language, finding recently translated works, or getting collection statistics.",
+      "Browse the catalog by metadata — filter by author/title fragment, language, category, or translation recency. Returns books with title, author, language, year, page counts, and translation progress. Use this to discover WHAT EXISTS by an author or in a tradition before searching content; for content matches (passages on a topic) use search_translations or search_concept.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -113,7 +113,7 @@ const TOOLS: Tool[] = [
   {
     name: "search_translations",
     description:
-      "Search inside translated page text across the entire library. THE tool for finding what historical authors wrote about a topic. Unlike search_library (which matches titles/authors), this searches inside the actual text. Returns passage snippets with page numbers, book info, and citation URLs. (Also available as 'search_passages'.)",
+      "Search inside translated page text across the entire library. THE tool for sweeping across many books for evidence on a theme. Unlike search_library (which matches titles/authors), this searches inside the actual text. Returns passage snippets with page numbers, book info, and citation URLs. ORIENTATION HINT: if the user has named a specific author or work, prefer get_book first — every book has an AI-generated summary + chapter outline that is usually the right first read. Use search_translations when looking for evidence across multiple books. (Also available as 'search_passages'.)",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -149,7 +149,7 @@ const TOOLS: Tool[] = [
   {
     name: "search_concept",
     description:
-      "Conceptual / semantic passage search. Use when the modern term won't literally appear in historical texts — e.g. \"distributed cognition\" maps to passages about active intellect, art of memory, wax tablet metaphors; \"social contract\" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings, so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Each passage includes a similarity score (0-1); treat scores below ~0.45 with skepticism.",
+      "Conceptual / semantic passage search across the whole library. Use when the modern term won't literally appear in historical texts — e.g. \"distributed cognition\" maps to passages about active intellect, art of memory, wax tablet metaphors; \"social contract\" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings, so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. ORIENTATION HINT: if the user named a specific author or work, prefer get_book first — semantic search is expensive and best reserved for cross-corpus discovery. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Similarity calibration: 0.70+ strong match, 0.55–0.70 worth reading but verify, below 0.55 mostly conceptual drift.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -202,7 +202,7 @@ const TOOLS: Tool[] = [
   {
     name: "get_book",
     description:
-      "Get detailed metadata about a book: summary, chapters, index stats, DOI, page counts, and processing status. Use this for context before reading with get_book_text.",
+      "Get a book's AI-generated summary, chapter list, index stats, edition metadata, DOI, page counts, and processing status. THIS IS THE RIGHT FIRST CALL whenever the user has named a specific author or work — the summary is typically a multi-paragraph orientation covering the book's argument, structure, and significance, often answering the question without any further searching. Pair with get_book_text to read selected chapters, or search_within_book to locate passages inside it.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -293,7 +293,7 @@ const READ_ONLY = { readOnlyHint: true, destructiveHint: false, idempotentHint: 
 const TOOLS: Tool[] = [
   {
     name: 'search_library',
-    description: 'Find BOOKS matching a topic. Searches titles, authors, subjects, and (as a secondary signal) translated text. Use this when you want a list of works on a subject. For locating specific passages inside books, use search_translations instead. Query tips: single distinctive words or short phrases work best ("memory palace", "ouroboros"); quoted phrases match exactly. Each result includes total_matches (full count) + returned (this page) + offset for pagination.',
+    description: 'Find BOOKS matching a topic. Searches titles, authors, subjects, and (as a secondary signal) translated text. Use this when you want a list of works on a subject. For locating specific passages inside books, use search_translations instead. ORIENTATION HINT: when the user has named a specific author or work, call get_book directly (or list_books to discover the ID) — the AI-generated book summary + chapter outline is often the right first answer and saves repeated passage hunting. Query tips: single distinctive words or short phrases work best ("memory palace", "ouroboros"); quoted phrases match exactly. Each result includes total_matches (full count) + returned (this page) + offset for pagination.',
     annotations: { title: 'Search Library', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -312,7 +312,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'search_translations',
-    description: 'Find specific PASSAGES inside books — returns page-level snippets with citation URLs. Use this when you want a quote or evidence on a topic. For finding which BOOKS cover a topic, use search_library. Query tips: single distinctive terms ("memory palace", "wax tablet") work best; multi-word natural-English queries ("unity of the intellect") may return fewer results because matching is term-based, not phrase-based. Each snippet has a snippet_type — "translation"/"ocr" means it is a verbatim extract from the source text; "summary" means it is AI-generated description (do not quote those as the author\'s words). Response includes total_matches, returned, and offset for pagination. Cross-cultural tip: for pre-modern or non-Western topics, search source-tradition vocabulary rather than modern English terms — e.g. for seminal economy search "jing" or "bindu" or "istimnāʾ", not "semen retention"; for female homoeroticism search "tribade" or "sahq", not "lesbian". The corpus is indexed via period translations that use tradition-internal terminology.',
+    description: 'Find specific PASSAGES inside books — returns page-level snippets with citation URLs. Use this when you want a quote or evidence on a topic across the whole library. ORIENTATION HINT: if the user has named a specific author or work, prefer get_book (returns a summary + chapter outline) over passage hunting — every book in the corpus has an AI-generated summary that is usually the right first read. Use search_translations when sweeping across many books for evidence of a theme. For finding which BOOKS cover a topic, use search_library. Query tips: single distinctive terms ("memory palace", "wax tablet") work best; multi-word natural-English queries ("unity of the intellect") may return fewer results because matching is term-based, not phrase-based. Each snippet has a snippet_type — "translation"/"ocr" means it is a verbatim extract from the source text; "summary" means it is AI-generated description (do not quote those as the author\'s words). Response includes total_matches, returned, and offset for pagination. Cross-cultural tip: for pre-modern or non-Western topics, search source-tradition vocabulary rather than modern English terms — e.g. for seminal economy search "jing" or "bindu" or "istimnāʾ", not "semen retention"; for female homoeroticism search "tribade" or "sahq", not "lesbian". The corpus is indexed via period translations that use tradition-internal terminology.',
     annotations: { title: 'Search Translations', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -331,7 +331,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'search_concept',
-    description: 'Conceptual / semantic passage search. Use when the modern term won\'t literally appear in historical texts — e.g. "distributed cognition" maps to passages about active intellect, art of memory, wax tablet metaphors; "social contract" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings (768d), so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Similarity calibration: 0.70+ is a strong match, 0.55–0.70 is worth reading but verify, below 0.55 is mostly conceptual drift. Set max_per_book to diversify results across many books rather than cluster on one source. Each passage carries a snippet_type — quote only "translation" snippets, never "summary". Cross-cultural tip: for pre-modern or non-Western topics, also try source-tradition vocabulary — e.g. for seminal economy try "jing preservation" or "bindu yoga" or "istimnāʾ"; for masturbation try "mollities" (Latin) or "hastamaithuna" (Sanskrit) or "shouyin" (Chinese). The corpus is indexed via period translations that use tradition-internal terminology, so adjacent/euphemistic terms often surface material that modern English keywords miss.',
+    description: 'Conceptual / semantic passage search across the whole library. Use when the modern term won\'t literally appear in historical texts — e.g. "distributed cognition" maps to passages about active intellect, art of memory, wax tablet metaphors; "social contract" maps to pre-Hobbesian discussions of consent and authority. Ranks passages by cosine similarity on Gemini embeddings (768d), so paraphrases and conceptually adjacent phrasings match even when no keyword overlaps. ORIENTATION HINT: if the user named a specific author or work, prefer get_book (returns the book\'s AI summary + chapter outline) — semantic search is expensive and best reserved for cross-corpus discovery. Prefer search_translations for literal phrases or distinctive single terms; use search_concept when the concept matters more than the wording. Similarity calibration: 0.70+ is a strong match, 0.55–0.70 is worth reading but verify, below 0.55 is mostly conceptual drift. Set max_per_book to diversify results across many books rather than cluster on one source. Each passage carries a snippet_type — quote only "translation" snippets, never "summary". Cross-cultural tip: for pre-modern or non-Western topics, also try source-tradition vocabulary — e.g. for seminal economy try "jing preservation" or "bindu yoga" or "istimnāʾ"; for masturbation try "mollities" (Latin) or "hastamaithuna" (Sanskrit) or "shouyin" (Chinese). The corpus is indexed via period translations that use tradition-internal terminology, so adjacent/euphemistic terms often surface material that modern English keywords miss.',
     annotations: { title: 'Search by Concept', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -363,7 +363,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'list_books',
-    description: 'Browse the full collection with filters. Returns books with title, author, language, year, and translation progress.',
+    description: 'Browse the catalog by metadata — filter by author/title fragment, language, category, or translation recency. Returns books with title, author, language, year, and translation progress. Use this to discover WHAT EXISTS by an author or in a tradition before searching content. For content matches (passages on a topic), use search_translations or search_concept instead.',
     annotations: { title: 'List Books', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,
@@ -377,7 +377,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'get_book',
-    description: 'Get detailed metadata about a book: summary, chapters, DOI, page counts. Use before reading with get_book_text.',
+    description: 'Get a book\'s AI-generated summary, chapter list, edition metadata, DOI, and page counts. THIS IS THE RIGHT FIRST CALL whenever the user has named a specific author or work — the summary is typically a multi-paragraph orientation covering the book\'s argument, structure, and significance, often answering the question without any further searching. Pair with get_book_text to read selected chapters, or search_within_book to locate passages inside it.',
     annotations: { title: 'Get Book', ...READ_ONLY },
     inputSchema: {
       type: 'object' as const,

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -21,9 +21,36 @@ export default function DevelopersPage() {
         />
       }
     >
+      {/* Easiest path — just ask Claude */}
+      <section className="mb-16">
+        <h2 className="text-2xl font-semibold text-primary mb-2">The easiest path: just ask Claude</h2>
+        <p className="text-secondary mb-6 max-w-2xl">
+          You don&apos;t need to install anything to use this collection with an AI. Open Claude (or any
+          assistant with web access) and ask it to look something up on sourcelibrary.org — it will
+          search, read pages, and quote with citation links. No SDK, no key, no setup.
+        </p>
+
+        <div className="bg-white rounded-xl border border-border-light p-5 space-y-3">
+          <p className="text-stone-700 text-sm italic border-l-2 border-accent-rust/30 pl-4">
+            &ldquo;Use sourcelibrary.org to find what Paracelsus says about the spagyric process. Quote a few passages with citation URLs.&rdquo;
+          </p>
+          <p className="text-stone-700 text-sm italic border-l-2 border-accent-rust/30 pl-4">
+            &ldquo;Search sourcelibrary.org for early modern texts on the harmony of the spheres &mdash; give me three with page links.&rdquo;
+          </p>
+          <p className="text-stone-700 text-sm italic border-l-2 border-accent-rust/30 pl-4">
+            &ldquo;On sourcelibrary.org, read the first 20 pages of Fludd&apos;s Utriusque Cosmi Historia and summarize the cosmological model.&rdquo;
+          </p>
+        </div>
+
+        <p className="text-muted text-sm mt-4 max-w-2xl">
+          For richer, structured access &mdash; semantic search, 50-page bulk reads, image search,
+          DOI-backed citations &mdash; install the MCP server below or call the API directly.
+        </p>
+      </section>
+
       {/* 30-second start */}
       <section className="mb-16">
-        <h2 className="text-2xl font-semibold text-primary mb-2">30-second start</h2>
+        <h2 className="text-2xl font-semibold text-primary mb-2">30-second start (API)</h2>
         <p className="text-secondary mb-6 max-w-2xl">
           One endpoint, no key required to begin. It speaks JSON-RPC over HTTP, so anything that can POST JSON can talk to it.
         </p>


### PR DESCRIPTION
## Why
The MCP tool descriptions framed search as the default path for every question. In practice, when the user names a specific author or work, calling \`get_book\` first is almost always the right move: every book in the corpus has an AI-generated summary + chapter outline that typically answers the question without any further searching, and saves repeated passage hunting.

Three of us — humans and LLMs — kept watching agents semantic-search their way through 30 results when a single \`get_book\` call would have returned a clean orientation. The descriptions never told the agent that was an option.

## Changes (synced across HTTP route and stdio mcp-server)
- **search_library, search_translations, search_concept**: each gets an \`ORIENTATION HINT\` noting that \`get_book\` should be preferred when an author or work has been named.
- **get_book**: description rewritten to emphasize its role as the right first call for named-work queries, not just a metadata lookup.
- **list_books**: reframed as the metadata-browse tool (discover what *exists* by author/language/tradition) vs the content-search tools.
- **search_concept** (stdio): similarity calibration text refreshed — was the stale \"below ~0.45\" wording; now matches the HTTP route's \"0.70+/0.55-0.70/below 0.55\" calibration.

## Effect
An LLM calling the MCP gets clearer steering on which tool to reach for. The semantic-vs-keyword tradeoff stays in the picture; the new addition is that *neither* may be the right answer when the user has named a specific work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)