### PR TITLE
bph: hide "neen" state shelf mark + catalogue spelling sweep

### DIFF
--- a/src/app/[tenant]/admin/AdminNav.tsx
+++ b/src/app/[tenant]/admin/AdminNav.tsx
@@ -18,7 +18,7 @@ const adminLinks: NavItem[] = [
   { href: '/admin/realtime', label: 'Realtime' },
   { href: '/admin/collections', label: 'Collections' },
   { href: '/admin/duplicates', label: 'Duplicates' },
-  { href: '/admin/catalog-coverage', label: 'Catalog' },
+  { href: '/admin/catalog-coverage', label: 'Catalogue' },
   { href: '/admin/r2-coverage', label: 'R2 Storage' },
   {
     href: '/admin/outreach',

--- a/src/app/[tenant]/admin/catalog-coverage/page.tsx
+++ b/src/app/[tenant]/admin/catalog-coverage/page.tsx
@@ -202,7 +202,7 @@ export default function CatalogCoveragePage() {
     return (
       <div className="min-h-screen bg-[#fdfcf9] p-8">
         <div className="max-w-2xl mx-auto text-center mt-20">
-          <h1 className="font-['Cormorant_Garamond'] text-3xl text-[#1a1612] mb-4">Catalog Coverage</h1>
+          <h1 className="font-['Cormorant_Garamond'] text-3xl text-[#1a1612] mb-4">Catalogue Coverage</h1>
           <p className="text-[#6b6560] mb-6">No data yet. Run the build script:</p>
           <pre className="bg-[#1a1612] text-[#f5f0e8] p-4 rounded-lg text-sm text-left overflow-x-auto">
 {`set -a; source .env.production.local; set +a
@@ -222,7 +222,7 @@ node scripts/catalog-coverage/build.mjs`}
       <div className="border-b border-[#e8e4dc] px-6 py-6">
         <div className="max-w-5xl mx-auto">
           <Link href="/admin" className="text-sm text-[#6b6560] hover:text-[#9e4a3a] mb-2 inline-block">&larr; Admin</Link>
-          <h1 className="font-['Cormorant_Garamond'] text-3xl font-semibold text-[#1a1612]">Catalog Coverage</h1>
+          <h1 className="font-['Cormorant_Garamond'] text-3xl font-semibold text-[#1a1612]">Catalogue Coverage</h1>
           <p className="text-[#6b6560] mt-1">
             Every edition printed in Europe, 1450{'\u2013'}1700. What has been scanned, what has been translated.
             {summary?.built_at && <span className="text-[#a09a92]"> {'\u00B7'} Built {new Date(summary.built_at).toLocaleDateString()}</span>}

--- a/src/app/[tenant]/catalog/page.tsx
+++ b/src/app/[tenant]/catalog/page.tsx
@@ -7,8 +7,8 @@ export const revalidate = 86400;
 export const maxDuration = 30;
 
 export const metadata: Metadata = {
-  title: 'Catalog - Source Library',
-  description: 'Browse the complete Source Library catalog — thousands of translated primary sources in alchemy, philosophy, theology, and the esoteric traditions.',
+  title: 'Catalogue - Source Library',
+  description: 'Browse the complete Source Library catalogue — thousands of translated primary sources in alchemy, philosophy, theology, and the esoteric traditions.',
   alternates: { canonical: '/catalog' },
 };
 

--- a/src/app/[tenant]/scan/page.tsx
+++ b/src/app/[tenant]/scan/page.tsx
@@ -763,7 +763,7 @@ export default function ScanPage() {
               {/* Catalog matches */}
               {catalogMatches.length > 0 && (
                 <div className="space-y-2">
-                  <p className="text-xs text-muted font-medium uppercase tracking-wide">Catalog matches</p>
+                  <p className="text-xs text-muted font-medium uppercase tracking-wide">Catalogue matches</p>
                   <div className="space-y-2">
                     {catalogMatches.map((match, i) => (
                       <button

--- a/src/app/[tenant]/search/page.tsx
+++ b/src/app/[tenant]/search/page.tsx
@@ -1488,7 +1488,7 @@ export default function SearchPage({ defaultLibrary, forceEmbedded = false }: { 
                       href={`/catalog?cq=${encodeURIComponent(query)}`}
                       className="text-sm text-accent-gold-dark hover:text-accent-gold font-medium transition-colors flex items-center gap-1"
                     >
-                      Open all {catalogTotal} catalog matches <ChevronRight className="w-3.5 h-3.5" />
+                      Open all {catalogTotal} catalogue matches <ChevronRight className="w-3.5 h-3.5" />
                     </Link>
                   )}
                 </>

--- a/src/app/[tenant]/upload/page.tsx
+++ b/src/app/[tenant]/upload/page.tsx
@@ -265,7 +265,7 @@ export default function UploadPage() {
             <div className="bg-accent-gold/8 border border-accent-gold/20 rounded-xl p-4 text-sm text-accent-gold-dark">
               <p className="font-medium mb-1">Two ways to add a book:</p>
               <ol className="list-decimal list-inside space-y-1 text-accent-rust">
-                <li><strong>Search catalogs</strong>: Find the book in Internet Archive or BPH to pre-fill metadata</li>
+                <li><strong>Search catalogues</strong>: Find the book in Internet Archive or BPH to pre-fill metadata</li>
                 <li><strong>Enter manually</strong>: Skip the search and fill in the form below</li>
               </ol>
             </div>
@@ -277,7 +277,7 @@ export default function UploadPage() {
                   <Search className="w-5 h-5 text-blue-700" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-stone-900">Search Catalogs</h2>
+                  <h2 className="text-lg font-semibold text-stone-900">Search Catalogues</h2>
                   <p className="text-sm text-stone-500">~37k books from Internet Archive and BPH</p>
                 </div>
               </div>

--- a/src/app/about/by-the-numbers/page.tsx
+++ b/src/app/about/by-the-numbers/page.tsx
@@ -434,7 +434,7 @@ export default function ByTheNumbersPage() {
             <StatCard label="OCR transcriptions" value={HERO.pagesOcr} sub="From scan to original-language text" icon={FileText} accent="gold" />
             <StatCard label="Page translations" value={HERO.pagesTranslated} sub="Original languages → English" icon={Languages} accent="violet" />
             <StatCard label="Book embeddings" value={HERO.bookEmbeddings} sub="For semantic similarity & search" icon={Sparkles} accent="sage" />
-            <StatCard label="Illustrations cataloged" value={HERO.galleryImages} sub="Subjects, figures, symbols, technique" icon={ImageIcon} accent="rust" />
+            <StatCard label="Illustrations catalogued" value={HERO.galleryImages} sub="Subjects, figures, symbols, technique" icon={ImageIcon} accent="rust" />
           </div>
         </section>
 

--- a/src/app/about/progress/page.tsx
+++ b/src/app/about/progress/page.tsx
@@ -258,7 +258,7 @@ export default async function ProgressPage() {
 
       {/* Hero stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <StatCard icon={BookOpen} label="Editions cataloged" value={fmt(data.total_editions)} sub="from the Universal Short Title Catalogue" />
+        <StatCard icon={BookOpen} label="Editions catalogued" value={fmt(data.total_editions)} sub="from the Universal Short Title Catalogue" />
         <StatCard icon={Scan} label="Digitally scanned" value={`${data.pct_scanned.toFixed(1)}%`} sub={`${fmt(data.total_scanned)} editions`} />
         <StatCard icon={Languages} label="Translated" value={`${data.pct_translated.toFixed(1)}%`} sub={`${fmt(data.total_translated)} editions`} />
         <StatCard icon={Globe2} label="In Source Library" value={fmt(data.total_in_sl)} sub="OCR&apos;d and translated" />

--- a/src/app/catalog/scholar/page.tsx
+++ b/src/app/catalog/scholar/page.tsx
@@ -7,8 +7,8 @@ export const revalidate = 86400;
 export const maxDuration = 30;
 
 export const metadata: Metadata = {
-  title: 'Scholar Catalog - Source Library',
-  description: 'Browse the Source Library catalog in a clean bibliographic format designed for researchers and librarians.',
+  title: 'Scholar Catalogue - Source Library',
+  description: 'Browse the Source Library catalogue in a clean bibliographic format designed for researchers and librarians.',
   alternates: { canonical: '/catalog/scholar' },
 };
 

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -418,7 +418,7 @@ source-library search "alchemy" --json | jq .results`}
                 <tr>
                   <td className="py-2.5 pr-3"><span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-mono rounded">GET</span></td>
                   <td className="py-2.5 pr-4 font-mono text-primary whitespace-nowrap">/catalog/csv</td>
-                  <td className="py-2.5 text-secondary">Download the full catalog as CSV</td>
+                  <td className="py-2.5 text-secondary">Download the full catalogue as CSV</td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -495,7 +495,7 @@ export default async function CatalogEntryPage({ params }: Props) {
         <Section title="Location at the BPH">
           <Field label="Present location" value={work.present_location} />
           <Field label="Shelf mark" value={work.shelf_mark} mono />
-          <Field label="State Collection shelf mark" value={work.state_shelf_mark} mono />
+          <Field label="State Collection shelf mark" value={work.state_shelf_mark?.trim().toLowerCase() === 'neen' ? null : work.state_shelf_mark} mono />
           <Field label="Provenance / collection" value={work.provenance} />
         </Section>
 

--- a/src/app/identify/page.tsx
+++ b/src/app/identify/page.tsx
@@ -330,7 +330,7 @@ export default function IdentifyPage() {
               {/* Catalog numbers */}
               {result.identification.catalog_numbers && result.identification.catalog_numbers.length > 0 && (
                 <div className="pt-3 border-t border-border-light">
-                  <h3 className="text-xs uppercase tracking-wider text-muted mb-1">Catalog references</h3>
+                  <h3 className="text-xs uppercase tracking-wider text-muted mb-1">Catalogue references</h3>
                   <div className="flex flex-wrap gap-1.5">
                     {result.identification.catalog_numbers.map((num, i) => (
                       <span key={i} className="text-xs bg-stone-100 text-stone-700 rounded px-2 py-0.5 font-mono">{num}</span>

--- a/src/components/book/BibliographicInfo.tsx
+++ b/src/components/book/BibliographicInfo.tsx
@@ -362,7 +362,7 @@ export default function BibliographicInfo({
                           </summary>
                           <div className="mt-1.5 pl-2 border-l border-stone-700/50 space-y-1">
                             <p className="text-stone-400">
-                              <span className="text-stone-500">Catalogs searched:</span>{' '}
+                              <span className="text-stone-500">Catalogues searched:</span>{' '}
                               {book.translation_verification.tools_called
                                 .filter((t: string) => t !== 'make_determination')
                                 .map((t: string) => t.replace('search_', '').replace(/_/g, ' '))

--- a/src/components/book/BookLibrary.tsx
+++ b/src/components/book/BookLibrary.tsx
@@ -875,7 +875,7 @@ export default function BookLibrary({ initialBooks, totalBooks, languages, colle
                             </a>
                           </>
                         ) : (
-                          <span className="text-xs text-stone-400">Catalog entry</span>
+                          <span className="text-xs text-stone-400">Catalogue entry</span>
                         )}
                       </div>
                     </div>

--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -167,14 +167,18 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
           </Section>
         )}
 
-        {(work.present_location || work.shelf_mark || work.state_shelf_mark || work.provenance) && (
-          <Section title="Location at the BPH">
-            <Field label="Present location" value={work.present_location} />
-            <Field label="Shelf mark" value={work.shelf_mark} mono />
-            <Field label="State Collection shelf mark" value={work.state_shelf_mark} mono />
-            <Field label="Provenance / collection" value={work.provenance} />
-          </Section>
-        )}
+        {(() => {
+          const stateShelfMark = work.state_shelf_mark?.trim().toLowerCase() === 'neen' ? null : work.state_shelf_mark;
+          if (!work.present_location && !work.shelf_mark && !stateShelfMark && !work.provenance) return null;
+          return (
+            <Section title="Location at the BPH">
+              <Field label="Present location" value={work.present_location} />
+              <Field label="Shelf mark" value={work.shelf_mark} mono />
+              <Field label="State Collection shelf mark" value={stateShelfMark} mono />
+              <Field label="Provenance / collection" value={work.provenance} />
+            </Section>
+          );
+        })()}
 
         {(work.bibliography || work.remarks) && (
           <Section title="Notes">

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -23,7 +23,7 @@ const NAV_LINKS: NavLink[] = [
     activePrefix: '/browse',
     children: [
       { label: 'Browse', href: '/browse' },
-      { label: 'Catalog', href: '/catalog' },
+      { label: 'Catalogue', href: '/catalog' },
     ],
   },
   { label: 'Explore', href: '/explore/map', activePrefix: '/explore' },

--- a/src/lib/taxonomy/faceted-vocabulary.ts
+++ b/src/lib/taxonomy/faceted-vocabulary.ts
@@ -527,7 +527,7 @@ export const FORM: Facet = {
     },
     {
       id: 'catalog',
-      label: 'Catalog / Bibliography',
+      label: 'Catalogue / Bibliography',
       differentia: 'Systematic list of books, manuscripts, specimens, or objects',
     },
   ],


### PR DESCRIPTION
## Summary
- **BPH "State Collection shelf mark"**: hide the field when its value is `neen` (Dutch "no") — only show it for real marks like `PH 123`. Collapses the whole "Location at the BPH" section if that was the only populated field there.
- **Catalogue spelling**: switch user-facing strings from "Catalog" → "Catalogue" across nav, page titles, headings, stat cards, table copy, and taxonomy labels (17 files / 13 distinct UI surfaces).
- Routes (`/catalog/[ubn]`), code identifiers, API field names, and published blog essays intentionally left alone — a route rename + redirects can be a separate PR.

## Test plan
- [ ] Open a BPH book whose `state_shelf_mark = "neen"` on `bph.sourcelibrary.org` → field is hidden in both the inline catalogue record (book page) and the standalone catalogue entry page (`/embed/bph/catalog/[ubn]`).
- [ ] Open a BPH book with `state_shelf_mark` like `PH 123` → field still shows.
- [ ] If a book has only `state_shelf_mark = "neen"` and nothing else in the "Location at the BPH" section → entire section is gone.
- [ ] Spot-check user-facing copy: `/catalog`, `/catalog/scholar`, `/admin/catalog-coverage`, `/scan`, `/upload`, `/identify`, `/about/progress`, `/about/by-the-numbers`, `/developers`, top nav → reads "Catalogue".
- [ ] `npx tsc --noEmit` ✅ (passed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)