### PR TITLE
Fix /dmca redirecting to home: add to NON_TENANT_PATHS

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,6 +22,8 @@ const NON_TENANT_PATHS = new Set([
   // Other root pages
   'admin', 'author', 'work', 'connect', 'data', 'read',
   'research', 'embed', 'shwep', 'for-researchers', 'for-libraries', 'identify',
+  // Legal / policy
+  'dmca',
   // Welcome flow (post-signup interstitial + temporary preview route)
   'welcome', 'welcome-preview',
   // Shortlinks — /q/[code] must pass through to src/app/q/[code]/route.ts


### PR DESCRIPTION
## Summary
- `/dmca` (linked from the footer as "Copyright & DMCA") was 307-redirecting to `/` because `dmca` wasn't in `NON_TENANT_PATHS`
- Same pattern as #1791 (`/q/`) and #1842 (`/for-libraries`)
- Audited the rest of `src/app/` against `NON_TENANT_PATHS` — `dmca` is the only remaining static top-level route that was missing

## Discovered while
Verifying the just-merged DMCA address/email update (#1843) in production — the page never rendered because middleware was redirecting before it could.

## Test plan
- [ ] Preview deploy: `curl -sI https://<preview>/dmca` returns 200, not 307
- [ ] Production `/dmca` after merge renders the policy page with the new Keizersgracht 123-4 address and contact@sourcelibrary.org email

🤖 Generated with [Claude Code](https://claude.com/claude-code)