### PR TITLE
curator skill: collection-page rendering quirks + PDF pipeline hardening

### DIFF
--- a/.claude/skills/curator/SKILL.md
+++ b/.claude/skills/curator/SKILL.md
@@ -45,12 +45,17 @@ Before building the script:
 ### Step 3: Determine Collection Assignment
 Before importing, decide which collection(s) the batch belongs to.
 
-**Existing collections (22 curated):**
-alchemy, hermetica, kabbalah, magic, natural-philosophy, demonology, secret-societies, astrology, mysticism, sacred-texts, theology, classical-philosophy, renaissance-philosophy, medicine, indic-traditions, chinese-classics, art-illustrated, literature, music, herbalism, leonardo-da-vinci, shwep-reading-room
+**Existing top-level collections (~36):** alchemy, hermetica, kabbalah, magic, natural-philosophy, demonology, secret-societies, astrology, mysticism, sacred-texts, theology, medicine, art-illustrated, literature, education, philosophy, south-asia, east-asia, the-human-condition, history-political-thought, european-vernacular-erotica, eastern-erotic-literature, games, pharmacopeias, arabic-medicine, miscellany, aesthetic-theory, sacred-plants, norse-antiquities, druids-megaliths, architecture, bhutan, psychology, shwep, banned-books, prehistory-of-ai.
+
+Plus ~308 sub-collections nested under those via the `parent` field.
 
 **Check if an existing collection fits:**
 ```bash
-curl -s "https://sourcelibrary.org/api/collections" | python3 -c "import sys,json; [print(c['slug'], '—', c['name']) for c in json.load(sys.stdin)]"
+# Top-level only (default API filter is `parent: {$exists: false}`):
+curl -s "https://sourcelibrary.org/api/collections" | python3 -c "import sys,json; [print(c['slug'], '—', c['name']) for c in json.load(sys.stdin)['collections']]"
+
+# All 344 including sub-collections (direct Mongo):
+python3 -c "from pymongo import MongoClient; import os; db=MongoClient(os.environ['MONGODB_URI'])['bookstore']; [print(c['slug']) for c in db.collections.find({}, {'slug':1})]"
 ```
 
 **If no collection fits, create a new one** using the API after import (see Step 5).
