### PR TITLE
fix(ocr): break recitation retry infinite loop + add page-level tracking

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -281,6 +281,7 @@ async function processOneJob(db, job) {
     const pageResults = [];
 
     let recitationCount = 0;
+    const recitationPageIds = []; // Track page IDs for per-page recitation stamping (single-page path only)
 
     if (isMultiPage && job.type === 'ocr') {
       for (const r of responses) {
@@ -307,7 +308,12 @@ async function processOneJob(db, job) {
           continue;
         }
         const candidate = r.response?.candidates?.[0];
-        if (candidate?.finishReason === 'RECITATION') { recitationCount++; failCount++; continue; }
+        if (candidate?.finishReason === 'RECITATION') {
+          recitationCount++;
+          failCount++;
+          if (job.type === 'ocr') recitationPageIds.push(pageId); // Stamp page-level tracking
+          continue;
+        }
         const text = candidate?.content?.parts?.[0]?.text;
         if (!text) { failCount++; continue; }
         pageResults.push({ pageId, text, usage: r.response?.usageMetadata });
@@ -316,6 +322,40 @@ async function processOneJob(db, job) {
 
     if (recitationCount > 0) {
       console.log(`  RECITATION: ${recitationCount}/${responses.length} responses blocked (book: ${job.book_id})`);
+    }
+
+    // ── Per-page RECITATION tracking (single-page OCR path only, where we have pageId) ──
+    // Mirrors the archive_metadata.failure_count pattern: stamp count + timestamp, and after
+    // N=3 consecutive blocks mark ocr.recitation_blocked: true to skip future submissions.
+    if (recitationPageIds.length > 0) {
+      const RECITATION_BLOCK_THRESHOLD = 3;
+      const recitationNow = new Date();
+      // Use $inc + $set so we don't need to read each page before writing
+      const recitationOps = recitationPageIds.map(pageId => ({
+        updateOne: {
+          filter: { id: pageId },
+          update: [
+            // Ensure ocr subdocument exists
+            { $set: { ocr: { $cond: { if: { $eq: ['$ocr', null] }, then: {}, else: '$ocr' } } } },
+            {
+              $set: {
+                'ocr.recitation_count': { $add: [{ $ifNull: ['$ocr.recitation_count', 0] }, 1] },
+                'ocr.last_recitation_at': recitationNow,
+                // Mark as blocked after threshold so the page-selection query can skip it
+                'ocr.recitation_blocked': {
+                  $gte: [{ $add: [{ $ifNull: ['$ocr.recitation_count', 0] }, 1] }, RECITATION_BLOCK_THRESHOLD],
+                },
+              },
+            },
+          ],
+        },
+      }));
+      try {
+        await db.collection('pages').bulkWrite(recitationOps, { ordered: false });
+        console.log(`  Stamped recitation tracking on ${recitationPageIds.length} pages`);
+      } catch (recErr) {
+        console.error(`  Failed to stamp recitation tracking: ${recErr.message}`);
+      }
     }
 
     // First pass: fix null ocr/translation subdocuments (skip for image_extraction)
@@ -1157,25 +1197,51 @@ async function run() {
 
   // RECITATION recovery: mark affected books for retry with a different model.
   // The batch API with gemini-3-flash-preview triggers RECITATION on some historical
-  // texts. Lambda workers have a fallback chain (2.5-flash → 2.0-flash → 1.5-flash).
-  // Reset to archive_complete with recitation_retry flag so the orchestrator can
-  // route these through Lambda or use a different batch model.
+  // texts. Orchestrator retries these with gemini-2.5-flash (modelOverride).
+  // If a book that already had recitation_retry=true fails RECITATION again,
+  // it means even the fallback model can't handle this content — mark as
+  // pipeline_auto.recitation_blocked=true so both Pass 1 and Pass 2 permanently skip it.
   if (recitationBooks.size > 0) {
     console.log(`\nRECITATION recovery: flagging ${recitationBooks.size} books for retry`);
     for (const bookId of recitationBooks) {
       try {
-        await db.collection('books').updateOne(
-          { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
-          {
-            $set: {
-              'pipeline_auto.status': 'archive_complete',
-              'pipeline_auto.last_updated': new Date(),
-              'pipeline_auto.recitation_retry': true,
-              updated_at: new Date(),
-            },
-          }
+        const book = await db.collection('books').findOne(
+          { id: bookId },
+          { projection: { 'pipeline_auto.recitation_retry': 1 } }
         );
-        console.log(`  Reset ${bookId} -> archive_complete (recitation_retry)`);
+        const alreadyRetried = book?.pipeline_auto?.recitation_retry === true;
+
+        if (alreadyRetried) {
+          // Second RECITATION failure: fallback model also blocked. Permanently skip.
+          await db.collection('books').updateOne(
+            { id: bookId },
+            {
+              $set: {
+                'pipeline_auto.status': 'needs_attention',
+                'pipeline_auto.last_updated': new Date(),
+                'pipeline_auto.recitation_blocked': true,
+                'pipeline_auto.recitation_blocked_at': new Date(),
+                updated_at: new Date(),
+              },
+              $unset: { 'pipeline_auto.recitation_retry': '' },
+            }
+          );
+          console.log(`  RECITATION permanently blocked ${bookId} -> needs_attention (both models failed)`);
+        } else {
+          // First RECITATION failure: reset to archive_complete for retry with fallback model.
+          await db.collection('books').updateOne(
+            { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
+            {
+              $set: {
+                'pipeline_auto.status': 'archive_complete',
+                'pipeline_auto.last_updated': new Date(),
+                'pipeline_auto.recitation_retry': true,
+                updated_at: new Date(),
+              },
+            }
+          );
+          console.log(`  Reset ${bookId} -> archive_complete (recitation_retry)`);
+        }
       } catch (e) { console.error(`  RECITATION reset error ${bookId}: ${e.message}`); }
     }
   }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -1326,6 +1326,7 @@ async function submitOcrDirectly(db, book, { modelOverride, maxPages } = {}) {
   const pages = await db.collection('pages')
     .find({
       book_id: book.id,
+      'ocr.recitation_blocked': { $ne: true }, // Skip pages permanently blocked after N=3 recitation hits
       $or: [
         { 'ocr.data': { $exists: false } },
         { 'ocr.data': null },
@@ -1656,6 +1657,7 @@ async function submitCrossBookOcrBatches(db, books) {
     const pages = await db.collection('pages')
       .find({
         book_id: book.id,
+        'ocr.recitation_blocked': { $ne: true }, // Skip pages permanently blocked after N=3 recitation hits
         $or: [{ 'ocr.data': { $exists: false } }, { 'ocr.data': null }, { 'ocr.data': '' }],
         $and: [{
           $or: [
@@ -3493,6 +3495,7 @@ Rules:
               'pipeline_auto.status': 'archive_complete',
               'pipeline_auto.split_checked': true,
               'pipeline_auto.recitation_blocked': { $ne: true },
+              'pipeline_auto.recitation_retry': { $ne: true }, // Recitation books go to Pass 2 w/ fallback model
               pages_ocr: { $in: [0, null, undefined] }, // No OCR yet
             }},
             { $addFields: {
@@ -3585,14 +3588,18 @@ Rules:
         }
       }
 
-      // --- Pass 2: Full OCR for books that already have some OCR (preview done, or partial) ---
+      // --- Pass 2: Full OCR for books that already have some OCR (preview done, or partial),
+      //            AND for books that hit RECITATION on a previous attempt (retried with fallback model) ---
       let readyForOcr = ocrLimit > 0 ? await db.collection('books')
         .aggregate([
           { $match: {
             'pipeline_auto.status': 'archive_complete',
             'pipeline_auto.split_checked': true,
             'pipeline_auto.recitation_blocked': { $ne: true },
-            pages_ocr: { $gt: 0 }, // Already has some OCR (preview pass done)
+            $or: [
+              { pages_ocr: { $gt: 0 } }, // Already has some OCR (preview pass done)
+              { 'pipeline_auto.recitation_retry': true }, // All pages were RECITATION-blocked — retry with fallback model regardless of pages_ocr
+            ],
           }},
           { $addFields: {
             _priority: {


### PR DESCRIPTION
## Summary

- **Root cause found**: Pass 1 (preview OCR) was re-picking up RECITATION-blocked books immediately after Pass 2's batch-collector reset them with `recitation_retry=true`, because Pass 1 only filters on `pages_ocr=0` + `status=archive_complete` — not on `recitation_retry`. This created a tight infinite loop resubmitting with the same failing model. 137/149 batch jobs (92%) were failing as a result.
- **Fix 1 (pipeline-orchestrator)**: Pass 1 now excludes `recitation_retry=true` books. Pass 2 now includes them via `$or` regardless of `pages_ocr` count (previously `pages_ocr > 0` was required, which zero-OCR books never satisfied). The existing `gemini-2.5-flash` modelOverride logic in Pass 2 now actually runs.
- **Fix 2 (batch-collector)**: If a book with `recitation_retry=true` hits RECITATION again (fallback model also blocked), escalate to `pipeline_auto.recitation_blocked=true` + `needs_attention`. Both Pass 1 and Pass 2 already filter on `$ne: true` for this flag, so the book is permanently skipped.
- **Fix 3 (page-level tracking)**: Single-page OCR path now stamps `ocr.recitation_count`, `ocr.last_recitation_at`, and `ocr.recitation_blocked=true` (after 3 hits). Page-selection queries in both `submitOcrDirectly` and `submitCrossBookOcrBatches` now filter `ocr.recitation_blocked: {$ne: true}`.

## Mitigation test results (code analysis, not live API calls)

| Mitigation | Status | Evidence |
|---|---|---|
| A: safetySettings BLOCK_NONE for all categories | Already present (lines 1464-1470 in pipeline-orchestrator), does NOT suppress RECITATION — it is not a user-controllable harm category | Code audit |
| B: gemini-2.5-flash fallback | Already coded (line 3640 `modelOverride: 'gemini-2.5-flash'`) but **unreachable** due to the Pass 1 loop bug | Code audit |
| C: 1-page batches | Not needed — the core issue is a routing bug, not batch size |

## Test plan

- [ ] After merge, pull on Hetzner and restart pipeline-orchestrator + batch-collector
- [ ] Watch for `RECITATION retry with gemini-2.5-flash` in logs (confirms Pass 2 is now reaching the retry path)
- [ ] Check batch_jobs failure rate drops from 92% over next 24h
- [ ] Verify books that previously looped now show `ocr_submitted` with model `gemini-2.5-flash` in batch_jobs
- [ ] Confirm permanently-blocked books (if any survive the 2.5-flash retry) show `pipeline_auto.recitation_blocked: true` and `status: needs_attention` in Atlas

🤖 Generated with [Claude Code](https://claude.com/claude-code)