### PR TITLE
archive-bulk: opj_decompress -threads 1, revert concurrency to 8

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -37,7 +37,7 @@ const hasFlag = (name) => args.includes(`--${name}`);
 
 const BOOK_LIMIT = parseInt(getArg('limit') || '20', 10);  // Books per cron run
 const BOOK_CONCURRENCY = parseInt(getArg('concurrency') || '2', 10);
-const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '16', 10);
+const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '8', 10);
 const DRY_RUN = hasFlag('dry-run');
 const JPEG_QUALITY = 85;
 const MAX_DIMENSION = 3000;
@@ -197,9 +197,12 @@ function extractJp2Zip(zipPath, destDir) {
 async function jp2ToJpeg(jp2Path) {
   // opj_decompress → BMP → sharp → JPEG
   // Sharp's libvips JP2 support is unreliable on some builds, so use opj_decompress
+  // Use -threads 1: PAGE_CONCURRENCY already runs N decodes in parallel; letting
+  // each opj_decompress also try to grab all cores caused load avg 23 on 8 cores
+  // with 0% idle, because parallel decodes were trampling each other.
   const bmpPath = jp2Path + '.out.tif';
   try {
-    await execFileAsync('opj_decompress', ['-i', jp2Path, '-o', bmpPath, '-threads', 'ALL_CPUS'], { timeout: 120000 });
+    await execFileAsync('opj_decompress', ['-i', jp2Path, '-o', bmpPath, '-threads', '1'], { timeout: 120000 });
   } catch (err) {
     if (!fs.existsSync(bmpPath)) throw new Error(`opj_decompress failed: ${err.stderr?.slice(0, 200) || err.message}`);
   }


### PR DESCRIPTION
Follow-up to #1819, addresses Phase 2 of #1814.

## What I observed

During an in-flight archive-bulk run on Hetzner, post-#1819:
- **Load avg 23.4 on 8 cores** (3× cores → severe queueing)
- **CPU: 78% user / 20% sys / 0% idle / 0% iowait**
- **3.3 GB / 4 GB swap in use**
- 7+ \`opj_decompress\` processes running concurrently, each at 100–300% CPU, all spawned with \`-threads ALL_CPUS\`

## Why #1819's concurrency bump backfired

\`PAGE_CONCURRENCY=16\` means 16 page workers may run \`opj_decompress\` in parallel. Each \`-threads ALL_CPUS\` tries to grab all 8 cores. They trample each other, the kernel thrashes scheduling, and memory pressure pushes node to swap. The throughput we *measured* was 128 p/min — barely above the ~115 p/min baseline, well below the 2–3× we hoped for.

## Fix

- \`opj_decompress -threads ALL_CPUS\` → \`-threads 1\`. Each decode uses one core; the JS layer controls parallelism cleanly.
- \`PAGE_CONCURRENCY\` default \`16\` → \`8\`. With 8 single-threaded decodes on 8 cores, the box saturates without contention.

The parallel-upload change from #1819 still pays off — R2 PUTs overlap with the next page's decode + sharp resize.

## Test plan

- [ ] After deploy, watch one archive-bulk run; load avg should drop from ~23 to ~8 with 0% idle
- [ ] Expected throughput: ~200–300 p/min (vs 128 p/min observed under contention)
- [ ] If still slow even with clean saturation → CPU genuinely capped → time for 2nd Hetzner (Phase 2 of #1814 final answer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)