### PR TITLE
Home Discover: defensively filter out artworks (Phase 4 of #1903)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,9 +263,12 @@ async function getDiscoverBooks(): Promise<Book[]> {
   // $sample FIRST so MongoDB uses fast random cursor (O(1) when size < 5% of collection).
   // $match after $sample filters the random sample down.
   // Over-sample to account for hidden/untranslated books being filtered out.
+  // `pages_translated >= 10` already excludes artworks today (they carry
+  // pages_translated: 0), but the explicit content_type guard makes the
+  // intent obvious and prevents a regression if the pages filter changes.
   const books = await db.collection('books').aggregate([
     { $sample: { size: 200 } },
-    { $match: { visible: true, pages_translated: { $gte: 10 } } },
+    { $match: { visible: true, pages_translated: { $gte: 10 }, content_type: { $ne: 'artwork' } } },
     { $limit: 10 },
     { $project: BOOK_PROJECTION },
   ], { maxTimeMS: 8000 }).toArray();


### PR DESCRIPTION
## Summary

Final phase of #1903, scoped down. \`getDiscoverBooks()\` already excludes artworks via the existing \`pages_translated >= 10\` filter (artworks all carry pages_translated: 0), but the link between the two is fragile — loosening the pages threshold to surface in-progress books would silently start rotating in painting thumbnails alongside text covers.

Add an explicit \`content_type: { $ne: 'artwork' }\` guard so the intent is recorded in code and a regression there fails closed.

## Sitemap deferred

The sitemap half of Phase 4 has been pulled out. Smoke-testing the preview surfaced a pre-existing chunked-sitemap regression: \`/sitemap/{n}.xml\` returns the same 5000 URLs for every chunk on production right now (out of ~80K books). Adding artwork chunks here would replace that limited book set with artwork URLs and make things worse. Filed as #1915.

## Test plan
- [ ] Visit \`/\` and reload several times — the Discover row never shows a painting tile.
- [ ] Confirm \`tsc --noEmit\` passes (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)