### PR TITLE
Fix /favorites empty for signed-in users after sl_visitor_id migration

### DIFF
--- a/src/app/[tenant]/favorites/page.tsx
+++ b/src/app/[tenant]/favorites/page.tsx
@@ -8,13 +8,7 @@ import SiteHeader from '@/components/layout/SiteHeader';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { likes } from '@/lib/api-client';
 import { getBookThumbnailUrl } from '@/lib/utils';
-
-const VISITOR_ID_KEY = 'sl_visitor_id';
-
-function getVisitorId(): string {
-  if (typeof window === 'undefined') return '';
-  return localStorage.getItem(VISITOR_ID_KEY) || '';
-}
+import { useIdentity } from '@/hooks/useIdentity';
 
 interface FeaturedImage {
   url: string;
@@ -67,6 +61,7 @@ type Tab = 'books' | 'pages' | 'images';
 type Mode = 'popular' | 'mine';
 
 export default function FavoritesPage() {
+  const identity = useIdentity();
   const [tab, setTab] = useState<Tab>('books');
   const [mode, setMode] = useState<Mode>('mine');
 
@@ -87,15 +82,21 @@ export default function FavoritesPage() {
   const [loadingMyPages, setLoadingMyPages] = useState(true);
   const [loadingMyImages, setLoadingMyImages] = useState(true);
 
-  // Load my likes on mount
+  // Load my likes once we know who the user is. `useIdentity` returns
+  // session.user.id for authenticated users and a localStorage v_… id for
+  // anonymous visitors. Reading sl_visitor_id directly here used to silently
+  // skip the fetch right after sign-in, because MigrateOnSignIn clears that
+  // key once it has migrated anonymous likes to the account.
   useEffect(() => {
-    const visitorId = getVisitorId();
-    if (!visitorId) {
+    if (identity.loading) return;
+    if (!identity.id) {
       setLoadingMyBooks(false);
       setLoadingMyPages(false);
       setLoadingMyImages(false);
       return;
     }
+
+    const visitorId = identity.id;
 
     likes.getMine<PopularBook>({ type: 'book', visitorId })
       .then(data => setMyBooks(data.items))
@@ -111,7 +112,7 @@ export default function FavoritesPage() {
       .then(data => setMyImages(data.items))
       .catch(console.error)
       .finally(() => setLoadingMyImages(false));
-  }, []);
+  }, [identity.id, identity.loading]);
 
   // Lazy-load popular data only when switching to that mode
   const loadPopular = useCallback(() => {

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -8,13 +8,7 @@ import SiteHeader from '@/components/layout/SiteHeader';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { likes } from '@/lib/api-client';
 import { getBookThumbnailUrl } from '@/lib/utils';
-
-const VISITOR_ID_KEY = 'sl_visitor_id';
-
-function getVisitorId(): string {
-  if (typeof window === 'undefined') return '';
-  return localStorage.getItem(VISITOR_ID_KEY) || '';
-}
+import { useIdentity } from '@/hooks/useIdentity';
 
 interface FeaturedImage {
   url: string;
@@ -67,6 +61,7 @@ type Tab = 'books' | 'pages' | 'images';
 type Mode = 'popular' | 'mine';
 
 export default function FavoritesPage() {
+  const identity = useIdentity();
   const [tab, setTab] = useState<Tab>('books');
   const [mode, setMode] = useState<Mode>('mine');
 
@@ -87,15 +82,21 @@ export default function FavoritesPage() {
   const [loadingMyPages, setLoadingMyPages] = useState(true);
   const [loadingMyImages, setLoadingMyImages] = useState(true);
 
-  // Load my likes on mount
+  // Load my likes once we know who the user is. `useIdentity` returns
+  // session.user.id for authenticated users and a localStorage v_… id for
+  // anonymous visitors. Reading sl_visitor_id directly here used to silently
+  // skip the fetch right after sign-in, because MigrateOnSignIn clears that
+  // key once it has migrated anonymous likes to the account.
   useEffect(() => {
-    const visitorId = getVisitorId();
-    if (!visitorId) {
+    if (identity.loading) return;
+    if (!identity.id) {
       setLoadingMyBooks(false);
       setLoadingMyPages(false);
       setLoadingMyImages(false);
       return;
     }
+
+    const visitorId = identity.id;
 
     likes.getMine<PopularBook>({ type: 'book', visitorId })
       .then(data => setMyBooks(data.items))
@@ -111,7 +112,7 @@ export default function FavoritesPage() {
       .then(data => setMyImages(data.items))
       .catch(console.error)
       .finally(() => setLoadingMyImages(false));
-  }, []);
+  }, [identity.id, identity.loading]);
 
   // Lazy-load popular data only when switching to that mode
   const loadPopular = useCallback(() => {


### PR DESCRIPTION
## Summary

User-reported in footer feedback at `/favorites` today (2026-05-20): **"Likes not working"**.

Root cause: both `src/app/favorites/page.tsx` and `src/app/[tenant]/favorites/page.tsx` had their own `getVisitorId()` that read `sl_visitor_id` from localStorage directly. After sign-in, `MigrateOnSignIn` migrates anonymous likes server-side and then calls `clearStoredVisitorId()` to delete the localStorage key. The favorites page then found no visitor_id, hit the early-return at line 93, and never called `/api/likes/mine` — even though the server still had the user's likes filed under their `session.user.id` (88 likes for the reporting account).

The `LikeButton` itself uses `useIdentity()` and continued working — which is why toggling the heart looked fine but the favorites screen rendered "No likes yet".

This PR switches both favorites pages to `useIdentity()`, the same hook the like button uses. For authenticated users it returns `session.user.id`; for anonymous visitors it returns (and persists) a `v_…` id. The fetch is now gated on `!identity.loading` and re-runs when identity hydrates.

## Verified

- Anonymous flow on production still works: liked a book on `/book/the-hermetic-museum-various-sendivogius` while anonymous, navigated to `/favorites`, book appears with `likeCount: 1`. POST `/api/likes` 200, GET `/api/likes/mine` 200 with the item.
- Authenticated flow before the fix: server-side, `/api/likes/mine?visitor_id=<reporter-user-id>` returns 88 enriched items, confirming the API is healthy and only the client gate was at fault.
- `npx tsc --noEmit` passes.

## Test plan

- [ ] Sign in fresh (so `sl_visitor_id` gets cleared by MigrateOnSignIn) and confirm `/favorites` populates with the books/pages/images you have liked.
- [ ] Anonymous (clear cookies, no localStorage) — like a book, visit `/favorites`, the book shows up.
- [ ] On a tenant subdomain (e.g. `bph.sourcelibrary.org/favorites`), same two checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)