### PR TITLE
fix(feedback): prevent submit button overflow on mobile

### DIFF
--- a/src/components/feedback/FeedbackWidget.tsx
+++ b/src/components/feedback/FeedbackWidget.tsx
@@ -120,14 +120,14 @@ export default function FeedbackWidget({ className, style, initialMessage, label
               />
             )}
 
-            <div className="flex items-center justify-between mt-4">
-              <p className="text-xs text-stone-400">
+            <div className="flex items-center justify-between gap-3 mt-4">
+              <p className="text-xs text-stone-400 truncate min-w-0 flex-1">
                 Sent from {typeof window !== 'undefined' ? window.location.pathname : '/'}
               </p>
               <button
                 onClick={submit}
                 disabled={!message.trim() || status === 'sending' || needsEmailForVolunteer}
-                className="px-4 py-2 bg-stone-800 hover:bg-stone-700 text-white text-sm font-medium rounded-lg disabled:opacity-50 transition-colors"
+                className="flex-shrink-0 px-4 py-2 bg-stone-800 hover:bg-stone-700 text-white text-sm font-medium rounded-lg disabled:opacity-50 transition-colors"
               >
                 {status === 'sending' ? 'Sending...' : status === 'error' ? 'Try again' : 'Send'}
               </button>


### PR DESCRIPTION
## Summary
- The footer feedback modal's bottom row showed the full page path next to the Send button without truncation. Long paths like `/bph/book/<id>/page/<id>` have no spaces, so the flex row grew wider than the modal on narrow viewports and pushed Send off-screen — users had to horizontally scroll to submit.
- Make the path `truncate min-w-0 flex-1` and pin the button with `flex-shrink-0` plus a `gap-3` between them.

Reported via the in-app feedback widget itself: *"Can't see submit button without horizontal scroll on submit feedback"*.

## Test plan
- [x] Preview deploy at 375×667 (iPhone SE width) on `/book/<long-id>/page/<long-id>` — opened footer **Give Feedback**, modal shows truncated path + visible Send button, no horizontal scroll.
- [ ] Sanity check on desktop after merge — long path should still display, just no longer overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)