### PR TITLE
fix: prevent ORAEC import orphans + propagate hides to Supabase

### DIFF
--- a/scripts/import/import-oraec.mjs
+++ b/scripts/import/import-oraec.mjs
@@ -297,10 +297,37 @@ async function main() {
       continue;
     }
 
+    // Atomic-by-construction: insert page FIRST, then book.
+    // If the page insert fails, no book is created (no orphan with 0 pages).
+    // If the book insert fails after the page is in, the orphan page is harmless
+    // (no book references it) and gets cleaned up by the standard page sweeper.
+    // We also defensively roll back if the book insert fails.
+    const bookId = new ObjectId();
+    const bookIdStr = bookId.toHexString();
+    const pageId = new ObjectId();
+
     try {
-      const bookId = new ObjectId();
-      const bookIdStr = bookId.toHexString();
       const slug = await generateSlug(db, title);
+
+      const pageDoc = {
+        _id: pageId,
+        id: pageId.toHexString(),
+        tenant_id: 'default',
+        book_id: bookIdStr,
+        page_number: 1,
+        photo: null,
+        thumbnail: null,
+        ocr: { data: ocrText, model: 'oraec-corpus', updated_at: new Date() },
+        translation: {
+          data: translationText,
+          model: 'oraec-corpus-de',
+          language: 'de',
+          updated_at: new Date(),
+        },
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+      await db.collection('pages').insertOne(pageDoc);
 
       const bookDoc = {
         _id: bookId,
@@ -335,7 +362,6 @@ async function main() {
           author: { source: 'oraec', method: 'import', confidence: 0.8, date: new Date() },
           language: { source: 'oraec', method: 'import', confidence: 1.0, date: new Date() },
         },
-        // ORAEC metadata
         oraec_id: oraecId,
         oraec_object_type: objectType,
         oraec_period: period,
@@ -360,35 +386,13 @@ async function main() {
         updated_at: new Date(),
       };
 
-      await db.collection('books').insertOne(bookDoc);
-
-      // Create single page with OCR + translation
-      const pageId = new ObjectId();
-      const pageDoc = {
-        _id: pageId,
-        id: pageId.toHexString(),
-        tenant_id: 'default',
-        book_id: bookIdStr,
-        page_number: 1,
-        // No photo — these are text-only digital editions
-        photo: null,
-        thumbnail: null,
-        ocr: {
-          data: ocrText,
-          model: 'oraec-corpus',
-          updated_at: new Date(),
-        },
-        translation: {
-          data: translationText,
-          model: 'oraec-corpus-de',
-          language: 'de',
-          updated_at: new Date(),
-        },
-        created_at: new Date(),
-        updated_at: new Date(),
-      };
-
-      await db.collection('pages').insertOne(pageDoc);
+      try {
+        await db.collection('books').insertOne(bookDoc);
+      } catch (bookErr) {
+        // Roll back the orphan page so we don't litter the pages collection
+        await db.collection('pages').deleteOne({ _id: pageId }).catch(() => {});
+        throw bookErr;
+      }
 
       imported++;
       totalSentences += contentSentences.length;

--- a/scripts/import/oraec-paginate-translate.mjs
+++ b/scripts/import/oraec-paginate-translate.mjs
@@ -108,8 +108,14 @@ async function processBook(db, bookId) {
     return;
   }
 
-  // Delete the old single page
-  await db.collection('pages').deleteOne({ _id: sourcePage._id });
+  // Park the old single page on a temp book_id so the new pages can use page_number: 1,2,...
+  // The book remains pointing at the new pages by book_id. We delete the parked page only
+  // after the new pages are fully written — this prevents a 0-pages book if we crash.
+  const tempBookId = `__paginate_temp_${bid}_${Date.now()}`;
+  await db.collection('pages').updateOne(
+    { _id: sourcePage._id },
+    { $set: { book_id: tempBookId } }
+  );
 
   // Create new pages with English translation
   let totalTranslated = 0;
@@ -163,6 +169,9 @@ async function processBook(db, bookId) {
     process.stdout.write(`  [${pageNum}/${numPages}] sentences ${start + 1}-${end} ✓\n`);
   }
 
+  // Now that new pages are written, delete the parked old page.
+  await db.collection('pages').deleteOne({ _id: sourcePage._id });
+
   // Update book counts
   await db.collection('books').updateOne(
     { _id: book._id },
@@ -178,11 +187,24 @@ async function processBook(db, bookId) {
   console.log(`  Done: ${numPages} pages, ${totalTranslated} sentences translated to English`);
 }
 
+async function sweepStaleTempPages(db) {
+  // Clean up pages parked on temp book_ids from crashed prior runs.
+  const sweep = await db.collection('pages').deleteMany(
+    { book_id: { $regex: /^__paginate_temp_/ } }
+  );
+  if (sweep.deletedCount > 0) {
+    console.log(`Swept ${sweep.deletedCount} stale paginate-temp pages from prior crashes`);
+  }
+}
+
 async function main() {
   const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 30000 });
   await client.connect();
   const db = client.db('bookstore');
   console.log('Connected to MongoDB');
+
+  // Clean up any temp pages left from prior crashed runs before starting.
+  await sweepStaleTempPages(db);
 
   if (BOOK_ID) {
     await processBook(db, BOOK_ID);

--- a/scripts/workers/sync-books-catalog.mjs
+++ b/scripts/workers/sync-books-catalog.mjs
@@ -122,15 +122,21 @@ const mongoClient = new MongoClient(MONGODB_URI, { maxPoolSize: 2 });
 await mongoClient.connect();
 const db = mongoClient.db('bookstore');
 
-// Sync all visible books (not just those with pages) — browse/language pages need all of them
-let query = { visible: true };
+// Sync books to Supabase.
+//   FULL_MODE: only visible books (cleanup handles the rest)
+//   incremental: any book changed since last sync, regardless of visibility,
+//                so hides propagate (transformBook writes visible:false)
+let query;
 
-if (!FULL_MODE) {
+if (FULL_MODE) {
+  query = { visible: true };
+} else {
   const lastSync = await getLastSyncTime();
   if (lastSync) {
-    query.updated_at = { $gt: lastSync };
-    console.log(`Incremental from: ${lastSync.toISOString()}`);
+    query = { updated_at: { $gt: lastSync } };
+    console.log(`Incremental from: ${lastSync.toISOString()} (visibility changes included)`);
   } else {
+    query = { visible: true };
     console.log('No existing data — doing full sync');
   }
 }
@@ -224,20 +230,43 @@ if (FULL_MODE && synced > 0) {
       if (data.length < 1000) break;
     }
 
+    // Split stale into HIDE (exists in Mongo but visible:false) vs DELETE (no Mongo record).
+    // The incremental sync handles hides, but full-mode also enforces parity for any rows
+    // it might have missed (e.g., a hide that happened during the sync window).
     const stale = sbIds.filter(id => !visibleIds.has(id));
+    const mongoStaleDocs = stale.length > 0
+      ? await db.collection('books').find(
+          { id: { $in: stale } },
+          { projection: { id: 1 } }
+        ).toArray()
+      : [];
+    const mongoStaleSet = new Set(mongoStaleDocs.map(d => d.id));
+    const toHide = stale.filter(id => mongoStaleSet.has(id));
+    const toDelete = stale.filter(id => !mongoStaleSet.has(id));
 
-    // Safety cap: never delete more than 50 rows or 1% of Supabase total
-    const maxDelete = Math.max(50, Math.floor(sbIds.length * 0.01));
-    if (stale.length > maxDelete) {
-      console.warn(`[${new Date().toISOString()}] books_catalog: SKIPPING cleanup — ${stale.length} stale rows exceeds safety cap of ${maxDelete}. Investigate before running manually.`);
-    } else if (stale.length > 0) {
+    // Safety cap on DELETE only: hides are non-destructive (row preserved, visible flipped).
+    // Cap is max(100, 5% of Supabase total) — generous enough to keep up with routine churn.
+    const maxDelete = Math.max(100, Math.floor(sbIds.length * 0.05));
+    if (toDelete.length > maxDelete) {
+      console.warn(`[${new Date().toISOString()}] books_catalog: SKIPPING delete — ${toDelete.length} truly-orphaned rows exceeds safety cap of ${maxDelete}. Investigate before running scripts/output/_tmp-supabase-drift-cleanup.mjs manually.`);
+    } else if (toDelete.length > 0) {
       let deleted = 0;
-      for (let i = 0; i < stale.length; i += 100) {
-        const batch = stale.slice(i, i + 100);
+      for (let i = 0; i < toDelete.length; i += 100) {
+        const batch = toDelete.slice(i, i + 100);
         const { error } = await supabase.from('books_catalog').delete().in('id', batch);
         if (!error) deleted += batch.length;
       }
-      console.log(`[${new Date().toISOString()}] books_catalog: cleaned ${deleted} stale rows (cursor: ${cursorCount}, expected: ${expectedCount})`);
+      console.log(`[${new Date().toISOString()}] books_catalog: deleted ${deleted} orphan rows (no Mongo record)`);
+    }
+
+    if (toHide.length > 0) {
+      let hidden = 0;
+      for (let i = 0; i < toHide.length; i += 100) {
+        const batch = toHide.slice(i, i + 100);
+        const { error } = await supabase.from('books_catalog').update({ visible: false }).in('id', batch);
+        if (!error) hidden += batch.length;
+      }
+      console.log(`[${new Date().toISOString()}] books_catalog: marked ${hidden} rows visible:false (hidden in Mongo)`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- **ORAEC importers (3 scripts):** insert the page before the book and roll back on failure, or park old pages on a temp `book_id` and delete only after new pages are written. Prevents the "book with 0 pages" state that triggered hard-deletes and left 48 orphan rows in Supabase.
- **`sync-books-catalog.mjs`:** drop the `visible:true` filter on the incremental sync so hides propagate every 5-minute cycle. Split full-mode cleanup into HIDE (preserve row, flip `visible:false`, no cap) vs DELETE (drop orphans, generous `max(100, 5%)` cap).

## Background

Investigating why the periodic Supabase sync was reporting "SKIPPING cleanup — 11309 stale rows exceeds safety cap of 381" revealed two layered bugs:

1. The ORAEC importers had a delete-old-pages-then-translate-then-insert sequence with no atomicity. A Gemini timeout or process kill in that window left books with 0 pages. A subsequent "no-pages" sweep then hard-deleted those books from Mongo (bypassing `deleted_books`). The corresponding Supabase rows had already been written by the periodic sync and became orphans.
2. The sync's incremental query filtered on `visible:true`, so hiding a book in Mongo never reached Supabase. The full-mode cleanup *was* designed to handle this, but the `max(50, 1% of total)` safety cap bailed forever once the backlog passed ~380. By the time we noticed: 10,484 hidden Mongo books still flagged `visible:true` in Supabase, 244 from `deleted_books` still present, plus the 48 orphans.

The drift state was repaired separately via `scripts/output/_tmp-supabase-drift-cleanup.mjs` (deleted 292 truly-orphaned rows, set `visible:false` on 10,484 hidden rows). This PR fixes the source so the drift can't accumulate again.

## Files

- `scripts/import/import-oraec.mjs` — insert page BEFORE book, roll back page if book insert fails
- `scripts/import/oraec-paginate-translate.mjs` — parked-temp `__paginate_temp_*` book_id during rewrite + sweep on every run start
- `scripts/workers/sync-books-catalog.mjs` — incremental query drops `visible:true`; full-mode cleanup splits HIDE vs DELETE with non-destructive cap

The fourth ORAEC script with the same pattern, `scripts/tmp-retranslate-oraec.mjs`, was fixed identically but isn't tracked in git (it's a `tmp-` scratch file per the repo convention).

## Test plan

- [ ] Hide a book in Mongo manually, run `node scripts/workers/sync-books-catalog.mjs`, confirm Supabase row shows `visible:false`
- [ ] Run `node scripts/workers/sync-books-catalog.mjs --full` on a fresh state with a few hidden Mongo books, confirm cleanup runs without bailing on safety cap and rows are correctly hidden / deleted
- [ ] Re-run ORAEC import on a small batch (`--limit 3`); kill the process mid-translation; restart; confirm no 0-page orphan books are left behind in Mongo
- [ ] Run `oraec-paginate-translate.mjs --all` after a previous crash; confirm the startup sweep cleans up `__paginate_temp_*` pages before processing new books

🤖 Generated with [Claude Code](https://claude.com/claude-code)