### PR TITLE
book page: polish Collections chips

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -1057,10 +1057,26 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     <Link
                       key={col.slug}
                       href={`/collections/${col.slug}`}
-                      className="text-xs px-2.5 py-1 rounded-full transition-colors"
-                      style={{ color: 'var(--text-secondary)', backgroundColor: 'var(--bg-tertiary)' }}
+                      className="group inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full border transition-colors hover:border-accent-rust/40"
+                      style={{
+                        color: 'var(--text-secondary)',
+                        backgroundColor: 'var(--bg-warm)',
+                        borderColor: 'var(--border-light)',
+                      }}
                     >
-                      {col.name}
+                      {col.color && (
+                        <span
+                          className="inline-block w-1.5 h-1.5 rounded-full shrink-0"
+                          style={{ backgroundColor: col.color }}
+                          aria-hidden
+                        />
+                      )}
+                      <span className="group-hover:text-accent-rust transition-colors">{col.name}</span>
+                      {typeof col.book_count === 'number' && col.book_count > 0 && (
+                        <span className="text-[10px] tabular-nums" style={{ color: 'var(--text-faint)' }}>
+                          {col.book_count}
+                        </span>
+                      )}
                     </Link>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- Collections chips on the book page referenced an undefined `--bg-tertiary` CSS variable, so they rendered as bare wrapped text instead of pills (see the Key of Solomon page).
- Swap to `--bg-warm` + `--border-light` for a visible chip, add a small accent dot from each collection's `color`, and surface the (already-fetched) `book_count` as a muted tabular number after the name.
- Hover lifts the border to `accent-rust/40` and shifts the label to `accent-rust` for affordance.

## Test plan
- [ ] Visit a book with several collections (e.g. /book/the-key-of-solomon-pseudo-solomon) on the Vercel preview — chips should have a visible warm background, subtle border, color dot, and trailing count
- [ ] Hover a chip — border + label should shift toward rust
- [ ] Verify on a tenant subdomain (e.g. bph.sourcelibrary.org) — `enableBookCollectionNavigation` should still hide the section there, no leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)