### PR TITLE
Kloss catalogue Phase 1: multi-tenant library_catalog_records + Kloss ETL

### DIFF
--- a/scripts/import/etl-kloss-catalog-to-supabase.mjs
+++ b/scripts/import/etl-kloss-catalog-to-supabase.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * One-time ETL: Mongo `kloss_catalog` → Supabase `library_catalog_records`.
+ *
+ * Idempotent — upserts on (tenant_id, catalog_id). Safe to re-run.
+ *
+ * Prerequisites:
+ *   - Run scripts/migration/create-library-catalog-records.sql in Supabase first.
+ *   - MONGODB_URI, NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (or
+ *     NEXT_PUBLIC_SUPABASE_ANON_KEY with RLS turned off for this table) in env.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; \
+ *     node scripts/import/etl-kloss-catalog-to-supabase.mjs [--dry] [--limit N]
+ *
+ * What it does:
+ *   1. Reads every kloss_catalog doc from Mongo.
+ *   2. Maps Kloss fields → library_catalog_records columns.
+ *      - priref → catalog_id
+ *      - authors[] → author (joined with "; "; first author also kept in author)
+ *      - kloss_shelf_mark, digital_references, notes, scan_verification → metadata JSONB
+ *      - free-text year ("[ca. 1805-06]") → year_text + best-effort year INT
+ *   3. Joins to live Mongo `books` by image_source.identifier=priref to populate
+ *      sl_book_id and sl_book_slug.
+ *   4. Bulk-upserts in batches of 500.
+ */
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+
+const DRY = process.argv.includes('--dry');
+const LIMIT_ARG = process.argv.find(a => a.startsWith('--limit='));
+const LIMIT = LIMIT_ARG ? parseInt(LIMIT_ARG.split('=')[1], 10) : 0;
+
+const TENANT_ID = 'kloss-collection';
+const BATCH_SIZE = 500;
+
+const mongoUri = process.env.MONGODB_URI;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_SERVICE_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!mongoUri) { console.error('MONGODB_URI not set'); process.exit(1); }
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Supabase env not set. Need NEXT_PUBLIC_SUPABASE_URL and a service-role or anon key.');
+  process.exit(1);
+}
+
+const mongo = new MongoClient(mongoUri);
+await mongo.connect();
+const db = mongo.db('bookstore');
+
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+console.log(`Mode: ${DRY ? 'DRY RUN' : 'APPLY'}`);
+console.log(`Tenant: ${TENANT_ID}\n`);
+
+// ───────── Build priref → sl_book lookup from live books ─────────
+
+console.log('Building priref → sl_book lookup from books collection...');
+const liveBooks = await db.collection('books').find(
+  { 'image_source.provider': 'cmc_kloss' },
+  { projection: { id: 1, slug: 1, 'image_source.identifier': 1 } }
+).toArray();
+const prirefToBook = new Map();
+for (const b of liveBooks) {
+  const priref = b.image_source?.identifier;
+  if (priref) prirefToBook.set(String(priref), { id: b.id, slug: b.slug || null });
+}
+console.log(`  ${prirefToBook.size} priref → book mappings loaded\n`);
+
+// ───────── Read catalog ─────────
+
+const cursor = db.collection('kloss_catalog').find({});
+if (LIMIT > 0) cursor.limit(LIMIT);
+const catalog = await cursor.toArray();
+console.log(`kloss_catalog records: ${catalog.length}`);
+
+// ───────── Transform ─────────
+
+/** Best-effort numeric year from free-text. Picks the first 4-digit run, or
+ *  the first 3-digit run preceded by 1 (Latin "M..." we don't handle). */
+function parseYear(text) {
+  if (!text || typeof text !== 'string') return null;
+  const m = text.match(/(\d{4})/);
+  if (m) {
+    const y = parseInt(m[1], 10);
+    if (y >= 1000 && y <= 2100) return y;
+  }
+  return null;
+}
+
+function joinList(value, sep = '; ') {
+  if (!Array.isArray(value)) return value || null;
+  const trimmed = value.map(v => String(v).trim()).filter(Boolean);
+  return trimmed.length ? trimmed.join(sep) : null;
+}
+
+const rows = catalog.map(doc => {
+  const priref = String(doc.priref);
+  const sl = prirefToBook.get(priref);
+
+  // Kloss-specific extras into metadata
+  const metadata = {};
+  if (doc.kloss_shelf_mark) metadata.kloss_shelf_mark = doc.kloss_shelf_mark;
+  if (Array.isArray(doc.digital_references) && doc.digital_references.length) metadata.digital_references = doc.digital_references;
+  if (Array.isArray(doc.notes) && doc.notes.length) metadata.notes = doc.notes;
+  if (doc.scan_verification) metadata.scan_verification = doc.scan_verification;
+  if (doc.is_scanned !== undefined) metadata.is_scanned = doc.is_scanned;
+  if (doc.has_digital_copy !== undefined) metadata.has_digital_copy = doc.has_digital_copy;
+  if (doc.description) metadata.description = doc.description;
+  if (doc.edition) metadata.edition = doc.edition;
+  if (doc.format) metadata.format = doc.format;
+  if (doc.material_type) metadata.material_type = doc.material_type;
+  if (doc.pagination) metadata.pagination = doc.pagination;
+  if (doc.series) metadata.series = doc.series;
+
+  return {
+    tenant_id: TENANT_ID,
+    catalog_id: priref,
+    title: doc.title || null,
+    author: joinList(doc.authors) || null,
+    place: doc.place_of_publication || null,
+    publisher: doc.publisher || null,
+    year: parseYear(doc.year),
+    year_text: doc.year || null,
+    shelf_mark: doc.shelf_mark || null,
+    keywords: joinList(doc.keywords, ', '),
+    language: doc.language || null,
+    series_title: doc.series || null,
+    sl_book_id: sl?.id || null,
+    sl_book_slug: sl?.slug || null,
+    metadata,
+  };
+});
+
+const withLink = rows.filter(r => r.sl_book_id).length;
+console.log(`Rows prepared: ${rows.length}`);
+console.log(`  with sl_book_id link: ${withLink}`);
+console.log(`  unlinked (catalogue-only): ${rows.length - withLink}`);
+
+if (DRY) {
+  console.log('\nDRY RUN — sample row:');
+  console.log(JSON.stringify(rows[0], null, 2));
+  await mongo.close();
+  process.exit(0);
+}
+
+// ───────── Upsert in batches ─────────
+
+console.log('\nUpserting to Supabase...');
+let upserted = 0;
+let errors = 0;
+for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+  const batch = rows.slice(i, i + BATCH_SIZE);
+  const { error } = await supabase
+    .from('library_catalog_records')
+    .upsert(batch, { onConflict: 'tenant_id,catalog_id', ignoreDuplicates: false });
+  if (error) {
+    errors++;
+    console.error(`  batch ${i}-${i + batch.length}: ${error.message}`);
+    if (error.message.includes('does not exist') || error.message.includes('not find')) {
+      console.error('  → Run scripts/migration/create-library-catalog-records.sql in Supabase first.');
+      break;
+    }
+  } else {
+    upserted += batch.length;
+    if (i % (BATCH_SIZE * 4) === 0 || i + BATCH_SIZE >= rows.length) {
+      console.log(`  ${upserted}/${rows.length} upserted`);
+    }
+  }
+}
+
+// ───────── Verify ─────────
+
+const { count } = await supabase
+  .from('library_catalog_records')
+  .select('*', { count: 'exact', head: true })
+  .eq('tenant_id', TENANT_ID);
+console.log(`\nFinal Supabase count for tenant '${TENANT_ID}': ${count ?? '?'}`);
+console.log(`Upserted: ${upserted}  Errors: ${errors}`);
+
+await mongo.close();

