### PR TITLE
Kloss catalogue parity Phase 2+3: generic /api/catalog/[tenant] & UnifiedCatalogue

### DIFF
--- a/src/app/[tenant]/page.tsx
+++ b/src/app/[tenant]/page.tsx
@@ -7,6 +7,8 @@ import {
   getTenantDominantProvider,
   fetchTenantBphDigitizedMap,
   fetchTenantBphCatalogTotal,
+  fetchTenantCatalogDigitizedMap,
+  fetchTenantCatalogTotal,
 } from '@/lib/tenant-library-loaders';
 import { getDb } from '@/lib/mongodb';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
@@ -64,14 +66,24 @@ export default async function TenantRoot({ params, searchParams }: Props) {
 
   // Check if this tenant is primarily BPH-based
   const isBph = canonicalPartner?.providerKey === 'bph' || dominantProvider === 'bph';
+  // Other tenants with a BPH-parity unified Books|Catalogue structure (kloss
+  // today; future tenants set the flag in library-partners.ts). Reads from
+  // library_catalog_records via /api/catalog/[tenant].
+  const hasUnifiedCatalogue = !isBph && !!canonicalPartner?.hasUnifiedCatalogue;
 
-  // Fetch BPH-specific data if applicable
+  // Fetch catalogue data — BPH uses its bespoke bph_works pipeline; other
+  // unified-catalogue tenants read the generic library_catalog_records table.
   const [digitizedUbns, catalogTotal] = isBph
     ? await Promise.all([
       fetchTenantBphDigitizedMap(tenantId),
       fetchTenantBphCatalogTotal(tenantId),
     ])
-    : [{} as Record<string, { id: string; slug: string }>, 0];
+    : hasUnifiedCatalogue
+      ? await Promise.all([
+        fetchTenantCatalogDigitizedMap(tenantId, canonicalPartner!.providerKey),
+        fetchTenantCatalogTotal(tenant),
+      ])
+      : [{} as Record<string, { id: string; slug: string }>, 0];
 
   const basePath = `/${tenant}`;
 
@@ -98,6 +110,7 @@ export default async function TenantRoot({ params, searchParams }: Props) {
     view,
     display,
     isBph,
+    hasUnifiedCatalogue,
     digitizedUbns,
     catalogTotal,
     tenantSlug,

--- a/src/app/api/catalog/[tenant]/route.ts
+++ b/src/app/api/catalog/[tenant]/route.ts
@@ -1,0 +1,224 @@
+// Generic per-tenant catalogue API. Reads from the unified
+// `library_catalog_records` table filtered by `tenant_id`.
+//
+// The legacy BPH route at /api/catalog/bph still reads from `bph_works` (its
+// own table with normalised search columns + a pinned digitised counter) and
+// continues to serve the EFM Webflow embed. Next.js prefers the static
+// `/api/catalog/bph` route for that path; everything else falls through here.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase, sanitizeFilterValue } from '@/lib/supabase';
+import { getReadDb } from '@/lib/mongodb';
+import { getBookThumbnailUrl } from '@/lib/utils';
+
+export const dynamic = 'force-dynamic';
+
+const PER_PAGE = 50;
+
+const FIELDS = [
+  'catalog_id',
+  'title', 'parallel_title', 'uniform_title',
+  'author', 'variant_author', 'pseudonym',
+  'editor', 'variant_editor',
+  'place', 'printer', 'publisher', 'variant_printer', 'variant_publisher',
+  'year', 'year_text',
+  'shelf_mark', 'state_shelf_mark', 'present_location',
+  'keywords', 'language',
+  'series_title', 'volume_title',
+  'bibliography', 'remarks',
+  'number_of_copies', 'object_size_cm', 'binding', 'bound_with',
+  'provenance', 'thumbnail', 'file_count',
+  'sl_book_id', 'sl_book_slug',
+  'sl_external_book_id', 'sl_external_slug', 'sl_external_source',
+  'ia_identifier', 'ustc_sn',
+  'metadata',
+].join(', ');
+
+interface RouteContext {
+  params: Promise<{ tenant: string }>;
+}
+
+export async function GET(req: NextRequest, { params }: RouteContext) {
+  const { tenant } = await params;
+  if (!tenant) {
+    return NextResponse.json({ error: 'Missing tenant' }, { status: 400 });
+  }
+
+  const sp = req.nextUrl.searchParams;
+
+  const q = sp.get('q')?.trim() || '';
+
+  const author = sp.get('author')?.trim() || '';
+  const title = sp.get('title')?.trim() || '';
+  const place = sp.get('place')?.trim() || '';
+  const printer = sp.get('printer')?.trim() || '';
+  const publisher = sp.get('publisher')?.trim() || '';
+  const editor = sp.get('editor')?.trim() || '';
+  const keyword = sp.get('keyword')?.trim() || '';
+  const language = sp.get('language')?.trim() || '';
+  const shelfMark = sp.get('shelf_mark')?.trim() || '';
+  const provenance = sp.get('provenance')?.trim() || '';
+
+  const yearFrom = sp.get('yearFrom') ? parseInt(sp.get('yearFrom')!, 10) : null;
+  const yearTo = sp.get('yearTo') ? parseInt(sp.get('yearTo')!, 10) : null;
+
+  const digitized = sp.get('digitized'); // 'true' | 'false' | 'sl' | null
+
+  const sort = sp.get('sort') || 'title';
+  const offset = Math.max(0, parseInt(sp.get('offset') || '0', 10) || 0);
+  const limit = Math.min(200, Math.max(1, parseInt(sp.get('limit') || String(PER_PAGE), 10) || PER_PAGE));
+
+  let query = supabase
+    .from('library_catalog_records')
+    .select(FIELDS, { count: 'exact' })
+    .eq('tenant_id', tenant);
+
+  if (q.length >= 2) {
+    const safe = sanitizeFilterValue(q);
+    query = query.or(
+      `title.ilike.%${safe}%,` +
+      `parallel_title.ilike.%${safe}%,` +
+      `uniform_title.ilike.%${safe}%,` +
+      `author.ilike.%${safe}%,` +
+      `variant_author.ilike.%${safe}%,` +
+      `pseudonym.ilike.%${safe}%,` +
+      `shelf_mark.ilike.%${safe}%,` +
+      `state_shelf_mark.ilike.%${safe}%,` +
+      `keywords.ilike.%${safe}%`,
+    );
+  }
+
+  const ilikeFilter = (val: string, columns: string[]) => {
+    if (!val) return;
+    const safe = sanitizeFilterValue(val);
+    if (columns.length === 1) {
+      query = query.ilike(columns[0], `%${safe}%`);
+    } else {
+      query = query.or(columns.map(c => `${c}.ilike.%${safe}%`).join(','));
+    }
+  };
+
+  ilikeFilter(author, ['author', 'variant_author', 'pseudonym']);
+  ilikeFilter(title, ['title', 'parallel_title', 'uniform_title']);
+  ilikeFilter(editor, ['editor', 'variant_editor']);
+  ilikeFilter(place, ['place']);
+  ilikeFilter(printer, ['printer', 'variant_printer']);
+  ilikeFilter(publisher, ['publisher', 'variant_publisher']);
+  ilikeFilter(shelfMark, ['shelf_mark', 'state_shelf_mark']);
+  ilikeFilter(language, ['language']);
+  ilikeFilter(provenance, ['provenance']);
+  if (keyword) {
+    const safe = sanitizeFilterValue(keyword);
+    query = query.ilike('keywords', `%${safe}%`);
+  }
+
+  if (yearFrom !== null && !Number.isNaN(yearFrom)) query = query.gte('year', yearFrom);
+  if (yearTo !== null && !Number.isNaN(yearTo)) query = query.lte('year', yearTo);
+
+  if (digitized === 'true') {
+    query = query.or('sl_book_id.not.is.null,ia_identifier.not.is.null,sl_external_book_id.not.is.null');
+  } else if (digitized === 'sl') {
+    query = query.not('sl_book_id', 'is', null);
+  } else if (digitized === 'false') {
+    query = query
+      .is('sl_book_id', null)
+      .is('ia_identifier', null)
+      .is('sl_external_book_id', null);
+  }
+
+  switch (sort) {
+    case 'year_asc':
+      query = query.order('year', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    case 'year_desc':
+      query = query.order('year', { ascending: false, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    case 'author':
+      query = query.order('author', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    case 'shelfmark':
+      query = query.order('shelf_mark', { ascending: true, nullsFirst: false }).order('title', { ascending: true });
+      break;
+    default:
+      query = query.order('title', { ascending: true });
+  }
+
+  const result = await query.range(offset, offset + limit - 1);
+
+  if (result.error) {
+    return NextResponse.json({ error: result.error.message }, { status: 500 });
+  }
+
+  let works = (result.data || []) as unknown as Array<Record<string, unknown>>;
+
+  // Title-prefix relevance bump (matches BPH route #1690): when there's a
+  // simple search query, rows whose title *starts* with the needle bubble to
+  // the top of the current page. Stable within each group; only re-orders
+  // the fetched page, not the global result set.
+  if (q.length >= 2 && works.length > 1) {
+    const needle = q.toLocaleLowerCase();
+    const decorated = works.map((row, idx) => {
+      const t = (row as { title?: string | null }).title || '';
+      const prefixMatch = t.toLocaleLowerCase().startsWith(needle) ? 0 : 1;
+      return { row, idx, prefixMatch };
+    });
+    decorated.sort((a, b) => a.prefixMatch - b.prefixMatch || a.idx - b.idx);
+    works = decorated.map(d => d.row);
+  }
+
+  // Attach SL cover URL for rows linked to a digitised book. Best-effort:
+  // any Mongo error leaves rows without covers (grid view degrades to icons).
+  const slBookIds = Array.from(
+    new Set(
+      works
+        .map(w => (w as { sl_book_id?: string | null }).sl_book_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  );
+  if (slBookIds.length > 0) {
+    try {
+      const db = await getReadDb();
+      const books = await db
+        .collection('books')
+        .find(
+          { id: { $in: slBookIds } },
+          {
+            projection: {
+              id: 1,
+              image_display: 1,
+              image_thumb: 1,
+              thumbnail: 1,
+              thumbnail_blob: 1,
+            },
+            maxTimeMS: 8_000,
+          },
+        )
+        .toArray();
+      const coverById = new Map<string, string | null>();
+      for (const b of books as unknown as Array<{
+        id: string;
+        image_display?: string | null;
+        image_thumb?: string | null;
+        thumbnail?: string | null;
+        thumbnail_blob?: string | null;
+      }>) {
+        coverById.set(b.id, getBookThumbnailUrl(b, 'display'));
+      }
+      works = works.map(w => {
+        const row = w as { sl_book_id?: string | null };
+        const id = row.sl_book_id;
+        return id ? { ...row, sl_cover: coverById.get(id) ?? null } : w;
+      });
+    } catch {
+      // Covers are decorative; skip silently.
+    }
+  }
+
+  return NextResponse.json({
+    works,
+    total: result.count || 0,
+    offset,
+    limit,
+    tenant,
+  });
+}

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -6,6 +6,8 @@ import {
     fetchTenantBphDigitizedMap,
     fetchTenantBphCatalogTotal,
     fetchTenantBphCataloguedBookIds,
+    fetchTenantCatalogDigitizedMap,
+    fetchTenantCatalogTotal,
 } from '@/lib/tenant-library-loaders';
 import { getDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
@@ -93,14 +95,19 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     // resolves only after the main loaders run; for parallelism we fall back
     // to the tenant slug here, which matches the current BPH tenant 1:1.
     const probablyBph = tenant === 'bph';
+    // Tenants opted into the generic unified-catalogue path (Phase 2/3 of
+    // Kloss BPH-parity work). Mirrors the BPH fast path: pre-resolve via slug
+    // so loaders can run in parallel.
+    const knownPartnerEarly = getPartnerBySlug(tenant);
+    const probablyHasUnified = !probablyBph && !!knownPartnerEarly?.hasUnifiedCatalogue;
 
-    // The BPH catalogue + books views render only <BphUnifiedCatalogue>,
-    // which sources its own data via /api/catalog/bph. The hero, gallery,
+    // The unified-catalogue views render only <UnifiedCatalogue> /
+    // <BphUnifiedCatalogue>, which source their own data. The hero, gallery,
     // Selected Books row, and contributing-libraries panel are all hidden,
     // so the heavy upstream loaders (Mongo + Supabase) are pure dead weight
     // on those URLs — and `view=catalog&display=list` was timing out in the
     // browser before render finished. Skip them and pass empty placeholders.
-    const skipHeavyLoaders = probablyBph && (view === 'catalog' || view === 'books');
+    const skipHeavyLoaders = (probablyBph || probablyHasUnified) && (view === 'catalog' || view === 'books');
 
     // dominantProvider is only consulted as a fallback when the tenant slug
     // doesn't map to a known partner — for known slugs (bph, ficino, bhutan,
@@ -143,12 +150,18 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         '';
 
     const isBph = canonicalPartner?.providerKey === 'bph' || dominantProvider === 'bph';
+    const hasUnifiedCatalogue = !isBph && !!canonicalPartner?.hasUnifiedCatalogue;
     const [digitizedUbns, catalogTotal] = isBph
         ? await Promise.all([
             fetchTenantBphDigitizedMap(tenantId),
             fetchTenantBphCatalogTotal(tenantId),
         ])
-        : [{} as Record<string, { id: string; slug: string }>, 0];
+        : hasUnifiedCatalogue
+            ? await Promise.all([
+                fetchTenantCatalogDigitizedMap(tenantId, canonicalPartner!.providerKey),
+                fetchTenantCatalogTotal(tenant),
+            ])
+            : [{} as Record<string, { id: string; slug: string }>, 0];
 
     const basePath = `/embed/${tenant}`;
 
@@ -174,6 +187,7 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         view,
         display,
         isBph,
+        hasUnifiedCatalogue,
         digitizedUbns,
         catalogTotal,
         tenantSlug: tenant,

--- a/src/components/libraries/CatalogBrowser.tsx
+++ b/src/components/libraries/CatalogBrowser.tsx
@@ -1,0 +1,747 @@
+'use client';
+
+// Generic per-tenant catalogue browser. Reads from `/api/catalog/[tenant]`,
+// which queries the unified `library_catalog_records` table. Modelled on
+// BphCatalogBrowser; the BPH version stays in place because BPH still uses
+// its own `bph_works` table with bespoke search columns.
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useDebouncedCallback } from 'use-debounce';
+import { Search, X, ChevronLeft, ChevronRight, BookMarked, SlidersHorizontal } from 'lucide-react';
+import { tenantBookUrl } from '@/lib/slugify';
+
+export interface CatalogRecord {
+  catalog_id: string;
+  title: string | null;
+  parallel_title: string | null;
+  uniform_title: string | null;
+  author: string | null;
+  variant_author: string | null;
+  pseudonym: string | null;
+  editor: string | null;
+  variant_editor: string | null;
+  place: string | null;
+  printer: string | null;
+  publisher: string | null;
+  variant_printer: string | null;
+  variant_publisher: string | null;
+  year: number | null;
+  year_text: string | null;
+  shelf_mark: string | null;
+  state_shelf_mark: string | null;
+  present_location: string | null;
+  keywords: string | null;
+  language: string | null;
+  series_title: string | null;
+  volume_title: string | null;
+  bibliography: string | null;
+  remarks: string | null;
+  number_of_copies: number | null;
+  object_size_cm: string | null;
+  binding: string | null;
+  bound_with: string | null;
+  provenance: string | null;
+  thumbnail: string | null;
+  file_count: number | null;
+  sl_book_id: string | null;
+  sl_book_slug: string | null;
+  sl_external_book_id?: string | null;
+  sl_external_slug?: string | null;
+  sl_external_source?: string | null;
+  ia_identifier: string | null;
+  ustc_sn: string | null;
+  metadata?: Record<string, unknown> | null;
+  /** Attached server-side when the row is linked to a digitised SL book. */
+  sl_cover?: string | null;
+}
+
+/** Display-friendly label for an external scan provider. */
+function externalSourceLabel(source: string | null | undefined): string {
+  if (!source) return 'another archive';
+  const map: Record<string, string> = {
+    internet_archive: 'Internet Archive',
+    cmc_kloss: 'CMC (Kloss collection)',
+    mdz: 'MDZ',
+    gallica: 'Gallica',
+    'e-rara': 'e-rara',
+    google_books: 'Google Books',
+    allard_pierson: 'Allard Pierson',
+    bodleian: 'Bodleian',
+    vatican: 'Vatican',
+    cambridge: 'Cambridge',
+    laurenziana: 'Laurenziana',
+  };
+  if (map[source]) return map[source];
+  return source.replace(/[_-]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+interface AdvancedFilters {
+  author: string;
+  title: string;
+  editor: string;
+  place: string;
+  printer: string;
+  publisher: string;
+  shelf_mark: string;
+  language: string;
+  yearFrom: string;
+  yearTo: string;
+  digitized: '' | 'true' | 'sl' | 'false';
+}
+
+const EMPTY_ADV: AdvancedFilters = {
+  author: '', title: '', editor: '', place: '', printer: '', publisher: '',
+  shelf_mark: '', language: '', yearFrom: '', yearTo: '', digitized: '',
+};
+
+const PER_PAGE = 50;
+
+const SORT_OPTIONS = [
+  { value: 'title', label: 'Title A-Z' },
+  { value: 'author', label: 'Author A-Z' },
+  { value: 'year_asc', label: 'Year (oldest first)' },
+  { value: 'year_desc', label: 'Year (newest first)' },
+  { value: 'shelfmark', label: 'Shelfmark' },
+];
+
+interface Props {
+  /** Tenant slug — used in the API path: `/api/catalog/${tenant}`. */
+  tenant: string;
+  /** Map of catalog_id → { id, slug } for digitised books (overrides sl_book_id from row). */
+  digitizedIds: Record<string, { id: string; slug: string }>;
+  /** Optional tenant slug for nested book URLs (often matches `tenant`). */
+  tenantSlug?: string;
+  /** When true, defaults to advanced search expanded. */
+  defaultAdvanced?: boolean;
+  /** Optional subject-keyword dropdown. Omit to hide it (Kloss has no curated subject list yet). */
+  keywordOptions?: Array<{ value: string; label: string }>;
+  /** Fires when the filtered result count changes so a parent shell can show "X of N works". */
+  onTotalChange?: (total: number, isFiltered: boolean) => void;
+  /** When true, hide the inline "{total} works" label on the simple-search row. */
+  hideInlineCount?: boolean;
+  /** Optional content rendered inline in the search row, between the subjects dropdown and Advanced. */
+  searchRowSlot?: React.ReactNode;
+  /** Optional content rendered in a results-header row above the table; receives the sort dropdown when present. */
+  resultsHeaderSlot?: React.ReactNode;
+  /** When set, the header reads "{total} of {catalogTotal} works". */
+  catalogTotal?: number;
+  /** Lock the digitised filter to "On Source Library" and hide its control in Advanced. */
+  lockDigitized?: boolean;
+  /** "list" renders the catalogue table; "grid" renders covers for the same filtered page. */
+  display?: 'list' | 'grid';
+}
+
+export default function CatalogBrowser({
+  tenant,
+  digitizedIds,
+  tenantSlug,
+  defaultAdvanced = false,
+  keywordOptions,
+  onTotalChange,
+  hideInlineCount = false,
+  searchRowSlot,
+  resultsHeaderSlot,
+  catalogTotal,
+  lockDigitized = false,
+  display = 'list',
+}: Props) {
+  const searchParams = useSearchParams();
+
+  const initialQ = searchParams.get('cq') || '';
+  const initialSort = searchParams.get('csort') || 'title';
+  const initialKeyword = searchParams.get('ckeyword') || '';
+  const initialOffset = parseInt(searchParams.get('coffset') || '0') || 0;
+  const initialAdv: AdvancedFilters = {
+    author: searchParams.get('cauthor') || '',
+    title: searchParams.get('ctitle') || '',
+    editor: searchParams.get('ceditor') || '',
+    place: searchParams.get('cplace') || '',
+    printer: searchParams.get('cprinter') || '',
+    publisher: searchParams.get('cpublisher') || '',
+    shelf_mark: searchParams.get('cshelf') || '',
+    language: searchParams.get('clang') || '',
+    yearFrom: searchParams.get('cyfrom') || '',
+    yearTo: searchParams.get('cyto') || '',
+    digitized: lockDigitized ? 'sl' : ((searchParams.get('cdig') || '') as AdvancedFilters['digitized']),
+  };
+  const hasAnyAdv = Object.entries(initialAdv).some(
+    ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
+  );
+  const cadvParam = searchParams.get('cadv') === '1';
+
+  const [works, setWorks] = useState<CatalogRecord[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState(initialQ);
+  const [sort, setSort] = useState(initialSort);
+  const [keyword, setKeyword] = useState(initialKeyword);
+  const [offset, setOffset] = useState(initialOffset);
+  const [adv, setAdv] = useState<AdvancedFilters>(initialAdv);
+  const [showAdvanced, setShowAdvanced] = useState(defaultAdvanced || hasAnyAdv || cadvParam);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const buildParams = useCallback((q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
+    const params = new URLSearchParams();
+    if (q) params.set('q', q);
+    if (s) params.set('sort', s);
+    if (kw) params.set('keyword', kw);
+    if (off) params.set('offset', String(off));
+    if (a.author) params.set('author', a.author);
+    if (a.title) params.set('title', a.title);
+    if (a.editor) params.set('editor', a.editor);
+    if (a.place) params.set('place', a.place);
+    if (a.printer) params.set('printer', a.printer);
+    if (a.publisher) params.set('publisher', a.publisher);
+    if (a.shelf_mark) params.set('shelf_mark', a.shelf_mark);
+    if (a.language) params.set('language', a.language);
+    if (a.yearFrom) params.set('yearFrom', a.yearFrom);
+    if (a.yearTo) params.set('yearTo', a.yearTo);
+    if (a.digitized) params.set('digitized', a.digitized);
+    return params;
+  }, []);
+
+  const fetchWorks = useCallback(async (q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const isFiltered = !!q || !!kw || Object.entries(a).some(
+      ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
+    );
+
+    setLoading(true);
+    try {
+      const params = buildParams(q, s, kw, off, a);
+      const res = await fetch(`/api/catalog/${encodeURIComponent(tenant)}?${params}`, { signal: controller.signal });
+      const data = await res.json();
+      setWorks(data.works || []);
+      setTotal(data.total || 0);
+      onTotalChange?.(data.total || 0, isFiltered);
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return;
+      setWorks([]);
+      setTotal(0);
+      onTotalChange?.(0, isFiltered);
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, [tenant, buildParams, onTotalChange, lockDigitized]);
+
+  const updateUrl = useCallback((q: string, s: string, kw: string, off: number, a: AdvancedFilters) => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const setOrDel = (key: string, val: string) => {
+      if (val) params.set(key, val);
+      else params.delete(key);
+    };
+    setOrDel('cq', q);
+    setOrDel('csort', s !== 'title' ? s : '');
+    setOrDel('ckeyword', kw);
+    setOrDel('coffset', off ? String(off) : '');
+    setOrDel('cauthor', a.author);
+    setOrDel('ctitle', a.title);
+    setOrDel('ceditor', a.editor);
+    setOrDel('cplace', a.place);
+    setOrDel('cprinter', a.printer);
+    setOrDel('cpublisher', a.publisher);
+    setOrDel('cshelf', a.shelf_mark);
+    setOrDel('clang', a.language);
+    setOrDel('cyfrom', a.yearFrom);
+    setOrDel('cyto', a.yearTo);
+    setOrDel('cdig', a.digitized);
+    const qs = params.toString();
+    const path = window.location.pathname;
+    window.history.replaceState(null, '', qs ? `${path}?${qs}` : path);
+  }, []);
+
+  useEffect(() => {
+    fetchWorks(initialQ, initialSort, initialKeyword, initialOffset, initialAdv);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const debouncedSearch = useDebouncedCallback((value: string) => {
+    setOffset(0);
+    fetchWorks(value, sort, keyword, 0, adv);
+    updateUrl(value, sort, keyword, 0, adv);
+  }, 300);
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    debouncedSearch(value);
+  };
+
+  const handleSortChange = (newSort: string) => {
+    setSort(newSort);
+    setOffset(0);
+    fetchWorks(searchQuery, newSort, keyword, 0, adv);
+    updateUrl(searchQuery, newSort, keyword, 0, adv);
+  };
+
+  const handleKeywordChange = (newKw: string) => {
+    setKeyword(newKw);
+    setOffset(0);
+    fetchWorks(searchQuery, sort, newKw, 0, adv);
+    updateUrl(searchQuery, sort, newKw, 0, adv);
+  };
+
+  const handlePage = (newOffset: number) => {
+    setOffset(newOffset);
+    fetchWorks(searchQuery, sort, keyword, newOffset, adv);
+    updateUrl(searchQuery, sort, keyword, newOffset, adv);
+  };
+
+  const applyAdvanced = (nextAdv: AdvancedFilters = adv) => {
+    setOffset(0);
+    fetchWorks(searchQuery, sort, keyword, 0, nextAdv);
+    updateUrl(searchQuery, sort, keyword, 0, nextAdv);
+  };
+
+  const debouncedApplyAdvanced = useDebouncedCallback((nextAdv: AdvancedFilters) => {
+    applyAdvanced(nextAdv);
+  }, 300);
+
+  const handleAdvChange = (key: keyof AdvancedFilters, value: string) => {
+    const next = { ...adv, [key]: value } as AdvancedFilters;
+    setAdv(next);
+    debouncedApplyAdvanced(next);
+  };
+
+  const clearAll = () => {
+    const cleared: AdvancedFilters = lockDigitized ? { ...EMPTY_ADV, digitized: 'sl' } : EMPTY_ADV;
+    setSearchQuery('');
+    setKeyword('');
+    setAdv(cleared);
+    setOffset(0);
+    fetchWorks('', sort, '', 0, cleared);
+    updateUrl('', sort, '', 0, cleared);
+  };
+
+  const advCount = useMemo(
+    () => Object.entries(adv).filter(([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')).length,
+    [adv, lockDigitized]
+  );
+  const currentPage = Math.floor(offset / PER_PAGE) + 1;
+  const totalPages = Math.ceil(total / PER_PAGE);
+
+  // Resolve the digitised destination for a row: prefer the parent-supplied
+  // live map (Mongo-fresh), fall back to the row's stored sl_book_id.
+  const resolveDigitized = (w: CatalogRecord) => {
+    const fromMap = digitizedIds[w.catalog_id];
+    if (fromMap) return fromMap;
+    if (w.sl_book_id) return { id: w.sl_book_id, slug: w.sl_book_slug || w.sl_book_id };
+    return null;
+  };
+
+  // Cross-provider link: tenant holds the physical work, scan lives elsewhere.
+  // Surfaced as a secondary "Read at [source]" link when no tenant-native scan.
+  const resolveExternal = (w: CatalogRecord, hasDigitized: boolean) => {
+    if (hasDigitized || !w.sl_external_book_id) return null;
+    return {
+      id: w.sl_external_book_id,
+      slug: w.sl_external_slug || w.sl_external_book_id,
+      source: w.sl_external_source || null,
+    };
+  };
+
+  const sortLivesInHeader = resultsHeaderSlot !== undefined;
+  const showKeywordDropdown = !!keywordOptions && keywordOptions.length > 0;
+
+  // Year for display: prefer parsed int, fall back to free-text ("[ca. 1805-06]").
+  const yearDisplay = (w: CatalogRecord): string =>
+    (w.year ? String(w.year) : '') || (w.year_text || '');
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 mb-3">
+        <div className="relative flex-1 min-w-[14rem] max-w-xl">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="Search across all fields…"
+            className="w-full text-sm border border-border-light rounded-md pl-9 pr-9 py-2 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => handleSearchChange('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted hover:text-primary"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+
+        {showKeywordDropdown && (
+          <select
+            value={keyword}
+            onChange={(e) => handleKeywordChange(e.target.value)}
+            className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
+          >
+            {keywordOptions!.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        )}
+
+        {searchRowSlot}
+
+        {!sortLivesInHeader && (
+          <select
+            value={sort}
+            onChange={(e) => handleSortChange(e.target.value)}
+            className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
+          >
+            {SORT_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        )}
+
+        <button
+          onClick={() => setShowAdvanced(s => !s)}
+          className="inline-flex items-center gap-1.5 text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary hover:bg-warm transition-colors"
+        >
+          <SlidersHorizontal className="w-3.5 h-3.5" />
+          Advanced
+          {advCount > 0 && (
+            <span className="ml-1 inline-flex items-center justify-center w-5 h-5 text-xs rounded-full bg-accent-rust text-white">
+              {advCount}
+            </span>
+          )}
+        </button>
+
+        {!hideInlineCount && !sortLivesInHeader && (
+          <span className="text-sm text-muted ml-auto">
+            {total.toLocaleString('en-US')} works
+          </span>
+        )}
+      </div>
+
+      {sortLivesInHeader && (
+        <div className="flex flex-wrap items-center gap-3 mb-4">
+          <span className="text-sm text-muted">
+            <span className="font-medium text-primary">{total.toLocaleString('en-US')}</span>
+            {catalogTotal && catalogTotal > 0 ? ` of ${catalogTotal.toLocaleString('en-US')} works` : ' works'}
+          </span>
+          <div className="flex items-center gap-3 ml-auto">
+            <label className="inline-flex items-center gap-2 text-sm text-muted">
+              <span>Sort by</span>
+              <select
+                value={sort}
+                onChange={(e) => handleSortChange(e.target.value)}
+                className="text-sm border border-border-light rounded-md px-3 py-2 bg-white text-primary"
+              >
+                {SORT_OPTIONS.map(o => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </label>
+            {resultsHeaderSlot}
+          </div>
+        </div>
+      )}
+
+      {showAdvanced && (
+        <div className="mb-4 p-4 bg-warm border border-border-light rounded-lg">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <AdvField label="Author" value={adv.author} onChange={v => handleAdvChange('author', v)} />
+            <AdvField label="Title" value={adv.title} onChange={v => handleAdvChange('title', v)} />
+            <AdvField label="Editor / translator" value={adv.editor} onChange={v => handleAdvChange('editor', v)} />
+            <AdvField label="Place of publication" value={adv.place} onChange={v => handleAdvChange('place', v)} placeholder="London, Lyon, Amsterdam…" />
+            <AdvField label="Printer" value={adv.printer} onChange={v => handleAdvChange('printer', v)} />
+            <AdvField label="Publisher" value={adv.publisher} onChange={v => handleAdvChange('publisher', v)} />
+            <AdvField label="Shelfmark" value={adv.shelf_mark} onChange={v => handleAdvChange('shelf_mark', v)} />
+            <AdvField label="Language" value={adv.language} onChange={v => handleAdvChange('language', v)} placeholder="Latin, German, English…" />
+            <div>
+              <label className="block text-xs text-muted mb-1">Year range</label>
+              <div className="flex gap-2">
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  value={adv.yearFrom}
+                  onChange={(e) => handleAdvChange('yearFrom', e.target.value)}
+                  placeholder="from"
+                  className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+                />
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  value={adv.yearTo}
+                  onChange={(e) => handleAdvChange('yearTo', e.target.value)}
+                  placeholder="to"
+                  className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+                />
+              </div>
+            </div>
+            {!lockDigitized && (
+              <div>
+                <label className="block text-xs text-muted mb-1">Digitization</label>
+                <select
+                  value={adv.digitized}
+                  onChange={(e) => handleAdvChange('digitized', e.target.value)}
+                  className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
+                >
+                  <option value="">All</option>
+                  <option value="sl">On Source Library</option>
+                  <option value="true">Digitised anywhere</option>
+                  <option value="false">Not digitised</option>
+                </select>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-4">
+            <button
+              onClick={clearAll}
+              className="px-3 py-1.5 text-sm text-muted hover:text-primary transition-colors"
+            >
+              Clear all
+            </button>
+            <span className="text-xs text-muted ml-auto">
+              Filters apply as you type. The simple search above queries every field at once.
+            </span>
+          </div>
+        </div>
+      )}
+
+      {display === 'list' ? (
+      <div className="border border-border-light rounded-lg overflow-hidden bg-white">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border-light bg-warm">
+                <th className="text-left px-3 py-2.5 font-medium text-secondary">Title</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden sm:table-cell">Author</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary w-16">Year</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Place</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden md:table-cell">Shelfmark</th>
+                <th className="text-left px-3 py-2.5 font-medium text-secondary hidden lg:table-cell">Subject</th>
+              </tr>
+            </thead>
+            <tbody className={loading ? 'opacity-50' : ''}>
+              {loading && works.length === 0 && (
+                Array.from({ length: 8 }, (_, i) => (
+                  <tr key={`skel-${i}`} className="border-b border-border-light last:border-0">
+                    <td className="px-3 py-3 align-top">
+                      <div className="h-4 w-3/4 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden sm:table-cell">
+                      <div className="h-4 w-1/2 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top tabular-nums">
+                      <div className="h-4 w-10 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden md:table-cell">
+                      <div className="h-4 w-16 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden md:table-cell">
+                      <div className="h-4 w-20 bg-border-light/40 rounded animate-pulse" />
+                    </td>
+                    <td className="px-3 py-3 align-top hidden lg:table-cell">
+                      <div className="h-5 w-20 bg-border-light/40 rounded-full animate-pulse" />
+                    </td>
+                  </tr>
+                ))
+              )}
+              {works.map((w) => {
+                const digitized = resolveDigitized(w);
+                const external = resolveExternal(w, !!digitized);
+                const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
+                const displayAuthor = w.author || w.variant_author || w.pseudonym;
+                // Title link target: digitised SL book if any, then external,
+                // then plain text. We deliberately do NOT link to a catalogue
+                // detail page here — Phase 6 introduces that per tenant.
+                const titleHref = digitized
+                  ? tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug)
+                  : external
+                    ? tenantBookUrl({ id: external.id, slug: external.slug }, tenantSlug)
+                    : null;
+                return (
+                  <tr
+                    key={w.catalog_id}
+                    className="border-b border-border-light last:border-0 hover:bg-cream/50 transition-colors"
+                  >
+                    <td className="px-3 py-2 align-top">
+                      <div className="font-medium text-primary leading-snug">
+                        {titleHref ? (
+                          <a href={titleHref} className="hover:text-accent-rust transition-colors">
+                            {displayTitle}
+                          </a>
+                        ) : (
+                          <span>{displayTitle}</span>
+                        )}
+                      </div>
+                      {digitized && (
+                        <a
+                          href={tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug)}
+                          className="inline-flex items-center gap-1 mt-1 text-xs text-accent-rust hover:underline"
+                        >
+                          <BookMarked className="w-3 h-3" />
+                          Digitised copy
+                        </a>
+                      )}
+                      {external && (
+                        <a
+                          href={tenantBookUrl({ id: external.id, slug: external.slug }, tenantSlug)}
+                          className="inline-flex items-center gap-1 mt-1 text-xs text-secondary hover:text-accent-rust hover:underline"
+                        >
+                          <BookMarked className="w-3 h-3 opacity-60" />
+                          Read at {externalSourceLabel(external.source)}
+                        </a>
+                      )}
+                      <div className="text-xs text-muted sm:hidden mt-0.5">
+                        {displayAuthor}{w.place ? ` · ${w.place}` : ''}
+                      </div>
+                      {w.printer && (
+                        <div className="text-[11px] text-muted mt-0.5 hidden md:block">
+                          {w.printer}{w.publisher && w.publisher !== w.printer ? ` / ${w.publisher}` : ''}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 align-top text-secondary hidden sm:table-cell">
+                      {displayAuthor || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 align-top text-secondary tabular-nums">
+                      {yearDisplay(w) || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 align-top text-secondary hidden md:table-cell">
+                      {w.place || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 align-top text-secondary font-mono text-xs hidden md:table-cell">
+                      {w.shelf_mark || <span className="text-muted">—</span>}
+                    </td>
+                    <td className="px-3 py-2 align-top hidden lg:table-cell">
+                      {w.keywords ? (
+                        <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-cream border border-border-light text-secondary capitalize">
+                          {w.keywords}
+                        </span>
+                      ) : (
+                        <span className="text-muted">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+              {!loading && works.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-12 text-center text-muted">
+                    No works found matching your search.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      ) : (
+        <div className={loading ? 'opacity-50' : ''}>
+          {loading && works.length === 0 ? (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {Array.from({ length: 12 }, (_, i) => (
+                <div key={`skel-${i}`} className="flex flex-col">
+                  <div className="aspect-[2/3] bg-border-light/40 rounded-md animate-pulse" />
+                  <div className="h-4 w-3/4 bg-border-light/40 rounded mt-2 animate-pulse" />
+                  <div className="h-3 w-1/2 bg-border-light/40 rounded mt-1 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          ) : works.length > 0 ? (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {works.map((w) => {
+                const digitized = resolveDigitized(w);
+                const external = resolveExternal(w, !!digitized);
+                const displayTitle = w.title || w.parallel_title || w.uniform_title || '(untitled)';
+                const displayAuthor = w.author || w.variant_author || w.pseudonym;
+                const href = digitized
+                  ? tenantBookUrl({ id: digitized.id, slug: digitized.slug }, tenantSlug)
+                  : external
+                    ? tenantBookUrl({ id: external.id, slug: external.slug }, tenantSlug)
+                    : '#';
+                return (
+                  <a
+                    key={w.catalog_id}
+                    href={href}
+                    className="group flex flex-col text-left"
+                  >
+                    <div className="relative aspect-[2/3] bg-warm rounded-md overflow-hidden border border-border-light group-hover:border-accent-rust/40 transition-colors">
+                      {w.sl_cover ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={w.sl_cover}
+                          alt={displayTitle}
+                          loading="lazy"
+                          className="absolute inset-0 w-full h-full object-cover"
+                        />
+                      ) : (
+                        <div className="absolute inset-0 flex items-center justify-center text-muted">
+                          <BookMarked className="w-8 h-8 opacity-40" />
+                        </div>
+                      )}
+                      {external && (
+                        <div className="absolute bottom-1 left-1 right-1 px-1.5 py-0.5 text-[10px] leading-tight text-white bg-black/55 rounded-sm text-center">
+                          via {externalSourceLabel(external.source)}
+                        </div>
+                      )}
+                    </div>
+                    <div className="mt-2 text-sm font-medium text-primary leading-snug line-clamp-2 group-hover:text-accent-rust transition-colors">
+                      {displayTitle}
+                    </div>
+                    {displayAuthor && (
+                      <div className="text-xs text-muted mt-0.5 line-clamp-1">
+                        {displayAuthor}
+                        {w.year ? ` · ${w.year}` : ''}
+                      </div>
+                    )}
+                  </a>
+                );
+              })}
+            </div>
+          ) : (
+            !loading && (
+              <div className="text-center py-16 text-muted">
+                No works found matching your search.
+              </div>
+            )
+          )}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-4">
+          <button
+            onClick={() => handlePage(Math.max(0, offset - PER_PAGE))}
+            disabled={offset === 0}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm border border-border-light rounded-md hover:bg-warm transition-colors disabled:opacity-30 disabled:cursor-default"
+          >
+            <ChevronLeft className="w-4 h-4" /> Previous
+          </button>
+          <span className="text-sm text-muted">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            onClick={() => handlePage(offset + PER_PAGE)}
+            disabled={currentPage >= totalPages}
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm border border-border-light rounded-md hover:bg-warm transition-colors disabled:opacity-30 disabled:cursor-default"
+          >
+            Next <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AdvField({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (v: string) => void; placeholder?: string }) {
+  return (
+    <div>
+      <label className="block text-xs text-muted mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary focus:outline-none focus:ring-2 focus:ring-accent-rust/30"
+      />
+    </div>
+  );
+}

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -15,6 +15,7 @@ import CollectionFilters from '@/components/collections/CollectionFilters';
 import { bookTitle } from '@/lib/collections-utils';
 import BphCatalogBrowser from '@/components/libraries/BphCatalogBrowser';
 import BphUnifiedCatalogue from '@/components/libraries/BphUnifiedCatalogue';
+import UnifiedCatalogue from '@/components/libraries/UnifiedCatalogue';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { getEmbedUiPolicy } from '@/lib/embed-ui-policy';
 import { useEmbed, useEmbedHref } from '@/lib/EmbedContext';
@@ -95,6 +96,11 @@ export interface SharedLibraryViewProps {
   /** Display dimension on the BPH unified catalogue. Independent of `view`. */
   display?: 'list' | 'grid';
   isBph: boolean;
+  /** True for tenants with a BPH-parity Books|Catalogue structure that is
+   *  NOT BPH itself (currently: kloss-collection). Reads `library_catalog_records`
+   *  via /api/catalog/[tenant]. Mutually exclusive with isBph for now — BPH
+   *  still uses its bespoke bph_works pipeline. */
+  hasUnifiedCatalogue?: boolean;
   digitizedUbns?: Record<string, { id: string; slug: string }>;
   catalogTotal?: number;
   /** Optional tenant slug to pass to nested components */
@@ -119,6 +125,7 @@ export default function SharedLibraryView({
   view,
   display,
   isBph,
+  hasUnifiedCatalogue = false,
   digitizedUbns = {},
   catalogTotal = 0,
   tenantSlug,
@@ -140,15 +147,23 @@ export default function SharedLibraryView({
   // clicking the list/grid icons changes display only; the Show all / Show
   // digitised toggle changes view only. Default landing (no view) keeps the
   // legacy Selected Books + Catalog combo.
+  //
+  // `hasUnifiedCatalogue` (kloss-collection and future tenants) opts into the
+  // same shell but reads from the generic library_catalog_records table via
+  // /api/catalog/[tenant]. BPH stays on its own bph_works pipeline for now.
+  const usesUnifiedCatalogue = isBph || hasUnifiedCatalogue;
   const showSelectedBooksRow = isBph && view !== 'books' && view !== 'catalog';
-  const showUnifiedCatalogue = isBph && (view === 'books' || view === 'catalog');
+  const showUnifiedCatalogue = usesUnifiedCatalogue && (view === 'books' || view === 'catalog');
   const catalogueMode = view === 'books' ? 'digitized' : 'all';
   const effectiveDisplay: 'list' | 'grid' =
     display ?? (catalogueMode === 'digitized' ? 'grid' : 'list');
-  // Render the books grid for non-BPH tenants always. BPH grid view is
-  // rendered inside BphUnifiedCatalogue/BphCatalogBrowser using the Supabase
-  // data source (so search + Advanced filter the covers live).
-  const showBooksGrid = !isBph;
+  // BPH renders covers inside its unified shell on every view, so the
+  // generic grid is always hidden there. Other unified-catalogue tenants
+  // (kloss) only swap to the unified shell when the user explicitly picks
+  // ?view=books|catalog (e.g. via the subdomain proxy's /catalogue rewrite);
+  // the default landing keeps the standard books grid so the main-domain
+  // /{tenant} path still has something to render.
+  const showBooksGrid = !isBph && !showUnifiedCatalogue;
 
   return (
     <div className="min-h-screen bg-cream">
@@ -183,7 +198,7 @@ export default function SharedLibraryView({
           {tenantSlug && (
             <div className="max-w-2xl mb-5">
               <UnifiedSearch dropdownPosition="bottom" />
-              {isBph && catalogTotal > 0 ? (
+              {usesUnifiedCatalogue && catalogTotal > 0 ? (
                 <Link
                   href={forceEmbedded ? '/catalogue' : `${basePath}/catalogue`}
                   className="inline-flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 transition-colors mt-3"
@@ -204,7 +219,7 @@ export default function SharedLibraryView({
           )}
 
           <div className="flex flex-wrap items-center gap-4 text-sm text-white/50">
-            {isBph && catalogTotal > 0 ? (
+            {usesUnifiedCatalogue && catalogTotal > 0 ? (
               <>
                 <span>{catalogTotal.toLocaleString('en-US')} works in catalogue</span>
                 <span className="w-px h-4 bg-white/20" />
@@ -302,7 +317,7 @@ export default function SharedLibraryView({
           Kloss, future partners) get an "Institution + Unknown" pair that
           adds noise without insight. Show only when there are >=3 distinct
           contributors. */}
-      {contributingLibraries.length >= 3 && !isBph && (
+      {contributingLibraries.length >= 3 && !usesUnifiedCatalogue && (
         <div className="bg-warm border-b border-border-light">
           <div className="max-w-7xl mx-auto px-6 py-6">
             <div className="flex items-center gap-2 mb-4">
@@ -335,14 +350,27 @@ export default function SharedLibraryView({
 
       <div className="max-w-7xl mx-auto px-6 py-10">
         {showUnifiedCatalogue && (
-          <BphUnifiedCatalogue
-            mode={catalogueMode}
-            display={effectiveDisplay}
-            catalogTotal={catalogTotal}
-            basePath={basePath}
-            digitizedUbns={digitizedUbns}
-            tenantSlug={tenantSlug ?? undefined}
-          />
+          isBph ? (
+            <BphUnifiedCatalogue
+              mode={catalogueMode}
+              display={effectiveDisplay}
+              catalogTotal={catalogTotal}
+              basePath={basePath}
+              digitizedUbns={digitizedUbns}
+              tenantSlug={tenantSlug ?? undefined}
+            />
+          ) : (
+            <UnifiedCatalogue
+              tenant={partner.slug}
+              mode={catalogueMode}
+              display={effectiveDisplay}
+              catalogTotal={catalogTotal}
+              basePath={basePath}
+              digitizedIds={digitizedUbns}
+              tenantSlug={tenantSlug ?? undefined}
+              libraryName={partner.name}
+            />
+          )
         )}
         {showBooksGrid ? (
           <>

--- a/src/components/libraries/UnifiedCatalogue.tsx
+++ b/src/components/libraries/UnifiedCatalogue.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+// Generic tenant catalogue shell, modelled on BphUnifiedCatalogue. Hosts the
+// Library Catalogue heading + the segmented "Show all / Show digitised &
+// translated" toggle + the list/grid view icons, and renders CatalogBrowser
+// for the actual table or covers grid.
+//
+// FILTER (view)        Show all (catalog)  vs  Show digitised & translated (books)
+// DISPLAY (display)    List  vs  Grid
+
+import Link from 'next/link';
+import { LayoutGrid, List } from 'lucide-react';
+import CatalogBrowser from '@/components/libraries/CatalogBrowser';
+import { useEmbedHref } from '@/lib/EmbedContext';
+
+export type CatalogueMode = 'all' | 'digitized';
+export type CatalogueDisplay = 'list' | 'grid';
+
+interface Props {
+  /** Tenant slug — used for the API path `/api/catalog/${tenant}`. */
+  tenant: string;
+  /** "all" → no filter, full catalogue. "digitized" → SL-digitised subset only. */
+  mode: CatalogueMode;
+  /** "list" → catalogue table. "grid" → covers grid. Independent of mode. */
+  display: CatalogueDisplay;
+  /** Total catalogue rows for this tenant. Denominator for the counter. */
+  catalogTotal: number;
+  /** basePath for embed/link construction (e.g. "/embed/kloss-collection"). */
+  basePath: string;
+  /** catalog_id → {id, slug} map for digitised books (live-Mongo override). */
+  digitizedIds: Record<string, { id: string; slug: string }>;
+  /** Tenant slug for nested book URLs (defaults to tenant). */
+  tenantSlug?: string;
+  /** Library name shown in the catalogue heading subtitle. */
+  libraryName: string;
+  /** Optional curated subject-keyword dropdown options. */
+  keywordOptions?: Array<{ value: string; label: string }>;
+}
+
+function makeHref(basePath: string, view: 'catalog' | 'books', display: CatalogueDisplay) {
+  return `${basePath}?view=${view}&display=${display}`;
+}
+
+export default function UnifiedCatalogue({
+  tenant,
+  mode,
+  display,
+  catalogTotal,
+  basePath,
+  digitizedIds,
+  tenantSlug,
+  libraryName,
+  keywordOptions,
+}: Props) {
+  const embedHref = useEmbedHref();
+
+  // "Show all" forces list display: grid only renders rows with thumbnails
+  // (the digitised subset). The grid icon is the inverse case — grid only
+  // makes sense on the digitised subset, so clicking grid lands on view=books.
+  const allHref = embedHref(makeHref(basePath, 'catalog', 'list'));
+  const digitizedHref = embedHref(makeHref(basePath, 'books', display));
+  const listHref = embedHref(makeHref(basePath, mode === 'digitized' ? 'books' : 'catalog', 'list'));
+  const gridHref = embedHref(makeHref(basePath, 'books', 'grid'));
+
+  const toggleNode = (
+    <SegmentedToggle mode={mode} allHref={allHref} digitizedHref={digitizedHref} />
+  );
+  const viewIconsNode = (
+    <ViewIcons display={display} listHref={listHref} gridHref={gridHref} />
+  );
+
+  // Grid view shows only the digitised subset (covers only exist for
+  // SL-backed books). Lock the catalogue filter to digitised so the count
+  // reflects what's visible.
+  const effectiveLockDigitized = mode === 'digitized' || display === 'grid';
+
+  return (
+    <>
+      <div className="mb-6">
+        <h2 className="text-2xl sm:text-3xl text-primary font-display">
+          Library Catalogue
+        </h2>
+        <p className="text-sm text-muted mt-1">
+          Complete catalogue of the {libraryName}.
+        </p>
+      </div>
+
+      <CatalogBrowser
+        key={`cat-${tenant}-${mode}-${display}`}
+        tenant={tenant}
+        digitizedIds={digitizedIds}
+        tenantSlug={tenantSlug}
+        hideInlineCount
+        searchRowSlot={toggleNode}
+        resultsHeaderSlot={viewIconsNode}
+        catalogTotal={catalogTotal}
+        lockDigitized={effectiveLockDigitized}
+        display={display}
+        keywordOptions={keywordOptions}
+      />
+    </>
+  );
+}
+
+function SegmentedToggle({
+  mode,
+  allHref,
+  digitizedHref,
+}: {
+  mode: CatalogueMode;
+  allHref: string;
+  digitizedHref: string;
+}) {
+  const base = 'px-4 py-2 text-sm font-medium transition-colors';
+  const active = 'bg-primary text-white';
+  const inactive = 'bg-white text-secondary hover:bg-warm';
+  return (
+    <div className="inline-flex border border-border-light rounded-md overflow-hidden">
+      <Link href={allHref} className={`${base} ${mode === 'all' ? active : inactive}`}>
+        Show all
+      </Link>
+      <Link
+        href={digitizedHref}
+        className={`${base} -ml-px ${mode === 'digitized' ? active : inactive}`}
+      >
+        Show digitised &amp; translated
+      </Link>
+    </div>
+  );
+}
+
+function ViewIcons({
+  display,
+  listHref,
+  gridHref,
+}: {
+  display: CatalogueDisplay;
+  listHref: string;
+  gridHref: string;
+}) {
+  const base = 'inline-flex items-center justify-center w-9 h-9 transition-colors border border-border-light';
+  const active = 'bg-primary text-white border-primary';
+  const inactive = 'bg-white text-muted hover:text-primary hover:bg-warm';
+  return (
+    <div className="inline-flex">
+      <Link
+        href={listHref}
+        title="List view"
+        aria-label="List view"
+        className={`${base} rounded-l-md ${display === 'list' ? active : inactive}`}
+      >
+        <List className="w-4 h-4" />
+      </Link>
+      <Link
+        href={gridHref}
+        title="Grid view"
+        aria-label="Grid view"
+        className={`${base} rounded-r-md -ml-px ${display === 'grid' ? active : inactive}`}
+      >
+        <LayoutGrid className="w-4 h-4" />
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/library-partners.ts
+++ b/src/lib/library-partners.ts
@@ -10,6 +10,12 @@ export interface LibraryPartner {
   color: 'rust' | 'sage' | 'violet' | 'gold';
   /** Hand-picked hero image URL — takes priority over auto-selected gallery images */
   heroImageOverride?: string;
+  /** Has a BPH-style "Books | Catalogue" tab structure driven by a Supabase
+   *  bibliographic export (library_catalog_records). When true, the tenant
+   *  page renders <UnifiedCatalogue> instead of the plain books grid. The
+   *  BPH-specific path (isBph branches) stays on its own bph_works pipeline
+   *  until a follow-up migration consolidates the two. */
+  hasUnifiedCatalogue?: boolean;
 }
 
 /**
@@ -231,6 +237,7 @@ export const LIBRARY_PARTNERS: Record<string, LibraryPartner> = {
     description: 'The Bibliotheca Klossiana at CMC Prins Frederik in The Hague preserves the collection of Georg Kloss (1787–1854), one of the most important Masonic, Rosicrucian, and esoteric manuscript collections in Europe.',
     color: 'gold',
     heroImageOverride: 'https://images.sourcelibrary.org/pages/69c1d094b82ba5d5bed99883/0355.jpg',
+    hasUnifiedCatalogue: true,
   },
   'library-of-congress': {
     slug: 'library-of-congress',

--- a/src/lib/tenant-library-loaders.ts
+++ b/src/lib/tenant-library-loaders.ts
@@ -535,3 +535,89 @@ export async function fetchTenantBphCataloguedBookIds(): Promise<Set<string> | n
     return null;
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Generic catalogue loaders (library_catalog_records)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build catalog_id → { id, slug } map for digitised books in a tenant's
+ * catalogue. Reads live Mongo books filtered by tenantId + providerKey, where
+ * `image_source.identifier` matches the catalogue's primary key (e.g. priref
+ * for Kloss). Overrides whatever's stored in the row at ETL time.
+ *
+ * Each tenant has its own short cache keyed by (tenantId, providerKey) so
+ * BPH-style cron sync isn't required for the visible counter to stay fresh
+ * within a single browsing session.
+ */
+const catalogDigitizedMapCache = new Map<string, { value: Record<string, { id: string; slug: string }>; expiresAt: number }>();
+const CATALOG_DIGITIZED_MAP_TTL_MS = 60_000;
+
+export async function fetchTenantCatalogDigitizedMap(
+  tenantId: string,
+  providerKey: string,
+): Promise<Record<string, { id: string; slug: string }>> {
+  const cacheKey = `${tenantId}::${providerKey}`;
+  const now = Date.now();
+  const cached = catalogDigitizedMapCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+  try {
+    const db = await getReadDb();
+    const books = await db.collection('books').find(
+      {
+        tenantId,
+        'image_source.provider': providerKey,
+        'image_source.identifier': { $exists: true },
+      },
+      { projection: { id: 1, slug: 1, 'image_source.identifier': 1 }, maxTimeMS: 4_000 }
+    ).toArray();
+
+    const map: Record<string, { id: string; slug: string }> = {};
+    for (const b of books as unknown as Array<{ id: string; slug?: string; image_source?: { identifier?: string | number } }>) {
+      const ident = b.image_source?.identifier;
+      if (ident !== undefined && ident !== null) {
+        map[String(ident)] = { id: b.id, slug: b.slug || b.id };
+      }
+    }
+    catalogDigitizedMapCache.set(cacheKey, { value: map, expiresAt: now + CATALOG_DIGITIZED_MAP_TTL_MS });
+    return map;
+  } catch (err) {
+    console.warn('[tenant-library-loaders] fetchTenantCatalogDigitizedMap failed, serving stale or empty:', err);
+    if (cached) return cached.value;
+    return {};
+  }
+}
+
+/**
+ * Total catalogue rows for a tenant in `library_catalog_records`. Cached
+ * for 60s so the displayed total stays stable across page navigations.
+ */
+const catalogTotalCache = new Map<string, { value: number; expiresAt: number }>();
+const CATALOG_TOTAL_TTL_MS = 60_000;
+
+export async function fetchTenantCatalogTotal(tenantSlug: string): Promise<number> {
+  const now = Date.now();
+  const cached = catalogTotalCache.get(tenantSlug);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+  try {
+    const { count } = await withTimeout(
+      supabase
+        .from('library_catalog_records')
+        .select('*', { count: 'exact', head: true })
+        .eq('tenant_id', tenantSlug),
+      SUPABASE_CALL_TIMEOUT_MS,
+      'fetchTenantCatalogTotal',
+    );
+    const value = count || 0;
+    catalogTotalCache.set(tenantSlug, { value, expiresAt: now + CATALOG_TOTAL_TTL_MS });
+    return value;
+  } catch (err) {
+    console.warn('[tenant-library-loaders] fetchTenantCatalogTotal failed, serving stale or 0:', err);
+    if (cached) return cached.value;
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary
- New `/api/catalog/[tenant]/route.ts` reads `library_catalog_records` (Phase 1's unified table) filtered by `tenant_id`. BPH stays on its `/api/catalog/bph` + `bph_works` pipeline untouched.
- New `CatalogBrowser` + `UnifiedCatalogue` components — generic versions of the BPH twins. Same dual filter × display shell; reads from the new generic route; keys rows on `catalog_id` and surfaces `year_text` alongside parsed year for Kloss's "[ca. 1805-06]" style strings.
- `library-partners.ts` gains `hasUnifiedCatalogue?: boolean` (set true for `kloss-collection`). `[tenant]/page.tsx`, `embed/[tenant]/page.tsx`, and `SharedLibraryView` branch on it alongside the existing `isBph` branch — BPH path is unchanged.

## Result
- `kloss.sourcelibrary.org/` (proxy default → `?view=books`) renders `UnifiedCatalogue` in covers-grid mode (1,521 digitised books).
- `kloss.sourcelibrary.org/catalogue` (proxy → `?view=catalog`) renders the full 1,614-row Kloss catalogue in list mode with search + advanced facets.
- BPH (Webflow embed + subdomain) is untouched.

## Out of scope (issue #1884 phases 4–6)
- Replace remaining `isBph` branches with `hasUnifiedCatalogue` flag.
- Tenant-aware advanced search page.
- Generic catalogue detail page (currently BPH-only at `/embed/[tenant]/catalog/[ubn]`); the new `CatalogBrowser` doesn't link there, so no 404 risk.

## Test plan
- [ ] `kloss.sourcelibrary.org/` shows the new covers grid with digitised Kloss books and the segmented `Show all | Show digitised & translated` toggle
- [ ] `kloss.sourcelibrary.org/catalogue` shows the full 1,614 Kloss records in list view, with shelf-mark search returning Klossiana shelf marks
- [ ] Advanced search filters (author, title, place, printer, publisher, shelfmark, year range, language) all filter the result set
- [ ] `bph.sourcelibrary.org/` and `/catalogue` still render the BPH catalogue (regression check — these are on a separate code path now but share the SharedLibraryView shell)
- [ ] `npx tsc --noEmit` is clean (confirmed locally)
- [ ] Vercel preview deploy renders the kloss subdomain

Refs #1884

🤖 Generated with [Claude Code](https://claude.com/claude-code)