### PR TITLE
founding-donors: refresh for $10M / 5yr institutional ask

### DIFF
--- a/.claude/docs/fundraising-plan-2026-05.md
+++ b/.claude/docs/fundraising-plan-2026-05.md
@@ -1,0 +1,75 @@
+# Source Library — Plan Summary
+
+**Status:** Canonical strategic document, May 2026. Supersedes prior versions in `~/sourcelibraryfundraising/`, `~/awt-fundraising-playbook/`, and `docs/fundraising/`.
+
+---
+
+## What we are
+
+SourceLibrary.org is the world's largest online library of translated ancient sources. It contains over 10,000 books translated from dozens of languages — Latin, Greek, Chinese, Sanskrit, Arabic, Hebrew, Egyptian, and more — ranging from sacred texts to early science.
+
+Our vision is to make ancient wisdom accessible to both people and AI — and to help contribute to the next renaissance in the age of AI.
+
+## Why this matters
+
+Ancient and lost knowledge, made accessible, can create an enormous social impact. The first Renaissance was triggered by the translation of classical wisdom texts (Plato, Hermes Trismegistus) from Greek into Latin. Yet the Renaissance itself was mostly written in Latin — and less than 3% of it has ever been translated into English.
+
+## The ask
+
+SourceLibrary.org is raising **$10 million in philanthropic funding over 5 years** to create a world-class institution with global impact — helping people and AI connect with ancient sources of lost knowledge.
+
+We are bringing ancient wisdom to the future.
+
+## Organizational Goals (5-year)
+
+| Goal | Budget |
+|---|---|
+| Translate 250,000+ books | $1.0M |
+| Scan 50,000+ new books | $2.5M |
+| Establish scalable technical foundation | $1.0M |
+| Partner with 1,000+ libraries around the world | $0.5M |
+| Create network of 10–50 founding donors | $0.1M |
+| Create braintrust of linguists and scholars for input | $1.0M |
+
+## Yearly Goals (annual operating)
+
+| Goal | Budget |
+|---|---|
+| Host 3 yearly global events and gatherings to activate community | $150K |
+| Host 2 yearly expeditions to gather | $150K |
+| 4 full-time staff | $800K |
+
+**Total program over 5 years: ~$11M**
+
+## Fundraising Plan
+
+We have so far been funded with seed funds from **two major donors**. Our goal now is to create a network of founding donors to support a global institution devoted to the stewardship of ancient wisdom — from books to oral histories to archaeological expeditions.
+
+We will reach out to private donors and seek corporate sponsorships of our globally accessible library.
+
+## What we have done already
+
+- Established a legal entity and 501(c)(3) tax-deductible organization
+- Translated 10,000+ books, 5,000+ for the first time
+- Built an API and MCP connection (so AI systems can research within the library)
+- Stood up a tech team
+- Stood up a marketing team
+- Stood up an organizational structure ← **this is the main goal of the current phase**
+
+---
+
+## Institutional structure
+
+- **Source Library is an initiative of the Embassy of the Free Mind** (Stichting Het Wereldhart, Amsterdam — home of the Bibliotheca Philosophica Hermetica, UNESCO Memory of the World Register).
+- **NL tax-deductibility:** Stichting Het Wereldhart holds Cultural ANBI status.
+- **US tax-deductibility:** Fiscally sponsored by the National Arts Fund (NAF), a 501(c)(3).
+- **Online giving:** https://form-renderer-app.donorperfect.io/give/naf/embassyofthefreemind
+
+## Implications for prior materials
+
+This plan supersedes earlier framings. Notable shifts:
+
+- **Scale:** $10M / 5 years / 250K books — not the earlier $500K / $1M frames.
+- **Scope:** Global ancient wisdom — Egyptian, Chinese, Sanskrit, Arabic, Hebrew alongside Greek/Latin. Not Renaissance-only.
+- **Frame:** "The next Renaissance in the age of AI" — for both human readers and AI systems.
+- **Organizational stage:** Already a real organization (legal entity in place via Stichting Het Wereldhart + NAF, teams, two seed donors). The case is no longer "fund a project"; it's "join a founding-donor network for a world-class institution."

