### PR TITLE
pipeline: close recitation loop gaps (SUSP-1, SUSP-2) — follow-up to #1854

### DIFF
--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -1160,22 +1160,61 @@ async function run() {
   // texts. Lambda workers have a fallback chain (2.5-flash → 2.0-flash → 1.5-flash).
   // Reset to archive_complete with recitation_retry flag so the orchestrator can
   // route these through Lambda or use a different batch model.
+  //
+  // Two-pass logic to detect second consecutive RECITATION (fallback model also failed):
+  //   1st RECITATION → set recitation_retry: true  (orchestrator will use gemini-2.5-flash)
+  //   2nd RECITATION → set recitation_blocked: true + needs_attention (permanent block, human review)
   if (recitationBooks.size > 0) {
-    console.log(`\nRECITATION recovery: flagging ${recitationBooks.size} books for retry`);
+    console.log(`\nRECITATION recovery: checking ${recitationBooks.size} books`);
+
+    // Fetch current recitation_retry state for all affected books in one query
+    const bookIdList = [...recitationBooks];
+    const existingBooks = await db.collection('books')
+      .find(
+        { id: { $in: bookIdList } },
+        { projection: { id: 1, 'pipeline_auto.recitation_retry': 1 } }
+      )
+      .toArray();
+    const alreadyInRetry = new Set(
+      existingBooks
+        .filter(b => b.pipeline_auto?.recitation_retry === true)
+        .map(b => b.id)
+    );
+
     for (const bookId of recitationBooks) {
       try {
-        await db.collection('books').updateOne(
-          { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
-          {
-            $set: {
-              'pipeline_auto.status': 'archive_complete',
-              'pipeline_auto.last_updated': new Date(),
-              'pipeline_auto.recitation_retry': true,
-              updated_at: new Date(),
-            },
-          }
-        );
-        console.log(`  Reset ${bookId} -> archive_complete (recitation_retry)`);
+        if (alreadyInRetry.has(bookId)) {
+          // Second consecutive RECITATION — fallback model also failed. Permanent block.
+          await db.collection('books').updateOne(
+            { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
+            {
+              $set: {
+                'pipeline_auto.status': 'archive_complete',
+                'pipeline_auto.last_updated': new Date(),
+                'pipeline_auto.recitation_blocked': true,
+                'pipeline_auto.recitation_blocked_at': new Date(),
+                needs_attention: true,
+                updated_at: new Date(),
+              },
+              $unset: { 'pipeline_auto.recitation_retry': '' },
+            }
+          );
+          console.log(`  RECITATION BLOCKED ${bookId} — fallback model also failed, needs human review`);
+        } else {
+          // First RECITATION — reset for retry with fallback model (gemini-2.5-flash)
+          await db.collection('books').updateOne(
+            { id: bookId, 'pipeline_auto.status': { $in: ['ocr_submitted', 'ocr_complete'] } },
+            {
+              $set: {
+                'pipeline_auto.status': 'archive_complete',
+                'pipeline_auto.last_updated': new Date(),
+                'pipeline_auto.recitation_retry': true,
+                updated_at: new Date(),
+              },
+            }
+          );
+          console.log(`  Reset ${bookId} -> archive_complete (recitation_retry, will use fallback model)`);
+        }
       } catch (e) { console.error(`  RECITATION reset error ${bookId}: ${e.message}`); }
     }
   }

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -2848,6 +2848,8 @@ Reply with ONLY: {"is_spread": true} or {"is_spread": false}` },
           'pipeline_auto.status': 'archive_complete',
           'pipeline_auto.split_checked': true,
           'pipeline_auto.preview_ocr_done': { $ne: true },
+          'pipeline_auto.recitation_retry': { $ne: true },
+          'pipeline_auto.recitation_blocked': { $ne: true },
         })
         .sort({ 'pipeline_auto.likely_first_translation': -1, hidden: 1 })
         .project({ id: 1, title: 1, language: 1, needs_splitting: 1 })


### PR DESCRIPTION
## Summary

Follow-up to #1854, closing two gaps found in the post-merge audit.

**SUSP-2 (batch-collector.mjs, lines 1158–1220):** `pipeline_auto.recitation_blocked` was filtered in the orchestrator but never set — the permanent-block path was unreachable. Added a two-pass check in the RECITATION recovery block: fetch current `recitation_retry` state for all affected books, then branch on whether this is the first or second consecutive RECITATION failure.

**SUSP-1 (pipeline-orchestrator.mjs, line 2851–2852):** Phase 1.5 preview-OCR query had no recitation guards. Added `recitation_retry: { $ne: true }` and `recitation_blocked: { $ne: true }` to match the pattern used in Pass 1 (line 3495) and Pass 2 (line 3594).

## State-transition walkthrough (Augustine's Confessions, 3 cycles)

| Cycle | Book enters | What happens | Book exits |
|-------|-------------|--------------|------------|
| 1st | `archive_complete` (no flags) | Batch OCR with `gemini-3-flash-preview` → all pages RECITATION | `archive_complete` + `recitation_retry: true` |
| 2nd | `archive_complete` + `recitation_retry: true` | Orchestrator Pass 2 picks it up, uses `gemini-2.5-flash` → all pages RECITATION again | batch-collector sees `recitation_retry` already set → `recitation_blocked: true` + `needs_attention: true`, `recitation_retry` unset |
| 3rd | `archive_complete` + `recitation_blocked: true` | Phase 1.5 filter excludes it; Pass 1 & Pass 2 both exclude it via `recitation_blocked: { $ne: true }` | Book sits at rest awaiting human review |

## Recitation filter audit (all book-selection queries)

| Location | Query | recitation_retry filter | recitation_blocked filter | Correct? |
|----------|-------|------------------------|--------------------------|---------|
| Phase 1.5 (line 2848) | preview OCR candidates | ✅ `$ne: true` (added this PR) | ✅ `$ne: true` (added this PR) | yes |
| Pass 1 (line 3492) | batch OCR, no OCR yet | absent (intentional — retry books have `pages_ocr > 0` after first cycle, won't match `pages_ocr: { $in: [0, null] }`) | ✅ `$ne: true` | yes |
| Pass 2 (line 3589) | batch OCR, has some OCR | absent (intentional — retry books need to go through Pass 2 with fallback model) | ✅ `$ne: true` | yes |

Note: Pass 1 excludes retry books structurally (`pages_ocr: { $in: [0, null, undefined] }`); a first-RECITATION book will have some pages_ocr > 0 after the batch result is collected, so it lands in Pass 2 where the fallback model is applied. This is correct.

## Additional issue spotted (not fixed in this PR)

Phase 1.5 uses `Promise.allSettled` for per-page OCR calls, so individual RECITATION errors are swallowed as rejected promises and `preview_ocr_done: true` is set unconditionally at line 2993 even with 0 pages OCR'd. This means a recitation-hit book in Phase 1.5 advances to `pages_ocr = 0` + `preview_ocr_done: true`, then falls into Pass 2 (full OCR) which does have the `recitation_blocked` filter. The SUSP-1 loop risk is therefore only active in the edge case where a Gemini HTTP error (not a RECITATION response in the JSON body) causes the outer `catch` to fire and leave `preview_ocr_done` unset. The filters added here close that window. A deeper fix would be to detect RECITATION in the `Promise.allSettled` results and set `recitation_retry` at Phase 1.5 time — left as a future improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)