### PR TITLE
Honest corpus framing: 12K searchable, not 26K cataloged; broaden the scope

### DIFF
--- a/.claude/docs/mcp-launch-posts.md
+++ b/.claude/docs/mcp-launch-posts.md
@@ -1,29 +1,33 @@
 # Source Library MCP — launch post drafts
 
-Numbers below match production as of 2026-05-16 (26,735 visible books,
-3,901,563 page embeddings, MCP v4.3.0). If you post weeks later, check
-`scripts/analyze-search-usage.mjs` for fresh stats and rerun the count
-queries from `MEMORY.md` style scripts before posting.
+Numbers below match production as of 2026-05-16: ~26,735 books cataloged,
+**12,926 with translation in progress** (the actually-searchable count),
+3,901,563 page embeddings, MCP v4.3.1. Re-run the count queries before
+posting if it's been more than a few weeks (corpus grows continuously).
 
-## Twitter / X (256 chars)
+## Twitter / X (270 chars)
 
-> Source Library is now an MCP for Claude. Ask about "distributed cognition" → get real citations from Bruno's *De Umbris*, Cicero's *De Oratore*, Aristotle on the active intellect. 26K pre-modern texts, semantic + keyword search, free, no install.
+> "distributed cognition" → Bruno's *De Umbris*, Cicero on rhetorical loci, Aristotle on the active intellect.
+>
+> Source Library: an MCP over 12K rare pre-modern texts translated to English. Theology, philosophy, history, literature, science, mysticism. Free, no install.
 > sourcelibrary.org/api/mcp
 
-## Bluesky (290 chars, room for more nuance)
+## Bluesky (300 chars)
 
-> Source Library is now an MCP server. Plug it into Claude.ai and ask about "distributed cognition" — you get back primary text from Bruno's *De Umbris*, Cicero on rhetorical loci, Aristotle on the active intellect, Plato's wax tablet. 26K pre-modern works, free, no install.
+> Source Library is now an MCP server. Ask Claude about "distributed cognition" — get back Bruno's *De Umbris*, Cicero on rhetorical loci, Aristotle on the active intellect, Plato's wax tablet. 12K rare pre-modern texts translated to English. Free, no install.
 > sourcelibrary.org/api/mcp
 
 ## Hacker News (Show HN)
 
-**Title:** `Show HN: Source Library – MCP server for 26K rare pre-modern texts`
+**Title:** `Show HN: Source Library – MCP server for 12K rare pre-modern texts`
 
 **Body:**
 
-Source Library is an MCP server that gives Claude (or any MCP-compatible LLM) primary-source search across 26,000+ rare pre-modern texts — alchemical, Hermetic, philosophical, and early scientific works translated into English from Latin, German, Arabic, Greek, and others. Nine tools cover keyword search, conceptual search (Gemini embeddings over 3.9M page embeddings), full-book reading, and stable citation URLs. Hosted, no install, no auth required to start: point your MCP client at https://sourcelibrary.org/api/mcp.
+Source Library is an MCP server that gives Claude (or any MCP-compatible LLM) primary-source search across 12,000+ rare pre-modern texts translated into English from Latin, German, Tibetan, Greek, Sanskrit, Arabic, Sumerian, Chinese, Hebrew, and more. The corpus covers theology, philosophy, history, literature, natural philosophy, mysticism, alchemy, Hermetica, medicine, mathematics, astronomy, law — the full breadth of pre-modern intellectual history, not only the esoteric flavor. Hosted, no install, no auth required to start: point your MCP client at https://sourcelibrary.org/api/mcp.
 
-The interesting part for LLM users is the conceptual search lane. Ask about "distributed cognition" and you get back the real ancestors of the modern idea: Bruno's *De Umbris Idearum* on artificial memory, Cicero's *De Oratore* on rhetorical loci, Aristotle on the active intellect, Plato's wax-tablet metaphor from the *Theaetetus*. The Gemini embeddings handle paraphrase, so the modern term doesn't need to appear in the historical text — they map to the historical concept directly.
+Ask about "distributed cognition" and you get back the real ancestors of the modern idea: Bruno's *De Umbris Idearum* on artificial memory, Cicero's *De Oratore* on rhetorical loci, Aristotle on the active intellect, Plato's wax-tablet metaphor from the *Theaetetus*. The Gemini embeddings handle paraphrase, so the modern term doesn't need to appear in the historical text.
+
+Nine tools cover keyword search, conceptual search (~4M Gemini-embedded pages), full-book reading, image search, and stable citation URLs (e.g. `sourcelibrary.org/q/abc123`) for every passage.
 
 I built this because I wanted something like arXiv for the period before peer review — a place you can search 16th-century alchemy or 5th-century BC philosophy and get back primary-source citations instead of Wikipedia summaries. Texts are CC-BY-SA. Code at https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2. Connect instructions at https://sourcelibrary.org/connect.
 
