### PR TITLE
ocr: catch "Digitized by the Internet Archive" credit pages

### DIFF
--- a/scripts/batch/collect-batch-results.mjs
+++ b/scripts/batch/collect-batch-results.mjs
@@ -36,14 +36,18 @@ function extractPageType(text) {
   return match ? match[1].toLowerCase().trim() : null;
 }
 
-/** Check if this page is a digitizer insert — via OCR tag or body-text fallback. */
+/** Check if this page is a digitizer insert — via OCR tag, body-text, or meta-descriptor fallback. */
 function isDigitizerPage(pageType, ocrText) {
   if (pageType === 'digitizer-insert') return true;
   if (!ocrText) return false;
-  // Fallback: match full-page Google/IA notices in body text (not <meta> descriptions)
+  // Body text: full Google "About this book" or IA credit boilerplate (not just a watermark mention)
   const bodyText = ocrText.replace(/<meta>[\s\S]*?<\/meta>/g, '');
-  return /this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText) ||
-    /inserted by the internet archive/i.test(bodyText);
+  if (/this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText)) return true;
+  if (/inserted by the internet archive|Digitized by the Internet Archive in \d{4}/i.test(bodyText)) return true;
+  // Meta descriptor: the OCR model sometimes correctly identifies the page as a credit in <meta> but mislabels page-type.
+  const metaText = ocrText.match(/<meta>[\s\S]*?<\/meta>/gi)?.join(' ') || '';
+  if (/digitization credit from the Internet Archive|Google Books digital preservation notice|digital preservation notice/i.test(metaText)) return true;
+  return false;
 }
 
 function extractColumns(text) {

--- a/scripts/batch/realtime-ocr.mjs
+++ b/scripts/batch/realtime-ocr.mjs
@@ -185,13 +185,16 @@ function extractPageType(text) {
   return match ? match[1].toLowerCase().trim() : null;
 }
 
-/** Check if this page is a digitizer insert — via OCR tag or body-text fallback. */
+/** Check if this page is a digitizer insert — via OCR tag, body-text, or meta-descriptor fallback. */
 function isDigitizerPage(pageType, ocrText) {
   if (pageType === 'digitizer-insert') return true;
   if (!ocrText) return false;
   const bodyText = ocrText.replace(/<meta>[\s\S]*?<\/meta>/g, '');
-  return /this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText) ||
-    /inserted by the internet archive/i.test(bodyText);
+  if (/this is a digital copy of a book|reproduction of a library book that was digitized|digitized by google as part of an ongoing/i.test(bodyText)) return true;
+  if (/inserted by the internet archive|Digitized by the Internet Archive in \d{4}/i.test(bodyText)) return true;
+  const metaText = ocrText.match(/<meta>[\s\S]*?<\/meta>/gi)?.join(' ') || '';
+  if (/digitization credit from the Internet Archive|Google Books digital preservation notice|digital preservation notice/i.test(metaText)) return true;
+  return false;
 }
 
 function extractColumns(text) {


### PR DESCRIPTION
## Summary
- `isDigitizerPage()` now catches the IA "Digitized by the Internet Archive in YYYY" credit-page text (distinct from the small corner watermark) and the ProQuest/Google "digital preservation notice" meta descriptors that the OCR model sometimes attaches to pages it otherwise mislabels as `text` / `blank` / `title-page`.
- Patched in both write paths: `scripts/batch/collect-batch-results.mjs` (batch API) and `scripts/batch/realtime-ocr.mjs` (Hetzner realtime).

## Why
Caxton's Game of Chess (`/book/the-game-of-the-chesse-caxton-facsimile-cessolis`) had its IA digitization-credit page on page 5 leaking the term "Internet Archive" into the AI-generated index. Investigation found 944 similar pages across the corpus the model had failed to flag.

A backfill against production:
- Reclassified 944 pages to `digitizer-insert` (conservative: only books with exactly one matched page).
- Marked 665 affected books `enrichment_stale: true` so their `book.index` regenerates without the IA/Google vocab.
- Deleted 2 stale `gallery_images` rows whose `page_id` pointed at the now-reclassified pages.
- 9 books were skipped — they're OCR hallucinations (Gemini saw the corner watermark and emitted the full Google boilerplate as the page text for real content scans). List saved to `scripts/output/digitizer-backfill-skipped.json` for re-OCR follow-up.

## Test plan
- [ ] Visit a previously-affected book (e.g. https://sourcelibrary.org/book/the-game-of-the-chesse-caxton-facsimile-cessolis) and confirm the IA credit page no longer shows in the reading view.
- [ ] After next enrichment run, confirm "Internet Archive" no longer appears in the book's index vocabulary.
- [ ] Submit a new IA-sourced book through the pipeline and confirm any "Digitized by the Internet Archive in YYYY" page lands as `digitizer-insert` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)