### PR TITLE
Fix: show editor UI to tenant editors on tenant subdomains

### DIFF
--- a/src/app/embed/[tenant]/layout.tsx
+++ b/src/app/embed/[tenant]/layout.tsx
@@ -1,0 +1,26 @@
+import { TenantSessionUpdater } from '@/components/auth/TenantSessionUpdater';
+
+/**
+ * Layout for /embed/[tenant]/* — the route group that tenant subdomains
+ * (e.g. bph.sourcelibrary.org) get rewritten to by src/proxy.ts.
+ *
+ * Mirrors src/app/[tenant]/layout.tsx in mounting TenantSessionUpdater so
+ * the user's tenant-scoped role (e.g. BPH editor) is resolved into their
+ * session. Without this, client gates like <AuthCheck role="inner_circle">
+ * never see the membership and editor-only UI stays hidden.
+ */
+export default async function EmbedTenantLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ tenant: string }>;
+}) {
+  const { tenant } = await params;
+  return (
+    <>
+      <TenantSessionUpdater tenantSlug={tenant} />
+      {children}
+    </>
+  );
+}

--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -9,13 +9,28 @@ interface AuthCheckProps {
   role?: 'admin' | 'inner_circle' | 'reader';
 }
 
+// Mirrors ROLE_LEVEL in src/lib/auth.ts, with legacy aliases (inner_circle, curator)
+// kept so older sessions/tokens still resolve.
+const ROLE_LEVEL: Record<string, number> = {
+  reader: 1,
+  inner_circle: 2,
+  curator: 2,
+  editor: 2,
+  admin: 3,
+  superadmin: 4,
+};
+
 /**
  * Client component that conditionally renders children based on auth status and role.
  *
+ * Effective role = max(global session role, tenant membership role). This lets a
+ * user who is only a `reader` globally but an `editor` on the BPH tenant see
+ * editor-gated UI when browsing under that tenant.
+ *
  * @example
  * <AuthCheck>                      // Any logged-in user
- * <AuthCheck role="inner_circle">  // Admin or inner circle
- * <AuthCheck role="admin">         // Admin-only (whitelist)
+ * <AuthCheck role="inner_circle">  // Editor or above (globally or on the current tenant)
+ * <AuthCheck role="admin">         // Admin or above
  */
 export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
   const { data: session, status } = useStableSession();
@@ -31,15 +46,16 @@ export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
     return <>{fallback}</>;
   }
 
-  const userRole = (session.user as any).role;
-  const ROLE_LEVEL: Record<string, number> = { reader: 1, inner_circle: 2, editor: 2, admin: 3, superadmin: 4 };
-  const level = ROLE_LEVEL[userRole] ?? 0;
+  const user = session.user as any;
+  const globalLevel = ROLE_LEVEL[user.role] ?? 0;
+  const tenantLevel = ROLE_LEVEL[user.tenantRole] ?? 0;
+  const level = Math.max(globalLevel, tenantLevel);
 
-  if (role === 'admin' && level < 3) {
+  if (role === 'admin' && level < ROLE_LEVEL.admin) {
     return <>{fallback}</>;
   }
 
-  if (role === 'inner_circle' && level < 2) {
+  if (role === 'inner_circle' && level < ROLE_LEVEL.editor) {
     return <>{fallback}</>;
   }
 


### PR DESCRIPTION
## Summary

- Tenant editors (Jose, Paul on BPH) weren't seeing edit buttons on bph.sourcelibrary.org because the embed routes never resolved their tenant-scoped role and `AuthCheck` only looked at the global session role.
- Adds `/embed/[tenant]/layout.tsx` mirroring `[tenant]/layout.tsx` so `TenantSessionUpdater` fires on tenant subdomain traffic.
- `AuthCheck` now uses effective role = max(global role, tenant role), matching the server-side `withAuth` helper in `auth-helpers.ts`.

## Test plan

- [ ] Sign in to bph.sourcelibrary.org as jbouman@efm.amsterdam.
- [ ] Open any BPH book page — confirm cover image is clickable (opens `CoverImagePicker`).
- [ ] Confirm "Edit" button appears next to "Bibliographic Info".
- [ ] Open the page reader for any page — confirm "Set as Cover" appears and the translation/OCR edit toggle is visible.
- [ ] Verify a logged-out visitor on bph.sourcelibrary.org still sees the static cover (fallback) with no edit affordances.
- [ ] Verify the same user on sourcelibrary.org (main site, no tenant context) does NOT see the editor UI (BPH editor scope is correctly limited to the BPH subdomain).