### PR TITLE
feat(reader): add "Open original" button for native mobile pinch-zoom

### DIFF
--- a/src/components/reader/FullscreenImageViewer.tsx
+++ b/src/components/reader/FullscreenImageViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { X, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
+import { X, ZoomIn, ZoomOut, RotateCcw, ExternalLink } from 'lucide-react';
 import { BookLoader } from '@/components/ui/BookLoader';
 
 interface FullscreenImageViewerProps {
@@ -295,12 +295,24 @@ export default function FullscreenImageViewer({ src, alt, isOpen, onClose }: Ful
             </button>
           )}
         </div>
-        <button
-          onClick={onClose}
-          className="p-2 rounded-full bg-white/10 hover:bg-white/20 transition-all"
-        >
-          <X className="w-6 h-6 text-white" />
-        </button>
+        <div className="flex items-center gap-2">
+          <a
+            href={src}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2 rounded-full bg-white/10 hover:bg-white/20 transition-all"
+            title="Open original image (for full pinch-zoom)"
+            aria-label="Open original image in new tab"
+          >
+            <ExternalLink className="w-5 h-5 text-white" />
+          </a>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full bg-white/10 hover:bg-white/20 transition-all"
+          >
+            <X className="w-6 h-6 text-white" />
+          </button>
+        </div>
       </div>
 
       {/* Image container */}


### PR DESCRIPTION
## Summary
- Mobile feedback on *Museum Wormianum*: *"It's hard to zoom in on papers on mobile. Maybe could just open image so you can zoom in normally?"*
- The in-app `FullscreenImageViewer` caps pinch-zoom at 5x, which on high-DPI scans (e.g. 3000×2423px Wormianum plates) isn't enough to read fine detail.
- Adds an external-link icon in the viewer header. Tap it to open the raw image in a new browser tab, where the OS-native pinch-zoom has no practical ceiling.
- Keeps the existing in-app pinch/double-tap/pan UX for the common case; just adds an escape hatch for deep zoom.

## Test plan
- [x] Preview at 390×844 (iPhone 12 width) on `/book/.../page/...` (Museum Wormianum, p.28) — tap source image, fullscreen opens, new external-link icon visible next to close, link target is the raw image URL.
- [x] Type-check passes.
- [ ] Sanity check on real mobile after merge: tap "Open original" → new tab opens raw JPG → native pinch-zoom reaches full image resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)