### PR TITLE
daily-health-snapshot: also strip em-dash from title

### DIFF
--- a/scripts/workers/daily-health-snapshot.mjs
+++ b/scripts/workers/daily-health-snapshot.mjs
@@ -337,8 +337,8 @@ async function run() {
     lines.push(`  Archive failures (24h): ${brokenImages}`);
 
     const message = lines.join('\n');
-    // Title must be ASCII (HTTP header constraint) — emoji belongs in body / Tags.
-    const title = `Daily snapshot — ${dateLabel}`;
+    // Title must be ASCII (HTTP header constraint) — emoji and em-dash belong in body / Tags.
+    const title = `Daily snapshot - ${dateLabel}`;
 
     console.log(`\n${title}\n${'─'.repeat(40)}`);
     console.log(message);


### PR DESCRIPTION
Follow-up to #1861 — turns out the em-dash was *also* non-ASCII. Same root cause, missed it in the first pass. Title is now `Daily snapshot - {date}` with a plain hyphen-minus. Body is unaffected.