### PR TITLE
Hide Contributing Libraries panel for single-institution tenants

### DIFF
--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -297,8 +297,12 @@ export default function SharedLibraryView({
         </div>
       )}
 
-      {/* Contributing Libraries (for IA and similar aggregators — hide for BPH since it IS the library) */}
-      {contributingLibraries.length > 0 && !isBph && (
+      {/* Contributing Libraries — only meaningful for aggregator tenants
+          (Internet Archive, Gallica, etc). Single-institution tenants (BPH,
+          Kloss, future partners) get an "Institution + Unknown" pair that
+          adds noise without insight. Show only when there are >=3 distinct
+          contributors. */}
+      {contributingLibraries.length >= 3 && !isBph && (
         <div className="bg-warm border-b border-border-light">
           <div className="max-w-7xl mx-auto px-6 py-6">
             <div className="flex items-center gap-2 mb-4">


### PR DESCRIPTION
## Problem
On `kloss.sourcelibrary.org` the Contributing Libraries panel renders just two chips: "CMC Prins Frederik" (281) and "Unknown" (23). The panel was designed for aggregator tenants like Internet Archive where many institutions contribute; for a single-institution collection it adds noise without insight.

## Fix
Show the panel only when there are 3+ distinct contributors. Single-institution tenants (BPH, Kloss, future) get hidden automatically. The existing `!isBph` check stays as belt-and-suspenders.

## Verified
- Kloss panel: hidden (2 contributors)
- BPH: panel was already hidden via `!isBph`, unaffected
- Internet Archive / Gallica / aggregator tenants: panel still renders when 3+ contributors exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)