### PR TITLE
fix(archive): route bulk-unsuitable IA books to per-page IIIF

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -300,17 +300,30 @@ async function processBook(book, db) {
     }
 
     // If JP2 zip is sparser than the candidate pages (or none match), bulk archive
-    // can't recover this book — route it to per-page IIIF (archive-ocr) by recording
-    // a failure. Without this, the book gets picked again every 20 min and silently
-    // no-ops, wasting the JP2 download.
+    // can't recover this book. Mark it bulk_unsuitable so we don't re-download the
+    // JP2 every cron round, and let archive-ocr pick it up via per-page IIIF.
     if (workItems.length === 0 && pages.length > 0) {
       const reason = skippedOutOfRange > 0
         ? `JP2 zip sparser than page count (${pageFiles.length} leaves, ${pages.length} pages unarchived)`
         : skippedNoLeaf > 0
         ? `pages have no /page/nN photo URL (${skippedNoLeaf} of ${pages.length})`
         : 'no work items after filtering';
-      console.log(`    [FAIL-BOOK] ${reason}`);
-      await recordBulkFailure(db, book, reason);
+      console.log(`    [FAIL-BOOK] ${reason} — marking bulk_unsuitable, routing to archive-ocr`);
+      await db.collection(booksCol).updateOne(
+        { id: book.id },
+        { $set: {
+          'archive_metadata.bulk_unsuitable': true,
+          'archive_metadata.bulk_unsuitable_at': new Date(),
+          'archive_metadata.bulk_unsuitable_reason': reason,
+          updated_at: new Date(),
+        }, $unset: {
+          // Clear stale bulk_failures so the book isn't double-blocked. The
+          // bulk_unsuitable flag is the new source of truth for "skip in bulk".
+          'archive_metadata.bulk_failures': '',
+          'archive_metadata.bulk_last_error': '',
+          'archive_metadata.bulk_last_failed_at': '',
+        }}
+      );
       stats.booksFailed++;
       return;
     }
@@ -460,6 +473,9 @@ async function main() {
         pages_count: { $gt: 0 },
         $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] },
         'archive_metadata.blocked': { $ne: true },
+        // bulk_unsuitable books have IA JP2 zips that don't align with photo URLs
+        // (archive drift, #1504) — leave them to archive-ocr's per-page IIIF path.
+        'archive_metadata.bulk_unsuitable': { $ne: true },
         $or: [
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
           { 'image_source.provider': 'internet_archive' },
@@ -494,6 +510,7 @@ async function main() {
         pages_count: { $gt: 0 },
         $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] },
         'archive_metadata.blocked': { $ne: true },
