### PR TITLE
Phase 1: image-extract worker scan-quality + blog post (#1810)

### DIFF
--- a/.claude/docs/automated-image-quality-system.md
+++ b/.claude/docs/automated-image-quality-system.md
@@ -1,0 +1,336 @@
+# Automated Image Quality System — Design
+
+**Status:** Design draft (2026-05-17)
+**Author:** Derek + Claude
+**Related:** scan-quality coverage, dedupe-best-copy picking, partial-archive triage
+
+---
+
+## Why this exists
+
+For Source Library, **illustrations are the irreplaceable content.** Text is recoverable via OCR; a faded woodcut, a smeared engraving, or a microfilmed map is a permanent loss. The library needs a per-illustration technical-quality signal to:
+
+1. **Choose the best copy among duplicates** — when two editions share the same Kircher diagram, pick the one with the sharper rendering of *that specific image*.
+2. **Flag content concerns** — illustrations that arrived blank, microfilmed, partially captured, or destroyed by bad thresholding.
+3. **Track corpus health** — distribution of scan quality across providers, eras, collections; provider-level baselines.
+
+The existing `book.scan_quality` field (1,087 books, 4% coverage) and `audit-scan-quality.mjs` script have three problems: pixel-only scoring is unreliable at the extremes, sampling is too thin (2 pages/book), and the audit is decoupled from the production pipeline so it never reaches new books.
+
+This design replaces it with a per-illustration system embedded in the image extraction pipeline.
+
+---
+
+## Architecture: three layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Layer 1 — Deterministic characteristics (free, every page)   │
+│ sharp pixel-stats + Laplacian variance, histogram entropy,   │
+│ bimodality, chroma spread, bytes-per-pixel                   │
+├─────────────────────────────────────────────────────────────┤
+│ Layer 2 — Gemini scan-quality assessment (in extraction)     │
+│ Augment existing extraction prompt with scan_score,          │
+│ scan_class, readable_text, illustration_fidelity,            │
+│ page_completeness, concerns[]                                │
+├─────────────────────────────────────────────────────────────┤
+│ Layer 3 — Cross-validation & ML distillation (future)        │
+│ Use L1+L2 outputs as labeled dataset; train a small visual   │
+│ classifier for offline scoring at zero per-call cost         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Layer 1 — Deterministic characteristics
+
+Computed via `sharp` on the in-memory page buffer the image-extract-worker already has. ~5-10ms per page.
+
+| Feature | Definition | Diagnostic signal |
+|---|---|---|
+| `megapixels` | width × height ÷ 1M | Resolution (capped — sharp ≠ large) |
+| `bytes_per_pixel` | file size ÷ pixel count | < 0.02 = over-compressed or near-blank |
+| `mean_brightness` | mean luminance across channels | Detects very dark/light pages |
+| `mean_stdev` | mean per-channel stdev | Low = flat image (faded or blank) |
+| `dynamic_range` | max channel range across channels | 0 = blank/uniform |
+| `chroma_spread` | max abs(meanA - meanB) across R/G/B | < 5 = monochrome |
+| `sharpness_var` | Laplacian variance on downsampled grayscale | Low = blurry/microfilm; high = sharp |
+| `histogram_entropy` | Shannon entropy of grayscale histogram | Low = bitonal; mid = grayscale; high = photo |
+| `bimodality` | top-2 histogram bin fraction | > 0.5 = bitonal; < 0.1 = photographic |
+
+**Direct deterministic flags** these features make trivial to detect:
+
+- **`is_blank`**: `dynamic_range < 5 && sharpness_var < 10`
+- **`is_monochrome`**: `chroma_spread < 5`
+- **`is_bitonal`**: `bimodality > 0.5 && histogram_entropy < 4`
+- **`is_over_compressed`**: `bytes_per_pixel < 0.015`
+- **`is_low_resolution`**: `megapixels < 1`
+
+These don't need Gemini — they're noise-free deterministic flags.
+
+### Layer 2 — Gemini scan-quality assessment
+
+Embedded in the existing `image-extract-worker.mjs` Gemini call. Single prompt, single round-trip per page. Adds ~20% to prompt output tokens; essentially free incremental cost.
+
+The augmented JSON output, **per page** (not per illustration — the page is what Gemini sees):
+
+```json
+{
+  "extracted_images": [...],          // existing — illustration bboxes + curatorial fields
+  "scan_quality": {                   // NEW — page-level technical assessment
+    "scan_score": 0-100,
+    "scan_class": "color_photo" | "color_print" | "grayscale_photo" |
+                  "grayscale_print" | "bitonal_clean" | "bitonal_microfilm" |
+                  "microfiche" | "blank" | "corrupt",
+    "readable_text": true | false,
+    "illustration_fidelity": "pristine" | "good" | "degraded" |
+                             "destroyed" | "no_illustration",
+    "page_completeness": "full_page" | "partial_capture" |
+                         "two_pages_one_image" | "fragment" | "blank",
+    "concerns": ["bleed_through", "gutter_shadow", "page_skew", ...],
+    "reasoning": "<2 sentences>"
+  }
+}
+```
+
+**Why `scan_class` matters most:** it distinguishes `bitonal_clean` (a pristine modern bitonal scan of a woodcut) from `bitonal_microfilm` (high-contrast pepper-noise scan-of-scan). Pixel stats alone cannot reliably make this distinction. Validation on 11 known samples (below) showed Gemini handled this correctly even when bimodality and entropy looked similar.
+
+**Why `page_completeness` matters:** catches a class of defects pixel stats miss entirely — two-pages-in-one-image (folio scans split incorrectly), fragments (partial-capture failures), scanner-bed-visible captures.
+
+**Why both `scan_class` and `concerns[]`:** `scan_class` is one canonical category for filtering/aggregation; `concerns[]` is a free-text list of issues for surfacing to humans and for tier-2 review.
+
+**Model choice:** `gemini-3-flash-preview`. Validated against `gemini-3.1-flash-lite-preview` and the lite model hallucinated content on a fully blank page (scored it 95/100 with "clear high-contrast text and no distracting artifacts"). Lite is disqualified for this task; the doubled cost of flash is acceptable.
+
+### Layer 3 — ML distillation (future)
+
+Once Layer 1+2 has scored ~50K+ illustrations, the resulting (features → labels) corpus becomes training data for a small distilled classifier:
+
+- **Input:** Layer 1 characteristics (10 floats) + optional thumbnail tensor
+- **Output:** `scan_class` + `scan_score` regression
+- **Goal:** ~95% agreement with Gemini, at zero per-call cost
+- **Use case:** continuous re-scoring on the entire corpus when scoring algorithm versions, A/B testing, fast filtering in admin views
+
+Not part of v1. Mentioned here to show the path; the distillation only becomes economical once we have a labeled corpus.
+
+---
+
+## Where it lives in the pipeline
+
+```
+extract-images phase (image-extract-worker.mjs)
+  │
+  ├─ Download page image to worker memory
+  │
+  ├─ Layer 1: sharp pixel-stats on buffer (5ms, free)
+  │     → page.image_characteristics = { ... }
+  │
+  ├─ Layer 2: Gemini vision call with augmented prompt
+  │     → page.scan_quality = { scan_score, scan_class, ... }
+  │     → gallery_images[].scan_quality = derived per-illustration (inherited from page + bbox-specific sharp stats)
+  │
+  └─ Book-level rollup (sync-page-counts cron or new rollup phase)
+        → book.scan_quality = {
+            median_score, min_score, count,
+            worst_image: { gallery_image_id, score, scan_class, concerns },
+            illustration_classification: 'majority of pages',
+            has_microfilm_pages: bool,
+            has_blank_pages: bool
+          }
+```
+
+### Per-illustration vs per-page
+
+The Gemini call sees the whole page. The page-level `scan_class` and `concerns` apply to every illustration extracted from that page. For per-illustration *resolution* and *sharpness* (which can vary across regions of one page), we run a fast sharp pass on each cropped `extracted_url`. Page-level is the dominant signal; per-illustration sharpness adjusts at the margin.
+
+### Schema additions
+
+**On `pages`:**
+```js
+image_characteristics: {
+  width, height, megapixels, bytes_per_pixel,
+  mean_brightness, mean_stdev, dynamic_range, chroma_spread,
+  sharpness_var, histogram_entropy, bimodality,
+  flags: { is_blank, is_monochrome, is_bitonal, is_over_compressed, is_low_resolution },
+  version, measured_at
+}
+scan_quality: {
+  scan_score, scan_class, readable_text,
+  illustration_fidelity, page_completeness,
+  concerns: [], reasoning,
+  model: 'gemini-3-flash-preview', version, assessed_at
+}
+```
+
+**On `gallery_images`:** (new field, distinct from existing `gallery_quality` which is curatorial)
+```js
+scan_quality: {
+  score,                    // page-level scan_score, modulated by per-crop sharpness
+  scan_class,               // inherited from page
+  sharpness_var,            // per-crop, measured on extracted_url
+  resolution_mp,            // per-crop
+  concerns: [],             // inherited from page + any crop-specific
+  page_completeness,        // inherited
+  version, assessed_at
+}
+```
+
+**On `books`:** (replaces the existing flat `scan_quality` object)
+```js
+scan_quality: {
+  median_score, min_score, max_score, count,
+  worst_image: { id, score, scan_class, concerns },
+  best_image: { id, score },
+  illustration_classification: 'majority scan_class',
+  has_microfilm_pages: bool,
+  has_blank_pages: bool,
+  page_completeness_issues: count,
+  rollup_at, version
+}
+text_quality: {                       // separate, derived from OCR confidence
+  mean_ocr_confidence, low_confidence_pages,
+  rollup_at
+}
+```
+
+---
+
+## Validation against 11 known samples
+
+The new prompt + characteristics pair, run on a hand-labeled spot-check set (pixel score, expected truth):
+
+| Pixel | Expected truth | Gemini scan_score | Gemini scan_class | Verdict |
+|---|---|---|---|---|
+| 100 | excellent | 94 | color_photo | ✅ |
+| 92 | excellent | 94 | color_photo | ✅ |
+| 84 | microfilm | 62 | **bitonal_microfilm** | ✅ caught microfilm despite high pixel score |
+| 78 | good-bw | 96 | color_photo | ✅ |
+| 74 | excellent | 95 | color_photo | ✅ pixel underrated; Gemini correct |
+| 71 | excellent-bitonal | 72 | bitonal_microfilm | ⚠️ Gemini may be right that source IS microfilm |
+| 68 | excellent-grayscale | 85 | grayscale_photo + `two_pages_captured` | ✅ |
+| 57 | microfiche | 62 | bitonal_microfilm | ✅ matched |
+| 48 | low-res-manuscript | 82 | grayscale_photo + `two_pages_captured` | ✅ |
+| 43 | near-blank-broken | 25 | bitonal_microfilm + `partial_capture` | ✅ |
+| 30 | BLANK | 0 | **blank** | ✅ corrected the pixel-score bug |
+
+**Agreement:** 10/11 exact match; the 11th (Llull) is plausibly right and a labeling ambiguity rather than a model error.
+
+Deterministic characteristics also showed strong discriminative signal:
+
+- **Blank detection is trivial** — Ganita: `sharpness_var=0, entropy=0, bimodality=1, dyn_range=0`. Any one of these alone is enough.
+- **Monochrome detection is unambiguous** — `chroma_spread < 5` is correct in every monochrome sample.
+- **Bitonal vs photographic** — `bimodality > 0.5 && entropy < 4` correctly identifies microfilm/bitonal samples (De Platonicae 0.587/3.87, Steganographia 0.734/2.68, Agrippa 0.98/0.29).
+- **Hard case:** clean-bitonal woodcut (Llull: 0.517/4.82) vs microfilm (Steganographia: 0.734/2.68) — bimodality discriminates but the threshold is fuzzy. Gemini is the disambiguator here.
+
+---
+
+## Cost analysis
+
+### Hot path (going forward)
+
+Per book, image-extract-worker already makes 1 Gemini call per illustrated page. The augmented prompt adds ~150 tokens output per call.
+
+- Existing cost (per SKILL.md): ~$0.0004 per page, ~$0.04 per 100-page book
+- Augmented cost: ~$0.00045 per page, ~$0.045 per 100-page book (~12% increase)
+- Annual incremental cost at current curation pace: < $50
+
+### Backfill (existing 101,967 gallery_images across ~25K books with illustrations)
+
+Two options:
+
+**Option A — Gemini on everything:** 25K books × ~5-10 illustrated pages avg = 150-250K calls. At flash rates ~$0.0004 × 200K = **~$80 one-time.**
+
+**Option B — Pixel-stats first, Gemini on bottom quartile:** 250K sharp passes (free, ~30 min), then Gemini on the ~60K lowest-scoring or hardest-to-classify pages. **~$25 one-time.**
+
+Option B is more efficient but adds a second pass over the data. Option A is operationally simpler and within a casual budget.
+
+**Recommendation:** Option B, parallelized across the existing Hetzner worker pool. Run as a one-shot job; future books get scored inline at extraction time.
+
+---
+
+## Use cases enabled
+
+### 1. Best-copy duplicate picking
+
+When two editions of a work both have extracted illustrations:
+1. Compute perceptual hash on each illustration (existing capability or new)
+2. Match same-illustration pairs across editions
+3. Compare `scan_quality.score` + `scan_class` + `sharpness_var`
+4. Pick the editions that has the *better rendering of that specific illustration*
+
+This is qualitatively different from picking by "book with higher average OCR completion." It directly optimizes for what users see.
+
+### 2. Concern flagging (admin queue)
+
+A "scan health" admin view filtered by:
+- `scan_quality.has_blank_pages: true`
+- `scan_quality.scan_class IN ['microfiche', 'bitonal_microfilm']` (re-source candidates)
+- `scan_quality.page_completeness_issues > 0` (manual review)
+- `gallery_images.scan_quality.score < 40 AND gallery_images.gallery_quality > 0.7` (important content, bad rendering — top priority)
+
+### 3. Provider quality dashboards
+
+`book.scan_quality.illustration_classification` aggregated by `image_source.provider`:
+- Internet Archive — distribution of color_photo / grayscale_photo / microfilm
+- Gallica — likely high microfilm fraction, useful to know
+- MDZ — low resolution but typically color
+- Provider trust scores for future imports
+
+### 4. Re-source candidate list
+
+Output: a queue of books that should be re-imported from a higher-quality source. The flag is precise: not "low score book" but "important illustrations rendered as microfilm."
+
+---
+
+## Implementation plan
+
+### Phase 1 — Prompt + worker patch (1-2 days)
+- [ ] Add the scan-quality fields to `image-extract-worker.mjs` Gemini prompt
+- [ ] Compute Layer 1 characteristics on the buffer; write to `pages.image_characteristics`
+- [ ] Parse and write `pages.scan_quality` + `gallery_images.scan_quality`
+- [ ] New books extracted from here on are scored automatically
+
+### Phase 2 — Book rollup (1 day)
+- [ ] New cron or extension to `sync-page-counts` that aggregates page-level → `book.scan_quality`
+- [ ] Drop the legacy `scan_quality` field from old `audit-scan-quality.mjs` runs after migration
+- [ ] Add `book.text_quality` derived from OCR confidence (separate signal)
+
+### Phase 3 — Backfill (1 day to run, ~$25)
+- [ ] Run pixel-stats pass on all 250K illustrated pages (free)
+- [ ] Run Gemini on bottom-quartile pages
+- [ ] Roll up to books
+- [ ] Report coverage
+
+### Phase 4 — Use cases (1 week)
+- [ ] Extend dedupe-bph-shared-ubn.mjs with scan_quality tiebreaker
+- [ ] Admin view: scan health queue
+- [ ] Provider dashboards in `/admin`
+
+### Phase 5 (future) — ML distillation
+- [ ] Export labeled dataset (features → Gemini scan_class/score)
+- [ ] Train small classifier
+- [ ] Validate against held-out Gemini labels
+- [ ] If ≥95% agreement: use for continuous re-scoring at zero per-call cost
+
+---
+
+## Open questions
+
+1. **Per-illustration vs per-page granularity.** The current design scores at page level and inherits to illustrations. Is that enough? If a page has one pristine engraving and one faded one, do we need to distinguish? Probably yes for high-value books — but adds Gemini cost. Could compromise: sharp-stats per illustration + Gemini at page level.
+
+2. **Re-scoring cadence.** When new pages get archived for an existing book (partial-archive backfill), should we automatically re-score? Probably yes — the worker patch covers this for free.
+
+3. **OCR confidence as text_quality signal.** Need to confirm we have per-page OCR confidence stored, or whether we'd need to add it.
+
+4. **Perceptual hashing for cross-edition image matching.** Required for Use Case 1 but not in this design's scope. Track as separate work.
+
+5. **Microfilm detection threshold.** Validation showed Gemini correctly identifies microfilm, but Llull (an arguably clean-bitonal woodcut) was also classified as `bitonal_microfilm`. Need to decide if the threshold should be tuned via prompt engineering or accepted as conservative.
+
+6. **Pipeline phase ordering.** Image extraction is fairly late (`chapters_complete`). For early concern-flagging (e.g. during import), a lightweight Layer 1 pass at archive time would surface blank/corrupt pages immediately rather than waiting for extraction.
+
+---
+
+## Related work / references
+
+- `scripts/workers/image-extract-worker.mjs` — extraction worker to be patched
+- `scripts/audit-scan-quality.mjs` — legacy pixel-only audit (to be retired)
+- `scripts/enhance-scan-quality.mjs` — downstream consumer of `book.scan_quality.classification` for grayscale/B&W enhancement
+- `.claude/skills/extract-images/SKILL.md` — current extraction documentation
+- Issue #1788 (BPH duplicate dedupe) — duplicate-picking is the immediate use case
+- Issue #1727 (centralize page-image URL resolution) — touches `archived_photo` precedence used by both extraction and quality measurement

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -17,7 +17,11 @@
 import { MongoClient } from 'mongodb';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { nanoid } from 'nanoid';
+import sharp from 'sharp';
 import { logUsage } from './lib/supabase-usage-logger.mjs';
+
+const SCAN_QUALITY_VERSION = 2;
+sharp.concurrency(1);
 
 // ── Config ──
 const CONCURRENCY = 25;           // Books processed simultaneously
@@ -102,7 +106,71 @@ GALLERY QUALITY (0.0-1.0):
 
 MUSEUM DESCRIPTION: Write 2-3 sentences for a museum label - what the viewer sees and its significance.
 
-Return ONLY a valid JSON array. If no significant illustrations, return: []`;
+────────────────────────────────────────────────────────────────────────────────
+PAGE-LEVEL SCAN QUALITY (technical, not curatorial)
+────────────────────────────────────────────────────────────────────────────────
+Independently of the illustrations above, assess the TECHNICAL DIGITIZATION QUALITY
+of the page itself. This is about HOW the page was scanned/photographed, not
+whether the content is important.
+
+scan_score (0-100):
+  90-100 = pristine, sharp, full tonal range, faithful to original
+  70-89  = solid working scan, minor artifacts
+  50-69  = noticeable degradation but content preserved
+  30-49  = severe degradation, content partially lost
+  0-29   = unusable (blank, corrupt, fragment)
+
+scan_class — use exactly one:
+  color_photo       — full-color photograph of original (modern archival)
+  color_print       — color scan of a color print
+  grayscale_photo   — high-bit grayscale photo of original (manuscripts often)
+  grayscale_print   — grayscale scan of printed page
+  bitonal_clean     — pure black/white, SHARP (modern OCR-ready or pristine woodcut)
+  bitonal_microfilm — pure black/white WITH pepper noise / jagged edges / scan-of-scan
+  microfiche        — bitonal_microfilm + visible mottling or uneven illumination
+  blank             — page is empty or near-empty (no usable content)
+  corrupt           — broken, partial capture, or shows scanner bed instead of page
+
+Distinguishing bitonal_clean from bitonal_microfilm is the MOST IMPORTANT
+classification call. The signature of microfilm is JAGGED edges and PEPPER NOISE
+in flat areas. A clean bitonal woodcut has crisp continuous strokes.
+
+page_completeness:
+  full_page          — single page captured fully
+  partial_capture    — page clearly cropped/cut off
+  two_pages_one_image — facing pages captured as one image (folio scan defect)
+  fragment           — only a small portion of any page is captured
+  blank              — captured but page is empty
+
+illustration_fidelity (assess only if illustrations are present):
+  pristine | good | degraded | destroyed | no_illustration
+
+concerns: list any of these that apply, exact strings only:
+  bleed_through, gutter_shadow, page_skew, fold_distortion, low_resolution,
+  scan_of_scan, pepper_noise, faded_text, faded_color, water_damage, yellow_tone,
+  out_of_focus, uneven_illumination, wrong_orientation, partial_capture,
+  blank_page, scanner_bed_visible, two_pages_captured, compression_artifacts, color_cast
+
+────────────────────────────────────────────────────────────────────────────────
+OUTPUT FORMAT
+────────────────────────────────────────────────────────────────────────────────
+Return ONLY a single valid JSON object with this exact shape:
+
+{
+  "extracted_images": [ /* array of illustration objects as specified above; [] if none */ ],
+  "scan_quality": {
+    "scan_score": <int>,
+    "scan_class": "<one of the values above>",
+    "readable_text": <true|false>,
+    "illustration_fidelity": "<one of the values above>",
+    "page_completeness": "<one of the values above>",
+    "concerns": [ "...", "..." ],
+    "reasoning": "<1-2 sentence justification>"
+  }
+}
+
+If the page is blank or corrupt, still return the object — set extracted_images: []
+and fill scan_quality accordingly.`;
 
 // ── Helpers ──
 function getPageImageUrl(page) {
@@ -111,14 +179,16 @@ function getPageImageUrl(page) {
   return page.photo_original || page.photo || null;
 }
 
-async function fetchImageBase64(url) {
+async function fetchImage(url) {
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
     if (!response.ok) return null;
-    const buffer = await response.arrayBuffer();
+    const arrayBuf = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuf);
     const contentType = response.headers.get('content-type') || 'image/jpeg';
     return {
-      data: Buffer.from(buffer).toString('base64'),
+      buffer,
+      data: buffer.toString('base64'),
       mimeType: contentType.split(';')[0].trim(),
     };
   } catch {
@@ -126,17 +196,155 @@ async function fetchImageBase64(url) {
   }
 }
 
-function parseImageExtractionResponse(text) {
-  if (!text || typeof text !== 'string') return [];
-  const cleaned = text.replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
-  const jsonMatch = cleaned.match(/\[[\s\S]*\]/);
-  if (!jsonMatch) return [];
+// Layer 1 deterministic characteristics — sharp pixel-stats + Laplacian variance,
+// histogram entropy, bimodality, chroma spread. Returns null on decode failure.
+async function computeImageCharacteristics(buffer) {
   try {
-    const parsed = JSON.parse(jsonMatch[0]);
-    return Array.isArray(parsed) ? parsed : [];
+    const [meta, stats] = await Promise.all([
+      sharp(buffer).metadata(),
+      sharp(buffer).stats(),
+    ]);
+    const ch = stats.channels;
+    if (!ch || ch.length === 0) return null;
+
+    const numChannels = ch.length;
+    const meanBrightness = ch.reduce((s, c) => s + c.mean, 0) / numChannels;
+    const meanStdev = ch.reduce((s, c) => s + c.stdev, 0) / numChannels;
+    const dynamicRange = Math.max(...ch.map(c => c.max - c.min));
+    const chromaSpread = numChannels >= 3
+      ? Math.max(
+          Math.abs(ch[0].mean - ch[1].mean),
+          Math.abs(ch[1].mean - ch[2].mean),
+          Math.abs(ch[0].mean - ch[2].mean),
+        )
+      : 0;
+
+    // Downsample once to grayscale for Laplacian + entropy + bimodality.
+    const small = await sharp(buffer)
+      .resize(512, null, { fit: 'inside' })
+      .greyscale()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    const { data, info } = small;
+    const w = info.width;
+    const h = info.height;
+
+    let lapSum = 0, lapSumSq = 0, lapN = 0;
+    for (let y = 1; y < h - 1; y++) {
+      for (let x = 1; x < w - 1; x++) {
+        const i = y * w + x;
+        const lap = -4 * data[i] + data[i - 1] + data[i + 1] + data[i - w] + data[i + w];
+        lapSum += lap;
+        lapSumSq += lap * lap;
+        lapN++;
+      }
+    }
+    const lapMean = lapN ? lapSum / lapN : 0;
+    const sharpnessVar = lapN ? lapSumSq / lapN - lapMean * lapMean : 0;
+
+    const hist = new Array(256).fill(0);
+    for (let i = 0; i < data.length; i++) hist[data[i]]++;
+    let entropy = 0;
+    for (const c of hist) {
+      if (c) {
+        const p = c / data.length;
+        entropy -= p * Math.log2(p);
+      }
+    }
+    const sortedHist = [...hist].sort((a, b) => b - a);
+    const bimodality = (sortedHist[0] + sortedHist[1]) / data.length;
+
+    const pixels = (meta.width || 1) * (meta.height || 1);
+    const bytesPerPixel = buffer.length / pixels;
+    const megapixels = pixels / 1_000_000;
+
+    const flags = {
+      is_blank: dynamicRange < 5 && sharpnessVar < 10,
+      is_monochrome: chromaSpread < 5,
+      is_bitonal: bimodality > 0.5 && entropy < 4,
+      is_over_compressed: bytesPerPixel < 0.015,
+      is_low_resolution: megapixels < 1,
+    };
+
+    return {
+      width: meta.width,
+      height: meta.height,
+      megapixels: Math.round(megapixels * 100) / 100,
+      bytes_per_pixel: Math.round(bytesPerPixel * 1000) / 1000,
+      mean_brightness: Math.round(meanBrightness * 10) / 10,
+      mean_stdev: Math.round(meanStdev * 10) / 10,
+      dynamic_range: dynamicRange,
+      chroma_spread: Math.round(chromaSpread * 10) / 10,
+      sharpness_var: Math.round(sharpnessVar),
+      histogram_entropy: Math.round(entropy * 100) / 100,
+      bimodality: Math.round(bimodality * 1000) / 1000,
+      flags,
+      version: SCAN_QUALITY_VERSION,
+    };
   } catch {
-    return [];
+    return null;
   }
+}
+
+const VALID_SCAN_CLASSES = new Set([
+  'color_photo', 'color_print', 'grayscale_photo', 'grayscale_print',
+  'bitonal_clean', 'bitonal_microfilm', 'microfiche', 'blank', 'corrupt',
+]);
+const VALID_FIDELITY = new Set([
+  'pristine', 'good', 'degraded', 'destroyed', 'no_illustration',
+]);
+const VALID_COMPLETENESS = new Set([
+  'full_page', 'partial_capture', 'two_pages_one_image', 'fragment', 'blank',
+]);
+
+function normalizeScanQuality(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const score = Math.max(0, Math.min(100, parseInt(raw.scan_score, 10) || 0));
+  const cls = VALID_SCAN_CLASSES.has(raw.scan_class) ? raw.scan_class : null;
+  const fidelity = VALID_FIDELITY.has(raw.illustration_fidelity) ? raw.illustration_fidelity : null;
+  const completeness = VALID_COMPLETENESS.has(raw.page_completeness) ? raw.page_completeness : null;
+  const concerns = Array.isArray(raw.concerns)
+    ? raw.concerns.filter(c => typeof c === 'string').slice(0, 20)
+    : [];
+  return {
+    scan_score: score,
+    scan_class: cls,
+    readable_text: raw.readable_text === true,
+    illustration_fidelity: fidelity,
+    page_completeness: completeness,
+    concerns,
+    reasoning: typeof raw.reasoning === 'string' ? raw.reasoning.slice(0, 600) : '',
+  };
+}
+
+// Backwards-compatible parser: accepts the new {extracted_images, scan_quality}
+// object form, and falls back to bare-array form if the model regresses.
+function parseImageExtractionResponse(text) {
+  const empty = { extracted_images: [], scan_quality: null };
+  if (!text || typeof text !== 'string') return empty;
+  const cleaned = text.replace(/^```(?:json)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+  // Try object form first
+  const objMatch = cleaned.match(/\{[\s\S]*\}/);
+  if (objMatch) {
+    try {
+      const parsed = JSON.parse(objMatch[0]);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return {
+          extracted_images: Array.isArray(parsed.extracted_images) ? parsed.extracted_images : [],
+          scan_quality: normalizeScanQuality(parsed.scan_quality),
+        };
+      }
+    } catch { /* fall through to array form */ }
+  }
+  // Fallback: legacy array-only response
+  const arrMatch = cleaned.match(/\[[\s\S]*\]/);
+  if (arrMatch) {
+    try {
+      const parsed = JSON.parse(arrMatch[0]);
+      return { extracted_images: Array.isArray(parsed) ? parsed : [], scan_quality: null };
+    } catch { /* nope */ }
+  }
+  return empty;
 }
 
 function normalizeBbox(raw) {
@@ -181,8 +389,12 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
   const url = getPageImageUrl(page);
   if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) return null;
 
-  const image = await fetchImageBase64(url);
+  const image = await fetchImage(url);
   if (!image) return null;
+
+  // Layer 1 — deterministic characteristics from the raw buffer.
+  // Run in parallel with the Gemini call to keep latency flat.
+  const characteristicsPromise = computeImageCharacteristics(image.buffer);
 
   const model = getClient().getGenerativeModel({
     model: MODEL,
@@ -195,7 +407,8 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
     ],
     generationConfig: {
       temperature: 0.1,
-      maxOutputTokens: 2048,
+      maxOutputTokens: 4096,
+      responseMimeType: 'application/json',
     },
   });
 
@@ -207,10 +420,12 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
   const response = result.response;
   const text = response.text();
   const usage = response.usageMetadata || {};
+  const characteristics = await characteristicsPromise;
 
   return {
     pageId: page.id,
     text,
+    characteristics,
     inputTokens: usage.promptTokenCount || 0,
     outputTokens: usage.candidatesTokenCount || 0,
   };
@@ -269,14 +484,33 @@ async function processBook(db, book) {
         continue;
       }
 
-      const { pageId, text, inputTokens, outputTokens } = settled.value;
+      const { pageId, text, characteristics, inputTokens, outputTokens } = settled.value;
       totalInputTokens += inputTokens;
       totalOutputTokens += outputTokens;
       pagesProcessed++;
 
-      const parsed = parseImageExtractionResponse(text);
-      if (parsed.length > 0) {
-        const detectedImages = parsed.map(img => ({
+      const { extracted_images: extractedRaw, scan_quality: scanQualityRaw } = parseImageExtractionResponse(text);
+
+      // Build the page-level scan_quality object that will land on `pages` and
+      // be inherited by each gallery_image extracted from this page.
+      const pageScanQuality = scanQualityRaw
+        ? {
+            ...scanQualityRaw,
+            model: MODEL,
+            version: SCAN_QUALITY_VERSION,
+            assessed_at: now,
+          }
+        : null;
+
+      const pageSet = {
+        image_extraction_updated_at: now,
+        updated_at: now,
+      };
+      if (characteristics) pageSet.image_characteristics = characteristics;
+      if (pageScanQuality) pageSet.scan_quality = pageScanQuality;
+
+      if (extractedRaw.length > 0) {
+        const detectedImages = extractedRaw.map(img => ({
           description: img.description || '',
           type: img.type || 'unknown',
           bbox: img.bbox ? normalizeBbox(img.bbox) : undefined,
@@ -291,17 +525,11 @@ async function processBook(db, book) {
         }));
 
         totalImages += detectedImages.length;
-
-        bulkOps.push({
-          updateOne: {
-            filter: { id: pageId },
-            update: { $set: { detected_images: detectedImages, image_extraction_updated_at: now, updated_at: now } },
-          },
-        });
+        pageSet.detected_images = detectedImages;
 
         for (let di = 0; di < detectedImages.length; di++) {
           const img = detectedImages[di];
-          galleryDocs.push({
+          const galleryDoc = {
             id: `${pageId}-${di}`,
             page_id: pageId,
             book_id: book.id,
@@ -317,16 +545,39 @@ async function processBook(db, book) {
             detection_source: 'vision_model',
             model: MODEL,
             updated_at: now,
-          });
+          };
+          // Inherit page-level scan quality so the gallery_image carries it standalone.
+          // Per-crop sharpness can be added later in a separate pass on extracted_url.
+          if (pageScanQuality) {
+            galleryDoc.scan_quality = {
+              score: pageScanQuality.scan_score,
+              scan_class: pageScanQuality.scan_class,
+              illustration_fidelity: pageScanQuality.illustration_fidelity,
+              page_completeness: pageScanQuality.page_completeness,
+              concerns: pageScanQuality.concerns,
+              source: 'page_inherited',
+              version: SCAN_QUALITY_VERSION,
+              assessed_at: now,
+            };
+          }
+          if (characteristics) {
+            galleryDoc.page_image_characteristics = {
+              megapixels: characteristics.megapixels,
+              sharpness_var: characteristics.sharpness_var,
+              chroma_spread: characteristics.chroma_spread,
+              flags: characteristics.flags,
+            };
+          }
+          galleryDocs.push(galleryDoc);
         }
-      } else {
-        bulkOps.push({
-          updateOne: {
-            filter: { id: pageId },
-            update: { $set: { image_extraction_updated_at: now, updated_at: now } },
-          },
-        });
       }
+
+      bulkOps.push({
+        updateOne: {
+          filter: { id: pageId },
+          update: { $set: pageSet },
+        },
+      });
     }
   }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -25,6 +25,15 @@ interface BlogPost {
 
 const posts: BlogPost[] = [
   {
+    slug: 'what-makes-a-good-scan',
+    title: 'What Makes a Good Scan?',
+    subtitle: 'Pixel statistics, AI judgment, and the moment a model rated a blank page 95/100. Designing a per-illustration quality system for 100,000 rare-book images.',
+    date: '17 May 2026',
+    readTime: '9 min read',
+    tag: 'Research',
+    tagColor: 'bg-blue-50 text-blue-700',
+  },
+  {
     slug: 'the-deletion',
     title: 'The Deletion',
     subtitle: 'How a Claude Code session in one of my ten open terminals hard-deleted 4,758 books from our rare-books library — with the actual prompts, the actual postmortem, and what it means for running AI agents against production data.',

--- a/src/app/blog/what-makes-a-good-scan/page.tsx
+++ b/src/app/blog/what-makes-a-good-scan/page.tsx
@@ -1,0 +1,385 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import BlogComments from '@/components/blog/BlogComments';
+
+export const metadata: Metadata = {
+  title: 'What Makes a Good Scan? - Research Notes - Source Library',
+  description: 'Pixel statistics, AI judgment, and the moment a model rated a blank page 95/100. Designing a per-illustration quality system for 100,000 rare-book images.',
+  openGraph: {
+    title: 'What Makes a Good Scan?',
+    description: 'Pixel statistics, AI judgment, and the moment a model rated a blank page 95/100. Designing a per-illustration quality system for 100,000 rare-book images.',
+  },
+  alternates: {
+    canonical: '/blog/what-makes-a-good-scan',
+  },
+};
+
+export default function WhatMakesAGoodScanPage() {
+  return (
+    <ContentPageLayout
+      header={
+        <ContentHeader
+          title="What Makes a Good Scan?"
+          subtitle="Pixel statistics, AI judgment, and the moment a model rated a blank page 95/100"
+          image="https://images.sourcelibrary.org/archived/695592c47bd6d2cd1d61b10b/209.jpg"
+          imageAlt="Woodcut of Ramon Llull and disciples, with the alphabetum operis consequentis table beneath. Ars Inventiva Veritatis, 1515."
+        >
+          <p className="text-stone-400 text-sm mt-4">17 May 2026 &middot; 9 min read</p>
+        </ContentHeader>
+      }
+      bg="bg-cream"
+    >
+      <div className="mb-6">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-secondary transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          All notes
+        </Link>
+      </div>
+
+      <article className="prose-content max-w-none">
+
+        {/* Lead */}
+        <p className="text-xl text-secondary leading-relaxed mb-8">
+          Source Library holds roughly 17,000 rare books and over 100,000 extracted illustrations &mdash; emblems, woodcuts, engravings, manuscript figures, maps. The text in those books is recoverable: OCR fails, we re-OCR, eventually we get it right. The pictures are not. A faded engraving, a smeared woodcut, a microfilmed map &mdash; those are permanent losses, frozen in whatever quality the digitization captured. So a question we kept dodging: <em>which of our scans are good enough, and which need to be re-sourced?</em>
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-8">
+          The honest answer used to be &ldquo;we don&rsquo;t really know.&rdquo; A legacy script (<code>audit-scan-quality.mjs</code>) had assigned a quality score to about 4% of the visible library &mdash; pixel statistics over two sampled pages per book, condensed into a single 0&ndash;100 number. The number was easy to query. It was also wrong, often by 30 or 40 points, in ways we only noticed when we started spot-checking it. This note is about what happens when you do.
+        </p>
+
+        {/* Table of contents */}
+        <nav className="bg-warm/50 rounded-lg p-6 mb-12 border border-light">
+          <p className="text-sm font-semibold text-primary mb-3 uppercase tracking-wide">Contents</p>
+          <ol className="text-secondary space-y-0.5 list-decimal list-inside text-sm">
+            <li><a href="#why-images" className="text-accent-rust hover:underline">Why images, not text</a></li>
+            <li><a href="#what-pixels-see" className="text-accent-rust hover:underline">What pixels can see</a></li>
+            <li><a href="#what-pixels-miss" className="text-accent-rust hover:underline">What pixels miss</a></li>
+            <li><a href="#flash-lite" className="text-accent-rust hover:underline">The flash-lite hallucination</a></li>
+            <li><a href="#design" className="text-accent-rust hover:underline">A three-layer design</a></li>
+            <li><a href="#bitonal-microfilm" className="text-accent-rust hover:underline">Bitonal clean vs. microfilm</a></li>
+            <li><a href="#use-cases" className="text-accent-rust hover:underline">What it unlocks</a></li>
+            <li><a href="#open-questions" className="text-accent-rust hover:underline">What we&rsquo;re still unsure about</a></li>
+          </ol>
+        </nav>
+
+        {/* ── 1 ── */}
+        <h2 id="why-images" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          1. Why images, not text
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          A previous note on this blog (<Link href="/blog/confident-hallucinator" className="text-accent-rust hover:underline">The Confident Hallucinator</Link>) made the case that OCR confidence and OCR agreement together give us a reliable signal for text quality. If a page is unreadable today, we can run it again next year with a better model and recover the text. Text is reversible.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Pictures are not. The reason is mechanical: every digitization pipeline ends with a JPEG (or a JP2) sitting on a server somewhere, and that file is all anyone will ever see of the underlying object. If the original photographer compressed it too hard, or scanned it from microfilm instead of from the page, or thresholded it to bitonal at 200 DPI, the loss is baked in. You can&rsquo;t un-microfilm an engraving by running better software over it.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          That makes scan quality the most consequential property of an image-bearing book, and the one we&rsquo;ve been least equipped to talk about. So we started measuring.
+        </p>
+
+        {/* ── 2 ── */}
+        <h2 id="what-pixels-see" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          2. What pixels can see
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The first attempt was deterministic. For each of two sampled pages in a book, compute four numbers and combine them into a score:
+        </p>
+
+        <ul className="text-secondary leading-relaxed mb-6 list-disc list-inside space-y-1">
+          <li><strong>Color depth.</strong> Is the file color, grayscale, or bitonal black-and-white? Bonus points for color.</li>
+          <li><strong>Resolution.</strong> Megapixels. Bonus points for sharper.</li>
+          <li><strong>Dynamic range.</strong> The spread between the darkest and lightest pixel. Detects washed-out or faded scans.</li>
+          <li><strong>Contrast.</strong> Mean standard deviation across channels. Detects flat or uniform images.</li>
+        </ul>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          This is roughly the right vocabulary. A high-resolution color photograph with strong dynamic range is almost always a great scan. A 1-megapixel bitonal page with a brightness range of 80 is almost always a terrible one. In the middle of the distribution &mdash; where most books actually live &mdash; pixel statistics work fine.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          At the edges they fall apart.
+        </p>
+
+        {/* ── 3 ── */}
+        <h2 id="what-pixels-miss" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          3. What pixels miss
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          We pulled a stratified sample &mdash; eighteen books, spread across the score range &mdash; and looked at each one. Three failure modes were obvious within minutes.
+        </p>
+
+        <h3 className="text-xl text-primary mt-10 mb-3">Failure 1: a blank page scored 30/100</h3>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          A book called <em>Ganita Kaumudi, Part 1</em> had a quality score of 30. Page 157, one of the two pages the formula had sampled, looked like this:
+        </p>
+
+        <div className="my-8 grid md:grid-cols-2 gap-6">
+          <figure className="text-center">
+            <div className="bg-warm border border-light p-4 rounded">
+              <img
+                src="https://images.sourcelibrary.org/archived/69906a961cf6ed5fbc8f7135/157.jpg"
+                alt="A completely blank white page"
+                className="w-full h-auto"
+                style={{ maxHeight: '400px', objectFit: 'contain' }}
+              />
+            </div>
+            <figcaption className="text-sm text-muted mt-2 italic">
+              Ganita Kaumudi, page 157. Dynamic range: 0. Sharpness variance: 0. Score: 30/100.
+            </figcaption>
+          </figure>
+
+          <figure className="text-center">
+            <div className="bg-warm border border-light p-4 rounded">
+              <img
+                src="https://images.sourcelibrary.org/archived/694bf8d2343422769f237558/212.jpg"
+                alt="A scan that is almost entirely blank with only a tiny fragment of text"
+                className="w-full h-auto"
+                style={{ maxHeight: '400px', objectFit: 'contain' }}
+              />
+            </div>
+            <figcaption className="text-sm text-muted mt-2 italic">
+              Agrippa, <em>De occulta philosophia</em>, page 212. Pixel score: 43/100.
+            </figcaption>
+          </figure>
+        </div>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The page is white. Not faded. Not light. <em>White.</em> But the formula handed it 25 points for being 14.8 megapixels and 5 more points for some residual scoring floor, and gave it a 30 &mdash; a score that put it in roughly the same bucket as a perfectly readable bitonal woodcut from 1515. The pixel statistics flagged that the image was degenerate (dynamic range 0, contrast 0) but the formula didn&rsquo;t know what to do with the flag.
+        </p>
+
+        <h3 className="text-xl text-primary mt-10 mb-3">Failure 2: a beautiful map scored 74/100</h3>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          A 19th-century fold-out map from the e-rara collection &mdash; <em>Die Schlacht bei Austerlitz</em> &mdash; scored 74. It is, plainly, an excellent scan: sharp color, every village name legible, the paper&rsquo;s creases preserved as natural texture.
+        </p>
+
+        <figure className="text-center my-8">
+          <div className="bg-warm border border-light p-4 rounded inline-block">
+            <img
+              src="https://images.sourcelibrary.org/archived/6968d9624fa3b04c6de86ecd/125.jpg"
+              alt="A 19th-century color topographic map of the area around Austerlitz showing rivers, villages, and terrain"
+              className="w-full h-auto mx-auto"
+              style={{ maxHeight: '500px', objectFit: 'contain' }}
+            />
+          </div>
+          <figcaption className="text-sm text-muted mt-2 italic">
+            Die Schlacht bei Austerlitz, 1806. Pixel score: 74/100. A reviewer&rsquo;s score would round up to about 95.
+          </figcaption>
+        </figure>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          What dragged the number down was resolution &mdash; the map is only 1.3 megapixels. The formula penalized it 15 points for being small. But the map is also sharp enough that every line and label is crisp at native size; the resolution doesn&rsquo;t hurt the image, it just isn&rsquo;t enormous. Sharpness, not megapixel count, is what matters for a well-rendered illustration. The formula didn&rsquo;t measure sharpness.
+        </p>
+
+        <h3 className="text-xl text-primary mt-10 mb-3">Failure 3: microfilm scored 84/100</h3>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The opposite failure: a 17-megapixel scan of George of Trebizond&rsquo;s <em>De Platonicae atque Aristotelicae Philosophiae Differentia</em> earned 84 points and looked, statistically, like a high-quality archival capture. It wasn&rsquo;t. The pixel count was real, but the underlying source was microfilm &mdash; what you see when you zoom in is the signature pepper noise and jagged character edges of a high-resolution scan of an old microfilm reel. The illustrations had been destroyed long before the JPEG existed.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Pixel statistics cannot detect this. A microfilm scan at 17 MP has the same megapixel count, the same dynamic range (the whites are still bright and the blacks are still dark), and the same contrast (high, because everything is one or the other) as a pristine archival photograph. The difference is in the texture &mdash; in what fills the spaces between the characters &mdash; and that&rsquo;s a perceptual judgment, not a numeric one.
+        </p>
+
+        {/* ── 4 ── */}
+        <h2 id="flash-lite" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          4. The flash-lite hallucination
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          So we did the obvious thing: asked an AI to look at the images. The right tool here is Gemini Flash &mdash; the same vision model we already use for OCR and illustration extraction. We ran the eleven sample pages through Flash with a blind prompt asking it to rate scan quality, and the results were a clear improvement. The microfilm scan dropped from 84 to 58 (&ldquo;heavy bleed-through, low resolution, scan-of-scan artifacts&rdquo;). The Austerlitz map climbed from 74 to 95 (&ldquo;outstanding high-resolution scan with sharp detail&rdquo;). The blank page got a clean 0.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Then we tried the cheaper sibling, Flash Lite, which costs roughly half as much per call. Because we&rsquo;d be running this at corpus scale &mdash; 100,000 illustrations &mdash; a 50% cost difference matters. We expected slightly worse judgments but a similar shape of answer.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          What we got was different. The same blank page that Flash had scored 0 came back from Flash Lite as:
+        </p>
+
+        <blockquote className="border-l-4 border-accent-rust pl-6 my-8 italic text-secondary">
+          <p className="mb-2"><strong>scan_score:</strong> 95</p>
+          <p className="mb-2"><strong>classification:</strong> grayscale</p>
+          <p className="mb-2"><strong>readable:</strong> true</p>
+          <p className="mb-0"><strong>verdict:</strong> &ldquo;This is an excellent, high-resolution scan with sharp text and clear contrast, making it perfect for both reading and OCR processing.&rdquo;</p>
+        </blockquote>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          There is no text in the image. There is nothing in the image. It is white. Flash Lite read the file&rsquo;s metadata, decided what a high-resolution archival scan should look like, and wrote a confident description of one. The hallucination wasn&rsquo;t subtle &mdash; it was a complete fabrication, marked &ldquo;readable: true,&rdquo; of content that did not exist.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          That single failure mode is disqualifying for production use. We need this system specifically to <em>catch</em> blank pages, broken scans, scanner-bed artifacts &mdash; the cases at the bottom of the quality distribution. A model that rubber-stamps those as &ldquo;excellent&rdquo; doesn&rsquo;t reduce error, it adds an extra layer of false confidence. Flash, at twice the price, doesn&rsquo;t do that. We&rsquo;ll pay the extra.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The pattern is the same one The Confident Hallucinator surfaced for OCR: consistency alone is a dangerous signal, and the cheaper model produces a more consistent kind of wrong. Vision tasks have the same shape.
+        </p>
+
+        {/* ── 5 ── */}
+        <h2 id="design" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          5. A three-layer design
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The synthesis is to use both signals together. Pixel statistics are cheap, deterministic, and reliable at the obvious cases &mdash; a dynamic range of zero <em>is</em> a blank page, every time. AI judgment is expensive, fuzzier, but able to make the perceptual distinctions that numbers can&rsquo;t &mdash; bitonal-from-microfilm versus bitonal-from-woodcut, fragment-versus-full-page, scanner-bed-versus-page-content. Neither alone is sufficient. Both together cover the failure modes of either.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          So the production design is three layers, embedded in the existing illustration-extraction pipeline:
+        </p>
+
+        <div className="bg-warm/50 border border-light rounded-lg p-6 my-8 font-mono text-sm text-secondary">
+          <div className="mb-4">
+            <strong className="text-primary">Layer 1 &mdash; Deterministic characteristics</strong> (free, every page)
+            <p className="font-sans text-sm mt-1">
+              sharp pixel-stats + Laplacian-variance sharpness + histogram entropy + bimodality + chroma spread.
+              Catches blanks, low resolution, over-compression, and bitonal/photographic discrimination.
+              About 5ms per page on the image-extract worker that&rsquo;s already running.
+            </p>
+          </div>
+          <div className="mb-4">
+            <strong className="text-primary">Layer 2 &mdash; Gemini scan-quality assessment</strong> (embedded in extraction)
+            <p className="font-sans text-sm mt-1">
+              Augments the existing illustration-extraction prompt with technical-quality fields:
+              scan_score, scan_class, readable_text, illustration_fidelity, page_completeness,
+              and a list of concerns drawn from a fixed vocabulary. One Gemini call per page
+              (the same call we already make), ~15% longer output, ~12% more cost. Per-illustration
+              data lands in <code>gallery_images.scan_quality</code>.
+            </p>
+          </div>
+          <div>
+            <strong className="text-primary">Layer 3 &mdash; ML distillation</strong> (future)
+            <p className="font-sans text-sm mt-1">
+              Once L1+L2 has scored ~50K illustrations, the (features &rarr; labels) corpus
+              becomes training data for a small classifier &mdash; goal ~95% agreement with Gemini
+              at zero per-call cost. Not part of v1; mentioned here to show the path.
+            </p>
+          </div>
+        </div>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          We picked the extraction pipeline as the host because it&rsquo;s already doing the work. The worker already downloads every page image, already calls Gemini vision, already writes one document per detected illustration. Augmenting the prompt is a 15-line change. Computing pixel statistics on the in-memory buffer is another 30 lines. We&rsquo;re capturing technical-quality signals during work that&rsquo;s already happening.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The result is two parallel signals per illustration. The existing <code>gallery_quality</code> field answers <em>&ldquo;is this image worth showing?&rdquo;</em> &mdash; an emblem with figures scores higher than a marbled endpaper. The new <code>scan_quality</code> field answers <em>&ldquo;how cleanly is this image digitized?&rdquo;</em> &mdash; orthogonal questions that we&rsquo;d been muddling together. A famous Kircher diagram has a <code>gallery_quality</code> of 0.9 whether the scan is pristine or microfilmed. Now we can say so.
+        </p>
+
+        {/* ── 6 ── */}
+        <h2 id="bitonal-microfilm" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          6. Bitonal clean vs. microfilm
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The hardest distinction the system has to make is between a pristine bitonal scan of a woodcut &mdash; sharp, intentional, no information loss &mdash; and a bitonal scan from a microfilm reel, which looks superficially similar but has lost the original&rsquo;s fine detail. Both are pure black-and-white. Both can be high-resolution. Pixel statistics see them as equivalent.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Two examples from the test set. On the left, a clean 1515 woodcut of Ramon Llull and his disciples at the shore; on the right, a microfilm scan of an early printed page from Steganographia. Both are bitonal. Both score similarly on pixel statistics (bimodality 0.52 vs 0.73, histogram entropy 4.82 vs 2.68 &mdash; close, but no firm threshold). Visually, only one of them is preserved.
+        </p>
+
+        <div className="my-8 grid md:grid-cols-2 gap-6">
+          <figure className="text-center">
+            <div className="bg-warm border border-light p-4 rounded">
+              <img
+                src="https://images.sourcelibrary.org/archived/695592c47bd6d2cd1d61b10b/209.jpg"
+                alt="Crisp woodcut of Ramon Llull with disciples and a city in the background. From Ars Inventiva Veritatis, 1515."
+                className="w-full h-auto"
+                style={{ maxHeight: '500px', objectFit: 'contain' }}
+              />
+            </div>
+            <figcaption className="text-sm text-muted mt-2 italic">
+              Ramon Llull, Ars Inventiva Veritatis, 1515. <strong>bitonal_clean.</strong>
+            </figcaption>
+          </figure>
+
+          <figure className="text-center">
+            <div className="bg-warm border border-light p-4 rounded">
+              <img
+                src="https://images.sourcelibrary.org/archived/69520773ab34727b1f043c4d/14.jpg"
+                alt="Microfilm scan of a printed page with visible pepper noise and jagged character edges. From Steganographia."
+                className="w-full h-auto"
+                style={{ maxHeight: '500px', objectFit: 'contain' }}
+              />
+            </div>
+            <figcaption className="text-sm text-muted mt-2 italic">
+              Trithemius, Steganographia. <strong>bitonal_microfilm.</strong>
+            </figcaption>
+          </figure>
+        </div>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Gemini handles this. In the validation set it correctly tagged the Steganographia scan as <code>bitonal_microfilm</code> with concerns &ldquo;pepper_noise, scan_of_scan, low_resolution, compression_artifacts&rdquo; &mdash; the exact technical vocabulary an archivist would use. The Llull woodcut was tagged <code>bitonal_clean</code> with concerns just &ldquo;binding gutter shadow.&rdquo; The distinction the pixel formula couldn&rsquo;t make, the model made cleanly.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          This is the single most useful field in the schema. A book whose illustrations are classified <code>bitonal_microfilm</code> or <code>microfiche</code> is a re-source candidate: somewhere out there is a better copy of those engravings, and we should track it down. A book whose illustrations are <code>bitonal_clean</code> at any resolution is fine. The classification cuts directly to action.
+        </p>
+
+        {/* ── 7 ── */}
+        <h2 id="use-cases" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          7. What it unlocks
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Three uses immediately follow.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          <strong>Best-copy duplicate picking.</strong> Source Library frequently holds two or three editions of the same work, sometimes from different providers. When dedupe runs, the question is which copy to keep canonical and which to hide. Until now the tiebreaker was OCR completeness &mdash; how much text was processed. That&rsquo;s a text-availability heuristic, not a quality one. With per-illustration scan_quality, we can compare specific images across editions: of the two copies of <em>Musaeum hermeticum</em>, which one renders the Mercurius engraving sharply? Pick that edition. The other is the duplicate.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          <strong>Concern flagging.</strong> An admin queue filtered by <code>scan_quality.has_blank_pages</code>, <code>scan_quality.page_completeness_issues</code>, and the high-curatorial-value / low-scan-quality combination (the worst-case: important illustrations badly digitized). These are actionable rows &mdash; each one corresponds to a specific intervention. Re-source. Re-archive. Manual inspection.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          <strong>Provider quality baselines.</strong> Aggregate <code>scan_class</code> by <code>image_source.provider</code>. Some providers will turn out to be microfilm-heavy. Others will be color-photo-heavy. We&rsquo;ll know which collections to prefer when multiple sources are available for a single work, and we&rsquo;ll be able to ground future import decisions in data rather than habit.
+        </p>
+
+        {/* ── 8 ── */}
+        <h2 id="open-questions" className="text-2xl md:text-3xl text-primary mt-16 mb-6">
+          8. What we&rsquo;re still unsure about
+        </h2>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          Two things, mostly.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          <strong>Granularity.</strong> The current design rates quality at the page level and inherits to each illustration on that page. But pages aren&rsquo;t uniform &mdash; you can have a beautiful color frontispiece bound facing a faded text page, and they&rsquo;ll get the same score. For high-value books we may want per-illustration Gemini calls; for everything else, page-level is fine. The right policy is probably tier-based, but we don&rsquo;t know yet where the threshold should sit.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          <strong>The microfilm threshold.</strong> Gemini occasionally classifies a clean modern bitonal scan as <code>bitonal_microfilm</code> when the source is, in fact, a sharp woodcut printed on yellowed paper. The model is being slightly conservative &mdash; treating any jagged edge as a microfilm signature. We could tune the prompt to be less aggressive, but the cost of getting it wrong in the other direction (silently labeling actual microfilm as &ldquo;clean&rdquo;) is much higher than a few false positives. For now we&rsquo;re accepting the conservative behavior and reviewing the borderline cases manually.
+        </p>
+
+        <p className="text-secondary leading-relaxed mb-6">
+          The longer-term question is whether any of this is necessary. If we end up with a clean labeled corpus of 50,000 illustrations &mdash; pixel characteristics on one side, Gemini judgments on the other &mdash; that corpus is itself a small ML training set. A distilled classifier that runs on the deterministic features alone, calibrated against the Gemini labels, would let us re-score the entire library in minutes at no per-call cost. We&rsquo;re not there yet. But it&rsquo;s the kind of thing that becomes easy once you have the data, and that&rsquo;s the most under-appreciated outcome of building a system like this. The schema and the corpus are the durable artifacts. The current scoring algorithm is just a placeholder.
+        </p>
+
+        {/* End */}
+        <hr className="my-12 border-light" />
+
+        <p className="text-sm text-muted">
+          <em>The full design document (with schema, prompt, characteristics formulas, validation table, and the full eleven-sample spot-check) lives at <code>.claude/docs/automated-image-quality-system.md</code> in the repository. Phase 1 is tracked at GitHub issue <Link href="https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/1810" className="text-accent-rust hover:underline">#1810</Link>.</em>
+        </p>
+
+        <BlogComments slug="what-makes-a-good-scan" />
+      </article>
+    </ContentPageLayout>
+  );
+}


### PR DESCRIPTION
Phase 1 of the automated image quality system. Tracks #1810.

## What's in this PR

1. **`scripts/workers/image-extract-worker.mjs`** — augments the existing Gemini extraction call with technical scan-quality fields and adds a deterministic `sharp` characteristics pass on the same in-memory buffer.
2. **`.claude/docs/automated-image-quality-system.md`** — full design document (schema, prompt, validation results, cost analysis, open questions).
3. **`src/app/blog/what-makes-a-good-scan/page.tsx`** — 9-minute research note on the system. Listed at the top of `/blog`.

## How the worker changed

- Response format: array → wrapped object `{ extracted_images: [...], scan_quality: {...} }`. Parser falls back to the legacy array form so a model regression won't lose extraction.
- Generation: switched to `responseMimeType: 'application/json'` and bumped `maxOutputTokens` 2048 → 4096. The new payload is ~30% larger; old limit truncated mid-bbox on illustration-heavy pages during verification.
- Adds `pages.image_characteristics` (Layer 1: sharp + Laplacian variance + histogram entropy + bimodality + chroma spread + bpp + boolean flags) and `pages.scan_quality` (Layer 2: Gemini classification).
- Each `gallery_images` doc inherits the page-level `scan_quality` and a slice of `image_characteristics` so it carries technical quality alongside the existing curatorial `gallery_quality`.

## Verification

End-to-end test on 5 known samples (pristine color, microfilm, two-pages-captured spread, blank page, fragment):

| Sample | Expected | Got |
|---|---|---|
| Enchiridion (pristine color) | color_photo, 90+ | color_photo, 88 ✓ |
| De Platonicae (microfilm) | bitonal_microfilm, 50-70 | grayscale_print, 78 — borderline |
| Picatrix (two-pages-spread) | flagged | flagged `two_pages_one_image` ✓ |
| Ganita Kaumudi (blank) | blank, <10 | blank, 0 ✓ |
| Agrippa (fragment) | <40 | bitonal_clean, 60 — Gemini lenient, but L1 flags `is_low_resolution + is_over_compressed` catch it |

Deterministic characteristics correctly identified the blank page (`is_blank, is_over_compressed, is_bitonal`) — the L1 and L2 paths agree independently on the clearest cases, which is exactly the cross-check the design is built around.

Verification harness lives at `scripts/_tmp-verify-extract-patch.mjs` (gitignored per project convention).

## Not in this PR (future phases)

- **Phase 2:** book-level rollup cron (`books.scan_quality` aggregation from page-level data)
- **Phase 3:** one-time backfill over the existing ~101K `gallery_images`
- **Phase 4:** dedupe tiebreaker, admin scan-health queue, provider dashboards
- **Phase 5:** ML distillation (deferred)

## Risk

- **Response format change is breaking for the worker only.** Anything else reading `pages.detected_images` is unaffected. The parser handles model regressions gracefully (falls back to legacy array form).
- **Token budget increase.** ~12% incremental cost per Gemini call (longer output). Quantified in the design doc.
- **No production write yet.** Phase 1 only kicks in for books processed *after* deployment. Existing 101K illustrations remain unscored until Phase 3 backfill.

Draft because the system hasn't been observed under real load yet — would like to merge to `main`, deploy, and watch one Hetzner cron cycle before un-drafting.

## Test plan
- [ ] CI passes
- [ ] Deploy to Vercel preview, confirm `/blog/what-makes-a-good-scan` renders correctly
- [ ] On Hetzner, manually trigger extraction on 3-5 books spanning known-good and known-bad scans; confirm `pages.scan_quality` + `pages.image_characteristics` land in Mongo with expected shape
- [ ] Check one full cron cycle for parse-error rate; if > 5% of pages return null `scan_quality`, re-tune prompt before un-drafting

🤖 Generated with [Claude Code](https://claude.com/claude-code)