### PR TITLE
MCP registry: trim server.json description under 100-char limit

### DIFF
--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Embassy-of-the-Free-Mind/source-library",
-  "description": "Search, read, and cite ~22,000 rare pre-modern texts (alchemy, Hermetica, Kabbalah, theology, early science) with AI-generated English translations, summaries, semantic search, and 73,000+ historical images.",
+  "description": "Search 22,000+ rare pre-modern texts with AI English translations, summaries, and 73K+ images.",
   "repository": {
     "url": "https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2",
     "source": "github",


### PR DESCRIPTION
## Summary

The MCP registry rejects publishes with `description > 100` chars. The description we shipped in #1849 was 210 chars, so `mcp-publisher publish` returned 422. Trimmed `server.json` description to 94 chars (still covers all four product pillars: search, AI translations, summaries, images) so future publishes don't fail.

This was caught at publish time today — 4.3.0 is already live on both registries with the trimmed description applied directly. This PR just brings the source-of-truth in `server.json` in line with what's actually published.

## Test plan

- [x] `mcp-publisher publish` already succeeded with this trimmed description.
- [x] Verified 4.3.0 is listed on https://registry.modelcontextprotocol.io with the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)