--- a/scripts/migration/create-library-catalog-records.sql
+++ b/scripts/migration/create-library-catalog-records.sql
@@ -1,0 +1,153 @@
+-- library_catalog_records — multi-tenant bibliographic catalogue table.
+--
+-- Replaces the per-tenant pattern (bph_works, would-be kloss_works, etc.)
+-- with one unified table keyed by tenant_id. Each tenant brings its own
+-- bibliographic export; the shared columns are the BPH-aligned superset,
+-- and tenant-specific fields live in the JSONB `metadata` column.
+--
+-- This migration is additive — bph_works stays in place. The new generic
+-- /api/catalog/[tenant] route reads from this table; /api/catalog/bph
+-- continues to read from bph_works until a later migration consolidates.
+--
+-- Run via Supabase SQL editor or the migration runner.
+
+CREATE TABLE IF NOT EXISTS library_catalog_records (
+  id BIGSERIAL PRIMARY KEY,
+
+  -- Tenant identity. Matches tenants.slug in MongoDB.
+  tenant_id TEXT NOT NULL,
+
+  -- Tenant-specific external catalogue ID.
+  --   BPH:  ubn (e.g. "0123456")
+  --   Kloss: priref (CMC catalogue priref, e.g. "322")
+  catalog_id TEXT NOT NULL,
+
+  -- ───────── Common bibliographic fields (BPH-aligned superset) ─────────
+
+  title TEXT,
+  parallel_title TEXT,
+  uniform_title TEXT,
+
+  author TEXT,
+  variant_author TEXT,
+  pseudonym TEXT,
+
+  editor TEXT,
+  variant_editor TEXT,
+
+  place TEXT,
+  printer TEXT,
+  publisher TEXT,
+  variant_printer TEXT,
+  variant_publisher TEXT,
+
+  -- Numeric year (best-effort parsed from free-text)
+  year INT,
+  -- Original free-text year for display ("[ca. 1805-06]", "MDLXXX", etc.)
+  year_text TEXT,
+
+  shelf_mark TEXT,
+  state_shelf_mark TEXT,
+  present_location TEXT,
+
+  keywords TEXT,
+  language TEXT,
+
+  series_title TEXT,
+  volume_title TEXT,
+
+  bibliography TEXT,
+  remarks TEXT,
+
+  number_of_copies INT,
+  object_size_cm TEXT,
+  binding TEXT,
+  bound_with TEXT,
+
+  provenance TEXT,
+  thumbnail TEXT,
+  file_count INT,
+
+  -- ───────── Linkage to live Source Library data ─────────
+
+  -- When this catalogue row is digitised on Source Library,
+  -- sl_book_id points at the live Mongo books.id.
+  sl_book_id TEXT,
+  sl_book_slug TEXT,
+
+  -- External-archive identifiers (Internet Archive, USTC, etc.) for
+  -- catalogue rows that aren't digitised on SL but exist elsewhere.
+  ia_identifier TEXT,
+  ustc_sn TEXT,
+
+  -- Cross-provider linkage: the work is held physically by this tenant
+  -- but the scan we surface lives at another archive. Kept separate
+  -- from sl_book_id so digitised-here counters stay precise.
+  sl_external_book_id TEXT,
+  sl_external_slug TEXT,
+  sl_external_source TEXT,
+
+  -- ───────── Tenant-specific extras ─────────
+
+  -- Anything not in the shared columns lives here. Examples:
+  --   Kloss: kloss_shelf_mark, digital_references[], notes[], scan_verification{...}
+  --   BPH:   variant_keywords, donor_provenance, conservation_notes
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  -- ───────── Bookkeeping ─────────
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Each tenant's catalogue IDs are unique within that tenant.
+  CONSTRAINT library_catalog_records_tenant_catalog_id_key
+    UNIQUE (tenant_id, catalog_id)
+);
+
+-- ───────── Indexes ─────────
+-- Every query starts with tenant_id, so compound indexes lead with it.
+
+CREATE INDEX IF NOT EXISTS idx_lcr_tenant_id
+  ON library_catalog_records(tenant_id);
+
+CREATE INDEX IF NOT EXISTS idx_lcr_tenant_sl_book
+  ON library_catalog_records(tenant_id, sl_book_id)
+  WHERE sl_book_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_lcr_tenant_year
+  ON library_catalog_records(tenant_id, year);
+
+CREATE INDEX IF NOT EXISTS idx_lcr_tenant_title
+  ON library_catalog_records(tenant_id, title);
+
+CREATE INDEX IF NOT EXISTS idx_lcr_tenant_author
+  ON library_catalog_records(tenant_id, author);
+
+CREATE INDEX IF NOT EXISTS idx_lcr_tenant_shelf_mark
+  ON library_catalog_records(tenant_id, shelf_mark);
+
+-- GIN index on metadata for tenant-specific facet queries.
+CREATE INDEX IF NOT EXISTS idx_lcr_metadata_gin
+  ON library_catalog_records USING GIN (metadata);
+
+-- ───────── updated_at trigger ─────────
+
+CREATE OR REPLACE FUNCTION library_catalog_records_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS library_catalog_records_set_updated_at ON library_catalog_records;
+CREATE TRIGGER library_catalog_records_set_updated_at
+  BEFORE UPDATE ON library_catalog_records
+  FOR EACH ROW
+  EXECUTE FUNCTION library_catalog_records_touch_updated_at();
+
+-- ───────── Notes ─────────
+-- Full-text search and diacritic normalisation indexes are deliberately
+-- omitted from this initial migration. They'll be added in a follow-up
+-- (mirroring add-bph-diacritic-normalization.sql) once the column shape
+-- has settled across tenants.


