### PR TITLE
Speed up R2 archiving: parallel variant uploads + unblock archive-ocr

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -37,7 +37,7 @@ const hasFlag = (name) => args.includes(`--${name}`);
 
 const BOOK_LIMIT = parseInt(getArg('limit') || '20', 10);  // Books per cron run
 const BOOK_CONCURRENCY = parseInt(getArg('concurrency') || '2', 10);
-const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '8', 10);
+const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '16', 10);
 const DRY_RUN = hasFlag('dry-run');
 const JPEG_QUALITY = 85;
 const MAX_DIMENSION = 3000;
@@ -406,7 +406,7 @@ async function main() {
 
   cleanupStaleTmpDirs();
 
-  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 5, serverSelectionTimeoutMS: 10000 });
+  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 10, serverSelectionTimeoutMS: 10000 });
   await client.connect();
   const db = client.db('bookstore');
 

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -221,7 +221,7 @@ async function archivePage(page, db) {
 
 async function main() {
   const start = Date.now();
-  const client = await MongoClient.connect(process.env.MONGODB_URI, { maxPoolSize: 5 });
+  const client = await MongoClient.connect(process.env.MONGODB_URI, { maxPoolSize: 10 });
   const db = client.db('bookstore');
 
   // Check processing_control pause
@@ -335,6 +335,16 @@ async function main() {
             { archived_photo: null },
             { archived_photo: '' },
           ],
+          // Skip pages that have failed 3+ times — they have permanently broken
+          // source URLs (e.g. malformed IIIF templates from old imports). They
+          // poison every run by tripping the per-domain circuit breaker (5 fails
+          // with 0 oks). Re-archiving these requires fixing the photo URL first.
+          $and: [{
+            $or: [
+              { 'archive_metadata.failure_count': { $exists: false } },
+              { 'archive_metadata.failure_count': { $lt: 3 } },
+            ],
+          }],
         },
         { projection: { _id: 1, book_id: 1, page_number: 1, photo: 1 } }
       )
