### PR TITLE
links: drop library-slug URL prefixes from book/page links

### DIFF
--- a/src/components/gallery/GalleryClient.tsx
+++ b/src/components/gallery/GalleryClient.tsx
@@ -95,8 +95,12 @@ export default function GalleryClient({ initialData, initialCollections, bookCol
   // shell renders its own chrome.
   const { isEmbedded } = useEmbedContext();
 
-  const pathParts = pathname.split('/').filter(Boolean);
-  const tenantPrefix = pathParts[1] === 'gallery' && pathParts[0] ? `/${pathParts[0]}` : '';
+  // Path-tenants (e.g. /internet-archive/gallery) should never propagate
+  // into book/page links — those URLs are canonical at /book/{id}. The
+  // pathname is intentionally unused; tenant subdomain rendering is handled
+  // upstream via proxy.ts rewrites.
+  void pathname;
+  const tenantPrefix = '';
 
   // Render the server-provided order on first paint (matches SSR HTML so we
   // don't trip React error #418 hydration mismatch), then shuffle once we're
@@ -744,8 +748,12 @@ function GalleryCard({ item, priority = false, tenantPrefix = '' }: { item: Gall
 
 function BookEmptyState({ bookInfo }: { bookInfo: BookInfo }) {
   const pathname = usePathname();
-  const pathParts = pathname.split('/').filter(Boolean);
-  const tenantPrefix = pathParts[1] === 'gallery' && pathParts[0] ? `/${pathParts[0]}` : '';
+  // Path-tenants (e.g. /internet-archive/gallery) should never propagate
+  // into book/page links — those URLs are canonical at /book/{id}. The
+  // pathname is intentionally unused; tenant subdomain rendering is handled
+  // upstream via proxy.ts rewrites.
+  void pathname;
+  const tenantPrefix = '';
   const [extracting, setExtracting] = useState(false);
 
   const handleExtract = async () => {

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -399,7 +399,6 @@ export default function SharedLibraryView({
                       : 0,
                   }}
                   priority={i < 10}
-                  bookUrlPrefix={basePath !== '/' ? basePath : undefined}
                 />
               ))}
             </div>
@@ -486,7 +485,6 @@ export default function SharedLibraryView({
                           : 0,
                       }}
                       priority={i < 5}
-                      bookUrlPrefix={basePath !== '/' ? basePath : undefined}
                     />
                   ))}
                   <Link


### PR DESCRIPTION
## Summary

- `/libraries/{slug}` was emitting book links as `/libraries/{slug}/book/{id}` — those are **404** (no such route)
- `/{slug}/gallery` was emitting book links as `/{slug}/book/{id}` — those **308-redirect** to the canonical `/book/{id}`

Both leak the library slug into shareable URLs without serving a purpose. Books are global content; canonical path is `/book/{id}`.

Tenant subdomain rendering (BPH at `bph.sourcelibrary.org`) is unaffected — that's handled by `src/proxy.ts` rewrites, not URL prefixing.

## Test plan

- [ ] Visit `https://<preview>.vercel.app/libraries/internet-archive`, click any book — should land on `/book/{id}` (not 404)
- [ ] Visit `https://<preview>.vercel.app/internet-archive/gallery` (path-tenant gallery), click any card — should land on `/book/{id}/page/{pageId}` (no `/internet-archive/` prefix)
- [ ] Visit `https://bph.sourcelibrary.org/gallery`, click any card — links stay on the BPH subdomain (no regression)
- [ ] `/internet-archive/book/{id}` still 308-redirects to `/book/{id}` (route unchanged; only generation site stopped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)