### PR TITLE
iiif-utils: rewrite NDL /full/max/ → /full/full/ (unblocks archive-ocr)

### DIFF
--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -120,6 +120,12 @@ export function upgradeToFullRes(url) {
     if (url.includes('digi.vatlib') && url.match(/\/full\/\d+,?\d*\//)) {
       return url.replace(/\/full\/\d+,?\d*\//, '/full/full/');
     }
+    // NDL Japan returns HTTP 500 on /full/max/ (IIIF v3 syntax their server
+    // doesn't honor); /full/full/ returns the native-resolution image. Many
+    // imported NDL URLs use /full/max/ from a v3-style manifest crawl.
+    if (url.includes('dl.ndl.go.jp') && url.includes('/full/max/')) {
+      return url.replace('/full/max/', '/full/full/');
+    }
     if (url.match(/\/full\/(?:pct:\d+|\d+,?\d*)\/\d+\/default\./)) {
       return url.replace(/\/full\/(?:pct:\d+|\d+,?\d*)\//, '/full/full/');
     }


### PR DESCRIPTION
Diagnoses and fixes the root cause of archive-ocr's 0-archive runs since the #1819 merge.

## Root cause

archive-ocr has logged 0 pages across 15 post-merge runs. Investigation showed every cycle the worker found ~12 NDL pages, all returned HTTP 500, tripped the 5-fail-0-ok per-domain circuit breaker, and exited.

Manual test from both Mac and Hetzner:
- \`https://dl.ndl.go.jp/api/iiif/2539607/R0000019/full/max/0/default.jpg\` → **HTTP 500**
- \`https://dl.ndl.go.jp/api/iiif/2539607/R0000019/full/full/0/default.jpg\` → **HTTP 200, 2.2 MB JPEG (6794×5650)**

NDL's IIIF server returns 500 on the v3 \`/full/max/\` syntax that most servers honor; it only accepts the older \`/full/full/\` form. Imported NDL URLs use \`/full/max/\` from when their manifests were crawled with a v3-style template.

## Fix

One branch added to \`upgradeToFullRes\` in \`scripts/lib/iiif-utils.mjs\` — same pattern as the existing per-host quirks for archive.org, digitale-sammlungen, gallica, vatlib. The worker already calls \`upgradeToFullRes(originalUrl)\` before fetching.

## Follow-up data reset (separate, no PR)

Existing NDL pages have \`failure_count >= 3\` from the 15 stuck runs, so the worker's poison-filter will skip them. I'll clear \`failure_count\` on NDL pages with HTTP 500 failures right after this merges so they're re-tried.

## Test plan

- [ ] After merge + DB reset + next archive-ocr cycle: log should show \`dl.ndl.go.jp\` with \`ok > 0\`
- [ ] cron_runs.actions.archived > 0 for the next archive-ocr run

🤖 Generated with [Claude Code](https://claude.com/claude-code)