### PR TITLE
Fix DMCA agent address + swap to contact@sourcelibrary.org

### DIFF
--- a/src/app/dmca/page.tsx
+++ b/src/app/dmca/page.tsx
@@ -55,7 +55,7 @@ export default function DmcaPage() {
             </tr>
             <tr>
               <td className="font-medium pr-6 py-1">Address</td>
-              <td>123 Keizersgraacht, Amsterdam, 1015 CJ, Netherlands</td>
+              <td>Keizersgracht 123-4, 1015 CJ Amsterdam, Netherlands</td>
             </tr>
             <tr>
               <td className="font-medium pr-6 py-1">Email</td>

--- a/src/app/dmca/page.tsx
+++ b/src/app/dmca/page.tsx
@@ -60,7 +60,7 @@ export default function DmcaPage() {
             <tr>
               <td className="font-medium pr-6 py-1">Email</td>
               <td>
-                <a href="mailto:dereklomas@gmail.com">dereklomas@gmail.com</a>
+                <a href="mailto:contact@sourcelibrary.org">contact@sourcelibrary.org</a>
               </td>
             </tr>
           </tbody>
@@ -98,7 +98,7 @@ export default function DmcaPage() {
         </ol>
         <p>
           Send notices to{' '}
-          <a href="mailto:dereklomas@gmail.com">dereklomas@gmail.com</a> with the subject
+          <a href="mailto:contact@sourcelibrary.org">contact@sourcelibrary.org</a> with the subject
           line <strong>DMCA Takedown Notice</strong>.
         </p>
         <p>


### PR DESCRIPTION
## Summary
- Fix typo and address ordering on `/dmca` page: `123 Keizersgraacht, Amsterdam, 1015 CJ` → `Keizersgracht 123-4, 1015 CJ Amsterdam`
- Swap designated-agent email from `dereklomas@gmail.com` to `contact@sourcelibrary.org` (both in the agent table and the "Send notices to" paragraph)

## Test plan
- [ ] Preview deploy: `/dmca` renders the corrected address
- [ ] Both `mailto:` links use `contact@sourcelibrary.org`
- [ ] `contact@sourcelibrary.org` inbox is set up and forwards somewhere monitored
- [ ] U.S. Copyright Office filing updated separately to match (the website fix doesn't propagate to the official directory record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)