### PR TITLE
Favorites: split Books and Artwork into separate tabs (Phase 1 of #1903)

### DIFF
--- a/src/app/[tenant]/favorites/page.tsx
+++ b/src/app/[tenant]/favorites/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp } from 'lucide-react';
+import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp, Palette } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { likes } from '@/lib/api-client';
@@ -28,6 +28,9 @@ interface PopularBook {
   thumbnail_blob?: string;
   featured_images?: FeaturedImage[];
   likeCount: number;
+  // 'artwork' for visual-art records (paintings, prints, etc.), 'book' for
+  // texts. Older API responses may omit this; treat missing as 'book'.
+  contentType?: 'book' | 'artwork';
 }
 
 interface PopularPage {
@@ -57,7 +60,7 @@ interface PopularImage {
   bookYear?: number;
 }
 
-type Tab = 'books' | 'pages' | 'images';
+type Tab = 'books' | 'artwork' | 'pages' | 'images';
 type Mode = 'popular' | 'mine';
 
 export default function FavoritesPage() {
@@ -143,16 +146,31 @@ export default function FavoritesPage() {
     if (newMode === 'popular') loadPopular();
   };
 
-  const books = mode === 'mine' ? myBooks : popularBooks;
+  // Both books and artwork come from the same API call (target_type=book).
+  // The server tags each one with contentType; we split client-side so we can
+  // render them under distinct tabs without making another round trip.
+  const allBookLikes = mode === 'mine' ? myBooks : popularBooks;
+  const books = allBookLikes.filter(b => b.contentType !== 'artwork');
+  const artwork = allBookLikes.filter(b => b.contentType === 'artwork');
   const pages = mode === 'mine' ? myPages : popularPages;
   const images = mode === 'mine' ? myImages : popularImages;
 
   const loadingBooks = mode === 'mine' ? loadingMyBooks : loadingPopularBooks;
+  // Artwork shares the books-likes fetch — same loading flag.
+  const loadingArtwork = loadingBooks;
   const loadingPages = mode === 'mine' ? loadingMyPages : loadingPopularPages;
   const loadingImages = mode === 'mine' ? loadingMyImages : loadingPopularImages;
 
-  const loading = tab === 'books' ? loadingBooks : tab === 'pages' ? loadingPages : loadingImages;
-  const items = tab === 'books' ? books : tab === 'pages' ? pages : images;
+  const loading =
+    tab === 'books' ? loadingBooks
+    : tab === 'artwork' ? loadingArtwork
+    : tab === 'pages' ? loadingPages
+    : loadingImages;
+  const items =
+    tab === 'books' ? books
+    : tab === 'artwork' ? artwork
+    : tab === 'pages' ? pages
+    : images;
   const isEmpty = items.length === 0;
 
   return (
@@ -165,8 +183,8 @@ export default function FavoritesPage() {
           <h1 className="text-4xl md:text-5xl mb-4">Favorites</h1>
           <p className="text-xl text-stone-300 max-w-2xl">
             {mode === 'mine'
-              ? 'Books, pages, and illustrations you\'ve liked.'
-              : 'The most loved books, pages, and illustrations \u2014 as chosen by readers.'}
+              ? 'Books, artworks, pages, and illustrations you\'ve liked.'
+              : 'The most loved books, artworks, pages, and illustrations \u2014 as chosen by readers.'}
           </p>
 
           {/* Mode toggle */}
@@ -203,6 +221,7 @@ export default function FavoritesPage() {
           <div className="flex gap-1">
             {([
               { key: 'books' as Tab, icon: BookOpen, label: 'Books', count: books.length, isLoading: loadingBooks },
+              { key: 'artwork' as Tab, icon: Palette, label: 'Artwork', count: artwork.length, isLoading: loadingArtwork },
               { key: 'pages' as Tab, icon: FileText, label: 'Pages', count: pages.length, isLoading: loadingPages },
               { key: 'images' as Tab, icon: ImageIcon, label: 'Gallery', count: images.length, isLoading: loadingImages },
             ]).map(({ key, icon: Icon, label, count, isLoading }) => (
@@ -244,30 +263,39 @@ export default function FavoritesPage() {
               {mode === 'mine'
                 ? tab === 'books'
                   ? 'Like books to see them here.'
-                  : tab === 'pages'
-                    ? 'Like pages while reading to see them here.'
-                    : 'Like images in the gallery to see them here.'
+                  : tab === 'artwork'
+                    ? 'Like artworks to see them here.'
+                    : tab === 'pages'
+                      ? 'Like pages while reading to see them here.'
+                      : 'Like images in the gallery to see them here.'
                 : 'No items have been liked yet.'}
             </p>
             <Link
-              href={tab === 'images' ? '/gallery' : '/'}
+              href={
+                tab === 'images' ? '/gallery'
+                : tab === 'artwork' ? '/artwork'
+                : '/'
+              }
               className="inline-flex items-center gap-2 px-5 py-2.5 bg-stone-800 text-white text-sm rounded-lg hover:bg-stone-700 transition-colors"
             >
-              {tab === 'images' ? 'Browse Gallery' : 'Browse Library'}
+              {tab === 'images' ? 'Browse Gallery' : tab === 'artwork' ? 'Browse Artwork' : 'Browse Library'}
             </Link>
           </div>
 
-        ) : tab === 'books' ? (
-          /* Books — collection-style cards with extracted illustrations */
+        ) : tab === 'books' || tab === 'artwork' ? (
+          /* Books + Artwork — same card layout, different link targets */
           <div className="grid gap-5 grid-cols-1 sm:grid-cols-2">
-            {books.map((book, i) => {
+            {(tab === 'books' ? books : artwork).map((book, i) => {
               const imgs = book.featured_images || [];
               const heroUrl = imgs[0]?.url || getBookThumbnailUrl(book);
+              const href = book.contentType === 'artwork'
+                ? `/artwork/${book.slug || book.id}`
+                : `/book/${book.slug || book.id}`;
 
               return (
                 <Link
                   key={book.id}
-                  href={`/book/${book.slug || book.id}`}
+                  href={href}
                   className="group relative block overflow-hidden rounded-lg"
                 >
                   {/* Image mosaic: 1 hero + up to 2 side images */}

--- a/src/app/api/[tenant]/likes/mine/route.ts
+++ b/src/app/api/[tenant]/likes/mine/route.ts
@@ -62,7 +62,7 @@ export async function GET(
     if (targetType === 'book') {
       const booksData = await db.collection('books').find(
         { id: { $in: targetIds }, tenantId },
-        { projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1 } }
+        { projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1, content_type: 1 } }
       ).toArray();
       const booksMap = new Map(booksData.map(b => [b.id, b]));
 
@@ -99,6 +99,7 @@ export async function GET(
             thumbnail: book.cover_image || thumbMap.get(book.id) || book.thumbnail_blob,
             featured_images: gallery,
             likeCount: countMap.get(id) || 1,
+            contentType: book.content_type === 'artwork' ? ('artwork' as const) : ('book' as const),
           };
         })
         .filter(Boolean);

--- a/src/app/api/[tenant]/likes/popular/route.ts
+++ b/src/app/api/[tenant]/likes/popular/route.ts
@@ -154,7 +154,7 @@ export async function GET(
       const bookIds = popularItems.map(item => item._id as string);
       const booksData = await db.collection('books').find(
         { id: { $in: bookIds }, tenantId },
-        { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1 } }
+        { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1, content_type: 1 } }
       ).toArray();
       const booksMap = new Map(booksData.map(b => [b.id, b]));
 
@@ -195,6 +195,7 @@ export async function GET(
             thumbnail: book.cover_image || thumbMap.get(book.id) || book.thumbnail_blob,
             featured_images: gallery,
             likeCount: item.count,
+            contentType: book.content_type === 'artwork' ? ('artwork' as const) : ('book' as const),
           };
         })
         .filter(Boolean);

--- a/src/app/api/likes/mine/route.ts
+++ b/src/app/api/likes/mine/route.ts
@@ -71,7 +71,7 @@ export async function GET(request: NextRequest) {
     if (targetType === 'book') {
       const booksData = await db.collection('books').find(
         { id: { $in: targetIds }, ...tenantFilter },
-        { projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1 } }
+        { projection: { id: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1, content_type: 1 } }
       ).toArray();
       const booksMap = new Map(booksData.map(b => [b.id, b]));
 
@@ -111,6 +111,7 @@ export async function GET(request: NextRequest) {
             thumbnail: book.cover_image || thumbMap.get(book.id) || book.thumbnail_blob,
             featured_images: gallery,
             likeCount: countMap.get(id) || 1,
+            contentType: book.content_type === 'artwork' ? ('artwork' as const) : ('book' as const),
           };
         })
         .filter(Boolean);

--- a/src/app/api/likes/popular/route.ts
+++ b/src/app/api/likes/popular/route.ts
@@ -161,7 +161,7 @@ export async function GET(request: NextRequest) {
       const bookIds = popularItems.map(item => item._id as string);
       const booksData = await db.collection('books').find(
         { id: { $in: bookIds } },
-        { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1 } }
+        { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, published: 1, language: 1, pages_count: 1, pages_ocr: 1, pages_translated: 1, thumbnail_blob: 1, image_thumb: 1, cover_image: 1, content_type: 1 } }
       ).toArray();
       const booksMap = new Map(booksData.map(b => [b.id, b]));
 
@@ -204,6 +204,7 @@ export async function GET(request: NextRequest) {
             thumbnail: book.cover_image || thumbMap.get(book.id) || book.thumbnail_blob,
             featured_images: gallery,
             likeCount: item.count,
+            contentType: book.content_type === 'artwork' ? ('artwork' as const) : ('book' as const),
           };
         })
         .filter(Boolean);

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp } from 'lucide-react';
+import { Heart, BookOpen, FileText, Image as ImageIcon, User, TrendingUp, Palette } from 'lucide-react';
 import SiteHeader from '@/components/layout/SiteHeader';
 import { BookLoader } from '@/components/ui/BookLoader';
 import { likes } from '@/lib/api-client';
@@ -28,6 +28,9 @@ interface PopularBook {
   thumbnail_blob?: string;
   featured_images?: FeaturedImage[];
   likeCount: number;
+  // 'artwork' for visual-art records (paintings, prints, etc.), 'book' for
+  // texts. Older API responses may omit this; treat missing as 'book'.
+  contentType?: 'book' | 'artwork';
 }
 
 interface PopularPage {
@@ -57,7 +60,7 @@ interface PopularImage {
   bookYear?: number;
 }
 
-type Tab = 'books' | 'pages' | 'images';
+type Tab = 'books' | 'artwork' | 'pages' | 'images';
 type Mode = 'popular' | 'mine';
 
 export default function FavoritesPage() {
@@ -143,16 +146,31 @@ export default function FavoritesPage() {
     if (newMode === 'popular') loadPopular();
   };
 
-  const books = mode === 'mine' ? myBooks : popularBooks;
+  // Both books and artwork come from the same API call (target_type=book).
+  // The server tags each one with contentType; we split client-side so we can
+  // render them under distinct tabs without making another round trip.
+  const allBookLikes = mode === 'mine' ? myBooks : popularBooks;
+  const books = allBookLikes.filter(b => b.contentType !== 'artwork');
+  const artwork = allBookLikes.filter(b => b.contentType === 'artwork');
   const pages = mode === 'mine' ? myPages : popularPages;
   const images = mode === 'mine' ? myImages : popularImages;
 
   const loadingBooks = mode === 'mine' ? loadingMyBooks : loadingPopularBooks;
+  // Artwork shares the books-likes fetch — same loading flag.
+  const loadingArtwork = loadingBooks;
   const loadingPages = mode === 'mine' ? loadingMyPages : loadingPopularPages;
   const loadingImages = mode === 'mine' ? loadingMyImages : loadingPopularImages;
 
-  const loading = tab === 'books' ? loadingBooks : tab === 'pages' ? loadingPages : loadingImages;
-  const items = tab === 'books' ? books : tab === 'pages' ? pages : images;
+  const loading =
+    tab === 'books' ? loadingBooks
+    : tab === 'artwork' ? loadingArtwork
+    : tab === 'pages' ? loadingPages
+    : loadingImages;
+  const items =
+    tab === 'books' ? books
+    : tab === 'artwork' ? artwork
+    : tab === 'pages' ? pages
+    : images;
   const isEmpty = items.length === 0;
 
   return (
@@ -165,8 +183,8 @@ export default function FavoritesPage() {
           <h1 className="text-4xl md:text-5xl mb-4">Favorites</h1>
           <p className="text-xl text-stone-300 max-w-2xl">
             {mode === 'mine'
-              ? 'Books, pages, and illustrations you\'ve liked.'
-              : 'The most loved books, pages, and illustrations \u2014 as chosen by readers.'}
+              ? 'Books, artworks, pages, and illustrations you\'ve liked.'
+              : 'The most loved books, artworks, pages, and illustrations \u2014 as chosen by readers.'}
           </p>
 
           {/* Mode toggle */}
@@ -203,6 +221,7 @@ export default function FavoritesPage() {
           <div className="flex gap-1">
             {([
               { key: 'books' as Tab, icon: BookOpen, label: 'Books', count: books.length, isLoading: loadingBooks },
+              { key: 'artwork' as Tab, icon: Palette, label: 'Artwork', count: artwork.length, isLoading: loadingArtwork },
               { key: 'pages' as Tab, icon: FileText, label: 'Pages', count: pages.length, isLoading: loadingPages },
               { key: 'images' as Tab, icon: ImageIcon, label: 'Gallery', count: images.length, isLoading: loadingImages },
             ]).map(({ key, icon: Icon, label, count, isLoading }) => (
@@ -244,30 +263,39 @@ export default function FavoritesPage() {
               {mode === 'mine'
                 ? tab === 'books'
                   ? 'Like books to see them here.'
-                  : tab === 'pages'
-                    ? 'Like pages while reading to see them here.'
-                    : 'Like images in the gallery to see them here.'
+                  : tab === 'artwork'
+                    ? 'Like artworks to see them here.'
+                    : tab === 'pages'
+                      ? 'Like pages while reading to see them here.'
+                      : 'Like images in the gallery to see them here.'
                 : 'No items have been liked yet.'}
             </p>
             <Link
-              href={tab === 'images' ? '/gallery' : '/'}
+              href={
+                tab === 'images' ? '/gallery'
+                : tab === 'artwork' ? '/artwork'
+                : '/'
+              }
               className="inline-flex items-center gap-2 px-5 py-2.5 bg-stone-800 text-white text-sm rounded-lg hover:bg-stone-700 transition-colors"
             >
-              {tab === 'images' ? 'Browse Gallery' : 'Browse Library'}
+              {tab === 'images' ? 'Browse Gallery' : tab === 'artwork' ? 'Browse Artwork' : 'Browse Library'}
             </Link>
           </div>
 
-        ) : tab === 'books' ? (
-          /* Books — collection-style cards with extracted illustrations */
+        ) : tab === 'books' || tab === 'artwork' ? (
+          /* Books + Artwork — same card layout, different link targets */
           <div className="grid gap-5 grid-cols-1 sm:grid-cols-2">
-            {books.map((book, i) => {
+            {(tab === 'books' ? books : artwork).map((book, i) => {
               const imgs = book.featured_images || [];
               const heroUrl = imgs[0]?.url || getBookThumbnailUrl(book);
+              const href = book.contentType === 'artwork'
+                ? `/artwork/${book.slug || book.id}`
+                : `/book/${book.slug || book.id}`;
 
               return (
                 <Link
                   key={book.id}
-                  href={`/book/${book.slug || book.id}`}
+                  href={href}
                   className="group relative block overflow-hidden rounded-lg"
                 >
                   {/* Image mosaic: 1 hero + up to 2 side images */}


### PR DESCRIPTION
## Summary

First phase of #1903 — separating artworks from books across user-facing surfaces. The library catalogues both texts and standalone artworks under `books` (distinguished by `content_type: 'artwork'`); the Favorites page used to lump them under one "Books" tab, so a liked Bosch painting and a Sendivogius treatise rendered side by side with no visual cue.

- **API:** `/api/likes/mine` and `/api/likes/popular` (root + tenant variants) project `content_type` and surface it as `contentType: 'book' | 'artwork'` on each book-branch item. Pages and gallery illustrations are unchanged.
- **UI:** `/favorites` and `/[tenant]/favorites` grow a fourth tab. The **Books** tab keeps text records; the new **Artwork** tab (Palette icon) holds visual-art records and links to `/artwork/[slug]` instead of `/book/[slug]`. Splitting happens client-side from the same fetch, so no extra round trip. Same split applies to the Most Popular mode.

Phases 2–4 (search, author pages, home Discover row, sitemap) remain in #1903 and ship separately.

## Test plan

- [ ] Anonymous: like a book and an artwork on production, visit `/favorites` preview — book under Books, artwork under Artwork; counts on tab labels match.
- [ ] Signed in: same as above; verify Most Popular mode also splits.
- [ ] Tenant subdomain (e.g. `bph.sourcelibrary.org/favorites`): tabs render and link targets are still under-tenant.
- [ ] Click an artwork card → lands on `/artwork/[slug]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)