### PR TITLE
meta: add explicit og:url to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,6 +55,7 @@ export const metadata: Metadata = {
     siteName: "Source Library",
     locale: "en_US",
     type: "website",
+    url: "https://sourcelibrary.org/",
     images: [{
       url: '/og-image.jpg',
       width: 1200,


### PR DESCRIPTION
## Summary

Silences the Facebook Sharing Debugger's "missing og:url" warning by adding an explicit `openGraph.url` to the root `layout.tsx` metadata. Next.js derives the canonical URL automatically, but Facebook's parser specifically looks for `<meta property="og:url">` and warns if it's absent.

One-line change. Per-page metadata can still override.

## Test plan

- [ ] After deploy, https://developers.facebook.com/tools/debug/ on `https://sourcelibrary.org/brand` shows no "Missing og:url" warning
- [ ] `og:url` appears in page source HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)