### PR TITLE
test: assert NON_TENANT_PATHS covers every static top-level route

### DIFF
--- a/tests/unit/proxy-non-tenant-paths.test.ts
+++ b/tests/unit/proxy-non-tenant-paths.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import path from 'path';
+
+// Static top-level routes (src/app/<slug>/page.tsx) need to be listed in
+// NON_TENANT_PATHS, or the proxy treats them as unknown tenant slugs and
+// 307-redirects to /. We've hit this three times in a row (/q, /for-libraries,
+// /dmca) — this test fails loudly when the next page is added without the
+// matching allowlist entry.
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..');
+const APP_DIR = path.join(PROJECT_ROOT, 'src/app');
+const PROXY_PATH = path.join(PROJECT_ROOT, 'src/proxy.ts');
+
+// Directories that are not user-facing routes or are intentionally handled
+// elsewhere in the proxy (e.g. /embed/* and /api/* have their own branches).
+const FRAMEWORK_DIRS = new Set([
+  'api',
+  'embed',
+  '_archived',
+]);
+
+function extractNonTenantPaths(): Set<string> {
+  const src = readFileSync(PROXY_PATH, 'utf8');
+  const match = src.match(/const NON_TENANT_PATHS = new Set\(\[([\s\S]*?)\]\)/);
+  if (!match) throw new Error('Could not locate NON_TENANT_PATHS in proxy.ts');
+  return new Set([...match[1].matchAll(/'([^']+)'/g)].map(m => m[1]));
+}
+
+function findStaticTopLevelRoutes(): string[] {
+  return readdirSync(APP_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(name => !name.startsWith('[')) // dynamic [param] routes
+    .filter(name => !name.startsWith('_')) // private (_components etc.)
+    .filter(name => !FRAMEWORK_DIRS.has(name))
+    .filter(name => existsSync(path.join(APP_DIR, name, 'page.tsx'))
+                 || existsSync(path.join(APP_DIR, name, 'route.ts')));
+}
+
+describe('proxy NON_TENANT_PATHS coverage', () => {
+  it('every static top-level route in src/app/ is listed in NON_TENANT_PATHS', () => {
+    const allowlist = extractNonTenantPaths();
+    const routes = findStaticTopLevelRoutes();
+    const missing = routes.filter(r => !allowlist.has(r));
+    expect(missing, `Add these to NON_TENANT_PATHS in src/proxy.ts: ${missing.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why
Three PRs in a row fixed the same trap:
- #1791 — `/q/` shortlinks were redirecting to `/`
- #1842 — `/for-libraries` (added in #1753) was redirecting to `/`
- #1844 — `/dmca` was redirecting to `/`

In each case, a page was added under `src/app/<slug>/` and the author forgot to also add the slug to `NON_TENANT_PATHS` in `src/proxy.ts`. The proxy then treats the slug as an unknown tenant and 307-redirects to home. The page is invisible in production, the bug only surfaces when someone tries to visit the URL, and the link in the footer / nav silently goes nowhere.

## What this adds
A small Vitest unit test that:
1. Reads `src/proxy.ts` and extracts `NON_TENANT_PATHS`.
2. Walks `src/app/` for static top-level directories that ship a `page.tsx` or `route.ts` (excluding `[param]` dynamic routes, `_`-prefixed private dirs, and the `api` / `embed` / `_archived` branches that the proxy handles separately).
3. Asserts every such directory is allowlisted.

When the test fails it names the missing slugs in the assertion message, so the fix is one line in `src/proxy.ts` and the author can self-serve from the CI failure.

Runs in the existing `unit-tests` workflow (no new CI cost). No changes to `src/proxy.ts` or any runtime code.

## Test plan
- [ ] `npx vitest run tests/unit/proxy-non-tenant-paths.test.ts` passes on current main
- [ ] Manually remove `'dmca'` from `NON_TENANT_PATHS` locally — test fails with `Add these to NON_TENANT_PATHS in src/proxy.ts: dmca`

🤖 Generated with [Claude Code](https://claude.com/claude-code)