### PR TITLE
BPH catalog quick wins: card impressum, sign-out chrome, filter labels (#1921 P1)

### DIFF
--- a/src/app/embed/[tenant]/layout.tsx
+++ b/src/app/embed/[tenant]/layout.tsx
@@ -1,4 +1,5 @@
 import { TenantSessionUpdater } from '@/components/auth/TenantSessionUpdater';
+import TenantUserChrome from '@/components/tenant/TenantUserChrome';
 
 /**
  * Layout for /embed/[tenant]/* — the route group that tenant subdomains
@@ -8,6 +9,10 @@ import { TenantSessionUpdater } from '@/components/auth/TenantSessionUpdater';
  * the user's tenant-scoped role (e.g. BPH editor) is resolved into their
  * session. Without this, client gates like <AuthCheck role="inner_circle">
  * never see the membership and editor-only UI stays hidden.
+ *
+ * TenantUserChrome is the only sign-out affordance on tenant subdomains —
+ * the standard SiteHeader is hidden in embed mode. It renders null for
+ * anonymous visitors so public browsing stays uncluttered.
  */
 export default async function EmbedTenantLayout({
   children,
@@ -20,6 +25,7 @@ export default async function EmbedTenantLayout({
   return (
     <>
       <TenantSessionUpdater tenantSlug={tenant} />
+      <TenantUserChrome />
       {children}
     </>
   );

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -563,8 +563,8 @@ export default function BphCatalogBrowser({
                   onChange={(e) => handleAdvChange('digitized', e.target.value)}
                   className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
                 >
-                  <option value="">All</option>
-                  <option value="sl">On Source Library</option>
+                  <option value="">All books</option>
+                  <option value="sl">Digitised on Source Library</option>
                   <option value="true">Digitised anywhere</option>
                   <option value="false">Not digitised</option>
                 </select>
@@ -769,15 +769,27 @@ export default function BphCatalogBrowser({
                         </div>
                       )}
                     </div>
-                    <div className="mt-2 text-sm font-medium text-primary leading-snug line-clamp-2 group-hover:text-accent-rust transition-colors">
-                      {displayTitle}
-                    </div>
+                    {/* Card layout follows librarian convention: author first,
+                        title prominent, then impressum (place, publisher, year)
+                        as a separate line. Paul's feedback (#1921). */}
                     {displayAuthor && (
-                      <div className="text-xs text-muted mt-0.5 line-clamp-1">
+                      <div className="mt-2 text-xs text-muted line-clamp-1">
                         {displayAuthor}
-                        {w.year ? ` · ${w.year}` : ''}
                       </div>
                     )}
+                    <div className={`${displayAuthor ? 'mt-0.5' : 'mt-2'} text-sm font-medium text-primary leading-snug line-clamp-2 group-hover:text-accent-rust transition-colors`}>
+                      {displayTitle}
+                    </div>
+                    {(() => {
+                      const imprint = [w.place, w.publisher || w.printer, w.year]
+                        .filter(Boolean)
+                        .join(', ');
+                      return imprint ? (
+                        <div className="mt-0.5 text-xs text-muted line-clamp-1">
+                          {imprint}
+                        </div>
+                      ) : null;
+                    })()}
                   </a>
                 );
               })}

--- a/src/components/tenant/TenantUserChrome.tsx
+++ b/src/components/tenant/TenantUserChrome.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { LogOut } from 'lucide-react';
+
+/**
+ * Floating user widget rendered on tenant subdomains (e.g. bph.sourcelibrary.org).
+ *
+ * The standard SiteHeader/UserMenu is hidden in embed mode (CSS in globals.css
+ * targeting body:has(.embed-mode)), which left tenant librarians with no way
+ * to sign out without leaving the subdomain. This widget gives authenticated
+ * users a minimal "you're signed in as X — sign out" affordance scoped to the
+ * subdomain.
+ *
+ * Subdomain lockdown rules (CLAUDE.md): we never link to sourcelibrary.org/...
+ * from inside a tenant subdomain. signOut's callbackUrl='/' keeps the user on
+ * the same host. We intentionally omit Account / Favorites links here — they
+ * resolve off-subdomain and would leak.
+ *
+ * Anonymous visitors render null — public BPH browsing shouldn't expose any
+ * Source Library account chrome.
+ */
+export default function TenantUserChrome() {
+  const { data: session, status } = useStableSession();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [handleClickOutside]);
+
+  if (status !== 'authenticated' || !session?.user) return null;
+
+  const name = session.user.name || session.user.email || 'Account';
+  const initials =
+    session.user.name
+      ?.split(' ')
+      .map(n => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2) || session.user.email?.[0]?.toUpperCase() || '?';
+
+  return (
+    <div
+      ref={ref}
+      className="fixed top-3 right-3 z-40"
+      data-tenant-user-chrome
+    >
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center gap-2 px-2.5 py-1.5 rounded-full bg-white/95 border border-border-light shadow-sm hover:bg-white text-xs font-medium text-primary transition-colors"
+        aria-label="Account menu"
+      >
+        <span
+          className="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-semibold text-white"
+          style={{ background: 'var(--accent-rust, #b25e2d)' }}
+        >
+          {initials}
+        </span>
+        <span className="hidden sm:inline max-w-[12rem] truncate">{name}</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-64 rounded-lg shadow-lg border border-border-light bg-white py-2">
+          <div className="px-3 py-2 border-b border-border-light">
+            <p className="text-sm font-medium text-primary truncate">{session.user.name}</p>
+            <p className="text-xs text-muted truncate">{session.user.email}</p>
+          </div>
+          <button
+            onClick={() => signOut({ callbackUrl: '/' })}
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-accent-rust hover:bg-warm transition-colors"
+          >
+            <LogOut className="w-4 h-4" />
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three of the four P1 quick wins from #1921 (Paul Dijstelberge's first-login feedback). Each is independent; bundled because they're all small UI fixes Paul will see immediately.

### 1. Grid card layout (`BphCatalogBrowser.tsx`)
Card now follows librarian convention: **author** → **title** → **impressum** (place, publisher, year). Place and publisher were missing from the card entirely. Falls back to printer when publisher is null (BPH data has many printer-only rows pre-1700).

### 2. Digitization filter labels
- `"All"` → `"All books"`
- `"On Source Library"` → `"Digitised on Source Library"`

Paul read \"All\" as filter-cleared rather than filter-set-to-all and \"On Source Library\" as ambiguous between \"hosted by SL\" vs \"present in SL's index\".

### 3. New `TenantUserChrome` floating widget
**Root cause for \"I did not succeed in signing out\":** the standard `SiteHeader` (with `UserMenu`) is hidden by CSS in embed mode (`body:has(.embed-mode) > header` in `globals.css`). Tenant subdomains rewrite to `/embed/[tenant]/*`, so on bph.sourcelibrary.org there is **no user menu rendered anywhere** — no avatar, no sign-out, no profile link. Paul could log in but had no way to log out without leaving the subdomain.

`TenantUserChrome` is a minimal floating widget (top-right, fixed) that:
- Renders **null** for anonymous visitors (public browsing stays uncluttered)
- Renders avatar + name + Sign out for authenticated users
- Intentionally omits `/account`, `/favorites`, admin links — these resolve off-subdomain via the `proxy.ts` rewrite and would violate the tenant subdomain lockdown rules from CLAUDE.md
- `signOut({ callbackUrl: '/' })` keeps the user on the same host post-logout

Mounted in `src/app/embed/[tenant]/layout.tsx` so it appears on every tenant page (homepage, catalog browse, catalog detail, book detail, search, gallery).

## Not included from #1921 P1

**Collation-formula asterisk stripping** — Paul cited *Polityke toet-steen* (UBN 11473), but that row has no `bibliographic_format` value in Supabase, so the bug isn't reproducible from that example. Need a specific UBN where the source has `*` characters that don't appear in display. Will follow up in a separate PR once Paul provides one.

## Test plan

- [ ] Anonymous on https://bph.sourcelibrary.org — no user chrome visible, no behavior change
- [ ] Signed in as Paul/Jose on bph.sourcelibrary.org — avatar + name visible top-right; click reveals dropdown; \"Sign out\" returns to bph.sourcelibrary.org root
- [ ] Grid view on /catalog — cards now show author / title / \"Place, Publisher, Year\" lines
- [ ] Filter dropdown labels read as expected
- [ ] `node scripts/audit-bph-leaks.mjs` still passes (no off-subdomain links from the new chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)