### PR TITLE
archive-ocr: skip e-rara.ch at domain level (Hetzner IPs are 403'd)

### DIFF
--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -358,9 +358,14 @@ async function main() {
   // Group by domain with per-domain cap
   // Skip Gallica pages — handled locally by archive-gallica.mjs (Hetzner gets 429)
   const byDomain = {};
+  // Skip domains that block Hetzner egress IPs outright — they're handled by
+  // launchd-driven local workers on Mac (archive-gallica, archive-erara).
+  // Including them here just trips the 5-fail-0-ok circuit breaker and burns
+  // failure_count budget on pages that have no chance of succeeding here.
+  const HETZNER_BLOCKED_DOMAINS = new Set(['gallica.bnf.fr', 'e-rara.ch']);
   for (const page of pages) {
     const domain = getDomain(page.photo);
-    if (domain === 'gallica.bnf.fr') continue;
+    if (HETZNER_BLOCKED_DOMAINS.has(domain)) continue;
     if (!byDomain[domain]) byDomain[domain] = [];
     if (byDomain[domain].length < MAX_PAGES_PER_DOMAIN) {
       byDomain[domain].push(page);


### PR DESCRIPTION
Follow-up to #1819 / part of #1814.

## What

Adds `e-rara.ch` to the same domain-level skip used for `gallica.bnf.fr` in the archive-ocr worker.

## Why

e-rara perma-blocks Hetzner's egress IPs (HTTP 403 on every request). The worker already tried to exclude e-rara via \`image_source.provider\`, but some e-rara-hosted pages slip through with other provider values (legacy data, cross-source imports) — they then trip the 5-fail-0-ok per-domain circuit breaker and burn through the \`failure_count\` budget on pages that have no chance of succeeding here. Filtering by URL domain stops them at the door.

In the post-merge archive-ocr run, 6 of 47 selected pages were e-rara, all 403'd, and triggered the circuit breaker that ended the run with 0 archives.

## Combined with the DB backfill just run

I also marked 20 currently-failing pages (1 live + 19 warehouse) with \`failure_count = 3\` so they're skipped on the next run without waiting 3 cron cycles for the count to accumulate organically.

## Test plan

- [ ] After merge + next archive-ocr cycle, log should show \`Domain breakdown:\` without an e-rara entry
- [ ] \`actions.archived > 0\` on the next archive-ocr cron_run (the remaining ~21 currently-failing pages are mostly NDL HTTP 500 — if they're transient, we'll get hits; if not, failure_count will accumulate and they'll drop out within 2–3 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)