### PR TITLE
fix(api): unbreak page reader on the main domain

### DIFF
--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
-import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { anonymizeIp } from '@/lib/anonymize-ip';
 
 /**
@@ -20,14 +19,10 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { event, book_id, page_id } = body;
-    const { id: tenantId } = getTenantContextFromRequest(request);
 
-    if (!tenantId) {
-      return NextResponse.json(
-        { error: 'Tenant not found' },
-        { status: 400 }
-      );
-    }
+    // No tenantId check: the events written below don't carry a tenant field
+    // anyway, and counter updates are keyed by book/page id alone. Requiring
+    // one just broke tracking on the global main domain.
 
     if (!event || !book_id) {
       return NextResponse.json(

--- a/src/app/api/pages/[id]/route.ts
+++ b/src/app/api/pages/[id]/route.ts
@@ -40,17 +40,21 @@ export async function GET(
     const db = await getDb();
     const { id: tenantId } = getTenantContextFromRequest(request);
 
-    if (!tenantId) {
-      return NextResponse.json({ error: 'Page not found' }, { status: 404 });
-    }
-
     const { searchParams } = new URL(request.url);
     const full = searchParams.get('full') === 'true';
 
     // Default: exclude detected_images (large array unused by the reader)
     const projection = full ? undefined : { detected_images: 0 };
+
+    // Tenant subdomains and /[tenant]/... paths get tenantId injected by the
+    // proxy and stay tenant-scoped. Calls from the global main domain (e.g.
+    // sourcelibrary.org/book/... prefetching adjacent pages) arrive with no
+    // tenantId — those are allowed to read globally.
+    const filter: Record<string, unknown> = { id };
+    if (tenantId) filter.tenantId = tenantId;
+
     let page = await db.collection('pages').findOne(
-      { id, tenantId },
+      filter,
       projection ? { projection } : undefined
     );
 
@@ -58,8 +62,10 @@ export async function GET(
     if (!page) {
       const { ObjectId } = await import('mongodb');
       if (ObjectId.isValid(id)) {
+        const oidFilter: Record<string, unknown> = { _id: new ObjectId(id) };
+        if (tenantId) oidFilter.tenantId = tenantId;
         page = await db.collection('pages').findOne(
-          { _id: new ObjectId(id), tenantId },
+          oidFilter,
           projection ? { projection } : undefined
         );
       }

--- a/src/app/api/pages/batch/route.ts
+++ b/src/app/api/pages/batch/route.ts
@@ -20,10 +20,6 @@ export async function POST(request: NextRequest) {
     const ids: string[] = body.ids;
     const { id: tenantId } = getTenantContextFromRequest(request);
 
-    if (!tenantId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
-    }
-
     if (!Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json({ error: 'ids array is required' }, { status: 400 });
     }
@@ -31,9 +27,16 @@ export async function POST(request: NextRequest) {
     // Cap at 20 pages per request
     const limitedIds = ids.slice(0, 20);
 
+    // Tenant subdomains and /[tenant]/... paths get tenantId injected by the
+    // proxy and stay tenant-scoped. Calls from the global main domain arrive
+    // with no tenantId — those are allowed to read globally (same semantics
+    // as the unscoped GET /api/pages/[id] route).
+    const filter: Record<string, unknown> = { id: { $in: limitedIds } };
+    if (tenantId) filter.tenantId = tenantId;
+
     const db = await getDb();
     const pages = await db.collection('pages').find(
-      { id: { $in: limitedIds }, tenantId },
+      filter,
       { projection: { detected_images: 0 } }
     ).toArray();
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 import { LoadingMetric } from './api-client/types';
 import { analytics } from './api-client';
+import { getTenantSlugFromPathname } from './api-client/client';
 
 /**
  * Loading Analytics - Track and record loading performance metrics
@@ -30,8 +31,11 @@ const config = {
 
 function getTenantSlug(): string {
   if (typeof window === 'undefined') return '';
-  const slug = window.location.pathname.split('/')[1] || '';
-  return /^[a-z0-9-]+$/.test(slug) ? slug : '';
+  // Use the canonical resolver — it excludes root segments like /book and
+  // /gallery that aren't tenants. The previous local version returned 'book'
+  // for /book/... URLs, causing requests to /api/book/analytics/loading
+  // (a route that doesn't exist) and "Tenant not found" 400s.
+  return getTenantSlugFromPathname(window.location.pathname) ?? '';
 }
 
 function getLoadingEndpoint(): string {

--- a/src/lib/api-client/client.ts
+++ b/src/lib/api-client/client.ts
@@ -53,6 +53,13 @@ export const apiClient: AxiosInstance = axios.create({
 // TODO: Robust system for setting headers based on auth state, tenant, etc.
 apiClient.interceptors.request.use(
   (config) => {
+    // Collapse `/api//foo` to `/api/foo`. Callers that interpolate an empty
+    // tenant slug (e.g. `/api/${tenant}/pages/...` on the global main domain)
+    // would otherwise force a 308 redirect on every request.
+    if (config.url) {
+      config.url = config.url.replace(/^(\/api)\/+/, '$1/');
+    }
+
     // Add auth token if available
     const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
     if (token) {


### PR DESCRIPTION
## Summary
Three compounding bugs caused 308+404 cascades on every adjacent-page prefetch when reading any book on the global `sourcelibrary.org` domain. Surfaced via user feedback *"no se puede cargar el editor de paginas"* on a Leiden book.

1. **api-client interceptor** — `pages.ts` and friends interpolate the tenant slug as `` `/api/${tenant}/...` ``. On main-domain reader URLs (`/book/...`) `getTenantSlug()` returns `''` and the URL becomes `/api//pages/...` — forcing a 308 redirect on every request. Collapse `/api//+` to `/api/` in the request interceptor so callers don't need fixing one by one.
2. **`/api/pages/[id]` and `/api/pages/batch`** — both required `tenantId` from headers and returned 404/403 otherwise. The proxy reliably injects the tenant header on tenant subdomains and `/[tenant]/...` paths, so filtering still applies there. Calls from the global main domain genuinely have no tenant context — global access is the correct semantic. Filter conditionally on `tenantId` instead of rejecting.
3. **`lib/analytics.ts` loading metrics** — its local `getTenantSlug()` didn't exclude root segments like `book`, so on `/book/...` pages it returned `'book'` as the tenant, producing `POST /api/book/analytics/loading` and a 400 "Tenant not found". Reuse `getTenantSlugFromPathname` from api-client which has the correct exclusion list.
4. **`/api/analytics/track`** — same guard pattern, 400 on main domain. Removed; events don't carry a tenant field anyway and counters are keyed by id.

## Test plan
- [x] Type-check passes.
- [x] Preview at https://sourcelibrary-v2-1lvd4mqg2-dereklomas-projects.vercel.app/leiden/book/... → `/api/pages/batch` returns 200 (was 403), zero `/api//*` redirects, zero `/api/pages/[id]` 404s, zero "Tenant not found" errors. Console errors went from 16 to 1.
- [ ] After the analytics/track follow-up commit lands: re-verify all console errors are gone.
- [ ] Sanity check on BPH subdomain after merge: still tenant-scoped filtering since proxy header is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)