### PR TITLE
skills: align model-selection guidance with ai-models.ts routing

### DIFF
--- a/.claude/skills/batch-translate/SKILL.md
+++ b/.claude/skills/batch-translate/SKILL.md
@@ -69,7 +69,7 @@ curl -s -X POST "https://sourcelibrary.org/api/jobs/queue-books" \
   -d '{"bookIds": ["BOOK_ID"], "action": "image_extraction"}'
 ```
 
-**IMPORTANT: Always use `gemini-3-flash-preview` for all OCR and translation tasks. Do NOT use `gemini-2.5-flash`.**
+**Model selection:** Don't hardcode a model — prefer `getModelForBook(book)` from `src/lib/types/ai-models.ts`, which routes BPH books and non-Latin-script languages to `gemini-3-flash-preview` (full quality) and everything else to `gemini-3.1-flash-lite-preview` (50% cheaper, comparable quality on Latin script). If you must specify a model in a job payload, pick based on this rule. Never use Gemini below v3 (`gemini-2.x` is deprecated).
 
 ### Option 2: Gemini Batch API (50% Cheaper, Automated Pipeline)
 
@@ -77,9 +77,11 @@ The post-import-pipeline cron uses Gemini Batch API for automated processing of 
 
 | Job Type | API | Model | Cost |
 |----------|-----|-------|------|
-| Single page | Realtime (Lambda) | gemini-3-flash-preview | Full price |
-| batch_ocr | Batch API | gemini-3-flash-preview | **50% off** |
-| batch_translate | Batch API | gemini-3-flash-preview | **50% off** |
+| Single page | Realtime (Lambda) | per `getModelForBook(book)` | Full price |
+| batch_ocr | Batch API | per `getModelForBook(book)` | **50% off** |
+| batch_translate | Batch API | per `getModelForBook(book)` | **50% off** |
+
+Stacking discounts: lite + Batch API on a Latin-script non-BPH book is ~75% off full flash realtime.
 
 ## OCR Output Format
 
@@ -195,7 +197,7 @@ curl -s -X POST "https://sourcelibrary.org/api/jobs" \
     \"type\": \"batch_ocr\",
     \"book_id\": \"BOOK_ID\",
     \"book_title\": \"BOOK_TITLE\",
-    \"model\": \"gemini-3-flash-preview\",
+    \"model\": \"gemini-3.1-flash-lite-preview\",
     \"language\": \"Latin\",
     \"page_ids\": $OCR_IDS
   }"
@@ -232,7 +234,7 @@ curl -s -X POST "https://sourcelibrary.org/api/jobs" \
     \"type\": \"batch_translate\",
     \"book_id\": \"BOOK_ID\",
     \"book_title\": \"BOOK_TITLE\",
-    \"model\": \"gemini-3-flash-preview\",
+    \"model\": \"gemini-3.1-flash-lite-preview\",
     \"language\": \"Latin\",
     \"page_ids\": $TRANS_IDS
   }"

--- a/.claude/skills/pipeline-context/SKILL.md
+++ b/.claude/skills/pipeline-context/SKILL.md
@@ -15,7 +15,7 @@ Read these files before proceeding with pipeline work:
 
 ## Critical Rules
 
-- ALWAYS use `gemini-3-flash-preview` for all AI tasks
+- Model selection: prefer `getModelForBook(book)` from `src/lib/types/ai-models.ts` over hardcoding. It routes BPH books and non-Latin-script languages to `gemini-3-flash-preview` (full quality) and everything else to `gemini-3.1-flash-lite-preview` (50% cheaper, comparable quality on Latin-script). Enrich-worker uses `gemini-3.1-flash-lite-preview` for all phases (summary+index, chapters, quality scoring, collection assignment). Never use anything below Gemini v3 — `gemini-2.x` is deprecated.
 - NEVER use Gemini Batch API for translation — use Lambda workers (SQS FIFO)
 - Any script overwriting `ocr.data` or `translation.data` MUST call `createRevision()` first
 - MongoDB Atlas saturates at ~40 concurrent Lambda jobs — global backpressure limit


### PR DESCRIPTION
Both \`pipeline-context/SKILL.md\` and \`batch-translate/SKILL.md\` had blanket "ALWAYS use \`gemini-3-flash-preview\`" instructions that contradicted the actual routing in \`src/lib/types/ai-models.ts:getModelForBook()\`:

- BPH books + non-Latin-script languages → \`gemini-3-flash-preview\` (full quality)
- Everything else → \`gemini-3.1-flash-lite-preview\` (50% cheaper, comparable on Latin script)

The skill text was sending devs to the more expensive model by default, which would cost ~50% more on every Latin-script non-BPH job. Internal inconsistency: the JSON examples used \`"language": "Latin"\` but specified the full flash-preview model anyway.

## Changes
- \`pipeline-context/SKILL.md\` Critical Rules: replaced "ALWAYS use gemini-3-flash-preview" with a pointer to \`getModelForBook()\` plus the routing summary
- \`batch-translate/SKILL.md\`: same fix, plus updated the model column in the Batch API table from hardcoded names to "per \`getModelForBook(book)\`" and added a note that lite + Batch API stacking is ~75% off
- Two JSON examples (batch_ocr + batch_translate) that used Latin language but hardcoded full flash now consistently show lite

🤖 Generated with [Claude Code](https://claude.com/claude-code)