### PR TITLE
book page: drop tenant prefix from gallery links

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -720,7 +720,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 </div>
                 {embedPolicy.showGalleryImages && imageCount > 0 && (
                   <Link
-                    href={`/${tenantSlug}/gallery?bookId=${book.id}`}
+                    href={`/gallery?bookId=${book.id}`}
                     className="flex items-center gap-2 text-accent-gold hover:text-accent-gold transition-colors"
                     title="View identified images in gallery"
                   >
@@ -1014,7 +1014,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     <span className="text-sm font-normal text-stone-400 ml-2">{imageCount}</span>
                   </h2>
                   <Link
-                    href={`/${tenantSlug}/gallery?bookId=${book.id}`}
+                    href={`/gallery?bookId=${book.id}`}
                     className="text-sm text-accent-rust hover:text-accent-gold-dark transition-colors"
                   >
                     View All &rarr;
@@ -1027,7 +1027,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     return (
                       <Link
                         key={img.id}
-                        href={`/${tenantSlug}/gallery/image/${img.id}`}
+                        href={`/gallery/image/${img.id}`}
                         className="flex-shrink-0 group"
                       >
                         <div className="w-28 h-28 sm:w-36 sm:h-36 rounded-lg overflow-hidden bg-stone-100 border border-stone-200 group-hover:border-accent-rust/40 transition-colors">


### PR DESCRIPTION
## Summary
- Book page links to the gallery (and gallery image detail) were emitting `/<tenant>/gallery?bookId=...` because the route is internally rewritten to `/[tenant]/book/[id]` even for main-domain visitors, leaving `tenantSlug` set to the book's home tenant (often "gallica").
- On the resulting page, the api-client interceptor derives `X-Tenant-Slug` from `window.location.pathname`, scoping the gallery query to that tenant. Since most `gallery_images` are global (no `tenantId`), the gallery showed "No images match your current filters" for nearly every book — even ones with the count badge saying 3+ images.
- The gallery links only render when `embedPolicy.showGalleryImages === true` (i.e. main-domain visitors), so the tenant prefix was wrong by construction. Link to `/gallery` and `/gallery/image/<id>` directly; `src/app/gallery/page.tsx` and `src/app/gallery/image/[id]/page.tsx` already re-export the `[tenant]` components, so embed mode is unaffected.

## Test plan
- [ ] Visit /book/the-key-of-solomon-pseudo-solomon, click "3 images" or "View All →" in the Illustrations card — gallery loads with the book's images visible, not "No images match".
- [ ] Click a thumbnail in the Illustrations row — image detail page opens correctly.
- [ ] Confirm a tenant subdomain (e.g. bph.sourcelibrary.org) still doesn't render these links (`showGalleryImages` is false in embed mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)