### PR TITLE
Fix #1825: read ia_identifier/id filter params on /api/books

### DIFF
--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -10,6 +10,11 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const limit = Math.min(parseInt(searchParams.get('limit') || '100', 10), 500);
     const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10), 0);
+    const iaIdentifier = searchParams.get('ia_identifier');
+    const bookId = searchParams.get('id');
+    // pages_count is a cache populated by sync-page-counts cron every ~6h, so
+    // freshly imported books are invisible by default. Opt-in for audit tools.
+    const includeUnindexed = searchParams.get('include_unindexed') === '1';
     const tenantContext = getTenantContextFromRequest(request.headers);
 
     if (tenantContext.slug && !tenantContext.id) {
@@ -21,9 +26,18 @@ export async function GET(request: NextRequest) {
     }
 
     const db = await getDb();
-    const query: Record<string, unknown> = { visible: true, pages_count: { $gt: 0 } };
+    const query: Record<string, unknown> = { visible: true };
+    if (!includeUnindexed) {
+      query.pages_count = { $gt: 0 };
+    }
     if (tenantContext.id) {
       query.tenantId = tenantContext.id;
+    }
+    if (iaIdentifier) {
+      query.ia_identifier = iaIdentifier;
+    }
+    if (bookId) {
+      query.id = bookId;
     }
 
     // pages_count is already cached on each book by the sync-page-counts cron.


### PR DESCRIPTION
Closes #1825.

## What

`/api/books` GET handler now reads:
- `?ia_identifier=X` — filter by Internet Archive identifier
- `?id=X` — filter by book id
- `?include_unindexed=1` — opt-in to include books with `pages_count=0` (freshly imported, not yet processed by the sync-page-counts cron — by default they're hidden from the public list, which makes "is this book in yet?" audits return empty even when imports succeeded)

Previously these params were silently ignored — the route only read `limit` and `offset`. Sort was hardcoded `created_at: -1` and remains so (the default is fine; no one asked for an override).

## While I was here

Audited the other API list endpoints for the same anti-pattern. Found similar silent-drop behavior on:
- `/api/books/timeline` — drops several reasonable date-range params
- `/api/books/status` — drops everything, no pagination
- `/api/books/deleted` — drops everything, no pagination
- `/api/books/search` — only `q` + pagination, no faceted filters
- `/api/collections` — no pagination/sort
- Plus a `/api/books/browse` vs `/api/books/library` duplication

Left those for a follow-up — they warrant a coordinated standardization (and probably a shared `parseListParams` helper) rather than 6 separate one-line patches.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] After preview deploy: `curl https://<preview>/api/books?ia_identifier=wotb_7597128&limit=1` returns Catherine of Siena Dialogo
- [ ] `curl https://<preview>/api/books?id=6a09068d44b481aa5a37c9d1&limit=1` returns Birgitta
- [ ] `curl https://<preview>/api/books?include_unindexed=1&limit=5` returns freshly-imported books with pages_count=0
- [ ] `curl https://<preview>/api/books?limit=5` (no filters) still works identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)