@@ -38,14 +42,14 @@ I built this because I wanted something like arXiv for the period before peer re
 - Best post time: weekday morning US Pacific
 - Be ready to engage in comments for ~3 hours after posting
 - Likely questions and short honest answers:
-  - "What was the hardest part?" → translation pipeline at scale; the OCR→translation→embedding chain runs on ~3.9M pages
+  - "What was the hardest part?" → translation pipeline at scale; the OCR→translation→embedding chain runs on ~3.9M pages across 15+ source languages
   - "What's the corpus source?" → digitised public-domain books from Internet Archive, Gallica, e-rara, BSB, etc.; translations are LLM-generated (currently Gemini)
-  - "What's the moat against just feeding text to an LLM?" → primary-source citations with stable URLs; the LLM alone hallucinates citations from these obscure works
-  - "How fresh is the corpus?" → still actively curated; ~1k books added per month
+  - "What's the moat against just feeding text to an LLM?" → primary-source citations with stable URLs; the LLM alone hallucinates citations for these obscure works
+  - "How fresh is the corpus?" → still actively curated; ~1k books added per month, with translations following
 
 **Communities beyond Twitter/HN:**
-- r/LocalLLaMA — angle: open MCP, works locally
-- r/ClaudeAI — angle: Claude.ai integration in 30s
+- r/LocalLLaMA — angle: open MCP, free remote endpoint
+- r/ClaudeAI — angle: one-click Claude.ai integration
 - r/AskHistorians — angle: searchable primary sources
 - r/digitalhumanities — angle: scholarly tool
 - r/SemanticWeb — angle: semantic search at corpus scale

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Embassy-of-the-Free-Mind/sourcelibrary",
   "title": "Source Library",
-  "description": "Search and cite 26K pre-modern primary sources: alchemy, Hermetica, philosophy, early science.",
-  "version": "4.3.0",
+  "description": "Search 12K rare pre-modern texts translated to English: philosophy, religion, science, literature.",
+  "version": "4.3.1",
   "repository": {
     "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
     "source": "github"

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -547,30 +547,31 @@ function buildNoResultsHint(tool: string, result: unknown, args: ToolArgs) {
       '(b) use your own pre-training knowledge to suggest which authors / works are likely relevant, then search those specifically; ' +
       '(c) web-search to find canonical texts on the topic, then come back here to look for them; ' +
       '(d) accept that this specific topic may not be in the corpus and answer from your own knowledge + web search instead. ' +
-      'This corpus is primarily pre-modern (c.1400-1900) esoteric, alchemical, philosophical, and scientific texts.',
+      'This corpus is rare pre-modern primary sources spanning Sumerian tablets to 19th-century works — theology, philosophy, history, literature, science, mysticism, medicine, and more. Not only esoteric/alchemical.',
     query,
   };
 }
 
 function createServer(reqContext: { ip: string; userAgent: string | null; identity: ApiIdentity }) {
   const server = new Server(
-    { name: 'source-library', version: '4.3.0' },
+    { name: 'source-library', version: '4.3.1' },
     { capabilities: { tools: {} } },
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: TOOLS,
     _meta: {
-      about: 'Source Library — 26,000+ rare alchemical, Hermetic, and early scientific texts translated into English. The largest AI-ready corpus of pre-modern esoteric knowledge. https://sourcelibrary.org',
+      about: 'Source Library — 12,000+ rare pre-modern texts translated into English from Latin, German, Tibetan, Greek, Sanskrit, Arabic, Sumerian, Chinese, Hebrew, and more. The full breadth of pre-modern intellectual history: theology, philosophy, history, literature, natural philosophy, mysticism, alchemy, Hermetica, medicine, mathematics, astronomy, law. Not only esoteric — also the canon. 3.9M searchable page embeddings. https://sourcelibrary.org',
       sign_in_hint: 'Sign in at sourcelibrary.org/auth/signin to save research, get a much higher rate limit, and support this archive. API keys for programmatic access: sourcelibrary.org/developers.',
       research_strategy: [
-        'Source Library is the primary-source citation layer in your research strategy — not the whole strategy. Its corpus is pre-modern texts (c.1400-1900). Use it together with your own knowledge and web search:',
+        'Source Library is the primary-source citation layer in your research strategy — not the whole strategy. Its corpus is rare pre-modern texts (mostly 1400-1900, ranging from Sumerian tablets to 19th-century scholarship) translated into English. Use it together with your own knowledge and web search:',
         '',
         '1. THINK BROADLY first. The user\'s literal phrase is rarely the right query. Use your own knowledge to brainstorm relevant authors, alternative terms, original-language forms, related works. "Renaissance Hermeticism" → Ficino, Pico, Corpus Hermeticum, Picatrix, Bruno, Patrizi. Search the expanded set.',
         '2. WEB-SEARCH for breadth when you can. Use it to confirm scholarly canon, find canonical editions, surface authors you didn\'t know about — then come back here to find the actual primary text.',
         '3. SEARCH THIS CORPUS iteratively. Try synonyms, original-language terms, related authors, the period one century earlier/later. search_concept is for paraphrase / conceptual matches; search_translations is for distinctive literal terms; search_library finds books. Don\'t over-rely on semantic — keyword is more precise for known phrases.',
         '4. CITE from here, frame from elsewhere. Use Source Library passages as evidence. Use your own knowledge and web search for context, scholarly consensus, author biography, modern interpretation, comparison to texts not in this corpus.',
         '5. EMPTY RESULTS mean "try a different angle" (broaden terms, try the original language, brainstorm adjacent authors) — not "doesn\'t exist."',
+        '6. CITE WITH URLS. Every passage you present to a user should include its short_url (e.g. sourcelibrary.org/q/abc123). These are stable, shareable citations — the standard way to refer to a Source Library passage.',
       ].join('\n'),
     },
   }));
