### PR TITLE
fix(archive): unstick R2 archive workers — silent no-op + bad candidate query

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -39,6 +39,7 @@ const BOOK_LIMIT = parseInt(getArg('limit') || '20', 10);  // Books per cron run
 const BOOK_CONCURRENCY = parseInt(getArg('concurrency') || '2', 10);
 const PAGE_CONCURRENCY = parseInt(getArg('page-concurrency') || '8', 10);
 const DRY_RUN = hasFlag('dry-run');
+const TARGET_BOOK_ID = getArg('book-id') || null;  // one-off: archive a single book, bypassing the queue
 const JPEG_QUALITY = 85;
 const MAX_DIMENSION = 3000;
 const STALE_TMP_AGE_MS = 6 * 60 * 60 * 1000;  // 6h — older sl-bulk-* dirs are leaked, sweep them
@@ -271,18 +272,47 @@ async function processBook(book, db) {
 
     const needsArchiveIds = new Set(pages.map(p => (p.id || p._id.toString())));
     const workItems = [];
+    let skippedNoLeaf = 0;
+    let skippedOutOfRange = 0;
+    let skippedMissingFile = 0;
 
     for (const page of allPages) {
       const pageId = page.id || page._id.toString();
       if (!needsArchiveIds.has(pageId)) continue;
       const photoUrl = page.photo_original || page.photo || '';
+      // IA URLs encode the JP2 leaf as /page/nN. If the page has no photo URL
+      // or a non-IA URL, we can't map it to a JP2 file in the zip.
       const leafMatch = photoUrl.match(/\/page\/n(\d+)/);
-      if (!leafMatch) continue;
+      if (!leafMatch) { skippedNoLeaf++; continue; }
       const leafNum = parseInt(leafMatch[1]);
-      if (leafNum >= pageFiles.length) continue;
+      // JP2 zips for partial scans can be sparser than the page count — leaves
+      // past the zip's end have no source file. Count these so the worker
+      // doesn't silently no-op the whole book.
+      if (leafNum >= pageFiles.length) { skippedOutOfRange++; continue; }
       const srcFile = pageFiles[leafNum];
-      if (!fs.existsSync(srcFile)) continue;
+      if (!fs.existsSync(srcFile)) { skippedMissingFile++; continue; }
       workItems.push({ page, srcFile, format: download.format });
+    }
+
+    const totalSkipped = skippedNoLeaf + skippedOutOfRange + skippedMissingFile;
+    if (totalSkipped > 0) {
+      console.log(`    [SKIP-PAGES] ${totalSkipped}/${pages.length}: ${skippedNoLeaf} no-leaf, ${skippedOutOfRange} leaf-out-of-range (zip has ${pageFiles.length}), ${skippedMissingFile} missing-file`);
+    }
+
+    // If JP2 zip is sparser than the candidate pages (or none match), bulk archive
+    // can't recover this book — route it to per-page IIIF (archive-ocr) by recording
+    // a failure. Without this, the book gets picked again every 20 min and silently
+    // no-ops, wasting the JP2 download.
+    if (workItems.length === 0 && pages.length > 0) {
+      const reason = skippedOutOfRange > 0
+        ? `JP2 zip sparser than page count (${pageFiles.length} leaves, ${pages.length} pages unarchived)`
+        : skippedNoLeaf > 0
+        ? `pages have no /page/nN photo URL (${skippedNoLeaf} of ${pages.length})`
+        : 'no work items after filtering';
+      console.log(`    [FAIL-BOOK] ${reason}`);
+      await recordBulkFailure(db, book, reason);
+      stats.booksFailed++;
+      return;
     }
 
     let workIdx = 0;
@@ -424,9 +454,9 @@ async function main() {
   // Find IA books with pages that may need archiving (regardless of pipeline status).
   // Priority: first translations > non-English > English
   const ENGLISH_VARIANTS = ['english', 'eng', 'en'];
-  const iaBooks = await db.collection('books')
-    .aggregate([
-      { $match: {
+  const matchStage = TARGET_BOOK_ID
+    ? { $match: { id: TARGET_BOOK_ID } }
+    : { $match: {
         pages_count: { $gt: 0 },
         $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] },
         'archive_metadata.blocked': { $ne: true },
@@ -434,7 +464,10 @@ async function main() {
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
           { 'image_source.provider': 'internet_archive' },
         ],
-      }},
+      }};
+  const iaBooks = await db.collection('books')
+    .aggregate([
+      matchStage,
       { $addFields: {
         _priority: {
           $switch: {
@@ -452,8 +485,10 @@ async function main() {
     ])
     .toArray();
 
-  // Also include warehouse IA books — prioritize likely first translations
-  const warehouseIaBooks = await db.collection('books_warehouse')
+  // Also include warehouse IA books — prioritize likely first translations.
+  // When targeting a single book by --book-id, only the live books collection
+  // is consulted (the live id is the canonical surface).
+  const warehouseIaBooks = TARGET_BOOK_ID ? [] : await db.collection('books_warehouse')
     .aggregate([
       { $match: {
         pages_count: { $gt: 0 },

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -249,12 +249,18 @@ async function main() {
   // Exclude IA (handled by archive-bulk.mjs via JP2 zip download, much faster).
   // Prioritize providers that are NOT yet fully archived (IIIF, Cambridge, etc.)
   const PRIORITY_PROVIDERS = ['iiif', 'bsb', 'cambridge', 'vatican', 'loc', 'wellcome', 'heidelberg', 'bl', 'eap', 'met', 'ndl', 'getty', 'stanford', 'darmstadt'];
+  // Candidate queries filter pages_archived < pages_count: without this they're
+  // dominated by fully-archived books and the per-book inner query returns 0
+  // unarchived pages for nearly every book. Symptom is "Found 6 pages across
+  // 3423 books" while the library has hundreds of thousands of unarchived pages.
+  const NEEDS_ARCHIVE_EXPR = { $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] } };
   const priorityBooks = await db.collection('books')
     .find(
       {
         pages_count: { $gt: 0 },
         'archive_metadata.blocked': { $ne: true },
         'image_source.provider': { $in: PRIORITY_PROVIDERS },
+        ...NEEDS_ARCHIVE_EXPR,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )
@@ -271,6 +277,7 @@ async function main() {
         pages_count: { $gt: 0 },
         'archive_metadata.blocked': { $ne: true },
         'image_source.provider': { $nin: ['e-rara', 'gallica', 'internet_archive', ...PRIORITY_PROVIDERS] },
+        ...NEEDS_ARCHIVE_EXPR,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
     )
@@ -288,6 +295,7 @@ async function main() {
         pages_count: { $gt: 0 },
         'archive_metadata.blocked': { $ne: true },
         'image_source.provider': { $in: HETZNER_SAFE_PROVIDERS },
+        ...NEEDS_ARCHIVE_EXPR,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1, language: 1, is_first_translation: 1 } }
     )


### PR DESCRIPTION
## Why

The R2 archive pipeline has been **stuck for ~24 hours** with 820K pages still unarchived (85.5% coverage). Both workers run on schedule but archive nothing:

- **archive-bulk** every 20 min: \`12 books processed, 0 pages archived, 0 failed\` — downloads ~1GB JP2 zips and silently exits clean.
- **archive-ocr** every 30 min: \`Found 6 pages across 3423 books → 0 archived\` — candidate set is huge, work set is empty.

Throughput collapse: **0 books completed in last 24h**, 235 in the prior 72h, 884 in 7d (down from a steady ~125/day).

## What was actually wrong

**archive-bulk silent skip** (\`scripts/workers/archive-bulk.mjs\`):

In \`processBook\`, candidate pages are mapped to JP2 leaves via \`/page/nN\` and \`pageFiles[leafNum]\`. Three skip paths silently dropped pages with no logging:

\`\`\`js
if (!leafMatch) continue;
if (leafNum >= pageFiles.length) continue;
if (!fs.existsSync(srcFile)) continue;
\`\`\`

When an IA \`_jp2.zip\` is sparser than the page count (partial scans, leaf-numbered photos past the zip's end, etc.), every page hits one of these and \`workItems\` ends up empty. The book exits with \`0 archived, 0 failed\` and gets re-queued every 20 min — a permanent silent no-op that wastes ~1GB of bandwidth per run.

**archive-ocr bad candidate query** (\`scripts/workers/archive-ocr.mjs\`):

The three candidate queries (priority / other / warehouse) filter on \`pages_count: { \$gt: 0 }\` and provider, but **not** on whether the book still has unarchived pages. So a 3000-book candidate set is dominated by books where \`pages_archived === pages_count\`, and the per-book inner query returns 0 each time.

\`archive-bulk\` already has the correct filter (\`\$expr: { \$lt: [pages_archived, pages_count] }\`) — \`archive-ocr\` just doesn't.

## What this PR does

1. **archive-bulk**: count and log skipped pages by category (\`no-leaf\`, \`leaf-out-of-range\`, \`missing-file\`). When every candidate page skips and \`pages > 0\`, record a bulk failure and increment \`booksFailed\` instead of returning silently. Books that consistently fail this way get marked blocked (existing circuit breaker) and can be re-routed to per-page IIIF.
2. **archive-ocr**: add \`\$expr: { \$lt: [pages_archived, pages_count] }\` to all three candidate queries.
3. **archive-bulk**: add \`--book-id=ID\` for one-off targeted archival (needed for ops/maintenance unsticking individual books).

## What this does NOT fix

These need follow-up:

- **148 books blocked** (50× HTTP 401, 39× 403, 37× terminated, 9× HTTP 500, 7× fetch failed, 5× spawnSync ETIMEDOUT, 1× aborted). Need an auto-unblock policy after N days and a re-route plan for 401/403 sources.
- **Wasted JP2 downloads on retried "blocked" candidates** — once a book is recorded as failed by this PR's new logic, subsequent runs still re-download until the 5-retry circuit fires. Could short-circuit earlier.

## Test plan

- [x] \`node --check\` passes on both scripts
- [ ] After merge, deploy to Hetzner and watch the next \`archive-bulk\` run (\`tail -F /var/log/sourcelibrary/archive-bulk.log\`). Expect to see \`[SKIP-PAGES]\` and \`[FAIL-BOOK]\` lines instead of silent \`0 archived, 0 failed\` rounds.
- [ ] Watch \`archive-ocr.log\`: expect "Found X pages across Y books" where X >> 6.
- [ ] Verify with: \`node scripts/workers/archive-bulk.mjs --book-id=69d8c9fea09828f83ddc9371 --concurrency=1 --limit=1\` (Theatrum Fungorum — already unblocked, has 491 unarchived pages, good test case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)