### PR TITLE
scheduler: bump archive-bulk to --concurrency=2

### DIFF
--- a/scripts/workers/scheduler.mjs
+++ b/scripts/workers/scheduler.mjs
@@ -198,11 +198,11 @@ const WORKERS = [
   },
   {
     name: 'archive-bulk',
-    cmd: 'node scripts/workers/archive-bulk.mjs --limit=30 --concurrency=1',
+    cmd: 'node scripts/workers/archive-bulk.mjs --limit=30 --concurrency=2',
     lock: '/tmp/sl-archive-bulk.lock',
     connections: 5,
     tier: 4,
-    interval: 1200,     // every 20 min — throttled 2026-05-15 after bulk import caused 8s search latency (Atlas write saturation from concurrent JP2 decompression + page inserts)
+    interval: 1200,     // every 20 min — throttled 2026-05-15 after bulk import caused 8s search latency (Atlas write saturation from concurrent JP2 decompression + page inserts). Concurrency bumped back to 2 on 2026-05-17 after #1829 thread fix dropped per-book CPU contention (load 23 → 4) and #1819 raised Mongo pool 5 → 10; with 82% idle CPU at concurrency=1 and ~3 Mongo writes/sec, doubling should fill local headroom without re-saturating Atlas. Watch search latency after deploy and revert to =1 if it spikes.
     healthMin: 'degraded',
     log: '/var/log/sourcelibrary/archive-bulk.log',
   },


### PR DESCRIPTION
Follow-up to #1819, #1829.

## Why

Live measurement during the first 8 archive-bulk runs after #1829 (thread fix):
- **Sustained 173 p/min** average across 7.7 hours, peak 213 p/min
- **Load avg 4–6 on 8 cores**, ~82% idle CPU during steady state
- Mongo write rate ~3 page updates/sec
- 68,570 pages archived in one workday — 3× the previous peak day

We have local headroom; the new bottleneck is network I/O on JP2 downloads (200–400 MB per book from archive.org) and Mongo writes between books. Running 2 books in parallel overlaps a book's download phase with another's decode/upload phase.

## What

\`--concurrency=1\` → \`--concurrency=2\` in the scheduler config for archive-bulk. Expected +30–50% throughput on top of existing wins.

## Risk + safeguards

Kept at 2 (not 3) because of the 2026-05-15 incident where higher bulk concurrency caused **8s search latency** on the production site (Atlas write saturation from concurrent JP2 work + page inserts). Two changes since then make 2 safer than it was:
1. #1819 raised Mongo \`maxPoolSize\` from 5 → 10 on archive workers
2. #1829 dropped per-book CPU contention (load avg 23 → 4) so each book's decode finishes faster, shorter overlapping write bursts

## Test plan

- [ ] After merge + next archive-bulk cycle, expect ~225–260 p/min sustained
- [ ] **Watch sourcelibrary.org search latency** on the next 2–3 runs. If it spikes >2s on book/page queries, revert to \`--concurrency=1\` immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)