### PR TITLE
api: filter/pagination params on books, deleted, collections (follow-up to #1825)

### DIFF
--- a/src/app/api/books/deleted/route.ts
+++ b/src/app/api/books/deleted/route.ts
@@ -3,29 +3,44 @@ import { getDb } from '@/lib/mongodb';
 import { withAuth } from '@/lib/auth-helpers';
 
 /**
- * List all deleted books available for restoration
+ * List deleted books available for restoration.
  *
- * GET /api/books/deleted
+ * GET /api/books/deleted?limit=100&offset=0&ia_identifier=X
  */
 export const GET = withAuth(async (request, session) => {
   try {
-    const db = await getDb();
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(parseInt(searchParams.get('limit') || '100', 10), 500);
+    const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10), 0);
+    const iaIdentifier = searchParams.get('ia_identifier');
 
-    const deletedBooks = await db.collection('deleted_books')
-      .find({})
-      .project({
-        id: 1,
-        title: 1,
-        author: 1,
-        language: 1,
-        ia_identifier: 1,
-        deleted_at: 1,
-        pages: 1
-      })
-      .sort({ deleted_at: -1 })
-      .toArray();
+    const db = await getDb();
+    const filter: Record<string, unknown> = {};
+    if (iaIdentifier) filter.ia_identifier = iaIdentifier;
+
+    const [deletedBooks, total] = await Promise.all([
+      db.collection('deleted_books')
+        .find(filter)
+        .project({
+          id: 1,
+          title: 1,
+          author: 1,
+          language: 1,
+          ia_identifier: 1,
+          deleted_at: 1,
+          pages: 1
+        })
+        .sort({ deleted_at: -1 })
+        .skip(offset)
+        .limit(limit)
+        .toArray(),
+      db.collection('deleted_books').countDocuments(filter),
+    ]);
 
     return NextResponse.json({
+      total,
+      offset,
+      limit,
       count: deletedBooks.length,
       books: deletedBooks.map(book => ({
         id: book.id,

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -15,6 +15,9 @@ export async function GET(request: NextRequest) {
     // pages_count is a cache populated by sync-page-counts cron every ~6h, so
     // freshly imported books are invisible by default. Opt-in for audit tools.
     const includeUnindexed = searchParams.get('include_unindexed') === '1';
+    // Imports start with visible:null/false and stay hidden until promoted.
+    // Audit tools need to see them too.
+    const includeHidden = searchParams.get('include_hidden') === '1';
     const tenantContext = getTenantContextFromRequest(request.headers);
 
     if (tenantContext.slug && !tenantContext.id) {
@@ -26,7 +29,10 @@ export async function GET(request: NextRequest) {
     }
 
     const db = await getDb();
-    const query: Record<string, unknown> = { visible: true };
+    const query: Record<string, unknown> = {};
+    if (!includeHidden) {
+      query.visible = true;
+    }
     if (!includeUnindexed) {
       query.pages_count = { $gt: 0 };
     }

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -15,8 +15,11 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const type = searchParams.get('type'); // 'category' | 'curated' | null (all)
+    const slug = searchParams.get('slug'); // exact-match lookup by slug
     const includeUnpublished = searchParams.get('unpublished') === 'true';
     const includeChildren = searchParams.get('includeChildren') === 'true';
+    const limit = Math.min(parseInt(searchParams.get('limit') || '500', 10), 1000);
+    const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10), 0);
 
     // Read tenant context resolved by proxy.ts
     const { slug: tenantSlug, id: tenantId } = getTenantContextFromRequest(request);
@@ -36,6 +39,9 @@ export async function GET(request: NextRequest) {
     if (type) {
       filter.type = type;
     }
+    if (slug) {
+      filter.slug = slug;
+    }
 
     // Curated collections have a published flag — hide unpublished by default
     if (!includeUnpublished) {
@@ -49,6 +55,8 @@ export async function GET(request: NextRequest) {
       .collection('collections')
       .find(filter)
       .sort({ order: 1 })
+      .skip(offset)
+      .limit(limit)
       .toArray();
 
     const cleaned = collections.map(({ _id, ...rest }: any) => ({


### PR DESCRIPTION
Follow-up to #1825 / #1826 — same silent-drop pattern on three more list endpoints. The audit also flagged search/timeline/status/browse-vs-library, but those are larger scope (caching strategy, faceting design, route consolidation) and warrant separate PRs.

## /api/books
- \`include_hidden=1\` — opt-in to include books with \`visible != true\`. Freshly imported books start hidden (\`visible: null/false\`) and stay so until promoted, so audit tools like "how many did I import today" need this. Used while diagnosing why ~200 imports were invisible to the API even though the import responses showed success.

## /api/books/deleted
- \`limit\`/\`offset\` pagination (default 100, max 500)
- \`ia_identifier\` filter for direct lookup
- Returns \`total/offset/limit\` alongside existing \`count/books\`

The only consumer in the codebase is a \`booksApi.deleted()\` wrapper in \`src/lib/api-client/books.ts\` with no callers — so practically zero breaking-change risk.

## /api/collections
- \`slug\` filter for exact-match lookup
- \`limit\`/\`offset\` pagination (default 500; only 34 collections today, so default returns all)

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] After deploy: \`curl https://sourcelibrary.org/api/books?include_hidden=1&include_unindexed=1&limit=5\` returns freshly imported books
- [ ] \`curl https://sourcelibrary.org/api/books/deleted?limit=10\` returns paginated list with \`total\` field
- [ ] \`curl https://sourcelibrary.org/api/collections?slug=alchemy\` returns single collection
- [ ] Admin \`/admin/book-collections\` page still renders all 34 collections

## Followups (not in this PR)
- \`/api/books/status\` — has a \$lookup-to-pages perf bug, separate concern
- \`/api/books/search\` — needs faceted filters (language/collection), design decision
- \`/api/books/browse\` vs \`/api/books/library\` — duplication question
- Decide on a shared \`parseListParams\` helper across all list endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)