### PR TITLE
Fix #1841: add for-libraries to NON_TENANT_PATHS in proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,7 +21,7 @@ const NON_TENANT_PATHS = new Set([
   'book', 'collections',
   // Other root pages
   'admin', 'author', 'work', 'connect', 'data', 'read',
-  'research', 'embed', 'shwep', 'for-researchers', 'identify',
+  'research', 'embed', 'shwep', 'for-researchers', 'for-libraries', 'identify',
   // Welcome flow (post-signup interstitial + temporary preview route)
   'welcome', 'welcome-preview',
   // Shortlinks — /q/[code] must pass through to src/app/q/[code]/route.ts


### PR DESCRIPTION
Closes #1841. One-line fix — same pattern as #1791 (shortlinks). The new `/for-libraries` page from #1753 redirects to homepage because `for-libraries` wasn't in the proxy's non-tenant-path allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)