--- a/src/app/founding-donors/page.tsx
+++ b/src/app/founding-donors/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
+import InputWidget from '@/components/InputWidget';
 
 export const metadata: Metadata = {
   title: 'Founding Donors - Source Library',
@@ -249,6 +250,10 @@ export default function FoundingDonorsPage() {
           <p>derek@sourcelibrary.org &middot; +31-6-3404-5748</p>
           <p>sourcelibrary.org</p>
         </div>
+
+        {/* Page-scoped review widget. Hidden by default in production;
+            activates on any URL with ?getinput so reviewers can edit copy inline. */}
+        <InputWidget allowedHosts={["localhost", "vercel.app"]} />
 
       </div>
     </ContentPageLayout>

--- a/src/app/founding-donors/page.tsx
+++ b/src/app/founding-donors/page.tsx
@@ -4,7 +4,7 @@ import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPag
 export const metadata: Metadata = {
   title: 'Founding Donors - Source Library',
   description:
-    'Join Source Library as a founding donor. Help translate 100,000 rare historical texts into English — the entire digitized Renaissance.',
+    'Join Source Library as a founding donor. Help build a world-class institution making the ancient wisdom of every civilization accessible to people and AI.',
   robots: { index: false }, // internal page, not indexed
 };
 
@@ -31,47 +31,63 @@ export default function FoundingDonorsPage() {
         </p>
 
         <h2 className="font-serif text-3xl md:text-4xl text-primary leading-snug mb-6">
-          95% of what the Renaissance wrote has never been translated.
+          The first Renaissance was triggered by translation. <br className="hidden md:block" />
+          The next one will be too.
         </h2>
 
         <div className="space-y-5 font-body text-lg text-secondary leading-relaxed">
           <p>
-            Thousands of books on alchemy, natural philosophy, and the origins of modern
-            science sit in European libraries &mdash; digitized but unreadable, locked behind
-            Latin, German, and Greek. The books that inspired Copernicus and shaped
-            Newton&rsquo;s thinking are inaccessible to virtually everyone alive today.
+            The first Renaissance began when Plato and Hermes Trismegistus were translated
+            from Greek into Latin. Yet the Renaissance itself was mostly written in Latin
+            &mdash; and less than <strong>3%</strong> has ever been translated into English.
+            The same is true across Egyptian, Chinese, Sanskrit, Arabic, Hebrew, and a dozen
+            other traditions. The wisdom is preserved. It is not accessible.
           </p>
 
           <p>
             Source Library uses AI to translate these texts at unprecedented scale and cost.
             Our pipeline reads every page in its original language, translates it into English,
             and presents the translation alongside the original scan &mdash; so scholars can
-            verify every line.
+            verify every line. The library is free to read, free to cite, and connected via
+            API and MCP to the AI systems that will read alongside us.
           </p>
 
           <p className="text-primary font-semibold text-xl">
-            Cost per book: $1.54. A professional translator charges $15,000&ndash;$50,000.
+            Direct AI translation cost: $1.54 per book. A professional translator charges $15,000&ndash;$50,000.
           </p>
         </div>
+
+        {/* ── Founder Quote ── */}
+        <blockquote className="mt-10 mb-2 pl-6 border-l-4 border-accent-rust">
+          <p className="font-serif italic text-lg md:text-xl text-primary leading-relaxed">
+            &ldquo;We always say here &lsquo;go back to the source&rsquo; &mdash;{' '}
+            <em>ad fontes</em> in Latin. When you go back deeper and further, then you come
+            to the ancient sources and you even become part of the source. Then you can be
+            the source. That&rsquo;s where the magic happens.&rdquo;
+          </p>
+          <footer className="mt-3 text-sm tracking-wide uppercase text-muted">
+            &mdash; Joost Ritman, Founder, Bibliotheca Philosophica Hermetica
+          </footer>
+        </blockquote>
 
         {/* ── Traction ── */}
         <h3 className="font-serif text-2xl text-primary pt-12 mb-6">Where we are today</h3>
 
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-8">
-          {/* Stats last verified 2026-04-12 */}
+          {/* Stats last verified 2026-05-19 — refresh quarterly from the live DB */}
           {[
-            { number: '10,000+', label: 'Books in collection' },
-            { number: '10,000+', label: 'Books fully translated' },
-            { number: '3M+', label: 'Pages translated' },
-            { number: '100+', label: 'Source languages' },
+            { number: '44,000+', label: 'Books catalogued' },
+            { number: '10,000+', label: 'Books translated to English' },
+            { number: '5,000+', label: 'First-ever English translations' },
+            { number: '6M+', label: 'Pages stored & searchable' },
+            { number: '12+', label: 'Source languages (Latin, Greek, Chinese, Sanskrit, Arabic, Hebrew, Egyptian, &hellip;)' },
             { number: '< 5,000', label: 'Perseus + Loeb + Sacred-texts combined' },
-            { number: 'Free', label: 'Open access to all' },
           ].map((stat) => (
             <div key={stat.label} className="bg-white rounded-xl p-5 border border-primary/10">
               <div className="text-2xl md:text-3xl text-accent-rust font-light mb-1">
                 {stat.number}
               </div>
-              <div className="text-muted text-sm">{stat.label}</div>
+              <div className="text-muted text-sm" dangerouslySetInnerHTML={{ __html: stat.label }} />
             </div>
           ))}
         </div>
@@ -85,13 +101,24 @@ export default function FoundingDonorsPage() {
 
         <div className="space-y-5 font-body text-lg text-secondary leading-relaxed">
           <p>
-            150,000&ndash;250,000 premodern books are already digitized in European research
-            libraries via IIIF, waiting to be translated. The technology exists. The pipeline
-            works. The unit economics are proven.
+            Hundreds of thousands of premodern books are already digitized across the
+            world&rsquo;s research libraries via IIIF, waiting to be translated. The technology
+            exists. The pipeline works. The unit economics are proven. Two seed donors funded
+            the proof of concept &mdash; 10,000 books translated, 5,000 of them for the first
+            time in history.
+          </p>
+
+          <p>
+            We are now opening a <strong>founding-donor circle of 10&ndash;50 people</strong>{' '}
+            to build Source Library into a world-class institution &mdash; a permanent home
+            for the stewardship of ancient wisdom, from books to oral histories to
+            archaeological expeditions.
           </p>
 
           <p className="text-primary font-semibold text-xl">
-            $250K translates 100,000 books by June &mdash; essentially the entire digitized Renaissance.
+            We are raising <span className="text-accent-rust">$10 million over 5 years</span>{' '}
+            to translate 250,000 books, scan 50,000 more, build a global library
+            partnership network, and convene the world&rsquo;s scholars of ancient wisdom.
           </p>
         </div>
 
@@ -110,9 +137,10 @@ export default function FoundingDonorsPage() {
               {[
                 ['$1,000', '650 books translated \u2014 more than the entire Loeb Classical Library'],
                 ['$10,000', 'One month of full-scale operations'],
-                ['$50,000', '3 months of scaling + first editorial hire'],
-                ['$100,000', '10,000 \u2192 50,000 translated texts'],
-                ['$250,000', '100,000 translated texts by June \u2014 the entire digitized Renaissance'],
+                ['$50,000', 'A full language program \u2014 e.g., a Sanskrit or Arabic corpus'],
+                ['$100,000', 'One year of a scholar-in-residence and a named translation series'],
+                ['$250,000', 'Three years of operations \u2014 or 60,000 books translated'],
+                ['$1,000,000', 'Founding Visionary \u2014 one of 10 named pillars of the institution'],
               ].map(([gift, impact]) => (
                 <tr key={gift} className="border-b border-primary/10">
                   <td className="py-3 pr-6 font-semibold text-accent-rust whitespace-nowrap">{gift}</td>
@@ -129,8 +157,13 @@ export default function FoundingDonorsPage() {
         <div className="space-y-4">
           {[
             {
+              tier: 'Founding Visionary',
+              range: '$1,000,000+',
+              perks: 'One of 10 named pillars of the institution. Permanent recognition on every translated work in a chosen language or tradition. Advisory Board seat, annual private convening at the BPH, multi-year stewardship.',
+            },
+            {
               tier: 'Patron of the Renaissance',
-              range: '$100,000+',
+              range: '$100,000–$999,999',
               perks: 'Named translation series, Advisory Board seat, private BPH tour (20 guests), logo on site',
             },
             {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
 import PageTracker from "@/components/reader/PageTracker";
 import BrokenImageReporter from "@/components/BrokenImageReporter";
+import InputWidget from "@/components/InputWidget";
 import SiteModeIndicator from "@/components/providers/SiteModeIndicator";
 import ClientToaster from "@/components/providers/ClientToaster";
 import CookieConsent from "@/components/providers/CookieConsent";
@@ -115,6 +116,7 @@ export default async function RootLayout({
         <AnalyticsScripts />
         <PageTracker />
         <BrokenImageReporter />
+        <InputWidget allowedHosts={["localhost", "vercel.app"]} />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import ConditionalFooter from "@/components/layout/ConditionalFooter";
 import Providers from "@/components/providers/Providers";
 import PageTracker from "@/components/reader/PageTracker";
 import BrokenImageReporter from "@/components/BrokenImageReporter";
-import InputWidget from "@/components/InputWidget";
 import SiteModeIndicator from "@/components/providers/SiteModeIndicator";
 import ClientToaster from "@/components/providers/ClientToaster";
 import CookieConsent from "@/components/providers/CookieConsent";
@@ -116,7 +115,6 @@ export default async function RootLayout({
         <AnalyticsScripts />
         <PageTracker />
         <BrokenImageReporter />
-        <InputWidget allowedHosts={["localhost", "vercel.app"]} />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

Refresh of the (noindex) `/founding-donors` page to match the new strategic plan: global scope, $10M over 5 years, founding-donor circle of 10–50, framed as "the next Renaissance in the age of AI."

Why now: the prior copy pitched a 6-month, $250K-for-100K-books project. The new ask is a 5-year, $10M institution. The page needed to tell that story.

## Changes

- **New H2:** *"The first Renaissance was triggered by translation. The next one will be too."*
- **New epigraph:** Joost Ritman's *ad fontes* quote — "When you go back deeper and further, then you come to the ancient sources and you even become part of the source."
- **Opening copy** rewritten for global scope (Egyptian, Chinese, Sanskrit, Arabic, Hebrew, Greek, Latin, …); leads with the 3% statistic
- **Stats refreshed** from the live DB: 44,000+ catalogued · 10,000+ translated · 5,000+ first-ever · 6M+ pages · 12+ source languages
- **"The opportunity" section** replaced with the $10M / 5yr founding-donor-circle pitch; references the two seed donors
- **Impact table** recalibrated: $1K/$10K kept; $50K/$100K/$250K rewritten for institutional scale; new $1M row
- **New top tier:** *Founding Visionary $1,000,000+* — 10 named pillars, Advisory Board seat, annual private BPH convening

## Held unchanged (confirmed correct)

- Source Library as an initiative of EFM (Stichting Het Wereldhart)
- NAF fiscal sponsorship for US donations
- Donation URL (existing NAF DonorPerfect link)
- Founder bio, Fludd *Integra Naturae* image, CTA, footer

## Open product calls

- **Naming the two seed donors** — currently unattributed; naming them (with permission) is high-leverage credibility
- **Top tier name** — "Founding Visionary" picked to match the existing aesthetic; alternates: *Founding Steward, Pillar of the Library, Renaissance Architect*

## Companion artifact

Adds `.claude/docs/fundraising-plan-2026-05.md` as the canonical strategic plan, superseding fragmented earlier versions across the repo and `~/sourcelibraryfundraising/`.

## Test plan

- [ ] Visit preview URL `/founding-donors`
- [ ] Verify Ritman quote renders correctly under the headline
- [ ] Verify all 6 tiers display in order, $1M Founding Visionary at top
- [ ] Verify "Donate Now" still links to NAF DonorPerfect URL
- [ ] Confirm the page is still `noindex` (donor-only link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)