### PR TITLE
Fix book_read tracking + view-count display on /book/ URLs

### DIFF
--- a/src/components/book/BookAnalytics.tsx
+++ b/src/components/book/BookAnalytics.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Eye, Edit3 } from 'lucide-react';
 import { analytics } from '@/lib/api-client';
+import { getTenantSlug } from '@/lib/api-client/client';
 
 interface BookAnalyticsProps {
   bookId: string;
@@ -18,12 +19,12 @@ export default function BookAnalytics({ bookId, className }: BookAnalyticsProps)
   const [stats, setStats] = useState<BookStats | null>(null);
 
   useEffect(() => {
-    // Track the read (fire-and-forget via sendBeacon to avoid blocking hydration)
+    // Track the read (fire-and-forget via sendBeacon to avoid blocking hydration).
+    // Use the same tenant inference as the api-client; fall back to the non-tenant
+    // route, which resolves tenant from proxy-injected host headers.
     try {
-      const tenant = window.location.pathname.split('/')[1] || '';
-      const trackPath = /^[a-z0-9-]+$/.test(tenant)
-        ? `/api/${tenant}/analytics/track`
-        : '/api/analytics/track';
+      const tenant = getTenantSlug();
+      const trackPath = tenant ? `/api/${tenant}/analytics/track` : '/api/analytics/track';
       const blob = new Blob([JSON.stringify({ event: 'book_read', book_id: bookId })], { type: 'application/json' });
       navigator.sendBeacon(trackPath, blob);
     } catch { /* ignore */ }

--- a/src/lib/api-client/analytics.ts
+++ b/src/lib/api-client/analytics.ts
@@ -22,7 +22,8 @@ export const analytics = {
    */
   stats: async (book_id?: string): Promise<AnalyticsStats> => {
     const tenant = getTenantSlug();
-    const url = book_id ? `/api/${tenant}/analytics/stats?book_id=${book_id}` : `/api/${tenant}/analytics/stats`;
+    const prefix = tenant ? `/api/${tenant}` : '/api';
+    const url = book_id ? `${prefix}/analytics/stats?book_id=${book_id}` : `${prefix}/analytics/stats`;
     return await apiClient.get(url);
   },
 
@@ -79,7 +80,8 @@ export const analytics = {
     page_id?: string;
   }): Promise<{ success: boolean; deduplicated?: boolean }> => {
     const tenant = getTenantSlug();
-    return await apiClient.post(`/api/${tenant}/analytics/track`, data);
+    const url = tenant ? `/api/${tenant}/analytics/track` : '/api/analytics/track';
+    return await apiClient.post(url, data);
   },
 
   /**


### PR DESCRIPTION
## Summary
- `BookAnalytics` rolled its own tenant inference (`pathname.split('/')[1]`). After #1604 stripped the tenant prefix from book URLs (2026-05-04), the call became `/api/book/analytics/track` → 400 → no `book_read` events recorded.
- Switch to the api-client's `getTenantSlug()` (already patched in #1630 to handle `NON_TENANT_SEGMENTS`) and fall back to the non-tenant `/api/analytics/track` route, which derives tenant from proxy-injected host headers.
- Same fix applied to `analytics.stats` and `analytics.track` in `src/lib/api-client/analytics.ts` to avoid emitting `/api//analytics/...` double-slash URLs that 308-redirect.

## Evidence of the regression
- Globally over the past 7 days: **14,809 `page_read`** events vs **1 `book_read`** event.
- `'t Nieuwe Jerusalem`: last `book_read` event was 2026-05-04 — the day #1604 shipped. `read_count` stuck at 18.
- BPH subdomain showed `reads: 18` correctly (host-based tenant resolution); the main domain showed `reads: 0` because the request had no tenant context.

## Test plan
- [ ] Visit a book page on `bph.sourcelibrary.org` — confirm `POST /api/bph/analytics/track` (200) fires in the Network panel.
- [ ] Confirm view count renders (no longer shows "0" for a book that has prior reads).
- [ ] Tail `analytics_events`: new `book_read` documents with the correct `tenantId` appear after a visit.
- [ ] `read_count` on the books document increments after a fresh visit (no IP-dedup hit within 1h).
- [ ] No double-slash URLs in Network: `/api//analytics/...` should not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)