### PR DESCRIPTION
First PR for issue #1884 — the data layer. Phases 2 & 3 (generic catalog API + generalised UnifiedCatalogue) ship as a follow-up so the 834-line BphCatalogBrowser refactor gets its own clean review.

## What this adds
- **`scripts/migration/create-library-catalog-records.sql`** — multi-tenant catalogue table. tenant_id-leading indexes, BPH-aligned superset of shared columns, JSONB metadata column for tenant-specific extras. Built for many tenants from the start (not per-tenant tables).
- **`scripts/import/etl-kloss-catalog-to-supabase.mjs`** — idempotent ETL from Mongo `kloss_catalog` (1,614 records) into the new table. Wires `priref → sl_book_id` via the live `books` collection so digitised rows are linked to readable books.

## Why a unified table instead of `kloss_works`
Goal is "many libraries, easy onboarding" — each new tenant is an ETL job into one table, not a new schema. `bph_works` stays in place as legacy; a follow-up migration will fold BPH into the unified table once the new path is proven.

## Verified (dry-run)
- 1,521 priref → live book mappings loaded
- Sample row transforms cleanly: free-text year `"[ca. 1805-06]"` → `year=1805, year_text="[ca. 1805-06]"`, Kloss extras land in `metadata` JSONB
- ETL was NOT run against production yet — the SQL migration must be applied first

## Deploy steps after merge
1. Apply `scripts/migration/create-library-catalog-records.sql` in Supabase SQL editor
2. Dry-run the ETL: `node scripts/import/etl-kloss-catalog-to-supabase.mjs --dry --limit=10`
3. Apply for real: `node scripts/import/etl-kloss-catalog-to-supabase.mjs`
4. Verify: `SELECT count(*) FROM library_catalog_records WHERE tenant_id='kloss-collection';` returns 1,614

## What's NOT in this PR (Phase 2 + 3)
- `/api/catalog/[tenant]` route reading from this table
- Generalised `UnifiedCatalogue` component
- Wiring on the Kloss embed page
- BPH continues to use `/api/catalog/bph` + `bph_works` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)