### PR TITLE
Fix /for-libraries redirecting to home

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,7 +21,7 @@ const NON_TENANT_PATHS = new Set([
   'book', 'collections',
   // Other root pages
   'admin', 'author', 'work', 'connect', 'data', 'read',
-  'research', 'embed', 'shwep', 'for-researchers', 'identify',
+  'research', 'embed', 'shwep', 'for-researchers', 'for-libraries', 'identify',
   // Welcome flow (post-signup interstitial + temporary preview route)
   'welcome', 'welcome-preview',
   // Shortlinks — /q/[code] must pass through to src/app/q/[code]/route.ts


### PR DESCRIPTION
## Summary
- `/for-libraries` (added in #1753) was redirecting to the homepage because the proxy treated `for-libraries` as an unknown tenant slug
- The slug matches `^[a-z0-9-]+$` and wasn't in `NON_TENANT_PATHS`, so `proxy.ts` resolved no tenant and hit the "Unknown slug → redirect to home" branch at line 577
- Fix: add `for-libraries` to `NON_TENANT_PATHS`, matching the existing `for-researchers` entry

## Test plan
- [ ] Visit https://sourcelibrary.org/for-libraries on the preview deploy → renders the partner page (not a redirect to /)
- [ ] Footer link to /for-libraries works
- [ ] `/for-researchers` still renders (regression check on the same line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)