### PR TITLE
Phase 2: book-level scan_quality rollup at extraction-time + backfill script (#1810)

### DIFF
--- a/scripts/rollup-scan-quality.mjs
+++ b/scripts/rollup-scan-quality.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * Roll up page-level scan_quality (v2) into book.scan_quality across the corpus.
+ * Use this for the one-shot backfill on books whose pages were scored by an
+ * earlier image-extract-worker run that didn't yet do inline rollup, and for
+ * targeted re-rollups when individual books need refreshing.
+ *
+ * The inline rollup in image-extract-worker.mjs handles the forward path
+ * (every book the worker touches gets rolled up at completion). This script
+ * is the catch-up tool.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/rollup-scan-quality.mjs [opts]
+ *
+ * Options:
+ *   --book ID           Roll up a single book by id
+ *   --all               Roll up every book that has v2 pages
+ *   --since YYYY-MM-DD  Roll up books with v2 pages updated since this date
+ *   --limit N           Cap to first N books in the candidate set
+ *   --dry-run           Compute rollups but do NOT write to Mongo
+ *   --concurrency N     Parallel rollups (default 8)
+ *
+ * Exit non-zero if no candidate set is selected.
+ */
+
+import { MongoClient } from 'mongodb';
+
+// Accept both --flag=value and --flag value forms.
+const flags = {};
+const argv = process.argv.slice(2);
+const valueExpected = new Set(['book', 'since', 'limit', 'concurrency']);
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (!a.startsWith('--')) continue;
+  const [rawK, rawV] = a.replace(/^--/, '').split('=');
+  if (rawV !== undefined) {
+    flags[rawK] = rawV;
+  } else if (valueExpected.has(rawK) && argv[i + 1] && !argv[i + 1].startsWith('--')) {
+    flags[rawK] = argv[++i];
+  } else {
+    flags[rawK] = true;
+  }
+}
+if (flags.book && flags.all) {
+  console.error('Choose --book OR --all, not both'); process.exit(1);
+}
+if (!flags.book && !flags.all && !flags.since) {
+  console.error('Pass --book ID, --all, or --since YYYY-MM-DD'); process.exit(1);
+}
+
+const DRY = !!flags['dry-run'];
+const CONCURRENCY = parseInt(flags.concurrency, 10) || 8;
+const LIMIT = flags.limit ? parseInt(flags.limit, 10) : 0;
+
+const SCAN_QUALITY_VERSION = 2;
+
+const CONTENT_SCAN_CLASSES = new Set([
+  'color_photo', 'color_print',
+  'grayscale_photo', 'grayscale_print',
+  'bitonal_clean', 'bitonal_microfilm', 'microfiche',
+]);
+
+function legacyClassificationFor(dominantClass) {
+  if (['bitonal_clean', 'bitonal_microfilm', 'microfiche'].includes(dominantClass)) return 'bw';
+  if (['grayscale_photo', 'grayscale_print'].includes(dominantClass)) return 'grayscale';
+  if (['color_photo', 'color_print'].includes(dominantClass)) return 'color';
+  return null;
+}
+
+async function computeRollup(db, bookId) {
+  const pages = await db.collection('pages').find(
+    { book_id: bookId, 'scan_quality.version': 2 },
+    {
+      projection: {
+        id: 1, page_number: 1,
+        'scan_quality.scan_score': 1,
+        'scan_quality.scan_class': 1,
+        'scan_quality.page_completeness': 1,
+        'scan_quality.concerns': 1,
+        'scan_quality.illustration_fidelity': 1,
+        'scan_quality.class_corrected': 1,
+      },
+    },
+  ).toArray();
+
+  if (pages.length === 0) return null;
+
+  const scores = pages
+    .map(p => p.scan_quality?.scan_score)
+    .filter(s => typeof s === 'number')
+    .sort((a, b) => a - b);
+  if (scores.length === 0) return null;
+
+  const median = scores[Math.floor(scores.length / 2)];
+  const min = scores[0];
+  const max = scores[scores.length - 1];
+
+  const classCounts = {};
+  const concernCounts = {};
+  let classCorrectedCount = 0;
+  let completenessIssues = 0;
+  for (const p of pages) {
+    const sq = p.scan_quality;
+    if (!sq) continue;
+    if (sq.scan_class) classCounts[sq.scan_class] = (classCounts[sq.scan_class] || 0) + 1;
+    for (const c of (sq.concerns || [])) concernCounts[c] = (concernCounts[c] || 0) + 1;
+    if (sq.class_corrected) classCorrectedCount++;
+    if (sq.page_completeness && sq.page_completeness !== 'full_page') completenessIssues++;
+  }
+
+  const classEntries = Object.entries(classCounts).sort((a, b) => b[1] - a[1]);
+  const dominantClass = classEntries[0]?.[0] || null;
+
+  const contentPages = pages
+    .filter(p => CONTENT_SCAN_CLASSES.has(p.scan_quality?.scan_class))
+    .filter(p => typeof p.scan_quality?.scan_score === 'number')
+    .sort((a, b) => a.scan_quality.scan_score - b.scan_quality.scan_score);
+  const worstImage = contentPages[0] ? {
+    page_id: contentPages[0].id,
+    page_number: contentPages[0].page_number,
+    scan_score: contentPages[0].scan_quality.scan_score,
+    scan_class: contentPages[0].scan_quality.scan_class,
+    concerns: contentPages[0].scan_quality.concerns || [],
+  } : null;
+  const bestImage = contentPages.length ? {
+    page_id: contentPages[contentPages.length - 1].id,
+    page_number: contentPages[contentPages.length - 1].page_number,
+    scan_score: contentPages[contentPages.length - 1].scan_quality.scan_score,
+    scan_class: contentPages[contentPages.length - 1].scan_quality.scan_class,
+  } : null;
+
+  return {
+    score: median,
+    classification: legacyClassificationFor(dominantClass),
+    median_score: median,
+    min_score: min,
+    max_score: max,
+    pages_assessed: pages.length,
+    content_pages_assessed: contentPages.length,
+    dominant_scan_class: dominantClass,
+    class_distribution: classCounts,
+    concerns_distribution: concernCounts,
+    has_microfilm_pages: !!(classCounts.bitonal_microfilm || classCounts.microfiche),
+    has_blank_pages: !!classCounts.blank,
+    has_scanner_metadata_pages: !!classCounts.scanner_metadata,
+    has_corrupt_pages: !!classCounts.corrupt,
+    completeness_issues_count: completenessIssues,
+    class_corrected_count: classCorrectedCount,
+    worst_image: worstImage,
+    best_image: bestImage,
+    rollup_at: new Date(),
+    version: SCAN_QUALITY_VERSION,
+  };
+}
+
+async function main() {
+  const client = new MongoClient(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 10000, maxPoolSize: 6 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  let candidateIds;
+
+  if (flags.book) {
+    candidateIds = [flags.book];
+  } else if (flags.all) {
+    // Books that have at least one page with scan_quality.version = 2
+    candidateIds = await db.collection('pages').distinct('book_id', { 'scan_quality.version': 2 });
+  } else if (flags.since) {
+    const since = new Date(flags.since);
+    if (isNaN(since.getTime())) { console.error('Invalid --since date:', flags.since); process.exit(1); }
+    const ids = await db.collection('pages').distinct('book_id', {
+      'scan_quality.version': 2,
+      'scan_quality.assessed_at': { $gte: since },
+    });
+    candidateIds = ids;
+  }
+
+  if (LIMIT > 0) candidateIds = candidateIds.slice(0, LIMIT);
+  console.log(`Candidate books: ${candidateIds.length}${DRY ? ' (DRY RUN — no writes)' : ''}`);
+
+  if (candidateIds.length === 0) {
+    await client.close();
+    return;
+  }
+
+  let processed = 0;
+  let withRollup = 0;
+  let writes = 0;
+  let errors = 0;
+  const classDist = {};
+
+  for (let i = 0; i < candidateIds.length; i += CONCURRENCY) {
+    const chunk = candidateIds.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(chunk.map(async (id) => {
+      const rollup = await computeRollup(db, id);
+      if (!rollup) return { id, skip: true };
+      if (!DRY) {
+        await db.collection('books').updateOne({ id }, { $set: { scan_quality: rollup, updated_at: new Date() } });
+      }
+      return { id, rollup };
+    }));
+    for (const r of results) {
+      processed++;
+      if (r.status === 'rejected') { errors++; console.error('  err:', r.reason?.message); continue; }
+      if (r.value.skip) continue;
+      withRollup++;
+      if (!DRY) writes++;
+      const dc = r.value.rollup.dominant_scan_class;
+      classDist[dc] = (classDist[dc] || 0) + 1;
+    }
+    if (processed % (CONCURRENCY * 10) === 0 || processed === candidateIds.length) {
+      process.stdout.write(`\r  ${processed}/${candidateIds.length}  with-rollup=${withRollup}  written=${writes}  errors=${errors}`);
+    }
+  }
+  process.stdout.write('\n');
+
+  console.log('\n=== SUMMARY ===');
+  console.log(`processed:        ${processed}`);
+  console.log(`with rollup:      ${withRollup}`);
+  console.log(`written:          ${writes}${DRY ? ' (DRY RUN)' : ''}`);
+  console.log(`errors:           ${errors}`);
+  console.log('dominant_scan_class distribution:');
+  for (const [c, n] of Object.entries(classDist).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${c.padEnd(20)} ${n}`);
+  }
+
+  await client.close();
+}
+
+main().catch(e => { console.error('fatal:', e); process.exit(1); });

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -501,6 +501,127 @@ function normalizeBbox(raw) {
   return { x, y, width, height };
 }
 
+// ── Phase 2: book-level scan_quality rollup ──
+// Aggregates pages.scan_quality (v2) into a book-level summary that downstream
+// use cases (dedupe tiebreaker, re-source queue, provider dashboards) can query
+// directly. Preserves legacy { score, classification } fields for backwards
+// compat with enhance-scan-quality.mjs.
+
+const CONTENT_SCAN_CLASSES = new Set([
+  'color_photo', 'color_print',
+  'grayscale_photo', 'grayscale_print',
+  'bitonal_clean', 'bitonal_microfilm', 'microfiche',
+]);
+
+function legacyClassificationFor(dominantClass) {
+  if (['bitonal_clean', 'bitonal_microfilm', 'microfiche'].includes(dominantClass)) return 'bw';
+  if (['grayscale_photo', 'grayscale_print'].includes(dominantClass)) return 'grayscale';
+  if (['color_photo', 'color_print'].includes(dominantClass)) return 'color';
+  return null;
+}
+
+async function computeBookScanQualityRollup(db, bookId) {
+  const pages = await db.collection('pages').find(
+    { book_id: bookId, 'scan_quality.version': 2 },
+    {
+      projection: {
+        id: 1, page_number: 1,
+        'scan_quality.scan_score': 1,
+        'scan_quality.scan_class': 1,
+        'scan_quality.page_completeness': 1,
+        'scan_quality.concerns': 1,
+        'scan_quality.illustration_fidelity': 1,
+        'scan_quality.class_corrected': 1,
+        'image_characteristics.megapixels': 1,
+        'image_characteristics.sharpness_var': 1,
+        'image_characteristics.flags': 1,
+      },
+    },
+  ).toArray();
+
+  if (pages.length === 0) return null;
+
+  const scores = pages
+    .map(p => p.scan_quality?.scan_score)
+    .filter(s => typeof s === 'number')
+    .sort((a, b) => a - b);
+  if (scores.length === 0) return null;
+
+  const median = scores[Math.floor(scores.length / 2)];
+  const min = scores[0];
+  const max = scores[scores.length - 1];
+
+  const classCounts = {};
+  const concernCounts = {};
+  let classCorrectedCount = 0;
+  let completenessIssues = 0;
+
+  for (const p of pages) {
+    const sq = p.scan_quality;
+    if (!sq) continue;
+    if (sq.scan_class) classCounts[sq.scan_class] = (classCounts[sq.scan_class] || 0) + 1;
+    for (const c of (sq.concerns || [])) {
+      concernCounts[c] = (concernCounts[c] || 0) + 1;
+    }
+    if (sq.class_corrected) classCorrectedCount++;
+    if (sq.page_completeness && sq.page_completeness !== 'full_page') completenessIssues++;
+  }
+
+  // Dominant class — most-frequent across all v2 pages
+  const classEntries = Object.entries(classCounts).sort((a, b) => b[1] - a[1]);
+  const dominantClass = classEntries[0]?.[0] || null;
+
+  // Content-page pointers (ignore blank / scanner_metadata / corrupt for worst/best — those
+  // are noise pages, not content quality signals)
+  const contentPages = pages
+    .filter(p => CONTENT_SCAN_CLASSES.has(p.scan_quality?.scan_class))
+    .filter(p => typeof p.scan_quality?.scan_score === 'number')
+    .sort((a, b) => a.scan_quality.scan_score - b.scan_quality.scan_score);
+  const worstImage = contentPages[0]
+    ? {
+        page_id: contentPages[0].id,
+        page_number: contentPages[0].page_number,
+        scan_score: contentPages[0].scan_quality.scan_score,
+        scan_class: contentPages[0].scan_quality.scan_class,
+        concerns: contentPages[0].scan_quality.concerns || [],
+      }
+    : null;
+  const bestImage = contentPages.length
+    ? {
+        page_id: contentPages[contentPages.length - 1].id,
+        page_number: contentPages[contentPages.length - 1].page_number,
+        scan_score: contentPages[contentPages.length - 1].scan_quality.scan_score,
+        scan_class: contentPages[contentPages.length - 1].scan_quality.scan_class,
+      }
+    : null;
+
+  return {
+    // ── legacy fields for backwards compat (enhance-scan-quality.mjs, audit-scan-quality.mjs) ──
+    score: median,
+    classification: legacyClassificationFor(dominantClass),
+
+    // ── v2 rollup fields ──
+    median_score: median,
+    min_score: min,
+    max_score: max,
+    pages_assessed: pages.length,
+    content_pages_assessed: contentPages.length,
+    dominant_scan_class: dominantClass,
+    class_distribution: classCounts,
+    concerns_distribution: concernCounts,
+    has_microfilm_pages: !!(classCounts.bitonal_microfilm || classCounts.microfiche),
+    has_blank_pages: !!classCounts.blank,
+    has_scanner_metadata_pages: !!classCounts.scanner_metadata,
+    has_corrupt_pages: !!classCounts.corrupt,
+    completeness_issues_count: completenessIssues,
+    class_corrected_count: classCorrectedCount,
+    worst_image: worstImage,
+    best_image: bestImage,
+    rollup_at: new Date(),
+    version: SCAN_QUALITY_VERSION,
+  };
+}
+
 async function setPipelineStatus(db, bookId, status, extra = {}) {
   const update = {
     'pipeline_auto.status': status,
@@ -746,9 +867,21 @@ async function processBook(db, book) {
     book_id: book.id,
     'detected_images.0': { $exists: true },
   });
+  const bookUpdate = { detected_images_count: imgCount, updated_at: now };
+
+  // Phase 2: roll up page-level scan_quality (v2) into book.scan_quality so downstream
+  // use cases (dedupe, re-source queue, dashboards) don't have to aggregate on the fly.
+  // Best-effort: any error here doesn't fail the book or block pipeline advance.
+  try {
+    const rollup = await computeBookScanQualityRollup(db, book.id);
+    if (rollup) bookUpdate.scan_quality = rollup;
+  } catch (err) {
+    console.error(`  scan_quality rollup failed for ${book.id}: ${err.message}`);
+  }
+
   await db.collection('books').updateOne(
     { id: book.id },
-    { $set: { detected_images_count: imgCount, updated_at: now } },
+    { $set: bookUpdate },
   );
 
   // Advance pipeline


### PR DESCRIPTION
Phase 2 of the automated image quality system. Builds on Phase 1's per-page scoring to produce \`book.scan_quality\` that downstream use cases can consume.

## What this enables

| Use case | Needs |
|---|---|
| Dedupe best-copy picking (#1788) | \`book.scan_quality.median_score\` + per-illustration comparison |
| Re-source candidate queue | \`has_microfilm_pages\` + \`min_score\` + \`worst_image.scan_class\` |
| Provider quality dashboards | \`dominant_scan_class\` aggregated by \`image_source.provider\` |
| Admin scan-health view | \`completeness_issues_count\`, \`has_corrupt_pages\`, \`worst_image\` |

Currently none of these can be computed without a per-book aggregation. This PR provides it.

## How the rollup runs

**Inline (forward path).** Every book the \`image-extract-worker\` touches gets its \`book.scan_quality\` rolled up right after \`detected_images_count\` is updated. Best-effort: any error in rollup logs and continues — does not fail the book or block pipeline advance.

**Standalone (catch-up).** \`scripts/rollup-scan-quality.mjs\` for backfilling books whose pages were scored by an earlier worker run that predates the inline rollup. Supports:
- \`--book ID\` — single book
- \`--all\` — every book with v2 pages
- \`--since YYYY-MM-DD\` — books with v2 pages assessed since
- \`--limit N\`, \`--dry-run\`, \`--concurrency N\`
- Accepts both \`--flag=value\` and \`--flag value\` forms

## Schema produced

\`book.scan_quality\` (version 2):

\`\`\`js
{
  // legacy compat — read by enhance-scan-quality.mjs and audit-scan-quality.mjs
  score: 95,                    // median of page scan_scores
  classification: 'color',      // dominant scan_class mapped to bw|grayscale|color

  // rich rollup
  median_score, min_score, max_score,
  pages_assessed,               // count of pages with scan_quality.version=2
  content_pages_assessed,       // pages excluding blank/scanner_metadata/corrupt
  dominant_scan_class,          // most-common scan_class across all v2 pages
  class_distribution,           // { color_photo: 6, bitonal_clean: 2, ... }
  concerns_distribution,        // { yellow_tone: 2, bleed_through: 5, ... }
  has_microfilm_pages,          // bool — any bitonal_microfilm or microfiche page
  has_blank_pages,
  has_scanner_metadata_pages,
  has_corrupt_pages,
  completeness_issues_count,    // pages where page_completeness !== 'full_page'
  class_corrected_count,        // pages where the v4 normalizer fixed scan_class
  worst_image: {                // worst-scoring content page (skip noise pages)
    page_id, page_number, scan_score, scan_class, concerns
  },
  best_image: { ... },
  rollup_at, version: 2
}
\`\`\`

Critically, \`worst_image\` only considers content-class pages (color_photo, grayscale_*, bitonal_*), so calibration cards and blank pages don't pollute the "worst image" pointer that the admin queue surfaces.

## Verification

Live test on Lesser Key of Solomon (\`695936103b43cb6630c91643\`), 8 v2 pages:

\`\`\`
score: 95
classification: 'color'
median_score: 95
min_score: 10        ← surfaced the bad page (page 98)
max_score: 98        ← surfaced the sigil grid (page 10)
dominant_scan_class: 'color_photo'
class_distribution: { color_photo: 6, bitonal_clean: 2 }
worst_image: page 98, score 10, concerns [blank_page, scanner_bed_visible]
best_image: page 10, score 98, bitonal_clean
\`\`\`

The min_score = 10 with worst_image pointing at the bad calibration page is exactly the shape the admin queue and dedupe tiebreaker need.

## Test plan
- [ ] CI passes
- [ ] After merge, Hetzner picks up the inline rollup automatically — no separate deploy needed
- [ ] Run \`node scripts/rollup-scan-quality.mjs --all --dry-run\` from Hetzner to see total candidate count
- [ ] Run \`--all\` for real to backfill existing v2 books (one-shot, should be fast — only ~20-50 books currently have v2 pages from the verification rounds)

## Out of scope
- Phase 3 backfill on the existing 101K gallery_images (needs Gemini-scoring those pages first via image-extract worker)
- Phase 4 use cases (dedupe extension, admin queue, provider dashboards)
- v5 prompt fixes (#16) — separate concern, not blocking rollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)