### PR TITLE
archive-bulk: prefer newest books within each priority bucket

### DIFF
--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -495,7 +495,7 @@ async function main() {
           },
         },
       }},
-      { $sort: { _priority: 1, hidden: 1 } },
+      { $sort: { _priority: 1, hidden: 1, _id: -1 } },
       { $project: { id: 1, title: 1, ia_identifier: 1, image_source: 1, pages_count: 1, language: 1, archive_metadata: 1 } },
       { $limit: BOOK_LIMIT },
     ])
@@ -527,7 +527,7 @@ async function main() {
           },
         },
       }},
-      { $sort: { _priority: 1 } },
+      { $sort: { _priority: 1, _id: -1 } },
       { $project: { id: 1, title: 1, ia_identifier: 1, image_source: 1, pages_count: 1, language: 1, archive_metadata: 1 } },
       { $limit: BOOK_LIMIT },
     ])


### PR DESCRIPTION
## Summary
- Adds `_id: -1` as the tiebreaker on the archive-bulk worker's sort, so recently-imported books archive before older ones at the same `_priority` (first-translation → non-English → English).
- ObjectId is timestamp-prefixed, so descending `_id` is effectively recency.

## Why
Derek asked: newly-imported books should reach R2 first, not last. Today the queue is ordered purely by `_priority, hidden` — meaning a fresh import lands behind the 5,940 books already in `archiving` status with the same priority. This tweak preserves the existing priority semantics and only changes the order within a bucket.

## Risk
- Pure sort-key change. No new fields, no schema changes, no behavior change for `--book-id` targeted runs (single-doc match).
- Both the live `books` and `books_warehouse` aggregates get the same treatment.

## Test plan
- [ ] Hetzner worker picks up the change on next sync
- [ ] Confirm next `archive-bulk` cycle processes recent yoga imports (Serpent Power 740pp, Tantrik Texts vols, Mahanirvana Tantra) before older queue items