@@ -638,8 +639,8 @@ function createServer(reqContext: { ip: string; userAgent: string | null; identi
 export async function GET() {
   return new Response(JSON.stringify({
     name: 'source-library',
-    version: '4.3.0',
-    description: 'Source Library MCP Server — search, read, and cite 26,000+ rare historical texts. Connect via POST to this endpoint.',
+    version: '4.3.1',
+    description: 'Source Library MCP Server — search, read, and cite 12,000+ rare pre-modern texts translated to English. Connect via POST to this endpoint.',
     docs: 'https://sourcelibrary.org/developers',
     tools: TOOLS.map(t => t.name),
   }), {

--- a/src/app/connect/page.tsx
+++ b/src/app/connect/page.tsx
@@ -7,7 +7,7 @@ export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title: 'Connect Source Library to Claude',
-  description: 'Give Claude access to 26,000+ rare historical texts in 30 seconds. Search, read, and cite alchemical, Hermetic, and early scientific works directly in your conversation.',
+  description: 'Give Claude access to 12,000+ rare pre-modern texts in 30 seconds — theology, philosophy, history, science, mysticism, literature. Search, read, and cite primary sources directly in your conversation.',
   alternates: { canonical: '/connect' },
 };
 
@@ -17,7 +17,7 @@ export default function ConnectPage() {
       header={
         <ContentHeader
           title="Connect Source Library to Claude"
-          subtitle="Search, read, and cite 26,000+ rare historical texts — directly in your conversation."
+          subtitle="Search, read, and cite 12,000+ rare pre-modern texts in English — directly in your conversation."
         />
       }
     >
@@ -149,25 +149,26 @@ export default function ConnectPage() {
       <section className="mb-16">
         <h2 className="text-2xl font-semibold text-primary mb-4">What&apos;s in the collection?</h2>
         <p className="text-secondary mb-6 max-w-2xl">
-          Source Library is the largest AI-ready corpus of pre-modern esoteric and scientific texts.
-          Most have been translated into English for the first time.
+          Theology, philosophy, history, literature, natural philosophy, mysticism, alchemy, Hermetica,
+          medicine, mathematics, astronomy — the full breadth of pre-modern intellectual history,
+          mostly translated into English for the first time.
         </p>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
           <div className="bg-white rounded-xl border border-border-light p-5">
-            <p className="text-2xl font-bold text-accent-rust">26,000+</p>
-            <p className="text-sm text-muted mt-1">books</p>
+            <p className="text-2xl font-bold text-accent-rust">12,000+</p>
+            <p className="text-sm text-muted mt-1">translated books</p>
           </div>
           <div className="bg-white rounded-xl border border-border-light p-5">
-            <p className="text-2xl font-bold text-accent-rust">90,000+</p>
-            <p className="text-sm text-muted mt-1">illustrations</p>
+            <p className="text-2xl font-bold text-accent-rust">3.9M</p>
+            <p className="text-sm text-muted mt-1">page embeddings</p>
           </div>
           <div className="bg-white rounded-xl border border-border-light p-5">
-            <p className="text-2xl font-bold text-accent-rust">30+</p>
-            <p className="text-sm text-muted mt-1">languages</p>
+            <p className="text-2xl font-bold text-accent-rust">15+</p>
+            <p className="text-sm text-muted mt-1">source languages</p>
           </div>
           <div className="bg-white rounded-xl border border-border-light p-5">
-            <p className="text-2xl font-bold text-accent-rust">1450&ndash;1800</p>
+            <p className="text-2xl font-bold text-accent-rust">Sumerian&ndash;1900</p>
             <p className="text-sm text-muted mt-1">date range</p>
           </div>
         </div>

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -5,7 +5,7 @@ import ApiKeyRequestForm from '@/components/developers/ApiKeyRequestForm';
 
 export const metadata: Metadata = {
   title: 'Developers - Source Library',
-  description: 'Open API over 26,000+ rare historical texts. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
+  description: 'Open API over 12,000+ rare pre-modern texts translated to English — theology, philosophy, history, science, mysticism, literature. No auth required — call /api/mcp from curl, the browser, or any MCP client. 9 research tools, REST endpoints, CLI.',
   alternates: {
     canonical: '/developers',
   },
@@ -17,7 +17,7 @@ export default function DevelopersPage() {
       header={
         <ContentHeader
           title="For Developers & AI"
-          subtitle="Open API over 26,000+ rare historical texts. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
+          subtitle="Open API over 12,000+ rare pre-modern texts translated to English. No auth needed to start — sign in for a free key to lift rate limits and help us see what you're building."
         />
       }
     >


### PR DESCRIPTION
Two real issues with the framing we shipped earlier today, both flagged by Derek on review.

## 1. Numbers were optimistic

| | claimed | reality |
|---|---|---|
| books | 26,000+ | 26,735 cataloged but only **12,926 have any translation** |
| ... | | the other ~13,800 are metadata-only entries waiting for OCR+translation |
| | | none of them surface in passage search |
| page embeddings | 3.9M | unchanged, still 3,901,563 |

Honest searchable count is **12K+**, not 26K+.

## 2. Scope was too narrow

\"alchemical, Hermetic, philosophical, and early scientific\" undersells the corpus by a lot. By translated-book count the top five categories are:

| category | count |
|---|---:|
| theology | 3,830 |
| philosophy | 3,608 |
| history | 3,267 |
| literature | 2,131 |
| natural-philosophy | 1,914 |
| Hermeticism | 1,254 |
| medicine | 1,207 |
| mysticism | 1,102 |
| alchemy | 1,043 |

Alchemy is #9 and Hermetica is #6 — the flavor, not the bulk. Languages span Latin, German, Tibetan, Greek, French, Chinese, Dutch, Sanskrit, Sumerian, Russian, Italian, Hebrew, Arabic, Syriac. Date range starts at Sumerian (-1000) and runs through the late 19th century, not just \"1450-1800.\"

## Changes

- \`src/app/api/mcp/route.ts\` — _meta.about, research_strategy, GET endpoint description, no_results_hint
- \`src/app/connect/page.tsx\` — SEO desc, hero subtitle, stats grid (12K translated books / 3.9M embeddings / 15+ source languages / Sumerian-1900 date range)
- \`src/app/developers/page.tsx\` — SEO desc and hero subtitle
- \`server.json\` — description + version bump 4.3.0 → 4.3.1
- \`.claude/docs/mcp-launch-posts.md\` — rewrote Twitter, Bluesky, Show HN drafts with broader framing + accurate numbers

## Also: \`research_strategy\` gained a citation-URL nudge

Step 6 of the standing guidance now says:

> CITE WITH URLS. Every passage you present to a user should include its short_url (e.g. sourcelibrary.org/q/abc123). These are stable, shareable citations — the standard way to refer to a Source Library passage.

This is the missing link between MCP usage and growth — every cited passage that lands in a Claude.ai conversation propagates a sourcelibrary.org URL.

## Follow-up after merge

Re-publish to the Official MCP Registry to surface the new framing:

\`\`\`
mcp-publisher publish    # picks up the 4.3.1 server.json
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)