@@ -205,7 +210,7 @@ For libraries that serve IIIF manifests (NDL Japan, Bodleian, Manchester, Kyoto 
 
 ## PDF Imports (Manual Pipeline)
 
-For large PDFs from sources without IIIF (QDL downloads, scanned books):
+For large PDFs from sources without IIIF (QDL downloads, manually-fetched Google Books PDFs, scanned books):
 
 1. Upload PDF to R2:
 ```javascript
@@ -214,12 +219,95 @@ const r2 = new S3Client({
   region: 'auto',
   endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
   credentials: { accessKeyId: process.env.R2_ACCESS_KEY_ID, secretAccessKey: process.env.R2_SECRET_ACCESS_KEY },
+  maxAttempts: 5,
 });
 ```
 
-2. Extract pages with `pdftoppm -r 150 -jpeg`
+2. Extract pages with `pdftoppm -jpeg -r 150 -jpegopt quality=85`
 3. Upload page images to R2 at `books/{bookId}/pages/0001.jpg`
 4. Create book + page records in MongoDB directly (pages need an `id` field — use `new ObjectId().toString()`)
+
+**Production-tested settings** (`_tmp-import-souter-pdf.mjs`, `_tmp-import-googles-batch.mjs`):
+- **Concurrency = 3** for R2 uploads — higher values (8+) cause SSL `bad record mac` errors mid-batch.
+- **Per-upload retry**: wrap `r2.send()` in a 4-6 attempt loop with exponential backoff (500ms × 2^attempt).
+- **pdftoppm timeout**: 30 minutes for ~600pp books, 60-90 minutes for 800pp+. Some Google Books PDFs take much longer than file size suggests.
+- **Inter-batch delay**: 150-200ms `setTimeout` between chunks to let R2 connections settle.
+- **Verify byte-exact download** before pdftoppm — IA's `/download/{id}/{id}.pdf` occasionally serves truncated PDFs; check `content-length` matches downloaded size.
+
+**Unrepairable corruption**: Some IA PDFs (especially Italian National Library `ita-bnc-mag-*`) have no PDF trailer dictionary. Neither `mutool clean` nor `gs -sDEVICE=pdfwrite` can repair them. The corruption is at IA's source. Try an alternative source rather than fighting the file.
+
+**Google Books → check IA mirror first**: Before manually downloading a Google Books PDF, try `https://archive.org/metadata/bub_gb_{google_id}`. If it exists, import via `ia` route instead of the PDF pipeline.
+
+**Cloudflare-protected catalogs (IRD Horizon, Persée, HAL, Wellcome)**: Anubis/JS-rendered search interfaces block automation. Either use `WebFetch` (which can render JS) or hand off to the user with a direct browser URL.
+
+---
+
+## Collection Page Rendering & `mentioned_books`
+
+**Critical:** The collection page (`/collections/{slug}`) renders `description` and `expanded_description` as **plain text** — Markdown is **NOT parsed**. Links written as `[text](url)` show literal brackets and parentheses; `*italic*` and `**bold**` show literal asterisks.
+
+Three things the renderer **does** handle:
+1. **Paragraph breaks** on `\n\n` (split into `<p>` tags).
+2. **Auto-linking of book titles** ≥8 chars that appear as exact substrings in the description text. Matches the book's `title` or `display_title` against the collection's books. Renders as `text-accent-rust hover:underline italic`.
+3. **Explicit `mentioned_books` overrides** that take priority over auto-detection.
+
+### When writing a new collection description
+
+- **Plain prose only.** No Markdown syntax.
+- **Use exact title substrings** ≥8 chars from books in the collection — they'll auto-link.
+- **For shorter references** (e.g. "Liezi" = 5 chars, "Hesiod" = 6) or paraphrased titles that don't match book records — populate `mentioned_books`.
+
+### `mentioned_books` schema
+
+```javascript
+{
+  slug: 'prehistory-of-ai',
+  mentioned_books: [
+    { text: "Synesius of Cyrene's On Dreams", book_id: "69a5e3d8006a4098422166a7" },
+    { text: "Hypnerotomachia Poliphili", book_id: "a7d82d02-1a76-4f5f-af99-339285a345f9" },
+    // Long-form variants first; short-form fallbacks after.
+    { text: "Synesius", book_id: "69a5e3d8006a4098422166a7" },
+    { text: "Hypnerotomachia", book_id: "a7d82d02-1a76-4f5f-af99-339285a345f9" },
+  ]
+}
+```
+
+Patch via `/api/collections` PATCH:
+```bash
+curl -sX PATCH "https://sourcelibrary.org/api/collections" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  -d @/tmp/mentions.json
+```
+
+### Ordering matters
+
+The matcher sorts `mentioned_books` longest-first to avoid sub-match collisions. So always list:
+1. **Most-specific phrases first** ("Author's Specific Work Title")
+2. **Then medium-specific** ("Author's Work")
+3. **Then short-form fallbacks** ("Title", "Author")
+
+A long-form claim ranges before a short-form, so subsequent occurrences of the short form only match unclaimed text spans.
+
+### Updating descriptions
+
+The PATCH endpoint accepts arbitrary update fields via `{ slug, addBookIds, ...updates }`. So this works:
+
+```bash
+curl -sX PATCH "https://sourcelibrary.org/api/collections" \
+  -d '{"slug":"my-collection","description":"...","mentioned_books":[...],"color":"gold"}'
+```
+
+When patching, the API echoes the full collection object including `description` (which may contain control characters that break `python3 -c 'json.load(...)'`). Use HTTP status (`curl -w '%{http_code}'`) instead of parsing the response body in shell scripts.
+
+### Audit existing collections
+
+```python
+# How many collections have populated mentioned_books?
+from pymongo import MongoClient; import os
+db = MongoClient(os.environ['MONGODB_URI'])['bookstore']
+print(db.collections.count_documents({'mentioned_books': {'$exists': True, '$ne': []}}))
+```
 
 ---
 

--- a/.claude/skills/curator/curatorreports.md
+++ b/.claude/skills/curator/curatorreports.md
@@ -1,0 +1,103 @@
+# Session 1: 2026-05-17 → 2026-05-18 — Mathematical Mysticism + Prehistory of AI
+
+A two-day curation marathon triggered by a conceptual question about mathematical mysticism, growing into a comprehensive comparative library of computational and proto-computational thought spanning 6,000 years and ~8 cultural traditions.
+
+## Final totals: **~117 books, ~38,000 pages**
+
+### Collections enriched
+- **south-asia, east-asia, mysticism, philosophy, natural-philosophy, sacred-texts**
+
+### Collections created
+- **prehistory-of-ai** (61 books, gold, rich linked description) — https://sourcelibrary.org/collections/prehistory-of-ai
+
+---
+
+## Strand 1 — Mathematical mysticism (11 books)
+Vedic geometry (Śulba Sūtras), Yoruba Ifá (Frobenius + Dennett + Farrow), Neo-Confucian numerology (Zhou Dunyi + Shao Yong slice), Ḥurūfī letter-mysticism (Huart + Astarābādī + Nesimi), Mesoamerican calendar codices (Landa + Sahagún context already in library).
+
+## Strand 2 — Non-Western Pythagoreanism (10 books)
+Thābit ibn Qurra Rasāʾil (Hyderabad Osmania) + Sphaerics + algebra treatise, Sima Qian Shiji (Qing 1884 photolithograph + Chavannes Vol III French), Lüshi Chunqiu (Wilhelm 1928 German), Huainanzi (Siku Quanshu juan 1-7 + Qian Tang commentary).
+
+## Strand 3 — Enumeration (18 books)
+Pali Abhidhamma core (Dhammasaṅgaṇī, Vibhaṅga, Tikapaṭṭhāna, Dukapaṭṭhāna, Yamaka, Atthasālinī), Aṅguttara Nikāya 5-vol PTS Pali + Index, Mesoamerican decipherment (Landa-Brasseur 1864, Motolinía 1858, Durán vols 1-2, Seler Codex Borgia, Förstemann Dresden).
+
+## Strand 4 — Pre-history of AI Western canon (14 books)
+Banū Mūsā Kitāb al-Ḥiyal, Pierre Grégoire Syntaxes Artis Mirabilis (1586), Leibniz De arte combinatoria (1666 FIRST edition), Dalgarno Ars Signorum (1661), Vaucanson FR+EN, Babbage Passages + Ninth Bridgewater + Menabrea + Lovelace (Sci Memoirs Vol III), Boole Mathematical Analysis + Laws of Thought, De Morgan Formal Logic, Jevons Substitution + Pure Logic.
+
+## Strand 5 — Schott & Baroque curiosa (5 books)
+Schott Technica Curiosa (1664, 1227pp) + Physica Curiosa vols 1+2 (1662), Schwenter/Harsdörffer Deliciae Physico-Mathematicae (1636), Ozanam Récréations (1735).
+
+## Strand 6 — Italian Baroque mechanics + cleanup (6 books)
+Taccola De ingeneis (1432-33 BNCF MS), Della Porta De Furtivis (1563 cryptography) + Phytognomonica (1589) + De Aeris Transmutationibus (1614), Biringuccio De la Pirotechnia (1550 first ed.), Llull Ars Brevis MS (c. 1490 Othmer MS 4).
+
+## Strand 7 — BSB MDZ imports (3 books)
+Cabeo Philosophia Magnetica (1629 bsb10860874), Lovelace's Scientific Memoirs Vol III (1843 IA scientificmemoir03memo), Bettini Apiaria Tomus I (1642 bsb11199743).
+
+## Strand 8 — Local PDF Google Books pipeline (10 books, ~5+ GB R2 blob)
+- Kircher Polygraphia Nova (1663) — Google Books `4_4KFFlnrEgC`
+- **Complete Salzinger Mainz Llull Opera Omnia (1721-1742) Tomi I-VI + IX-X** — 8 of 8 published volumes, all from Google Books (Národní knihovna ČR scans). Tomi VII-VIII were planned but never printed; the published canon is now complete.
+
+## Strand 9 — Shao Yong complete (25 juan = 25 books)
+Huangji Jingshi Shu fascicles 1-25 (Siku Quanshu IA `.cn` series 06071571-06071595).
+
+## Strand 10 — Manasara Shilpa Shastra (5 books)
+Acharya Sanskrit text + translation + illustrations + dictionary + Indian Architecture according to Manasara.
+
+## Strand 11 — Non-Western automata (5 books)
+- Karakuri Zui 機巧図彙 (1796 Hosokawa Hanzō) — Edo Japanese mechanical-doll manual
+- Samarāṅgaṇa Sūtradhāra of King Bhoja (GOS 1924-25, 2 vols) — Sanskrit yantras chapter 31
+- Bhojaprabandha of Ballāla (1900) — King Bhoja's mechanical guards legend
+- Resshi 列子 (1912 Japanese kanbun edition with Zhang Zhan commentary) — Yan Shi automaton
+
+## Strand 12 — Final stragglers via German oriental journals (2 books)
+- Der Islam vol 8 (1918, IA `derislam08berluoft`) — Wiedemann's German edition of al-Jazarī + Banū Mūsā cup/table automata treatises
+- Sitzungsberichte Erlangen Bd 39 (1907, IA `sitzungsbericht00erlagoog`) — Wiedemann's lamps + clocks article
+
+---
+
+## Added to "Prehistory of AI" collection from existing library holdings
+- Liezi 1615 Chinese vol 1 + vol 2 (Yan Shi automaton story)
+- Lionel Giles Liezi English 1912
+- Ibn Khaldūn Muqaddimah 1858 (Zairja chapter — combinatorial divination wheel that influenced Llull)
+- Qiqi Tushu 奇器圖說 (1627 Wang Zheng + Jesuit Schreck — Chinese-European mechanics fusion)
+- Baopuzi Neipian (Ge Hong Daoist alchemy)
+- Hermetic Asclepius 1170 MS + Pimander Corpus Hermeticum 1493 (Ficino)
+
+## Categorical gaps that remain
+
+| Item | Reason | Workaround |
+|---|---|---|
+| **Bettini Aerarii T2** (Bologna 1648) | IA scan structurally corrupted (no PDF trailer); only the corrupted copy exists openly; Wellcome physical-only | Tomus I covers same project; request Wellcome digitization |
+| **Lokapaññatti** (Pali Mauryan automata legend) | Denis 1977 EFEO edition still copyrighted; no open Burmese-script edition | Strong 1983 *Legend of King Asoka* discusses the yantakāra story (secondary lit) |
+| **Maupoil 1943** *La géomancie* | PD in France since 2015 but only accessible behind JS-rendered French academic catalogs (IRD Horizon, Persée, HAL — all Anubis/CAPTCHA-protected) | Manual browser hunt by user |
+| **al-Jazarī as compilation** | Wiedemann/Hauser articles scattered 1908-1920; 1970 Olms compilation copyrighted | ✅ Indirectly solved: Wiedemann's individual 1918 + 1907 articles imported (Der Islam + Sitzungsberichte Erlangen) |
+| **Su Song *Xinyi Xiangfayao*** (1092) | Only text-only transcription on ctext.org / Chinese Wikisource | Cite externally |
+| **Pre-1900 Chinese Lüshi Chunqiu** | Not on IA/BSB/HathiTrust | Wilhelm 1928 German complete translation already in library |
+| **Topkapi al-Jazarī manuscript** | Gated behind Turkish institutional login | — |
+
+## Pipeline status
+OCR (Hetzner, Gemini 3 flash + flash-lite by tenant), translation, image extraction, summary generation, collection auto-assignment — all running automatically. The full 117-book corpus will be readable + translated + searchable within 24-72 hours.
+
+## Temp scripts created this session (all gitignored, `_tmp-` prefix)
+- _tmp-batch-import-math-mysticism.mjs
+- _tmp-batch-import-pythagorean-east.mjs
+- _tmp-batch-import-enumeration-tier1.mjs
+- _tmp-batch-import-early-ai.mjs
+- _tmp-batch-import-curiosa.mjs
+- _tmp-batch-import-italian-baroque.mjs
+- _tmp-batch-import-cleanup.mjs
+- _tmp-batch-import-final.mjs
+- _tmp-import-googles-batch.mjs
+- _tmp-import-salzinger-2-3.mjs
+- _tmp-import-salzinger-4-9-bettini3.mjs
+- _tmp-import-salzinger-final-3.mjs
+- _tmp-import-salzinger-5.mjs
+- _tmp-batch-import-ia-gaps.mjs
+- _tmp-shaoyong-continuation.mjs
+- _tmp-create-ai-collection.mjs
+- _tmp-update-ai-collection-desc.mjs
+- _tmp-update-ai-desc-v2.mjs
+- _tmp-import-bettini-t2.mjs
+- _tmp-import-bettini-t2-local.mjs
+- _tmp-batch-nonwestern-automata.mjs
+- _tmp-batch-stragglers.mjs


### PR DESCRIPTION
## Summary

- Document the collection-page renderer's behavior (plain text + `\n\n` paragraphs + 8-char-min title auto-link + explicit `mentioned_books` override) — what tripped me up this session was treating it as Markdown-aware
- Capture production-tested PDF pipeline settings (concurrency=3 + 4-6 attempt retry, 30-90 min pdftoppm timeouts, byte-exact download check, unrepairable-IA-PDF handling, Google Books → IA mirror precheck)
- Update top-level collection list (~36 slugs, was stale at 22) and add direct-Mongo query for the full 344 incl. sub-collections
- Add session log `curatorreports.md` documenting 117 imports across math mysticism, non-Western Pythagoreanism, enumerative traditions, prehistory of AI, Schott curiosa, Italian Baroque mechanics, the complete Salzinger Llull *Opera Omnia* (Mainz 1721–1742), Manasara Shilpa Shastra, non-Western automata legends (Liezi, Karakuri Zui, Samarāṅgaṇa Sūtradhāra, Bhojaprabandha), and Wiedemann's *Der Islam* + Sitzungsberichte Erlangen al-Jazarī/Banū Mūsā articles

## Test plan

- [ ] `cat .claude/skills/curator/SKILL.md` — sections render cleanly, no syntax errors
- [ ] Visit https://sourcelibrary.org/collections/prehistory-of-ai — verify rich linked description renders (`mentioned_books` working)
- [ ] Visit any sub-collection (e.g. /collections/sleep-and-dreams, /collections/daoist-alchemy) — verify literal `*asterisks*` are gone and book references are clickable links

No code paths touched. Documentation/skill-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)