### PR TITLE
library-curator: remove stale priority list

### DIFF
--- a/.claude/skills/library-curator/SKILL.md
+++ b/.claude/skills/library-curator/SKILL.md
@@ -308,23 +308,21 @@ curl -s "https://sourcelibrary.org/api/books" | jq '.[] | select(.author | conta
 - `FLAG:INCOMPLETE` - Missing pages
 - `FLAG:DUPLICATE` - Already in collection
 
-## Current Gaps (Priority Acquisitions)
+## Identifying Current Gaps
 
-### URGENT - Missing Key Authors
-| Author | What We Need | Priority |
-|--------|--------------|----------|
-| Thomas Vaughan | Lumen de Lumine, Aula Lucis, Anima Magica Abscondita | HIGH |
-| Gichtel | Theosophia Practica | HIGH |
-| Jane Lead | English Philadelphian Society | MEDIUM |
-| Cudworth | True Intellectual System | MEDIUM |
+Don't trust a hardcoded gap list — the collection drifts. Always check what's actually there before treating something as a priority acquisition:
 
-### Have Some, Need More
-| Author/Text | Have | Need |
-|-------------|------|------|
-| Boehme | 3 works | More German originals (Aurora, Signatura Rerum) |
-| Fludd | 3 works | Complete Utriusque Cosmi (5+ volumes) |
-| Dee | 1 work | True Relation, Monas hieroglyphica |
-| Paracelsus | Several | Individual treatises in German |
+```bash
+# Author coverage check — how many works do we have by this author?
+curl -s "https://sourcelibrary.org/api/search?q=AUTHOR_NAME" | jq '[.[] | select(.author | test("AUTHOR_NAME"; "i"))] | length'
+
+# What editions of a specific work do we have?
+curl -s "https://sourcelibrary.org/api/search?q=TITLE+KEYWORD" | jq '[.[] | {title, author, published}]'
+```
+
+Note open gaps in [issue #1815](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/1815) (non-Western originals) and check it before declaring a "gap." When you fill one, update the issue.
+
+For thematic priorities, follow the Primary/Secondary Collections taxonomy above rather than a fixed-author hit list — those are stable, individual coverage shifts every batch.
 
 ## Batch Size & Pacing
 - **Target**: 5-20 books per acquisition session


### PR DESCRIPTION
Removes the \`Current Gaps — URGENT\` and \`Have Some, Need More\` tables that were sending curators to acquire books we already had multiple editions of.

## Verification (today)

| Listed as | Actually in collection |
|---|---|
| Thomas Vaughan: missing | 9 works (Aula Lucis 1690, Anthroposophia Theomagica 1650, Lumen de Lumine 1651 + 1698 German, Waite edition) |
| Gichtel: missing | 7 works (multiple Theosophia Practica + Eröffnung der dreyen Principien editions 1722-1736) |
| Jane Lead: missing | 10 works (Revelation of Revelations, Enochian Walks, Tree of Faith, etc.) |
| Cudworth: missing | True Intellectual System 1678 |
| Boehme: "3 works" | 19+ works |
| Fludd: "3 works" | 19+ works |
| Dee: "1 work" | 10 works |
| Paracelsus: "Several" | 20+ works |

The replacement section tells curators to **check before declaring a gap** (via API search), and points at [issue #1815](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/1815) which tracks genuine, persistent non-Western original-language gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)