### PR TITLE
Fix tenant leak in Contributing Libraries panel

### DIFF
--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -351,26 +351,24 @@ async function fetchTenantLibraryDataUncached(
     } catch { /* Gallery is optional */ }
   }
 
-  // Contributing libraries (for tenant diversity insight)
-  // Query books visible from any provider in this tenant
-  const { data: contribData } = await supabase
-    .from('books_catalog')
-    .select('contributing_library')
-    .eq('visible', true)
-    .gt('pages_count', 0)
-    .gt('pages_translated', 0)
-    .not('contributing_library', 'is', null);
+  // Contributing libraries — query MongoDB scoped to this tenant.
+  // Supabase books_catalog has no tenant_id column (see tenant-browse.ts),
+  // so the previous Supabase path returned global counts and leaked
+  // unrelated institutions onto tenant subdomains.
+  const contribAgg = await db.collection('books').aggregate<{ _id: string; count: number }>([
+    { $match: {
+        tenantId,
+        visible: true,
+        pages_count: { $gt: 0 },
+        pages_translated: { $gt: 0 },
+        'image_source.contributing_library': { $exists: true, $nin: [null, ''] },
+    }},
+    { $group: { _id: '$image_source.contributing_library', count: { $sum: 1 } } },
+    { $sort: { count: -1 } },
+    { $limit: 20 },
+  ]).toArray();
 
-  const contribCounts = new Map<string, number>();
-  for (const row of (contribData || [])) {
-    if (row.contributing_library) {
-      contribCounts.set(row.contributing_library, (contribCounts.get(row.contributing_library) || 0) + 1);
-    }
-  }
-  const contributingLibraries = [...contribCounts.entries()]
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 20);
+  const contributingLibraries = contribAgg.map(row => ({ name: row._id, count: row.count }));
 
   return {
     books: booksResult.books,


### PR DESCRIPTION
## Problem
On `kloss.sourcelibrary.org`, the "Contributing Libraries" panel was showing institutions that don't contribute to the Kloss collection — ETCSL (Sumerian), ORAEC (Egyptian), Cuneiform Digital Library Initiative, etc. with counts in the hundreds. Same bug would surface on any future tenant subdomain.

## Root cause
`fetchTenantLibraryData()` in `src/lib/tenant-library-loaders.ts` queried Supabase `books_catalog` for `contributing_library` with no tenant filter. The comment claimed it was scoped "in this tenant" but the code wasn't. Supabase `books_catalog` has no `tenant_id` column (already documented in `tenant-browse.ts`), so the result was global.

## Fix
Replace the Supabase query with a tenant-scoped MongoDB aggregation over `books.image_source.contributing_library`, matching `{ tenantId, visible: true, pages_count > 0, pages_translated > 0 }`. Drops 20 lines of map/sort/slice plumbing into a single aggregation.

## Verified against production data
- Kloss → 1 contributor: "CMC Prins Frederik — Bibliotheca Klossiana (The Hague)" with 261 books
- BPH → 4 contributors: EFM (1153) + 3 British Library variants (panel is suppressed for BPH via `!isBph`, but the data is correct)

## Test plan
- [ ] Vercel preview renders `kloss.sourcelibrary.org` with only "CMC Prins Frederik" chip
- [ ] BPH unaffected (panel suppressed regardless)
- [ ] Type-check passes (`npx tsc --noEmit` clean locally)

## Followups (separate)
This was caught by a manual screenshot. A generic `scripts/audit-tenant-leaks.mjs` covering Contributing Libraries, related-editions, gallery, and the embed-policy flags would catch the next one earlier — tracked as a follow-up in `.claude/docs/multitenant-current-state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)