### PR TITLE
health/auth: retry MongoDB probe on transient TLS disconnect

### DIFF
--- a/src/app/api/health/auth/route.ts
+++ b/src/app/api/health/auth/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDb } from '@/lib/mongodb';
+import { getDb, forceReconnect } from '@/lib/mongodb';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 15;
@@ -130,18 +130,25 @@ async function checkEmailProvider(): Promise<AuthCheck> {
 }
 
 async function checkMongoAdapter(): Promise<AuthCheck> {
-  try {
-    const db = await getDb();
-    // Check that the users collection exists and is queryable
-    const count = await db.collection('users').estimatedDocumentCount({ maxTimeMS: 5000 } as any);
-    if (count === 0) {
-      return { provider: 'database', status: 'error', detail: 'Users collection is empty' };
+  // One retry with forced reconnect: Atlas TLS handshakes occasionally drop
+  // ("Client network socket disconnected before secure TLS connection was established").
+  // The MongoDB client recovers transparently for user requests, so a single failed
+  // probe should not page Derek.
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const db = attempt === 0 ? await getDb() : await forceReconnect();
+      const count = await db.collection('users').estimatedDocumentCount({ maxTimeMS: 5000 } as any);
+      if (count === 0) {
+        return { provider: 'database', status: 'error', detail: 'Users collection is empty' };
+      }
+      return { provider: 'database', status: 'ok' };
+    } catch (e) {
+      lastErr = e;
     }
-    return { provider: 'database', status: 'ok' };
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return { provider: 'database', status: 'error', detail: `MongoDB check failed: ${msg}` };
   }
+  const msg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  return { provider: 'database', status: 'error', detail: `MongoDB check failed (after retry): ${msg}` };
 }
 
 async function sendAuthAlert(failures: AuthCheck[]) {


### PR DESCRIPTION
## Summary
- One Atlas TLS handshake failure was firing the "sign-in is broken" alert email even though `getDb()` reconnects transparently for real user traffic.
- `checkMongoAdapter()` now retries once via `forceReconnect()` before declaring the database broken. The error detail tags `(after retry)` so we can tell a real outage from a single blip.

## Context
The alert fired earlier today with `MongoDB check failed: Client network socket disconnected before secure TLS connection was established`. Sign-in itself never broke — five consecutive polls of `/api/health/auth` immediately afterward were all healthy, and `/auth/signin` loaded normally. Vercel cron hits this endpoint every 10 min (`vercel.json:29-32`); a single transient TLS drop on a cross-region (iad1 → eu-central-1) call was enough to page.

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] After merge, watch `/api/health/auth` for one full cron cycle (10 min)
- [ ] Confirm no false-alarm email arrives over the next 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)