@@ -371,7 +381,7 @@ async function main() {
 
   // Process all domains in parallel — each domain runs multiple concurrent workers.
   // The token bucket ensures we stay within rate limits even with concurrency.
-  const DOMAIN_CONCURRENCY = 5; // Workers per domain (token bucket throttles them)
+  const DOMAIN_CONCURRENCY = 8; // Workers per domain (token bucket throttles them)
   let circuitBroken = new Set(); // Domains that hit circuit breaker
 
   const domainWorkers = Object.entries(byDomain).map(async ([domain, domainPages]) => {

--- a/scripts/workers/lib/display-image.mjs
+++ b/scripts/workers/lib/display-image.mjs
@@ -127,22 +127,22 @@ async function applyProvenanceMarks(buffer) {
  * @returns {{ display: Buffer, thumb: Buffer }} - The generated variants
  */
 export async function generateDisplayVariants(fullResBuffer) {
-  // Display: 1200px wide, provenance marks on ~10% of pages (random)
-  const displayResized = await sharp(fullResBuffer)
-    .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
-    .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
-    .toBuffer();
+  const displayPromise = (async () => {
+    const displayResized = await sharp(fullResBuffer)
+      .resize(DISPLAY_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: DISPLAY_QUALITY, progressive: true })
+      .toBuffer();
+    return Math.random() < 0.1
+      ? await applyProvenanceMarks(displayResized)
+      : displayResized;
+  })();
 
-  const display = Math.random() < 0.1
-    ? await applyProvenanceMarks(displayResized)
-    : displayResized;
-
-  // Thumbnail: 150px wide, no provenance marks (too small)
-  const thumb = await sharp(fullResBuffer)
+  const thumbPromise = sharp(fullResBuffer)
     .resize(THUMB_WIDTH, null, { fit: 'inside', withoutEnlargement: true })
     .jpeg({ quality: THUMB_QUALITY })
     .toBuffer();
 
+  const [display, thumb] = await Promise.all([displayPromise, thumbPromise]);
   return { display, thumb };
 }
 
@@ -170,28 +170,38 @@ export async function uploadPageVariants(fullResBuffer, bookId, pageNumber, uplo
   if (!bookId) throw new Error(`uploadPageVariants: bookId is ${bookId} for page ${pageNumber}`);
   const num = String(pageNumber).padStart(4, '0');
 
-  // Read full-res dimensions before any resizing
-  const meta = await sharp(fullResBuffer).metadata();
-  const width = meta.width || null;
-  const height = meta.height || null;
-
-  // Upload full-res (to the existing archived/ path for backward compat)
   const archivedKey = `archived/${bookId}/${pageNumber}.jpg`;
-  validateR2Key(archivedKey);
-  const archivedUrl = await uploadFn(archivedKey, fullResBuffer, 'image/jpeg');
-
-  // Generate variants
-  const { display, thumb } = await generateDisplayVariants(fullResBuffer);
-
-  // Upload display (1200px with provenance)
   const displayKey = `pages/${bookId}/${num}.jpg`;
-  validateR2Key(displayKey);
-  const displayUrl = await uploadFn(displayKey, display, 'image/jpeg');
-
-  // Upload thumbnail (150px)
   const thumbKey = `pages/${bookId}/${num}-thumb.jpg`;
+  validateR2Key(archivedKey);
+  validateR2Key(displayKey);
   validateR2Key(thumbKey);
-  const thumbUrl = await uploadFn(thumbKey, thumb, 'image/jpeg');
 
-  return { archived: archivedUrl, display: displayUrl, thumb: thumbUrl, width, height };
+  // Kick off full-res upload and metadata read against the buffer we already have,
+  // while sharp generates the resized variants in parallel.
+  const metaPromise = sharp(fullResBuffer).metadata();
+  const archivedUploadPromise = uploadFn(archivedKey, fullResBuffer, 'image/jpeg');
+  const variantsPromise = generateDisplayVariants(fullResBuffer);
+
+  // Once variants are ready, start their uploads — they run alongside the full-res upload.
+  const variantUploadsPromise = variantsPromise.then(({ display, thumb }) =>
+    Promise.all([
+      uploadFn(displayKey, display, 'image/jpeg'),
+      uploadFn(thumbKey, thumb, 'image/jpeg'),
+    ])
+  );
+
+  const [archivedUrl, [displayUrl, thumbUrl], meta] = await Promise.all([
+    archivedUploadPromise,
+    variantUploadsPromise,
+    metaPromise,
+  ]);
+
+  return {
+    archived: archivedUrl,
+    display: displayUrl,
+    thumb: thumbUrl,
+    width: meta.width || null,
+    height: meta.height || null,
+  };
 }


### PR DESCRIPTION
Phase 1 of #1814.

## Changes

**`scripts/workers/lib/display-image.mjs`** — parallel variant uploads
- The three R2 PUTs (archived/display/thumb) now run via `Promise.all` instead of sequential `await`s. Full-res upload kicks off immediately against the buffer we already have, while sharp generates display+thumb variants in parallel.
- `generateDisplayVariants` also runs the 1200px and 150px sharp pipelines in parallel instead of serially.
- Net effect: per-page wallclock should drop ~40-50% on the upload-bound portion.

**`scripts/workers/archive-bulk.mjs`** — raise concurrency
- `PAGE_CONCURRENCY` default `8` → `16`
- Mongo `maxPoolSize` `5` → `10`

**`scripts/workers/archive-ocr.mjs`** — raise concurrency + unblock
- `DOMAIN_CONCURRENCY` `5` → `8` (still bounded by per-domain token bucket)
- Mongo `maxPoolSize` `5` → `10`
- **Critical fix**: page selection now skips `archive_metadata.failure_count >= 3`. Sampling showed 25 poison pages with malformed IIIF URLs (e.g. `https://archive.org/.../full/pct:50/0/` missing `default.jpg`) were re-selected every run, all 404'd, and tripped the 5-fail-0-ok per-domain circuit breaker — which is why archive-ocr archived **0 pages over the past 7 days** despite 47 runs/24h.

## Why this matters

Current backlog: ~5.6M pages (~1.0M live, ~4.6M warehouse) across ~12K books. At the 7-day average of 25K pages/day, that's ~7.5 months to drain. After this PR, expected ~2-3x throughput on archive-bulk, and archive-ocr should start making progress on the non-IA warehouse backlog (currently ~0 p/day).

## Test plan

- [ ] `node --check` passes on all three files (verified locally)
- [ ] Push to Hetzner, watch one `archive-bulk` cycle: verify pages still get all three R2 objects (archived/display/thumb) and pages_archived counter advances
- [ ] Watch one `archive-ocr` cycle after deploy: verify it now archives >0 pages per run on at least one of `digitale-sammlungen.de`, `dl.ndl.go.jp`, `wellcomecollection.org`
- [ ] Spot-check `htop` on Hetzner during a bulk run — informs whether a second box is justified (Phase 2 of #1814)

🤖 Generated with [Claude Code](https://claude.com/claude-code)