+        'archive_metadata.bulk_unsuitable': { $ne: true },
         $or: [
           { ia_identifier: { $exists: true, $ne: null, $ne: '' } },
           { 'image_source.provider': 'internet_archive' },

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -304,6 +304,27 @@ async function main() {
     .toArray()
     .catch(() => []);
 
+  // Bulk-unsuitable IA fallback. archive-bulk marks books bulk_unsuitable when
+  // the JP2 zip doesn't align with the IIIF-derived photo URLs (archive drift,
+  // #1504). Those books can't be archived by bulk; route them here so their
+  // per-page photo URLs get fetched directly. archive.org rate limit (15 req/s)
+  // is in the per-domain table.
+  const bulkUnsuitableIa = await db.collection('books')
+    .find(
+      {
+        pages_count: { $gt: 0 },
+        'archive_metadata.blocked': { $ne: true },
+        'archive_metadata.bulk_unsuitable': true,
+        'image_source.provider': 'internet_archive',
+        ...NEEDS_ARCHIVE_EXPR,
+      },
+      { projection: { id: 1, title: 1, 'image_source.provider': 1 } }
+    )
+    .limit(500)
+    .maxTimeMS(30_000)
+    .toArray()
+    .catch(() => []);
+
   // Sort warehouse: likely first translations first (non-English = likely first)
   const ENGLISH_VARIANTS = ['english', 'eng', 'en'];
   warehouseBooks.sort((a, b) => {
@@ -318,8 +339,8 @@ async function main() {
   // Tag warehouse books so we know which collections to query
   warehouseBooks.forEach(b => { b._warehouse = true; });
 
-  const books = [...priorityBooks, ...otherBooks, ...warehouseBooks];
-  console.log(`[archive-ocr] Checking ${priorityBooks.length} priority + ${otherBooks.length} other + ${warehouseBooks.length} warehouse books`);
+  const books = [...priorityBooks, ...bulkUnsuitableIa, ...otherBooks, ...warehouseBooks];
+  console.log(`[archive-ocr] Checking ${priorityBooks.length} priority + ${bulkUnsuitableIa.length} bulk-unsuitable IA + ${otherBooks.length} other + ${warehouseBooks.length} warehouse books`);
 
   if (books.length === 0) {
     console.log(`[archive-ocr] No books with pages found`);


### PR DESCRIPTION
## Why

The merged PR #1909 surfaced the underlying archive drift problem (#1504): some IA books have JP2 zips whose leaf indices don't line up with the \`/page/nN\` photo URLs in the DB. archive-bulk can't archive them at all — but right now it keeps trying, downloads the JP2 (often >100MB) every cron round for 5 strikes, then blocks the book, and archive-ocr won't pick it up either (it blanket-excludes \`internet_archive\`).

Examples from the just-completed 23:38 run:

\`\`\`
[SKIP-PAGES] 44/44: 0 no-leaf, 44 leaf-out-of-range (zip has 45), 0 missing-file
[FAIL-BOOK] JP2 zip sparser than page count (45 leaves, 44 pages unarchived)
[SKIP-PAGES] 1/1: 0 no-leaf, 1 leaf-out-of-range (zip has 485), 0 missing-file
[FAIL-BOOK] JP2 zip sparser than page count (485 leaves, 1 pages unarchived)
\`\`\`

The 44/45-leaf book is an obvious off-by-N (likely a re-scan). The single-page cases are stragglers where one page's leaf number drifted past the end.

## What this PR does

When archive-bulk hits the sparse-JP2 / no-match-URL case, it now sets \`archive_metadata.bulk_unsuitable: true\` on the book directly (instead of recording a strike). Then:

- **archive-bulk** excludes \`bulk_unsuitable\` books from its candidate query — no more wasted re-downloads.
- **archive-ocr** adds a fourth candidate stream: IA books with \`bulk_unsuitable: true\`. Per-page \`photo\` URLs (\`archive.org/download/IDENT/page/nN/full/pct:50/...\`) get fetched directly at archive.org's 15 req/s rate limit (already in the per-domain table).
- Stale \`bulk_failures\` / \`bulk_last_error\` counters are cleared so the existing circuit breaker doesn't fight the new flag.

archive-ocr now logs \`"Checking N priority + M bulk-unsuitable IA + K other + L warehouse books"\` so the IA fallback stream is visible per run.

## What this does NOT cover

- \`spawnSync /bin/sh ETIMEDOUT\` failures (opj_decompress crashes on malformed JP2 leaves) are NOT routed — different failure mode, different fix (per-leaf timeout or smaller batch).
- Books where the photo URLs themselves are wrong (point to non-existent IA leaves) will still fail in archive-ocr, but at per-page granularity, and the existing failure_count circuit breaker will skip them after 3 strikes per page.
- Migrating any already-blocked sparse-JP2 books — none exist right now (0 books match the pattern in blocked state), and the 4 in-flight cases (Cosmologia Generalis, Erotemata, Elegantiarum, Rasaratnākara) will flip on their next failed run within the next 20 min.

## Status of the broader effort

After PR #1909 merged, the new candidate query lifted archive-ocr from "Found 6 pages across 3423 books" to **"Found 7644 pages across 2021 books"** in the very next run. The fixes from #1909 are flowing as expected.

Tracking #1912 for the full prioritization + efficiency strategy. This PR is one of the priority follow-ups listed there.

## Test plan

- [x] \`node --check\` passes
- [ ] After merge + Hetzner pull: next archive-bulk run shows the 4 in-flight sparse-JP2 books getting flipped to bulk_unsuitable (single failure, no re-download next round).
- [ ] Next archive-ocr run shows \`bulk-unsuitable IA = 4\` (or more) in the candidate breakdown line.
- [ ] Verify those books actually archive via IIIF: \`gh api repos/.../contents/...\` or just watch \`archive-ocr.log\` for archive.org rate-limited fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)