### PR TITLE
Jung Küsnacht ↔ BPH bibliographic alignment (for Jozef)

### DIFF
--- a/.claude/docs/jung-bph-alignment-2026-05-22.json
+++ b/.claude/docs/jung-bph-alignment-2026-05-22.json
@@ -1,0 +1,9392 @@
+{
+  "generated_at": "2026-05-22T09:15:52.502Z",
+  "oai_set": "cgj",
+  "jung_count": 345,
+  "matched_count": 151,
+  "not_in_bph_count": 194,
+  "results": [
+    {
+      "jung": {
+        "erara_id": "1529301",
+        "title": "Triumph Wagen Antimonii fratris Basilii Valentini ... allen so den Grund suchen der uhralten Medicin, auch zu der hermetischen Philosophy beliebnis tragen zu gut publiciret und an Tag geben",
+        "author": "Thölde, Johann",
+        "year": 1611,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1529301"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14801",
+            "title": "Triumph Wagen antimonii",
+            "author": "Basilius Valentinus",
+            "year": 1611,
+            "place": "Leipzig",
+            "publisher": "Apel, Jakob II",
+            "printer": "Ende, Valentin am",
+            "shelf_mark": "A",
+            "ustc_sn": 2137504,
+            "_normTitle": "triumph wagen antimonii",
+            "_normAuthor": "basilius valentinus"
+          },
+          "score": 9,
+          "titleShared": [
+            "triumph",
+            "wagen",
+            "antimonii"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "23143",
+            "title": "Triumph Wagen antimonii",
+            "author": "Basilius Valentinus",
+            "year": 1604,
+            "place": "Leipzig",
+            "publisher": "Apel, Jakob II",
+            "printer": "Popporeich, Jakob|Bärwald, Zacharias",
+            "shelf_mark": "A",
+            "ustc_sn": 2078936,
+            "_normTitle": "triumph wagen antimonii",
+            "_normAuthor": "basilius valentinus"
+          },
+          "score": 7,
+          "titleShared": [
+            "triumph",
+            "wagen",
+            "antimonii"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1171064",
+        "title": "Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque theologica : opus antiquissimae philosophiae barbaricae variis speciminibus refertissimum ... / [Tomus primus.]",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1171064"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "7623",
+            "title": "Kabbala denudata seu doctrina hebraeorum transendentalis et metaphysica atque theologica",
+            "author": null,
+            "year": 1677,
+            "place": "Sulzbach",
+            "publisher": "Zunner, Johann David",
+            "printer": "Lichtenthaler, Abraham|Wust, Balthasar Christoph",
+            "shelf_mark": "Q",
+            "ustc_sn": null,
+            "_normTitle": "kabbala denudata seu doctrina hebraeorum transendentalis et metaphysica atque theologica",
+            "_normAuthor": ""
+          },
+          "score": 17,
+          "titleShared": [
+            "kabbala",
+            "denudata",
+            "doctrina",
+            "hebraeorum",
+            "metaphysica",
+            "atque",
+            "theologica"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1172145",
+        "title": "Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque theologica : opus antiquissimae philosophiae barbaricae variis speciminibus refertissimum ... / Tomus secundus.",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1172145"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "7623",
+            "title": "Kabbala denudata seu doctrina hebraeorum transendentalis et metaphysica atque theologica",
+            "author": null,
+            "year": 1677,
+            "place": "Sulzbach",
+            "publisher": "Zunner, Johann David",
+            "printer": "Lichtenthaler, Abraham|Wust, Balthasar Christoph",
+            "shelf_mark": "Q",
+            "ustc_sn": null,
+            "_normTitle": "kabbala denudata seu doctrina hebraeorum transendentalis et metaphysica atque theologica",
+            "_normAuthor": ""
+          },
+          "score": 17,
+          "titleShared": [
+            "kabbala",
+            "denudata",
+            "doctrina",
+            "hebraeorum",
+            "metaphysica",
+            "atque",
+            "theologica"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1190973",
+        "title": "Aurea catena Homeri oder eine Beschreibung von dem Ursprung der Natur und natürlichen Dingen ...",
+        "author": "Kirchweger, Anton Joseph",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1190973"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1174",
+            "title": "Aurea Catena Homeri. Das ist: eine Beschreibung von dem Ursprung der Natur",
+            "author": "[Kirchweger, Anton Joseph]",
+            "year": 1728,
+            "place": "Leipzig",
+            "publisher": "Walther, Samuel Benjamin",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "aurea catena homeri das ist eine beschreibung von dem ursprung der natur",
+            "_normAuthor": "kirchweger anton joseph"
+          },
+          "score": 19,
+          "titleShared": [
+            "aurea",
+            "catena",
+            "homeri",
+            "beschreibung",
+            "ursprung",
+            "natur"
+          ],
+          "authorShared": [
+            "kirchweger",
+            "anton",
+            "joseph"
+          ],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "1173",
+            "title": "Aurea Catena Homeri",
+            "author": "[Kirchweger, Anton Joseph]",
+            "year": 1723,
+            "place": "Frankfurt|Leipzig",
+            "publisher": "Böhme, Johann Georg",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "aurea catena homeri",
+            "_normAuthor": "kirchweger anton joseph"
+          },
+          "score": 15,
+          "titleShared": [
+            "aurea",
+            "catena",
+            "homeri"
+          ],
+          "authorShared": [
+            "kirchweger",
+            "anton",
+            "joseph"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1192211",
+        "title": "Alberti Magni philosophie naturalis isagoge: sive introductiones: emendate nuper et impresse summa diligentia. In libros phisicorum, de celo et mundo, de generatione, metheororum, de anima Aristotelis ...",
+        "author": "Albertus",
+        "year": 1514,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1192211"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1192219",
+        "title": "Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque theologica : opus antiquissimae philosophiae barbaricae variis speciminibus refertissimum ...",
+        "author": "Knorr von Rosenroth, Christian",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1192219"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "7623",
+            "title": "Kabbala denudata seu doctrina hebraeorum transendentalis et metaphysica atque theologica",
+            "author": null,
+            "year": 1677,
+            "place": "Sulzbach",
+            "publisher": "Zunner, Johann David",
+            "printer": "Lichtenthaler, Abraham|Wust, Balthasar Christoph",
+            "shelf_mark": "Q",
+            "ustc_sn": null,
+            "_normTitle": "kabbala denudata seu doctrina hebraeorum transendentalis et metaphysica atque theologica",
+            "_normAuthor": ""
+          },
+          "score": 17,
+          "titleShared": [
+            "kabbala",
+            "denudata",
+            "doctrina",
+            "hebraeorum",
+            "metaphysica",
+            "atque",
+            "theologica"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1342014",
+        "title": "De alchimia opuscula complura veterum philosophorum, quorum catalogum sequens pagella indicabit",
+        "author": "[s.n.]",
+        "year": 1550,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1342014"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "363",
+            "title": "De alchimia opuscula complura",
+            "author": "anonymous",
+            "year": 1550,
+            "place": "Frankfurt",
+            "publisher": "Jacob, Cyriacus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "alchimia opuscula complura",
+            "_normAuthor": "anonymous"
+          },
+          "score": 9,
+          "titleShared": [
+            "alchimia",
+            "opuscula",
+            "complura"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "364",
+            "title": "De alchimia opuscula. Apertorium. Magica naturalis. De secretis naturae",
+            "author": "Lull, Ramón",
+            "year": 1546,
+            "place": "Nuremberg",
+            "publisher": "Petreius, Johann",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 689790,
+            "_normTitle": "alchimia opuscula apertorium magica naturalis de secretis naturae",
+            "_normAuthor": "lull ramon"
+          },
+          "score": 5,
+          "titleShared": [
+            "alchimia",
+            "opuscula"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1342369",
+        "title": "Alchemiae Gebri Arabis philosophi solertissimi, libri, cum reliquis, ut versa pagella indicabit",
+        "author": "Ǧābir Ibn-Ḥaiyān",
+        "year": 1545,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1342369"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1342698",
+        "title": "Artemidori ... De somniorum interpretatione, libri quinque",
+        "author": "Cornarius, Janus",
+        "year": 1539,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1342698"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1343192",
+        "title": "Henrici Cornelii Agrippae ... De occulta philosophia libri tres",
+        "author": "Agrippa von Nettesheim, Heinrich Cornelius",
+        "year": 1533,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1343192"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1343590",
+        "title": "Adumbratio Kabbalae Christianae id est Syncatabasis Hebraizans, sive brevis applicatio doctrinae Hebraeorum cabbalisticae ad dogmata novi foederis; pro formanda hypothesi, ad conversionem Judaeorum proficua",
+        "author": "Helmont, Franciscus Mercurius van",
+        "year": 1684,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1343590"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "17042",
+            "title": "Adumbratio kabbalae Christianae id est syncatabasis hebraizans",
+            "author": "[Helmont, Franciscus Mercurius van]",
+            "year": 1684,
+            "place": "Frankfurt",
+            "publisher": "Zunner, Johann David II",
+            "printer": null,
+            "shelf_mark": "Q",
+            "ustc_sn": 2694724,
+            "_normTitle": "adumbratio kabbalae christianae id est syncatabasis hebraizans",
+            "_normAuthor": "helmont franciscus mercurius van"
+          },
+          "score": 19,
+          "titleShared": [
+            "adumbratio",
+            "kabbalae",
+            "christianae",
+            "syncatabasis",
+            "hebraizans"
+          ],
+          "authorShared": [
+            "helmont",
+            "franciscus",
+            "mercurius"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1343674",
+        "title": "Aurei Velleris oder der güldin Schatz und Kunstkammer. Tractatus III. Alter und Newer obriger philosophischer Schrifften und Bücher, so etwas fürnembs, und von der warhafftigen Composition Lapidis Philosophorum geschrieben aber zuvor in Druck nicht aussgangen sind ...",
+        "author": "Trismosin, Salomon",
+        "year": 1600,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1343674"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1187",
+            "title": "Aurei velleris oder der güldin Schatz und Kunstkammer. Tractatus III",
+            "author": "[Trissmosin, Salomon]",
+            "year": 1600,
+            "place": "[Leipzig]",
+            "publisher": "[Grosse, Henning I]",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2026933,
+            "_normTitle": "aurei velleris oder der guldin schatz und kunstkammer tractatus iii",
+            "_normAuthor": "trissmosin salomon"
+          },
+          "score": 17,
+          "titleShared": [
+            "aurei",
+            "velleris",
+            "guldin",
+            "schatz",
+            "kunstkammer",
+            "tractatus"
+          ],
+          "authorShared": [
+            "salomon"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1190",
+            "title": "Aurei velleris oder der guldin Schatz und Kunstkammer. Tractatus II",
+            "author": "[Trissmosin, Salomon]|Paracelsus, Theophrastus|Korndorff, Bartholomeus",
+            "year": 1599,
+            "place": "Rorschach",
+            "publisher": "Schnell, Bartholomaeus I",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 4040606,
+            "_normTitle": "aurei velleris oder der guldin schatz und kunstkammer tractatus ii",
+            "_normAuthor": "trissmosin salomon paracelsus theophrastus korndorff bartholomeus"
+          },
+          "score": 16,
+          "titleShared": [
+            "aurei",
+            "velleris",
+            "guldin",
+            "schatz",
+            "kunstkammer",
+            "tractatus"
+          ],
+          "authorShared": [
+            "salomon"
+          ],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "1191",
+            "title": "Aurei velleris oder der guldin Schatz und Kunstkammer. Tractatus III",
+            "author": "[Trissmosin, Salomon]",
+            "year": 1599,
+            "place": "Rorschach",
+            "publisher": "Schnell, Bartholomaeus I",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 4040606,
+            "_normTitle": "aurei velleris oder der guldin schatz und kunstkammer tractatus iii",
+            "_normAuthor": "trissmosin salomon"
+          },
+          "score": 16,
+          "titleShared": [
+            "aurei",
+            "velleris",
+            "guldin",
+            "schatz",
+            "kunstkammer",
+            "tractatus"
+          ],
+          "authorShared": [
+            "salomon"
+          ],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1344381",
+        "title": "Artis auriferae quam chemiam vocant, volumen primum [- secundum]",
+        "author": "[s.n.]",
+        "year": 1593,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1344381"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1051",
+            "title": "Artis auriferae, quam chemiam vocant, volumen prium ... Turbam philosophorum. Artis auriferae, quam chemiam vocant, volumen secundum... De re metallica",
+            "author": "Morienus",
+            "year": 1593,
+            "place": "Basel",
+            "publisher": "Marne, Claude de| Aubry, Jean",
+            "printer": "Waldkirch, Konrad von",
+            "shelf_mark": "A|geplaatst onder Ars",
+            "ustc_sn": null,
+            "_normTitle": "artis auriferae quam chemiam vocant volumen prium turbam philosophorum artis auriferae quam chemiam vocant volumen secundum de re metallica",
+            "_normAuthor": "morienus"
+          },
+          "score": 15,
+          "titleShared": [
+            "artis",
+            "auriferae",
+            "chemiam",
+            "vocant",
+            "volumen",
+            "secundum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1345635",
+        "title": "Henrici Cornelii Agrippae ab Nettesheym De incertitudine et vanitate scientiarum declamatio invectiva, ex postrema authoris recognitione",
+        "author": "Agrippa von Nettesheim, Heinrich Cornelius",
+        "year": 1584,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1345635"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1346273",
+        "title": "Collectanea medico-physica, oder Holländisch Jahr-Register, sonderbarer Anmerckungen, die so wol in der Artzney-Kunst, als Wissenschaft der Natur in gantz Europa vorgefallen, auf das Jahr 1680 [- 1682] ...",
+        "author": "Blankaart, Steven",
+        "year": 1690,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1346273"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1347504",
+        "title": "Ars chemica, quod sit licita recte exercentibus, probationes doctissimorum iurisconsultorum. Septem tractatus seu capitula Hermetis Trismegisti, aurei. Eiusdem Tabula Smaragdina, in ipsius sepulchro inventa, cum commento Hortulani Philosophi. Studium consilii coniugii de massa solis et lunae",
+        "author": "Hermes",
+        "year": 1566,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1347504"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "997",
+            "title": "Ars chemica. Septem tractatus. Tabula smaragdina. Studium consilii coniugii de massa solis et lunae",
+            "author": "Hermes Trismegistus",
+            "year": 1566,
+            "place": "Strasburg",
+            "publisher": "Emmel, Samuel",
+            "printer": null,
+            "shelf_mark": "A|geplaatst onder Ars",
+            "ustc_sn": 613176,
+            "_normTitle": "ars chemica septem tractatus tabula smaragdina studium consilii coniugii de massa solis et lunae",
+            "_normAuthor": "hermes trismegistus"
+          },
+          "score": 27,
+          "titleShared": [
+            "chemica",
+            "septem",
+            "tractatus",
+            "tabula",
+            "smaragdina",
+            "studium",
+            "consilii",
+            "coniugii",
+            "massa",
+            "solis",
+            "lunae"
+          ],
+          "authorShared": [
+            "hermes"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1347781",
+        "title": "Traumbuch Artemidori ... darinnen Ursprung, Unterscheid und Bedeutung, allerhand Träumen ... : sambt eyner Erinnerung Philippi Melanchtonis von Unterscheid der Träume unnd angehencktem Bericht, was von Träumen zu halten seie",
+        "author": "Artemidorus",
+        "year": 1570,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1347781"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1348258",
+        "title": "Artemidori Daldiani &amp; Achmetis Sereimi F. Oneirocritica : Astrampsychi et Nicephori versus etiam Oneirocritici. Nicolai Rigaltii ad Artemidorum notae",
+        "author": "Muḥammad Ibn-Sīrīn",
+        "year": 1603,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1348258"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1348960",
+        "title": "Des Sibylles celebrées tant par l'antiquité payenne que par les saincts pères : discours traittant des noms &amp; du nombre des Sibylles, de leurs conditions, de la forme &amp; matière de leurs vers ...",
+        "author": "Blondel, David",
+        "year": 1649,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1348960"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1349506",
+        "title": "Secreta secretorum Aristotelis",
+        "author": "Achillini, Alessandro",
+        "year": 1528,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1349506"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1349691",
+        "title": "Le  tableau des riches inventions couvertes du voile des feintes amoureuses, qui sont représentées dans le Songe de Poliphile",
+        "author": "Béroalde de Verville, François",
+        "year": 1600,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1349691"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13977",
+            "title": "Le tableau des riches inventions qui sont representees dans le songe de Poliphile",
+            "author": "[Colonna, Francesco]",
+            "year": 1600,
+            "place": "Paris|",
+            "publisher": "Guillemot, Matthieu",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 47254,
+            "_normTitle": "tableau des riches inventions qui sont representees dans le songe de poliphile",
+            "_normAuthor": "colonna francesco"
+          },
+          "score": 15,
+          "titleShared": [
+            "tableau",
+            "riches",
+            "inventions",
+            "representees",
+            "songe",
+            "poliphile"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1350065",
+        "title": "[De anima. De intellectu]",
+        "author": "Albertus",
+        "year": 1481,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1350065"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1350330",
+        "title": "Mutus liber, in quo tamen tota philosophia hermetica, figuris hieroglyphicis depingitur, ter optimo maximo Deo misericordi consecratus, solisque filiis artis dedicatus",
+        "author": "Baulot, Isaac",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1350330"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1386543",
+        "title": "Bibliothèque des philosophes chimiques",
+        "author": "Maugin de Richebourg, Jean",
+        "year": 1741,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1386543"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1698",
+            "title": "Bibliotheque des philosophes chimiques",
+            "author": "Richebourg, Jean Maugin de",
+            "year": 1741,
+            "place": "Parijs",
+            "publisher": "Cailleau, Andre",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "richebourg jean maugin de"
+          },
+          "score": 15,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [
+            "maugin",
+            "richebourg",
+            "jean"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1699",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "23132",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1386545",
+        "title": "Bibliothèque des philosophes chimiques / Tome premier.",
+        "author": "[s.n.]",
+        "year": 1741,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1386545"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1699",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "23132",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1698",
+            "title": "Bibliotheque des philosophes chimiques",
+            "author": "Richebourg, Jean Maugin de",
+            "year": 1741,
+            "place": "Parijs",
+            "publisher": "Cailleau, Andre",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "richebourg jean maugin de"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1387143",
+        "title": "Bibliothèque des philosophes chimiques / Tome second.",
+        "author": "[s.n.]",
+        "year": 1741,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1387143"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1699",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "23132",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1698",
+            "title": "Bibliotheque des philosophes chimiques",
+            "author": "Richebourg, Jean Maugin de",
+            "year": 1741,
+            "place": "Parijs",
+            "publisher": "Cailleau, Andre",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "richebourg jean maugin de"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1387726",
+        "title": "Bibliothèque des philosophes chimiques / Tome troisième.",
+        "author": "[s.n.]",
+        "year": 1741,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1387726"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1699",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "23132",
+            "title": "Bibliothèque des philosophes chimiques",
+            "author": "[Salmon, William]",
+            "year": 1741,
+            "place": "Paris",
+            "publisher": "Cailleau, André",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "salmon william"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1698",
+            "title": "Bibliotheque des philosophes chimiques",
+            "author": "Richebourg, Jean Maugin de",
+            "year": 1741,
+            "place": "Parijs",
+            "publisher": "Cailleau, Andre",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "bibliotheque des philosophes chimiques",
+            "_normAuthor": "richebourg jean maugin de"
+          },
+          "score": 9,
+          "titleShared": [
+            "bibliotheque",
+            "philosophes",
+            "chimiques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1388324",
+        "title": "Bedencken über Esaiae Stiefels Büchlein: von dreyerley Zustand des Menschen und dessen newen Gebuhrt ...",
+        "author": "Böhme, Jakob",
+        "year": 1682,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1388324"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1388711",
+        "title": "[Commentarii a Philippo Beroaldo conditi in asinum aureum Lucii Apuleii]",
+        "author": "Apuleius",
+        "year": 1501,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1388711"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1604297",
+        "title": "Ulyssis Aldrovandi ... serpentum et draconum historiae libri duo",
+        "author": "Ambrosini, Bartolommeo",
+        "year": 1640,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1604297"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1476039",
+        "title": "R. Abrahami Eleazaris uraltes chymisches Werk, welches ehedessen von dem Autore theils in lateinischer und arabischer, theils auch in chaldäischer und syrischer Sprache geschrieben, nachmals von einem Anonymo in unsere deutsche Muttersprache übersetzet, nun aber nebst zugehörigen Kupfern, Figuren, Gefässen, Oefen, einer kurzen Vorrede, nöthigen Registern, wie auch beygefügtem Schlüssel derer in selbigem vorkommenden fremden Wörter ... zum öffentlichen Druck befördert worden",
+        "author": "Gervasius, Julius",
+        "year": 1760,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1476039"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1476362",
+        "title": "A  true &amp; faithful relation of what passed for many yeers between ... John Dee ... and some spirits tending (had it succeeded) to a general alteration of most states and kingdomes in the world ...",
+        "author": "Dee, John",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1476362"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1476867",
+        "title": "Quaestiones theosophicae oder Betrachtung göttlicher Offenbarung, was Gott, Natur und Creatur, sowol Himmel, Hölle und Welt, samt allen Creaturen sind ...",
+        "author": "Böhme, Jakob",
+        "year": 1730,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1476867"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11853",
+            "title": "Quaestiones theosophicae, oder Betrachtung göttlicher Offenbarung",
+            "author": "Böhme, Jacob",
+            "year": 1730,
+            "place": "[Leiden ?]",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": null,
+            "_normTitle": "quaestiones theosophicae oder betrachtung gottlicher offenbarung",
+            "_normAuthor": "bohme jacob"
+          },
+          "score": 15,
+          "titleShared": [
+            "quaestiones",
+            "theosophicae",
+            "betrachtung",
+            "gottlicher",
+            "offenbarung"
+          ],
+          "authorShared": [
+            "bohme"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1477009",
+        "title": "De vita et scriptis Jacobi Böhmii oder ausführlich erläuterter historischer Bericht von dem Leben und Schriften des teutschen Wunder-Mannes und hocherleuchteten Theosophi Jacob Böhmens ...",
+        "author": "Böhme, Jakob",
+        "year": 1730,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1477009"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15508",
+            "title": "De vita et scriptis Jacobi Boehmii oder ausfuehrlich erlaeuterter historischer Bericht",
+            "author": null,
+            "year": 1730,
+            "place": "[Leiden ?]",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": null,
+            "_normTitle": "vita et scriptis jacobi boehmii oder ausfuehrlich erlaeuterter historischer bericht",
+            "_normAuthor": ""
+          },
+          "score": 11,
+          "titleShared": [
+            "scriptis",
+            "jacobi",
+            "historischer",
+            "bericht"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1477187",
+        "title": "Epistolae theosophicae oder theosophische Send-Briefe",
+        "author": "Böhme, Jakob",
+        "year": 1730,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1477187"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4360",
+            "title": "Epistolae theosophicae, oder theosophische Send-Briefe",
+            "author": "Boehme, Jacob",
+            "year": 1730,
+            "place": "[Leiden ?]",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": null,
+            "_normTitle": "epistolae theosophicae oder theosophische send briefe",
+            "_normAuthor": "boehme jacob"
+          },
+          "score": 11,
+          "titleShared": [
+            "epistolae",
+            "theosophicae",
+            "theosophische",
+            "briefe"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1477504",
+        "title": "Register über alle theosophischen Schriften des ... Jacob Böhmens",
+        "author": "Böhme, Jakob",
+        "year": 1730,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1477504"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1477926",
+        "title": "Oswaldi Crollii ... Hassi Chymisch Kleynod : hiebevor zwar aussgangen, jetzo aber durch den hochgelehrten Johann Hartmannum ... gemehrt verbessert, mit nothwendigen Notis spagyricis zu Erläuterung der Artzneyen geziert und zum ersten Mal neben dem hermetischen Wunderbaum in Truck aussgangen ...",
+        "author": "Croll, Oswald",
+        "year": 1647,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1477926"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1478514",
+        "title": "Henrici Cornelii Agrippae ab Nettesheym de incertitudine &amp; vanitate omnium scientiarum &amp; artium liber, lectu plane iucundus &amp; elegans et de nobilitate et praecellentia foeminei sexus, eiusdemque supra virilem eminentia libellus, lectu etiam iucundissimus ...",
+        "author": "Agrippa von Nettesheim, Heinrich Cornelius",
+        "year": 1653,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1478514"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1479110",
+        "title": "Von der Menschwerdung Jesu Christi, wie das ewige Wort sey Mensch worden ...",
+        "author": "Böhme, Jakob",
+        "year": 1682,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1479110"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9137",
+            "title": "Von der Menschwerdung Jesu Christi",
+            "author": "Boehme, Jacob",
+            "year": 1682,
+            "place": "Amsterdam",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": 5098079,
+            "_normTitle": "von der menschwerdung jesu christi",
+            "_normAuthor": "boehme jacob"
+          },
+          "score": 7,
+          "titleShared": [
+            "menschwerdung",
+            "christi"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1479338",
+        "title": "Viertzig Fragen von der Seelen Urstand, Essentz, Wesen, Natur und Eigenschafft, was sie von Ewigkeit in Ewigkeit sey : darbey am Ende beygefüget ist das umgewandte Auge von der Seelen und ihrer Bildnüss",
+        "author": "Walther, Balthasar",
+        "year": 1682,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1479338"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15431",
+            "title": "Viertzig Fragen von der Seelen Urstand",
+            "author": "Boehme, Jacob",
+            "year": 1682,
+            "place": "Amsterdam",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": 1837159,
+            "_normTitle": "viertzig fragen von der seelen urstand",
+            "_normAuthor": "boehme jacob"
+          },
+          "score": 11,
+          "titleShared": [
+            "viertzig",
+            "fragen",
+            "seelen",
+            "urstand"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1479527",
+        "title": "Traumbuch Cardani : warhafftige, gewüsse und unbetrügliche Underweisung, wie allerhandt Träum, Erscheinungen unnd nächtliche Gesicht, welche uns von der Seelen wann sich der Leib zu ruwen begeben eingebildet und fürbracht werden, wie solche natürlich unnd recht erklärt unnd aussgelegt werden sollend ... ; auch von den kleinsten und nächsten Dingen und vom aller besten und säligsten Läben ...",
+        "author": "Cardano, Girolamo",
+        "year": 1563,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1479527"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1480459",
+        "title": "Fr. Basilii Valentini ... Chymische Schriften, aus einigen alten MSten aufs Fleissigste verbessert, mit vielen Tractaten, auch etlichen Figuren vermehret, und nebst einem vollständigen Register in drey Theile verfasset ...",
+        "author": "Basilius",
+        "year": 1740,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1480459"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1481126",
+        "title": "Fratris Basilii Valentini ... chymische Schriften alle so viel derer verhanden",
+        "author": "Basilius",
+        "year": 1700,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1481126"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1500794",
+        "title": "De signatura rerum, das ist: von der Gebuhrt und Bezeichnung aller Wesen: wie alle Wesen aus einem einigen Mysterio urständen; und wie sich dasselbe Mysterium von Ewigkeit immer in sich selber erbähre und wie das Gute ins Böse und das Böse ins Gute verwandelt werde. Item: wie die äussere Cur des Leibes durch seine Gleichheit müsse geführet werden. Was jedes Dinges Anfang auch Zerbrechung und Heilung sey ...",
+        "author": "Böhme, Jakob",
+        "year": 1682,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1500794"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13236",
+            "title": "De signatura rerum, das ist: Von der Gebuhrt und Bezeichnung aller Wesen",
+            "author": "Boehme, Jacob",
+            "year": 1682,
+            "place": "Amsterdam",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": 5081159,
+            "_normTitle": "signatura rerum das ist von der gebuhrt und bezeichnung aller wesen",
+            "_normAuthor": "boehme jacob"
+          },
+          "score": 15,
+          "titleShared": [
+            "signatura",
+            "rerum",
+            "gebuhrt",
+            "bezeichnung",
+            "aller",
+            "wesen"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1505396",
+        "title": "Der  Weeg zu Christo: verfasset in neun Büchlein. Das 1. Von wahrer Busse. 2. Vom heiligen Gebeth. 3. Ein Schlüssel göttlicher Geheimnüsse. 4. Von wahrer Gelassenheit. 5. Von der Wiedergebuhrt. 6. Vom übersinnlichen Leben. 7. Von göttlicher Beschauligkeit. 8. Von der erleuchteten und unerleuchteten Seele. 9. Von den vier Complexionen",
+        "author": "Böhme, Jakob",
+        "year": 1682,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1505396"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15804",
+            "title": "Der Weeg zu Christo",
+            "author": "Boehme, Jacob",
+            "year": 1682,
+            "place": "Amsterdam",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": null,
+            "_normTitle": "weeg zu christo",
+            "_normAuthor": "boehme jacob"
+          },
+          "score": 5,
+          "titleShared": [
+            "christo"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1505678",
+        "title": "Symbolographia sive de arte symbolica sermones septem : quibus accessit studio &amp; opera eiusdem Sylloge celebriorum symbolorum in quatuor divisa classes sacrorum, heroicorum, ethicorum et satyricorum bis mille iconismis expressa ...",
+        "author": "Bosch, Jacob",
+        "year": 1702,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1505678"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13923",
+            "title": "Symbolographia sive de arte symbolica",
+            "author": "Bosch, Jacob",
+            "year": 1702,
+            "place": "Augsburg  Dillingen",
+            "publisher": "Bencard, Johann Kaspar",
+            "printer": null,
+            "shelf_mark": "H folio",
+            "ustc_sn": null,
+            "_normTitle": "symbolographia sive de arte symbolica",
+            "_normAuthor": "bosch jacob"
+          },
+          "score": 11,
+          "titleShared": [
+            "symbolographia",
+            "symbolica"
+          ],
+          "authorShared": [
+            "bosch",
+            "jacob"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1506460",
+        "title": "Morgen-Röte im Aufgangk das ist die Wurtzel oder Mutter der Philosophiae, Astrologiae und Theologiae, aus rechtem Grunde oder Beschreibung der Natur ...",
+        "author": "Böhme, Jakob",
+        "year": 1656,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1506460"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1507169",
+        "title": "Sal, lumen, et spiritus mundi philosophici or the dawning of the day, discovered by the beams of light: shewing the true salt and secret of the philosophers, the first and universal spirit of the world ...",
+        "author": "Combach, Ludwig",
+        "year": 1657,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1507169"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1507440",
+        "title": "Alberti Magni, de secretis mulierum libellus, scholiis auctus, &amp; a mendis repurgatus : eiusdem de virtutibus herbarum, lapidum, et animalium quorundam libellus ; item de mirabilibus mundi, ac de quibusdam effectibus causatis a quibusdam animalibus, &amp;c.. adiecimus et ob materiae similitudinem Michaelis Scoti ... de secretis naturae opusculum",
+        "author": "Albertus",
+        "year": 1598,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1507440"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1529968",
+        "title": "Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii, der zwölff Schlüssel von dem Stein der uhralten Weisen und desselben aussdrücklichen unnd warhafften Praeparation ... : item Ausslegung Rythmorum Basilii von der Materia des Steins der Philosophen ...",
+        "author": "Meisner, Lorenz",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1529968"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "5383",
+            "title": "Gemma gemmarum alchimistarum. Oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii. Ausslegung Rythmorum Basilii",
+            "author": "Meisner, Lorentz|Schüler, Conrad",
+            "year": 1608,
+            "place": "Eisleben|Leipzig",
+            "publisher": "[Apel, Jakob II]",
+            "printer": "[Gaubisch, Jakob I]",
+            "shelf_mark": "A",
+            "ustc_sn": 2079749,
+            "_normTitle": "gemma gemmarum alchimistarum oder erleuterung der parabolischen und philosophischen schrifften fratris basilii ausslegung rythmorum basilii",
+            "_normAuthor": "meisner lorentz schuler conrad"
+          },
+          "score": 27,
+          "titleShared": [
+            "gemma",
+            "gemmarum",
+            "alchimistarum",
+            "erleuterung",
+            "parabolischen",
+            "philosophischen",
+            "schrifften",
+            "fratris",
+            "basilii",
+            "ausslegung",
+            "rythmorum"
+          ],
+          "authorShared": [
+            "meisner"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1529971",
+        "title": "Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii, der zwölff Schlüssel von dem Stein der uhralten Weisen und desselben aussdrücklichen unnd warhafften Praeparation ... : item Ausslegung Rythmorum Basilii von der Materia des Steins der Philosophen ... / Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii.",
+        "author": "[s.n.]",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1529971"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "5383",
+            "title": "Gemma gemmarum alchimistarum. Oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii. Ausslegung Rythmorum Basilii",
+            "author": "Meisner, Lorentz|Schüler, Conrad",
+            "year": 1608,
+            "place": "Eisleben|Leipzig",
+            "publisher": "[Apel, Jakob II]",
+            "printer": "[Gaubisch, Jakob I]",
+            "shelf_mark": "A",
+            "ustc_sn": 2079749,
+            "_normTitle": "gemma gemmarum alchimistarum oder erleuterung der parabolischen und philosophischen schrifften fratris basilii ausslegung rythmorum basilii",
+            "_normAuthor": "meisner lorentz schuler conrad"
+          },
+          "score": 25,
+          "titleShared": [
+            "gemma",
+            "gemmarum",
+            "alchimistarum",
+            "erleuterung",
+            "parabolischen",
+            "philosophischen",
+            "schrifften",
+            "fratris",
+            "basilii",
+            "ausslegung",
+            "rythmorum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1530085",
+        "title": "Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii, der zwölff Schlüssel von dem Stein der uhralten Weisen und desselben aussdrücklichen unnd warhafften Praeparation ... : item Ausslegung Rythmorum Basilii von der Materia des Steins der Philosophen ... / Gründliche Ausslegung und warhafftige Erklerung der rythmorum Fratris Basilii Valentini Monachi.",
+        "author": "[s.n.]",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1530085"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "5383",
+            "title": "Gemma gemmarum alchimistarum. Oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii. Ausslegung Rythmorum Basilii",
+            "author": "Meisner, Lorentz|Schüler, Conrad",
+            "year": 1608,
+            "place": "Eisleben|Leipzig",
+            "publisher": "[Apel, Jakob II]",
+            "printer": "[Gaubisch, Jakob I]",
+            "shelf_mark": "A",
+            "ustc_sn": 2079749,
+            "_normTitle": "gemma gemmarum alchimistarum oder erleuterung der parabolischen und philosophischen schrifften fratris basilii ausslegung rythmorum basilii",
+            "_normAuthor": "meisner lorentz schuler conrad"
+          },
+          "score": 25,
+          "titleShared": [
+            "gemma",
+            "gemmarum",
+            "alchimistarum",
+            "erleuterung",
+            "parabolischen",
+            "philosophischen",
+            "schrifften",
+            "fratris",
+            "basilii",
+            "ausslegung",
+            "rythmorum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1530175",
+        "title": "Das  Valete: uber den Tractat der Arcanorum Basilii Valentini zusammen gesetzten Hauptschluss Puncten dess Liechts der Natur",
+        "author": "Reinhart, Hans Christoph",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1530175"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15151",
+            "title": "Das Valete: Uber den Tractat der Arcanorum Basilii Valentini",
+            "author": "Rheinhart sr, Hans Christoff",
+            "year": 1608,
+            "place": "Halle",
+            "publisher": "Krusicke, Joachim",
+            "printer": "Hynitzsch, Erasmus",
+            "shelf_mark": "A  Geplaatst onder Basilius Valentinus",
+            "ustc_sn": 509685,
+            "_normTitle": "valete uber den tractat der arcanorum basilii valentini",
+            "_normAuthor": "rheinhart sr hans christoff"
+          },
+          "score": 15,
+          "titleShared": [
+            "valete",
+            "tractat",
+            "arcanorum",
+            "basilii",
+            "valentini"
+          ],
+          "authorShared": [
+            "hans"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1530278",
+        "title": "Aetii medici Graeci contractae ex veteribus medicinae tetrabiblos : hoc est quaternio, id est libri universales quatuor, singuli quatuor sermones complectentes, ut sint in summa quatuor sermonum quaterniones, id est sermones XVI",
+        "author": "Aetios",
+        "year": 1542,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1530278"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1531250",
+        "title": "Andreae Alciati emblemata cum commentariis Claudii Minois I. C. Francisci Sanctii Brocensis &amp; notis Laurentii Pignorii ...",
+        "author": "Alciati, Andrea",
+        "year": 1661,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1531250"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1557095",
+        "title": "Antonii van Dale ... Dissertationes de origine ac progressu idololatriae et superstitionum: de vera ac falsa prophetia; uti et de divinationibus idololatricis Judaeorum",
+        "author": "Dale, Antonius van",
+        "year": 1696,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1557095"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1557940",
+        "title": "Lucii Apuleii ... Opera",
+        "author": "Apuleius",
+        "year": 1778,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1557940"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1557942",
+        "title": "Lucii Apuleii ... Opera / Tomus I.",
+        "author": "[s.n.]",
+        "year": 1778,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1557942"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1558300",
+        "title": "Lucii Apuleii ... Opera / Tomus II.",
+        "author": "[s.n.]",
+        "year": 1778,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1558300"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1558622",
+        "title": "Der  Compass der Weisen ...",
+        "author": "Birkholz, Adam Michael",
+        "year": 1782,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1558622"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3028",
+            "title": "Der Compass der Weisen, von einem Mitverwandten der innern Verfassung der ächten und rechten Freymäurerey beschrieben",
+            "author": "[Jolyfief, Augustin Anton Pocquieres de]",
+            "year": 1782,
+            "place": "Berlin",
+            "publisher": "Maurer, Friedrich",
+            "printer": null,
+            "shelf_mark": "Rv",
+            "ustc_sn": null,
+            "_normTitle": "compass der weisen von einem mitverwandten der innern verfassung der achten und rechten freymaurerey beschrieben",
+            "_normAuthor": "jolyfief augustin anton pocquieres de"
+          },
+          "score": 7,
+          "titleShared": [
+            "compass",
+            "weisen"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "3029",
+            "title": "Der Compass der Weisen von einen Mitverwandten der innern Verfassung der ächten und rechten Freymäurerey beschrieben",
+            "author": "[Jolyfief, Augustin Anton Pocquieres de]",
+            "year": 1779,
+            "place": "Berlin|Leipzig",
+            "publisher": "Ringmacher, Christian Ulrich",
+            "printer": null,
+            "shelf_mark": "Rv",
+            "ustc_sn": null,
+            "_normTitle": "compass der weisen von einen mitverwandten der innern verfassung der achten und rechten freymaurerey beschrieben",
+            "_normAuthor": "jolyfief augustin anton pocquieres de"
+          },
+          "score": 5,
+          "titleShared": [
+            "compass",
+            "weisen"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1559088",
+        "title": "Elpidii Berrettarii ... Tractatus de risu",
+        "author": "Berrettari, Elpidio",
+        "year": 1603,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1559088"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1559181",
+        "title": "Le  pilote de l'onde vive, ou le secret du flux et reflux de la mer ...",
+        "author": "Eyquem du Martineau, Mathurin",
+        "year": 1678,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1559181"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11307",
+            "title": "Le pilote de l'onde vive",
+            "author": "[Eyquem de Martineau, Mathurin]",
+            "year": 1678,
+            "place": "Paris",
+            "publisher": "Houry, Jean d'| Eyquem de Martineau, Mathurin",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6129822,
+            "_normTitle": "pilote de l onde vive",
+            "_normAuthor": "eyquem de martineau mathurin"
+          },
+          "score": 11,
+          "titleShared": [
+            "pilote"
+          ],
+          "authorShared": [
+            "eyquem",
+            "martineau",
+            "mathurin"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1559437",
+        "title": "Drey curieuse chymische Tractätlein. Das erste betitult güldene Rose ... Das ander Brunn der Weissheit ... Das dritte Blut der Natur",
+        "author": "[s.n.]",
+        "year": 1706,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1559437"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3887",
+            "title": "Drey curieuse chymische Tractätlein. Güldene Rose. Brunn der Weissheit und Erkänntnis der Natur. Blut der Natur",
+            "author": "anonymous",
+            "year": 1706,
+            "place": "Frankfurt|Leipzig",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "drey curieuse chymische tractatlein guldene rose brunn der weissheit und erkanntnis der natur blut der natur",
+            "_normAuthor": "anonymous"
+          },
+          "score": 17,
+          "titleShared": [
+            "curieuse",
+            "chymische",
+            "tractatlein",
+            "guldene",
+            "brunn",
+            "weissheit",
+            "natur"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "3888",
+            "title": "Drey curieuse chymische Tractätlein. Paradeis-Spiegel. Der Teutschen Schützen-Hoff. Beschreibung des grossen Geheimnisses des Steins der Weisen",
+            "author": "Müller, Ambrosius",
+            "year": 1704,
+            "place": "Lauenburg|Frankfurt|Leipzig",
+            "publisher": "Liebezeit, Christian",
+            "printer": "Pfeiffer, Christian Albrecht",
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "drey curieuse chymische tractatlein paradeis spiegel der teutschen schutzen hoff beschreibung des grossen geheimnisses des steins der weisen",
+            "_normAuthor": "muller ambrosius"
+          },
+          "score": 8,
+          "titleShared": [
+            "curieuse",
+            "chymische",
+            "tractatlein"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1559646",
+        "title": "Aurum superius &amp; inferius aurae superioris &amp; inferioris hermeticum",
+        "author": "Balduin, Christian Adolf",
+        "year": 1675,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1559646"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1238",
+            "title": "Aurum superius et inferius",
+            "author": "Balduinus, Christianus Adolphus",
+            "year": 1675,
+            "place": "Amsterdam",
+            "publisher": "Janssonius van Waesberge, Johannes I",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 1811901,
+            "_normTitle": "aurum superius et inferius",
+            "_normAuthor": "balduinus christianus adolphus"
+          },
+          "score": 9,
+          "titleShared": [
+            "aurum",
+            "superius",
+            "inferius"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1237",
+            "title": "Aurum superius et inferius",
+            "author": "Balduinus, Christianus Adolphus",
+            "year": 1675,
+            "place": "Frankfurt en Leipzig",
+            "publisher": "Fromann, Georg Heinrich",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 1811901,
+            "_normTitle": "aurum superius et inferius",
+            "_normAuthor": "balduinus christianus adolphus"
+          },
+          "score": 9,
+          "titleShared": [
+            "aurum",
+            "superius",
+            "inferius"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1559866",
+        "title": "Phosphorus hermeticus sive magnes luminaris",
+        "author": "Balduin, Christian Adolf",
+        "year": 1675,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1559866"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11259",
+            "title": "Phosphorus hermeticus",
+            "author": "Balduinus, Christianus Adolphus",
+            "year": 1675,
+            "place": "Frankfurt  Leipzig",
+            "publisher": "Fromann, Georg Heinrich",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2582174,
+            "_normTitle": "phosphorus hermeticus",
+            "_normAuthor": "balduinus christianus adolphus"
+          },
+          "score": 7,
+          "titleShared": [
+            "phosphorus",
+            "hermeticus"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2206662",
+        "title": "Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, avec une explication des hiéroglyphes, et de la guerre de Troye / Tome premier.",
+        "author": "[s.n.]",
+        "year": 1758,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2206662"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4792",
+            "title": "Les fables égyptiennes et grecques",
+            "author": "Pernety, Antoine-Joseph",
+            "year": 1758,
+            "place": "Paris",
+            "publisher": "Bauche",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "fables egyptiennes et grecques",
+            "_normAuthor": "pernety antoine joseph"
+          },
+          "score": 9,
+          "titleShared": [
+            "fables",
+            "egyptiennes",
+            "grecques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1604772",
+        "title": "Aureum seculum patefactum oder die eröffnete güldene Zeit ...",
+        "author": "Chrysander, Alitophilus",
+        "year": 1706,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1604772"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1196",
+            "title": "Aureum seculum patefactum: oder, Die eröffnete güldene Zeit",
+            "author": "Chrysandrus Alitophilus",
+            "year": 1706,
+            "place": "Neurenberg",
+            "publisher": "Zieger, Johann",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "aureum seculum patefactum oder die eroffnete guldene zeit",
+            "_normAuthor": "chrysandrus alitophilus"
+          },
+          "score": 15,
+          "titleShared": [
+            "aureum",
+            "seculum",
+            "patefactum",
+            "eroffnete",
+            "guldene"
+          ],
+          "authorShared": [
+            "alitophilus"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1604995",
+        "title": "Eirenaei Philalethae Erklärung der hermetisch poetischen Werke Herrn Georgii Riplaei : enthaltend die kläreste und fürtreflichste Entdeckung der verborgensten Geheimnisse der alten Philosophen, so bishero niemals öffentlich kund gemachet",
+        "author": "Starkey, George",
+        "year": 1741,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1604995"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1605508",
+        "title": "Catalogus haereticorum omnium pene qui ad haec usque tempora passim literarum monumentis proditi sunt ...",
+        "author": "Bernardus de Lutzemburgo",
+        "year": 1529,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1605508"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1605827",
+        "title": "Gallerie der neuen Propheten, apokalyptischen Träumer, Geisterseher und Revolutionsprediger : ein Beytrag zur Geschichte der menschlichen Narrheit",
+        "author": "[s.n.]",
+        "year": 1799,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1605827"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1606332",
+        "title": "Des hochgelahrten Philalethae drey schöne und auserlesene Tractätlein von Verwandelung der Metallen : samt Wigands vom rothen Schilde ... beygefügtem Tractätlein genannt Die Herrligkeit der Welt ...",
+        "author": "Starkey, George",
+        "year": 1675,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606332"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1606525",
+        "title": "Edouardi Kellaei Angli tractatus duo egregii de lapide philosophorum, una cum theatro astronomiae terrestri ...",
+        "author": "Kelley, Edward",
+        "year": 1676,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606525"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1606666",
+        "title": "Hexastichon Sebastiani Brant in memorabiles evangelistarum figuras : quisquis percupies facile evangelica dicta servare &amp; memori mente tenere cito ...",
+        "author": "Petrus",
+        "year": 1503,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606666"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6532",
+            "title": "Hexastichon Sebastiani Brant in memorabiles evangelistarum figuras",
+            "author": "[Petrus von Rosenheim]",
+            "year": 1502,
+            "place": "Pforzheim",
+            "publisher": "Anshelm, Thomas",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": 662469,
+            "_normTitle": "hexastichon sebastiani brant in memorabiles evangelistarum figuras",
+            "_normAuthor": "petrus von rosenheim"
+          },
+          "score": 16,
+          "titleShared": [
+            "hexastichon",
+            "sebastiani",
+            "brant",
+            "memorabiles",
+            "evangelistarum",
+            "figuras"
+          ],
+          "authorShared": [
+            "petrus"
+          ],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "6533",
+            "title": "Hexastichon Sebastiani Brant n[!] memorabiles evangelistarum figuras",
+            "author": "[Petrus von Rosenheim]",
+            "year": 1502,
+            "place": "[Pforzheim]",
+            "publisher": "Anshelm, Thomas",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": 662469,
+            "_normTitle": "hexastichon sebastiani brant n memorabiles evangelistarum figuras",
+            "_normAuthor": "petrus von rosenheim"
+          },
+          "score": 16,
+          "titleShared": [
+            "hexastichon",
+            "sebastiani",
+            "brant",
+            "memorabiles",
+            "evangelistarum",
+            "figuras"
+          ],
+          "authorShared": [
+            "petrus"
+          ],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1606718",
+        "title": "Chymisches Zwey-Blat, das ist zwey vortreffliche chymische Tractätlein: Das erste eröffneter Eingang zu dess Königs verschlossenem Pallaste anonymi philalethae. Das ander von dem Stein der Weisen, wie man den recht bereiten soll fratris Ferrarii ...",
+        "author": "Lange, Johann",
+        "year": 1673,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606718"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2720",
+            "title": "Chymisches Zwey-Blat. Das ist zwey vortreffliche chymische Tractätlein  Eröffneter Eingang zu dess Königs verschlossenem Pallaste. Von dem Stein der Weisen",
+            "author": "[Starkey, George]|Ferrarius",
+            "year": 1673,
+            "place": "Frankfurt|Hamburg",
+            "publisher": "Guth, Christian",
+            "printer": "Görlin, Johann",
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "chymisches zwey blat das ist zwey vortreffliche chymische tractatlein eroffneter eingang zu dess konigs verschlossenem pallaste von dem stein der weisen",
+            "_normAuthor": "starkey george ferrarius"
+          },
+          "score": 25,
+          "titleShared": [
+            "chymisches",
+            "vortreffliche",
+            "chymische",
+            "tractatlein",
+            "eroffneter",
+            "eingang",
+            "konigs",
+            "verschlossenem",
+            "pallaste",
+            "stein",
+            "weisen"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "2719",
+            "title": "Chymisches Zwey-Blat. Das ist zwey vortreffliche chymische Tractätlein  Eroeffneter Eingang zu dess Königs verschlossenem Pallaste. Vom dem Stein der Weisen",
+            "author": "[Starkey, George]|Ferrarius",
+            "year": 1674,
+            "place": "Frankfurt  Hamburg",
+            "publisher": "Goerlin, Johann| Guth, Christian",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "chymisches zwey blat das ist zwey vortreffliche chymische tractatlein eroeffneter eingang zu dess konigs verschlossenem pallaste vom dem stein der weisen",
+            "_normAuthor": "starkey george ferrarius"
+          },
+          "score": 22,
+          "titleShared": [
+            "chymisches",
+            "vortreffliche",
+            "chymische",
+            "tractatlein",
+            "eingang",
+            "konigs",
+            "verschlossenem",
+            "pallaste",
+            "stein",
+            "weisen"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1606898",
+        "title": "Vier chymische Tractätlein: I. Lucens lux in tenebris, das ist: Das hellscheinende Licht in Finsternis. II. De vitriolo &amp; eius oleo secretissimo, das ist: Von dem Vitriol und seinem geheimesten Oehle [Roger Bacon] III. De animali rationali: Vom vernünfftigen Thiere und seiner herrlichen Artzney. IV. Aurum vitae oder Gold des Lebens",
+        "author": "Bacon, Roger",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606898"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15415",
+            "title": "Vier chymische Tractätlein. Lucens lux in tenebris Das ist: das hellscheinende Licht in Finsternis. De vitriolo & ejus oleo secretissimo Das ist: Von dem Vitriol, und seinem geheimesten Oehle. De animali rationali Von dem Venünfftigen Thiere. Aurum vitae oder Gold des Lebens",
+            "author": "anonymous",
+            "year": 1677,
+            "place": "Bautzen",
+            "publisher": "Kretschmar, Bartold",
+            "printer": "Richter, Andreas",
+            "shelf_mark": "A",
+            "ustc_sn": 2651353,
+            "_normTitle": "vier chymische tractatlein lucens lux in tenebris das ist das hellscheinende licht in finsternis de vitriolo ejus oleo secretissimo das ist von dem vitriol und seinem geheimesten oehle de animali rationali von dem venunfftigen thiere aurum vitae oder gold des lebens",
+            "_normAuthor": "anonymous"
+          },
+          "score": 41,
+          "titleShared": [
+            "chymische",
+            "tractatlein",
+            "lucens",
+            "tenebris",
+            "hellscheinende",
+            "licht",
+            "finsternis",
+            "vitriolo",
+            "secretissimo",
+            "vitriol",
+            "seinem",
+            "geheimesten",
+            "oehle",
+            "animali",
+            "rationali",
+            "thiere",
+            "aurum",
+            "vitae",
+            "lebens"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1606981",
+        "title": "An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the Soul is evinced from the Principles of Reason and Philosophy",
+        "author": "[s.n.]",
+        "year": 1745,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606981"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1606983",
+        "title": "An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the Soul is evinced from the Principles of Reason and Philosophy / Volume I.",
+        "author": "[s.n.]",
+        "year": 1745,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1606983"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1607437",
+        "title": "An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the Soul is evinced from the Principles of Reason and Philosophy / Volume II.",
+        "author": "[s.n.]",
+        "year": 1745,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1607437"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1607901",
+        "title": "In disem teütschen kalender vindet man gar hübsch nach einander die zwelff zeychen unnd die siben planeten, wie yegklicher regieren sol. Dar nach vindet man die guldin zal und wie man den sunteglichen buchstaben suchen soll und zu welicher adern man lassen soll",
+        "author": "[s.n.]",
+        "year": 1495,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1607901"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1608051",
+        "title": "Tractatus posthumus Jani Jacobi Boissardi ... De divinatione &amp; magicis praestigiis: quarum veritas ac vanitas solide exponitur per descriptionem deorum fatidicorum qui olim responsa dederunt; eorundemque prophetarum, sacerdotum ...",
+        "author": "Boissard, Jean Jacques",
+        "year": 1615,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1608051"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14571",
+            "title": "Tractatus posthumus, sive Ulysses. Una cum annexis tractatibus de Fraternitate Roseae Crucis",
+            "author": "Maier, Michael",
+            "year": 1624,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": null,
+            "shelf_mark": "R",
+            "ustc_sn": 2071831,
+            "_normTitle": "tractatus posthumus sive ulysses una cum annexis tractatibus de fraternitate roseae crucis",
+            "_normAuthor": "maier michael"
+          },
+          "score": 5,
+          "titleShared": [
+            "tractatus",
+            "posthumus"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1632680",
+        "title": "De symbolica Aegyptiorum sapientia : in qua symbola, parabolae, historiae selectae, quae ad omnem emblematum, aenigmatum, hieroglyphicorum cognitionem viam praestant",
+        "author": "Caussin, Nicolas",
+        "year": 1623,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1632680"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13882",
+            "title": "De symbolica aegyptiorum sapientia",
+            "author": "Caussinus, Nicolaus",
+            "year": 1623,
+            "place": "Cologne",
+            "publisher": "Kinckius, Johann",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6016566,
+            "_normTitle": "symbolica aegyptiorum sapientia",
+            "_normAuthor": "caussinus nicolaus"
+          },
+          "score": 9,
+          "titleShared": [
+            "symbolica",
+            "aegyptiorum",
+            "sapientia"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "19449",
+            "title": "De symbolica Aegyptiorum sapientia",
+            "author": "Caussinus, Nicolaus",
+            "year": 1618,
+            "place": "Paris",
+            "publisher": "Beauvais, Romain de",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6016566,
+            "_normTitle": "symbolica aegyptiorum sapientia",
+            "_normAuthor": "caussinus nicolaus"
+          },
+          "score": 7,
+          "titleShared": [
+            "symbolica",
+            "aegyptiorum",
+            "sapientia"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "21006",
+            "title": "De symbolica aegyptiorum sapientia",
+            "author": "Caussinus, Nicolaus",
+            "year": 1631,
+            "place": "Cologne",
+            "publisher": "Kinckius, Johann",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6814812,
+            "_normTitle": "symbolica aegyptiorum sapientia",
+            "_normAuthor": "caussinus nicolaus"
+          },
+          "score": 7,
+          "titleShared": [
+            "symbolica",
+            "aegyptiorum",
+            "sapientia"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1632874",
+        "title": "Polyhistor symbolicus, electorum symbolorum &amp; parabolarum historicarum stromata, XII libris complectens",
+        "author": "Caussin, Nicolas",
+        "year": 1623,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1632874"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "21004",
+            "title": "Polyhistor symbolicus",
+            "author": "Caussinus, Nicolaus",
+            "year": 1623,
+            "place": "Cologne",
+            "publisher": "Kinckius, Johann",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6016179,
+            "_normTitle": "polyhistor symbolicus",
+            "_normAuthor": "caussinus nicolaus"
+          },
+          "score": 7,
+          "titleShared": [
+            "polyhistor",
+            "symbolicus"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "19450",
+            "title": "Polyhistor symbolicus",
+            "author": "Caussinus, Nicolaus",
+            "year": 1618,
+            "place": "Paris",
+            "publisher": "Beauvais, Romain de",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6016179,
+            "_normTitle": "polyhistor symbolicus",
+            "_normAuthor": "caussinus nicolaus"
+          },
+          "score": 5,
+          "titleShared": [
+            "polyhistor",
+            "symbolicus"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "21005",
+            "title": "Polyhistor symbolicus",
+            "author": "Caussinus, Nicolaus",
+            "year": 1631,
+            "place": "Cologne",
+            "publisher": "Kinckius, Johann",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 2133651,
+            "_normTitle": "polyhistor symbolicus",
+            "_normAuthor": "caussinus nicolaus"
+          },
+          "score": 5,
+          "titleShared": [
+            "polyhistor",
+            "symbolicus"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1633536",
+        "title": "Aphorismi hieroglyphici : quibus veterum philosophorum mysteria quaedam declarantur: ex commentariis hieroglyphicis Ioannis Pierii Valeriani &amp; Caelii Augustini Curionis collecti, inq. usum eorum, qui de recondita veterum doctrina aliquid cognoscere desiderant",
+        "author": "Valeriano, Pierio",
+        "year": 1592,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1633536"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1633876",
+        "title": "Somniorum synesiorum omnis generis insomnia explicantes, libri IIII : quibus accedunt, eiusdem haec etiam De libris propriis ... ; De curationibus et praedictionibus admirandis ; Neronis encomium ; Geometriae encomium",
+        "author": "Cardano, Girolamo",
+        "year": 1585,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1633876"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1652796",
+        "title": "Das  Geheimniss der hermetischen Philosophie, in welchem die Verborgenheit der Natur und der Kunst, die Materie und Weise zu würken betreffende, vom Steine der Weisen, durch gewisse Regeln ordentlich geoffenbaret wird",
+        "author": "[s.n.]",
+        "year": 1770,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1652796"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "5290",
+            "title": "Das Geheimniss der hermetischen Philosophie",
+            "author": "anonymous",
+            "year": 1770,
+            "place": "Frankfurt|Leipzig",
+            "publisher": "Fleischerische Buchhandlung",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "geheimniss der hermetischen philosophie",
+            "_normAuthor": "anonymous"
+          },
+          "score": 9,
+          "titleShared": [
+            "geheimniss",
+            "hermetischen",
+            "philosophie"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1652897",
+        "title": "Geheimniss der Natur des grossen und kleinen Bauers, in welchem die Materie und Erkänntniss des einigen und wahren Subjecti universalis magni &amp; illius Praeparatio umständlich beschrieben wird ...",
+        "author": "Walch, Johannes",
+        "year": 1731,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1652897"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "5291",
+            "title": "Geheimniss der Natur des grossen und kleinen Bauers",
+            "author": "[Grasshoff, Johann]",
+            "year": 1731,
+            "place": "n.p.",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "geheimniss der natur des grossen und kleinen bauers",
+            "_normAuthor": "grasshoff johann"
+          },
+          "score": 13,
+          "titleShared": [
+            "geheimniss",
+            "natur",
+            "grossen",
+            "kleinen",
+            "bauers"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1653360",
+        "title": "Hermann Fictulds Abhandlung von der Alchymie und derselben Gewissheit",
+        "author": "Fictuld, Hermann",
+        "year": 1754,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1653360"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "65",
+            "title": "Hermann Fictulds Abhandlung von der Alchymie, und derselben Gewissheit",
+            "author": "Fictuld, Hermann",
+            "year": 1754,
+            "place": "Erlangen",
+            "publisher": null,
+            "printer": null,
+            "shelf_mark": "Alch F",
+            "ustc_sn": null,
+            "_normTitle": "hermann fictulds abhandlung von der alchymie und derselben gewissheit",
+            "_normAuthor": "fictuld hermann"
+          },
+          "score": 19,
+          "titleShared": [
+            "hermann",
+            "fictulds",
+            "abhandlung",
+            "alchymie",
+            "derselben",
+            "gewissheit"
+          ],
+          "authorShared": [
+            "fictuld",
+            "hermann"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1653609",
+        "title": "Henrici Cornelii Agrippae ab Nettesheym de incertitudine &amp; vanitate omnium scientiarum &amp; artium liber, lectu plane iucundus &amp; elegans et de nobilitate et praecellentia foeminei sexus, eiusdemque supra virilem eminentia libellus, lectu etiam iucundissimus ... / Geschichte des Teuffels ... in zwey Theilen",
+        "author": "Defoe, Daniel",
+        "year": 1733,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1653609"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1654166",
+        "title": "Das  Geheimniss von dem Salz, als dem edelsten Wesen der höchsten Wohlthat Gottes in dem Reich der Natur ...",
+        "author": "Oetinger, Friedrich Christoph",
+        "year": 1770,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1654166"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "5284",
+            "title": "Das Geheimniss von dem Salz",
+            "author": "anonymous",
+            "year": 1770,
+            "place": "n.p.",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "geheimniss von dem salz",
+            "_normAuthor": "anonymous"
+          },
+          "score": 5,
+          "titleShared": [
+            "geheimniss"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1654349",
+        "title": "Azoth et ignis, das ist, das wahre elementarische Wasser und Feuer, oder Mercurius philosophorum ... : Aureum vellus oder goldenes Vliess, was dasselbe sey, sowohl in seinem Ursprunge, als erhabenen Zustande ...",
+        "author": "Fictuld, Hermann",
+        "year": 1749,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1654349"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1323",
+            "title": "Azoth et Ignis, Das ist, das wahre elementarische Wasser und Feuer. Aureum vellus  oder goldenes Vliess",
+            "author": "Fictuld, Hermann",
+            "year": 1749,
+            "place": "Cahla|Leipzig",
+            "publisher": "Blochberger, Michael",
+            "printer": "Schreiber, Georg Friedrich",
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "azoth et ignis das ist das wahre elementarische wasser und feuer aureum vellus oder goldenes vliess",
+            "_normAuthor": "fictuld hermann"
+          },
+          "score": 27,
+          "titleShared": [
+            "azoth",
+            "ignis",
+            "wahre",
+            "elementarische",
+            "wasser",
+            "feuer",
+            "aureum",
+            "vellus",
+            "goldenes",
+            "vliess"
+          ],
+          "authorShared": [
+            "fictuld",
+            "hermann"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1654747",
+        "title": "Das edele Perlein und theurer Schatz der himmlischen Weisheit; in zwölff königlichen Palästen vorgestellet und beschrieben; nemlich wie der Stein der Weisen ... gemacht und bereitet werde : nebst einem Anhang und Anweisung vom Chaos, daraus alles herkommt, so zu unserer Kunst gehöret : samt einem Gespräche um vieler Ursachen willen genöthiget worden, solches heraus zu geben ...",
+        "author": "Fictuld, Hermann",
+        "year": 1734,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1654747"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4001",
+            "title": "Das edele Perlein und theurer Schatz der himmlischen Weisheit",
+            "author": "Fictuld, Hermann",
+            "year": 1734,
+            "place": "Frankfurt|Leipzig",
+            "publisher": "Göpner, Johann Christoph",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "edele perlein und theurer schatz der himmlischen weisheit",
+            "_normAuthor": "fictuld hermann"
+          },
+          "score": 19,
+          "titleShared": [
+            "edele",
+            "perlein",
+            "theurer",
+            "schatz",
+            "himmlischen",
+            "weisheit"
+          ],
+          "authorShared": [
+            "fictuld",
+            "hermann"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1655003",
+        "title": "Der längst gewünschte und versprochene chymisch-philosophische Probier-Stein",
+        "author": "Fictuld, Hermann",
+        "year": 1740,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1655003"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "8021",
+            "title": "Der längst gewünschte und versprochene chymisch-philosophische Probier-Stein",
+            "author": "Fictuld, Hermann",
+            "year": 1740,
+            "place": "Frankfurt  Leipzig",
+            "publisher": "Blochberger, Michael",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "langst gewunschte und versprochene chymisch philosophische probier stein",
+            "_normAuthor": "fictuld hermann"
+          },
+          "score": 21,
+          "titleShared": [
+            "langst",
+            "gewunschte",
+            "versprochene",
+            "chymisch",
+            "philosophische",
+            "probier",
+            "stein"
+          ],
+          "authorShared": [
+            "fictuld",
+            "hermann"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1655136",
+        "title": "Escalier des sages ou la philosophie des anciens",
+        "author": "Coenders van Helpen, Barent",
+        "year": 1686,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1655136"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4476",
+            "title": "Escalier des sages",
+            "author": "[Coenders van Helpen, Barend]",
+            "year": 1689,
+            "place": "Groningen",
+            "publisher": null,
+            "printer": "Pieman, Charles",
+            "shelf_mark": "A folio",
+            "ustc_sn": 1819648,
+            "_normTitle": "escalier des sages",
+            "_normAuthor": "coenders van helpen barend"
+          },
+          "score": 9,
+          "titleShared": [
+            "escalier",
+            "sages"
+          ],
+          "authorShared": [
+            "coenders",
+            "helpen"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1683295",
+        "title": "Lob der Narrheit",
+        "author": "Erasmus, Desiderius",
+        "year": 1780,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1683295"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1683735",
+        "title": "De alchemia dialogi II. quorum prior, genuinam librorum Gebri sententiam, de industria ab authore celatam, &amp; figurato sermone involutam retegit, &amp; certis argumentis probat. Alter, Raimundi Lullii Maioricani, mysteria in lucem producit ...",
+        "author": "Bracesco, Giovanni",
+        "year": 1548,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1683735"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "241",
+            "title": "De alchemia dialogi duo. Sententia. Lignum vitae",
+            "author": "[Bracesco, Giovanni]|Geber|Lull, Ramón",
+            "year": 1548,
+            "place": "Lyon",
+            "publisher": "Beringen, Godefroy| Beringen, Marcellin",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 628923,
+            "_normTitle": "alchemia dialogi duo sententia lignum vitae",
+            "_normAuthor": "bracesco giovanni geber lull ramon"
+          },
+          "score": 11,
+          "titleShared": [
+            "alchemia",
+            "dialogi"
+          ],
+          "authorShared": [
+            "bracesco",
+            "giovanni"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1683877",
+        "title": "Utriusque cosmi maioris scilicet et minoris metaphysica, physica atque technica historia in duo volumina secundum cosmi differentiam divisa",
+        "author": "Fludd, Robert",
+        "year": 1617,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1683877"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15137",
+            "title": "Utriusque cosmi maioris scilicet minoris metaphysica, physica atque technica historia. Tomus primus de macrocosmi historia",
+            "author": "Fludd, Robert",
+            "year": 1617,
+            "place": "Oppenheim",
+            "publisher": "Bry, Johann Theodor de",
+            "printer": "Galler, Hieronymus",
+            "shelf_mark": "H folio",
+            "ustc_sn": 2030476,
+            "_normTitle": "utriusque cosmi maioris scilicet minoris metaphysica physica atque technica historia tomus primus de macrocosmi historia",
+            "_normAuthor": "fludd robert"
+          },
+          "score": 27,
+          "titleShared": [
+            "utriusque",
+            "cosmi",
+            "maioris",
+            "scilicet",
+            "minoris",
+            "metaphysica",
+            "physica",
+            "atque",
+            "technica",
+            "historia"
+          ],
+          "authorShared": [
+            "fludd",
+            "robert"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "15136",
+            "title": "Utriusque cosmi maioris scilicet minoris metaphysica, physica atque technica historia. Tomus primus de macrocosmi historia",
+            "author": "Fludd, Robert",
+            "year": 1617,
+            "place": "Oppenheim",
+            "publisher": "Bry, Johann Theodor de",
+            "printer": "Galler, Hieronymus",
+            "shelf_mark": "H folio",
+            "ustc_sn": 2030476,
+            "_normTitle": "utriusque cosmi maioris scilicet minoris metaphysica physica atque technica historia tomus primus de macrocosmi historia",
+            "_normAuthor": "fludd robert"
+          },
+          "score": 27,
+          "titleShared": [
+            "utriusque",
+            "cosmi",
+            "maioris",
+            "scilicet",
+            "minoris",
+            "metaphysica",
+            "physica",
+            "atque",
+            "technica",
+            "historia"
+          ],
+          "authorShared": [
+            "fludd",
+            "robert"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1684113",
+        "title": "Saturnus saturatus dissolutus, et coelo restitutus, seu modus componendi lapidem philosophicum tam album, quam rubeum e plumbo; ac etiam eadem methodo e Iove, sive Stanno ...",
+        "author": "Nortonus, Samuel",
+        "year": 1630,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1684113"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "12674",
+            "title": "Saturnus saturatus",
+            "author": "Norton, Samuel",
+            "year": 1630,
+            "place": "Frankfurt",
+            "publisher": "Fitzer, William",
+            "printer": "Stoltzenberger, Johann Nikolaus",
+            "shelf_mark": "A",
+            "ustc_sn": 2034330,
+            "_normTitle": "saturnus saturatus",
+            "_normAuthor": "norton samuel"
+          },
+          "score": 9,
+          "titleShared": [
+            "saturnus",
+            "saturatus"
+          ],
+          "authorShared": [
+            "samuel"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1684152",
+        "title": "Divi Ioannis Chrysostomi Psegmata quaedam",
+        "author": "Johannes",
+        "year": 1523,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1684152"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1684589",
+        "title": "Arnobii Afri ... commentarii ... In omnes psalmos, sermone Latino, sed tum apud Afros vulgari",
+        "author": "Erasmus, Desiderius",
+        "year": 1522,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1684589"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1684924",
+        "title": "Epitome Galeni Pergameni operum in quatuor partes digesta, pulcherrima methodo universam illius viri doctrinam complectens : accesserunt eiusdem And. Lacunae annotationes in Galeni interpretes quibus varii loci, in quos hactenus impegerunt lectores, &amp; explicantur et summa fide restituuntur : item de ponderibus &amp; mensuris medicinalibus utilis commentarius",
+        "author": "Galenus",
+        "year": 1604,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1684924"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1685755",
+        "title": "Enchiridion physicae restitutae, in quo verus naturae concentus exponitur, plurimique antiquae philosophiae errores per canones &amp; certas demonstrationes dulcide aperiuntur : tractatus alter inscriptus arcanum hermeticae philosophiae opus: in quo occulta naturae &amp; artis circa lapidis philosophorum materiam &amp; operandi modum canonice &amp; ordinate fiunt manifesta",
+        "author": "Espagnet, Jean d'",
+        "year": 1653,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1685755"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4215",
+            "title": "Enchiridion physicae restitutae. Arcanum hermeticae philosophiae opus",
+            "author": "[Espagnet, Jean d']",
+            "year": 1647,
+            "place": "Rouen",
+            "publisher": "Berthelin, Jean",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6037421,
+            "_normTitle": "enchiridion physicae restitutae arcanum hermeticae philosophiae opus",
+            "_normAuthor": "espagnet jean d"
+          },
+          "score": 17,
+          "titleShared": [
+            "enchiridion",
+            "physicae",
+            "restitutae",
+            "philosophiae",
+            "arcanum",
+            "hermeticae"
+          ],
+          "authorShared": [
+            "espagnet",
+            "jean"
+          ],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "4213",
+            "title": "Enchiridion physicae restitutae",
+            "author": "[Espagnet, Jean d']",
+            "year": 1653,
+            "place": "Geneva",
+            "publisher": "Tournes, Jean Antoine de| Tournes, Samuel de",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6004836,
+            "_normTitle": "enchiridion physicae restitutae",
+            "_normAuthor": "espagnet jean d"
+          },
+          "score": 13,
+          "titleShared": [
+            "enchiridion",
+            "physicae",
+            "restitutae"
+          ],
+          "authorShared": [
+            "espagnet",
+            "jean"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1685963",
+        "title": "Iacobi Gaffarelli curiositates inauditae, sive selectae observationes de variis superstitionibus ... de figuris talismanicis ...",
+        "author": "Gaffarel, Jacques",
+        "year": 1706,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1685963"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1686380",
+        "title": "Trinum chymicum oder drey chymische Tractätlein : Trinum chymicum oder drey chymische Tractätlein secundum",
+        "author": "Kofski, Vinzenz",
+        "year": 1699,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1686380"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1686630",
+        "title": "Anima magica abscondita, or a discourse of the universall spirit of nature ...",
+        "author": "Vaughan, Thomas",
+        "year": 1650,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1686630"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "644",
+            "title": "Anima magica abscondita; or a discourse of the universall spirit of nature",
+            "author": "[Vaughan, Thomas]",
+            "year": 1650,
+            "place": "London",
+            "publisher": "Blunden, Humphrey",
+            "printer": "T.W",
+            "shelf_mark": "R",
+            "ustc_sn": 3062652,
+            "_normTitle": "anima magica abscondita or a discourse of the universall spirit of nature",
+            "_normAuthor": "vaughan thomas"
+          },
+          "score": 21,
+          "titleShared": [
+            "anima",
+            "magica",
+            "abscondita",
+            "discourse",
+            "universall",
+            "spirit",
+            "nature"
+          ],
+          "authorShared": [
+            "vaughan",
+            "thomas"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1705641",
+        "title": "Anthroposophia Theomagica or a Discourse of the Nature of Man and his State after Death ...",
+        "author": "Vaughan, Thomas",
+        "year": 1650,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1705641"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "691",
+            "title": "Anthroposophia theomagica; or a discourse of the nature of man and his state after death",
+            "author": "[Vaughan, Thomas]",
+            "year": 1650,
+            "place": "London",
+            "publisher": "Blunden, Humphrey",
+            "printer": "T.W",
+            "shelf_mark": "R",
+            "ustc_sn": 3062287,
+            "_normTitle": "anthroposophia theomagica or a discourse of the nature of man and his state after death",
+            "_normAuthor": "vaughan thomas"
+          },
+          "score": 21,
+          "titleShared": [
+            "anthroposophia",
+            "theomagica",
+            "discourse",
+            "nature",
+            "state",
+            "after",
+            "death"
+          ],
+          "authorShared": [
+            "vaughan",
+            "thomas"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1719033",
+        "title": "In hoc vo lumine De alchemia continentur haec .... : De investigatione perfectionis metallorum, liber I. Summae perfectionis metallorum, sive perfecti magisterii, libri II. quae sequuntur, omnia nunc primum excusa sunt ... De inventione veritatis seu perfectionis metallorum, liber I.. De fornacibus construendis, liber I",
+        "author": "Ǧābir Ibn-Ḥaiyān",
+        "year": 1541,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1719033"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1719448",
+        "title": "Vollenkommene Geomantia, deren erster Theil die aufs neue revidirte und ... vermehrte Punctier-Kunst in sich begreifft ... der ander Theil aber des berühmten Arabers Abu-Heil-Ben-Omar ... Astrologia Terrestris oder Irrdische Stern-Kunde ...",
+        "author": "Ben-Omar, Abuhali",
+        "year": 1703,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1719448"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1720269",
+        "title": "D. Epiphanii Episcopi Constantiae Cypri, contra octoaginta haereses opus , panarium, sive arcula, aut capsula medica appellatum, continens libros tres, &amp; tomos sive sectiones ex toto septem : item, eiusdem D. Epiphanii epistola sive liber Ancoratus appellatus, docens de vera fide Christiana ; eiusdem D. Epiphanii Anacephaleosis, sive summa totius operis Panarii appellati, &amp; contra octoaginta haereses conscripti ; eiusdem D. Epiphanii libellus de mensuris ac ponderibus ...",
+        "author": "Epiphanius",
+        "year": 1543,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1720269"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1720949",
+        "title": "Adagiorum Desiderii Erasmi Roterodami epitome",
+        "author": "Erasmus, Desiderius",
+        "year": 1663,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1720949"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1728947",
+        "title": "Nicol Catani, geomantischer Schöpffen-Stul, worinnen der kunstmässig constituirte Richter samt denen beeden Zeugen als Beysitzern auff vorgelegte Fragen richtigen Bescheid ertheilet, zumehrer Erleuchterung derer in der vollenkommenen Geomantia angewiesenen Operationen ...",
+        "author": "Catanus, Nicolaus",
+        "year": 1704,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1728947"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1760634",
+        "title": "Der hermetische Triumph oder der siegende philosophische Stein : ein Tractat völliger und verständlicher eingerichtet als einer iemals bissher gewesen handelnde von der hermetischen Meisterschafft hiebevor in frantzösischer Sprache gedruckt zu Amsterdam bey Henrich Wetstein, Anno 1689 nunmehro gegenwärtig ins Deutsche versetzt",
+        "author": "[s.n.]",
+        "year": 1707,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1760634"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6491",
+            "title": "Der hermetische Triumph oder der siegende philosophische Stein",
+            "author": "[Limojon de Saint-Didier, Alexandre Toussaint de]",
+            "year": 1707,
+            "place": "Leipzig|Görlitz",
+            "publisher": "Laurentio, Johann Gottlob",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "hermetische triumph oder der siegende philosophische stein",
+            "_normAuthor": "limojon de saint didier alexandre toussaint de"
+          },
+          "score": 13,
+          "titleShared": [
+            "hermetische",
+            "triumph",
+            "siegende",
+            "philosophische",
+            "stein"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1760867",
+        "title": "Viatorium spagyricum. Das ist ein gebenedeyter spagyrischer Wegweiser in den edlen Sonnengarten der Hesperidum zu kommen unnd daselbst den güldenen Tincturzweig dess Universals (sonsten Lapis philosophorum genandt) zu erlangen ...",
+        "author": "Jamsthaler, Herbrandt",
+        "year": 1625,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1760867"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15370",
+            "title": "Viatorium spagyricum. Das ist: ein gebenedeyter spagyrischer Wegweiser",
+            "author": "Jamsthaler, Herbrandt",
+            "year": 1625,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2132030,
+            "_normTitle": "viatorium spagyricum das ist ein gebenedeyter spagyrischer wegweiser",
+            "_normAuthor": "jamsthaler herbrandt"
+          },
+          "score": 17,
+          "titleShared": [
+            "viatorium",
+            "spagyricum",
+            "gebenedeyter",
+            "spagyrischer",
+            "wegweiser"
+          ],
+          "authorShared": [
+            "jamsthaler",
+            "herbrandt"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1761179",
+        "title": "Trithemius sui-ipsius vindex sive steganographiae ... viri Ioannis Trithemii, primo Spanheimensis ... apologetica defensio : accessit in fine fragmentum quaestionum eiusdem Trithemii",
+        "author": "Trithemius, Johannes",
+        "year": 1616,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1761179"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1761325",
+        "title": "Philosophisch- und physikalischer Zeitvertreib in einigen sonderbaren Materien ...",
+        "author": "Indagine, I. L. von",
+        "year": 1783,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1761325"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1761661",
+        "title": "Tractatus de natura Salium oder aussfürliche Beschreibung deren bekanten Salien ... : sambt angehängtem Tractätlein De signatura salium, metallorum, &amp; planetarum",
+        "author": "Glauber, Johann Rudolph",
+        "year": 1658,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1761661"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14556",
+            "title": "Tractatus de natura salium. Oder aussfürliche Beschreibung, deren bekanten Salien. De signatura salium",
+            "author": "Glauber, Johann Rudolph",
+            "year": 1658,
+            "place": "Amsterdam",
+            "publisher": "Janssonius, Johannes",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2615387,
+            "_normTitle": "tractatus de natura salium oder aussfurliche beschreibung deren bekanten salien de signatura salium",
+            "_normAuthor": "glauber johann rudolph"
+          },
+          "score": 27,
+          "titleShared": [
+            "tractatus",
+            "natura",
+            "salium",
+            "aussfurliche",
+            "beschreibung",
+            "deren",
+            "bekanten",
+            "salien",
+            "signatura"
+          ],
+          "authorShared": [
+            "glauber",
+            "johann",
+            "rudolph"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "16393",
+            "title": "Tractatus de tribus principiis metallorum",
+            "author": "Glauber, Johann Rudolph",
+            "year": 1667,
+            "place": "Amsterdam",
+            "publisher": "Janssonius van Waesberge, Johannes I|Weyerstraten, widow of Elizaeus I",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2615387,
+            "_normTitle": "tractatus de tribus principiis metallorum",
+            "_normAuthor": "glauber johann rudolph"
+          },
+          "score": 11,
+          "titleShared": [
+            "tractatus",
+            "metallorum"
+          ],
+          "authorShared": [
+            "glauber",
+            "johann",
+            "rudolph"
+          ],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "14560",
+            "title": "Tractatus de vero sale",
+            "author": "Nuysement, Jacques de",
+            "year": 1651,
+            "place": "Kassel",
+            "publisher": "Köhler, Sebald",
+            "printer": "Gentsch, Jakob",
+            "shelf_mark": "A",
+            "ustc_sn": 2685201,
+            "_normTitle": "tractatus de vero sale",
+            "_normAuthor": "nuysement jacques de"
+          },
+          "score": 3,
+          "titleShared": [
+            "tractatus"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1811244",
+        "title": "Isaaci Hollandi tractatus de lapide philosophico oder vom Stein der Weisen",
+        "author": "Holland, Johann Isaak",
+        "year": 1669,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1811244"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1811437",
+        "title": "Praxis exercitiorum spiritualium P.N.S. Ignatii",
+        "author": "Izquierdo, Sebastián",
+        "year": 1695,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1811437"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1811575",
+        "title": "Iul. Pacii Artis Lullianae emendatae libri 4 : quibus docetur methodus, per quam magna terminorum generalium, ... ad inveniendum sermonem de quacunque re, ... suppetat",
+        "author": "Pace, Giulio",
+        "year": 1618,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1811575"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1811677",
+        "title": "Hermaphroditisches Sonn- und Monds-Kind, das ist des Sohns deren Philosophen natürlich-übernatürliche Gebährung, Zerstöhrung und Regenerirung oder vorgestellte Theorie und Practic den Stein der Weissen zu suchen und zu machen ...",
+        "author": "L.C.S",
+        "year": 1752,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1811677"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6399",
+            "title": "Hermaphroditisches Sonn- und Monds-Kind",
+            "author": "[Brunnhofer, Johann Augustin]",
+            "year": 1752,
+            "place": "Mainz",
+            "publisher": "Krebs, Johann Friedrich",
+            "printer": "Bayer, Elias Peter",
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "hermaphroditisches sonn und monds kind",
+            "_normAuthor": "brunnhofer johann augustin"
+          },
+          "score": 7,
+          "titleShared": [
+            "hermaphroditisches",
+            "monds"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1811787",
+        "title": "Hōrou Apollōnos Neilōou Hieroglyphika eklekta = : Hori Apollinis selecta hieroglyphica, sive sacrae notae Aegyptiorum, &amp; insculptae imagines",
+        "author": "Horapollo",
+        "year": 1597,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1811787"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1812073",
+        "title": "Miraculi mundi continuatio : in qua tota natura denudatur, &amp; toti mundo nude ob oculos ponitur; imo dilucide &amp; aperte demonstratur, fieri posse, ut ex sale petrae omnium vegetabilium, animalium &amp; mineralium summa medicina paretur, ac ideo sal petrae iure ac merito verum subiectum solvens, sive menstruum universale ...",
+        "author": "Glauber, Johann Rudolph",
+        "year": 1658,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1812073"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9274",
+            "title": "Miraculi mundi continuatio. Darinnen die gantze Natur entdecket, und der Weldt nackent und bloss vor Augen gelegt",
+            "author": "Glauber, Johann Rudolph",
+            "year": 1657,
+            "place": "Amsterdam",
+            "publisher": "Janssonius, Johannes",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2624181,
+            "_normTitle": "miraculi mundi continuatio darinnen die gantze natur entdecket und der weldt nackent und bloss vor augen gelegt",
+            "_normAuthor": "glauber johann rudolph"
+          },
+          "score": 14,
+          "titleShared": [
+            "miraculi",
+            "mundi",
+            "continuatio"
+          ],
+          "authorShared": [
+            "glauber",
+            "johann",
+            "rudolph"
+          ],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1830945",
+        "title": "Von den Träumen und Nachtwandlern",
+        "author": "[s.n.]",
+        "year": 1784,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1830945"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1831581",
+        "title": "Prodromus Rhodo-Stauroticus, Parergi philosophici. Das ist: Vortrab und Entdeckung derer hocherleuchten, gottseligen und weitberühmten Bruderschafft vom Rosen Creutz philosophischen Parergi, sonsten Lapis Philosophorum genandt, wie derselbe am füglichsten kan erlangt und ins Werck gerichtet werden ...",
+        "author": "Mögling, Daniel",
+        "year": 1620,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1831581"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11687",
+            "title": "Prodromus rhodo-stauroticus, parergi philosophici. Das ist: Vortrab und Entdeckung, derer hocherleuchten, gottseligen, und weitberühmten Brüderschafft vom Rosen Creutz",
+            "author": "[Mögling, Daniel]",
+            "year": 1620,
+            "place": "n.p.",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "R",
+            "ustc_sn": 2096762,
+            "_normTitle": "prodromus rhodo stauroticus parergi philosophici das ist vortrab und entdeckung derer hocherleuchten gottseligen und weitberuhmten bruderschafft vom rosen creutz",
+            "_normAuthor": "mogling daniel"
+          },
+          "score": 35,
+          "titleShared": [
+            "prodromus",
+            "rhodo",
+            "stauroticus",
+            "parergi",
+            "philosophici",
+            "vortrab",
+            "entdeckung",
+            "derer",
+            "hocherleuchten",
+            "gottseligen",
+            "weitberuhmten",
+            "bruderschafft",
+            "rosen",
+            "creutz"
+          ],
+          "authorShared": [
+            "mogling",
+            "daniel"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1831694",
+        "title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ...",
+        "author": "[s.n.]",
+        "year": 1744,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1831694"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6638",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "[Lenglet Dufresnoy, Nicolas]",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustelier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "6639",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "Lenglet Dufresnoy, Nicolas",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustellier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1831696",
+        "title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ... / 1",
+        "author": "[s.n.]",
+        "year": 1744,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1831696"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6638",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "[Lenglet Dufresnoy, Nicolas]",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustelier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "6639",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "Lenglet Dufresnoy, Nicolas",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustellier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1832242",
+        "title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ... / 2",
+        "author": "[s.n.]",
+        "year": 1744,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1832242"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6638",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "[Lenglet Dufresnoy, Nicolas]",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustelier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "6639",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "Lenglet Dufresnoy, Nicolas",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustellier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1832773",
+        "title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ... / 3",
+        "author": "[s.n.]",
+        "year": 1744,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1832773"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6638",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "[Lenglet Dufresnoy, Nicolas]",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustelier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "6639",
+            "title": "Histoire de la philosophie hermetique",
+            "author": "Lenglet Dufresnoy, Nicolas",
+            "year": 1742,
+            "place": "Paris",
+            "publisher": "Coustellier",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "histoire de la philosophie hermetique",
+            "_normAuthor": "lenglet dufresnoy nicolas"
+          },
+          "score": 8,
+          "titleShared": [
+            "histoire",
+            "philosophie",
+            "hermetique"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1833247",
+        "title": "Histoire des diables de Loudun ou de la possession des religieuses ursulines et de la condamnation et du suplice d'Urbain Grandier ...",
+        "author": "Aubin, Nicolas",
+        "year": 1752,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1833247"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1833657",
+        "title": "Index eor um, quae hoc in libro habentur De mysteriis Aegyptiorum, Chaldaeorum, Assyriorum : Proclus in Platonicum Alcibiadem de anima, atque daemone. De sacrificio &amp; magia",
+        "author": "Iamblichus",
+        "year": 1497,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1833657"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1834044",
+        "title": "Verae alchemiae artisque metallicae, citra aenigmata, doctrina certusque modus, scriptis tum novis tum veteribus nunc primum &amp; fideliter maiori ex parte editis, comprehensus quorum elenchum a praefatione reperies",
+        "author": "Grataroli, Guglielmo",
+        "year": 1561,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1834044"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1834629",
+        "title": "Von hylealischen das ist pri-materialischen catholischen oder algemeinem natürlichen Chaos, der naturgemessen Alchymiae und Alchymisten; wiederholete ... Confessio oder Bekentnus",
+        "author": "Khunrath, Heinrich",
+        "year": 1597,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1834629"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "6914",
+            "title": "Von hylealischen, das ist, Pri-materialischen catholischen, oder algemeinem [sic] natürlichen Chaos",
+            "author": "Khunrath, Heinrich",
+            "year": 1597,
+            "place": "Magdeburg",
+            "publisher": "Gehne, heirs of Andreas",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2536623,
+            "_normTitle": "von hylealischen das ist pri materialischen catholischen oder algemeinem sic naturlichen chaos",
+            "_normAuthor": "khunrath heinrich"
+          },
+          "score": 19,
+          "titleShared": [
+            "hylealischen",
+            "materialischen",
+            "catholischen",
+            "algemeinem",
+            "naturlichen",
+            "chaos"
+          ],
+          "authorShared": [
+            "khunrath",
+            "heinrich"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1835136",
+        "title": "Iohannis Saresberiensis policraticus de nugis curialium et vestigiis philosophorum continens libros octo",
+        "author": "Johannes",
+        "year": 1513,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1835136"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1835929",
+        "title": "De nativitate mediatoris ultima, nunc futura, et toti orbi terrarum in singulis ratione praeditis manifestanda, Opus : in quo totius naturae obscuritas, origo &amp; creatio, ita cum sua causa illustratur, exponiturque, ut vel pueris sint manifesta, quae in theosofiae &amp; filosofiae arcanis hactenus fuere ...",
+        "author": "Postel, Guillaume",
+        "year": 1547,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1835929"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "22898",
+            "title": "De nativitate mediatoris ultima",
+            "author": "Postel, Guillaume",
+            "year": 1547,
+            "place": "[Basel]",
+            "publisher": null,
+            "printer": "[Oporinus, Johannes]",
+            "shelf_mark": "H",
+            "ustc_sn": 630601,
+            "_normTitle": "nativitate mediatoris ultima",
+            "_normAuthor": "postel guillaume"
+          },
+          "score": 13,
+          "titleShared": [
+            "nativitate",
+            "mediatoris",
+            "ultima"
+          ],
+          "authorShared": [
+            "postel",
+            "guillaume"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1836136",
+        "title": "Amphitheatrum sapientiae aeternae, solius verae, christiano-kabalisticum, divino-magicum, nec non physico-chymicum, tertriunum, catholicon",
+        "author": "Khunrath, Heinrich",
+        "year": 1609,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1836136"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "565",
+            "title": "Amphitheatrum sapientiae aeternae",
+            "author": "Khunrath, Heinrich",
+            "year": 1609,
+            "place": "Hanau",
+            "publisher": "Antonius, Wilhelm",
+            "printer": null,
+            "shelf_mark": "A folio",
+            "ustc_sn": 2106102,
+            "_normTitle": "amphitheatrum sapientiae aeternae",
+            "_normAuthor": "khunrath heinrich"
+          },
+          "score": 13,
+          "titleShared": [
+            "amphitheatrum",
+            "sapientiae",
+            "aeternae"
+          ],
+          "authorShared": [
+            "khunrath",
+            "heinrich"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "564",
+            "title": "Amphitheatrum sapientiae aeternae",
+            "author": "Khunrath, Heinrich",
+            "year": 1608,
+            "place": "Magdeburg|Hanau",
+            "publisher": "Braun, Levin",
+            "printer": "Antonius, Wilhelm",
+            "shelf_mark": "A folio",
+            "ustc_sn": 2106102,
+            "_normTitle": "amphitheatrum sapientiae aeternae",
+            "_normAuthor": "khunrath heinrich"
+          },
+          "score": 12,
+          "titleShared": [
+            "amphitheatrum",
+            "sapientiae",
+            "aeternae"
+          ],
+          "authorShared": [
+            "khunrath",
+            "heinrich"
+          ],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "563",
+            "title": "Amphitheatrum aeternae providentiae divino-magicum",
+            "author": "Vanini, Giulio Cesare",
+            "year": 1615,
+            "place": "Lyon",
+            "publisher": "Harsy, widow of Antoine de",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6901994,
+            "_normTitle": "amphitheatrum aeternae providentiae divino magicum",
+            "_normAuthor": "vanini giulio cesare"
+          },
+          "score": 9,
+          "titleShared": [
+            "amphitheatrum",
+            "aeternae",
+            "divino",
+            "magicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1836468",
+        "title": "Miraculum mundi, sive plena perfectaque descriptio admirabilis naturae, ac proprietatis potentissimi subiecti, ab antiquis menstruum universale sive mercurius philosophorum dicti: quo vegetabilia, animalia &amp; mineralia facillime in saluberrima medicamenta, &amp; imperfecta metalla in permanentia ac perfecta transmutari possunt ...",
+        "author": "Glauber, Johann Rudolph",
+        "year": 1653,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1836468"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9277",
+            "title": "Miraculum mundi, oder aussführliche Beschreibung der wunderbaren Natur",
+            "author": "Glauber, Johann Rudolph",
+            "year": 1653,
+            "place": "Amsterdam",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2537381,
+            "_normTitle": "miraculum mundi oder aussfuhrliche beschreibung der wunderbaren natur",
+            "_normAuthor": "glauber johann rudolph"
+          },
+          "score": 13,
+          "titleShared": [
+            "miraculum",
+            "mundi"
+          ],
+          "authorShared": [
+            "glauber",
+            "johann",
+            "rudolph"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1836807",
+        "title": "Ioh. Rud. Glauberi Annotationes in nuper editam continuationem miraculi mundi, secreta ibidem contenta, aurumque potabile verum, cujus simul mentio ibidem facta est, explicantes &amp; defendentes ...",
+        "author": "Glauber, Johann Rudolph",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1836807"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1836851",
+        "title": "Athanasii Kircheri ... China monumentis qua sacris qua profanis, nec non variis naturae &amp; artis spectaculis, aliarumque rerum memorabilium argumentis illustrata ...",
+        "author": "Kircher, Athanasius",
+        "year": 1667,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1836851"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1837195",
+        "title": "Liber ethymologiarum Isidori Hyspalensis episcopi",
+        "author": "Isidorus",
+        "year": 1489,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1837195"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1837428",
+        "title": "Athanasii Kircheri ... Mundus subterraneus in XII libros digestus",
+        "author": "Kircher, Athanasius",
+        "year": 1678,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1837428"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1838399",
+        "title": "Explicatio tractatuli qui miraculum mundi inscribitur ...",
+        "author": "Glauber, Johann Rudolph",
+        "year": 1656,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1838399"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1838481",
+        "title": "Miraculum mundi, sive plena perfectaque descriptio admirabilis naturae, ac proprietatis potentissimi subiecti, ab antiquis menstruum universale sive mercurius philosophorum dicti: quo vegetabilia, animalia &amp; mineralia facillime in saluberrima medicamenta, &amp; imperfecta metalla in permanentia ac perfecta transmutari possunt ...",
+        "author": "Glauber, Johann Rudolph",
+        "year": 1653,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1838481"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9277",
+            "title": "Miraculum mundi, oder aussführliche Beschreibung der wunderbaren Natur",
+            "author": "Glauber, Johann Rudolph",
+            "year": 1653,
+            "place": "Amsterdam",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2537381,
+            "_normTitle": "miraculum mundi oder aussfuhrliche beschreibung der wunderbaren natur",
+            "_normAuthor": "glauber johann rudolph"
+          },
+          "score": 13,
+          "titleShared": [
+            "miraculum",
+            "mundi"
+          ],
+          "authorShared": [
+            "glauber",
+            "johann",
+            "rudolph"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1853229",
+        "title": "Magistri Ioannis Isaaci Hollandi ... Opera mineralia, sive de lapide philosophico philosophico, omnia duobus libris comprehensa : nunquam antehac edita, ac nunc primum ex optimis manu-scriptis Teutonicis exemplaribus fidelissime in Latinum sermonem translata ...",
+        "author": "Holland, Johann Isaak",
+        "year": 1600,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1853229"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1853689",
+        "title": "Historiæ aliquot transmutationis metallicae ... pro defensione alchymiae contra hostium rabiem : adiecta est ... Raymundi Lullii vita, &amp; alia quædam",
+        "author": "Hoghelande, Theobaldus van",
+        "year": 1604,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1853689"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1853752",
+        "title": "Johann Gottfried Jugels natürliche Berg-Schmelz- und Figier-Kunst, in drey Theilen abgefasset, deren I. Theil von der Natur aller wesentlichen Kräfte des mineralischen Reichs, der II. von dem Bergwesen und der Beschaffenheit der Metalle und Mineralien, der III. aber, wie dieselben untersuchet, ihrer Natur gemäss geröstet und geschmelzet werden sollen, handelt",
+        "author": "Jugel, Johann Gottfried",
+        "year": 1766,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1853752"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1854638",
+        "title": "Disquisitio de helia artium ...",
+        "author": "Eglin, Raphael",
+        "year": 1606,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1854638"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1854796",
+        "title": "Philosophiae chymicae IV vetustissima scripta : Tabula chymica",
+        "author": "Ibn-Umail, Muḥammad",
+        "year": 1605,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1854796"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1905969",
+        "title": "Atalanta fugiens, hoc est, emblemata nova de secretis naturae chymica, accommodata partim oculis &amp; intellectui, figuris cupro incisis, adiectisque sententiis, epigrammatis &amp; notis, partim auribus &amp; recreationi animi plus minus 50 fugis musicalibus trium vocum, quarum duae ad unam simplicem melodiam distichis canendis peraptam, correspondeant, non absque singulari iucunditate videnda, legenda, meditanda, intelligenda, diiudicanda, canenda &amp; audienda",
+        "author": "Maier, Michael",
+        "year": 1617,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1905969"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1112",
+            "title": "Atalanta fugiens",
+            "author": "Maier, Michael",
+            "year": 1618,
+            "place": "Oppenheim",
+            "publisher": "Bry, Johann Theodor de",
+            "printer": "Galler, Hieroymus",
+            "shelf_mark": "A",
+            "ustc_sn": 2082523,
+            "_normTitle": "atalanta fugiens",
+            "_normAuthor": "maier michael"
+          },
+          "score": 10,
+          "titleShared": [
+            "atalanta",
+            "fugiens"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1906204",
+        "title": "Arcana arcanissima hoc est hieroglyphica Aegyptio-Graeca, vulgo necdum cognita, ad demonstrandam falsorum apud antiquos deorum, dearum, heroum, animantium &amp; institutorum pro sacris receptorum, originem, ex uno Aegyptiorum artificio, quod aureum animi &amp; corporis medicamentum peregit, deductam, unde tot poetarum allegoriae, scriptorum narrationes fabulosae &amp; pertotam encyclopaediam errores sparsi clarissima veritatis luce manifestantur, suaeque tribui singula restituuntur, sex libris exposita",
+        "author": "Maier, Michael",
+        "year": 1614,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1906204"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "918",
+            "title": "Arcana arcanissima hoc est hieroglyphica Aegyptio-Graeca",
+            "author": "Maier, Michael",
+            "year": 1614,
+            "place": "[London ?]",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2094778,
+            "_normTitle": "arcana arcanissima hoc est hieroglyphica aegyptio graeca",
+            "_normAuthor": "maier michael"
+          },
+          "score": 17,
+          "titleShared": [
+            "arcana",
+            "arcanissima",
+            "hieroglyphica",
+            "aegyptio",
+            "graeca"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1906527",
+        "title": "Michaelis Maieri ... secretioris naturae secretorum scrutinium chymicum, per oculis et intellectui accurate accommodata, figuris cupro appositissime incisa, ingeniosissima emblemata, hisque confines, &amp; ad rem egregie facientes sententias, doctissimaque item epigrammata, illustratum. Opusculum ingeniis altioribus ...",
+        "author": "Maier, Michael",
+        "year": 1687,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1906527"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1906698",
+        "title": "Lusus serius, quo Hermes sive Mercurius rex mundanorum omnium sub homine existentium, post longam disceptationem in concilio octovirali habitam, homine rationali arbitro, iudicatus &amp; constitutus est",
+        "author": "Maier, Michael",
+        "year": 1616,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1906698"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "8640",
+            "title": "Lusus serius",
+            "author": "Maier, Michael",
+            "year": 1616,
+            "place": "Oppenheim|Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": "Galler, Hieronymus",
+            "shelf_mark": "R",
+            "ustc_sn": 2069254,
+            "_normTitle": "lusus serius",
+            "_normAuthor": "maier michael"
+          },
+          "score": 11,
+          "titleShared": [
+            "lusus",
+            "serius"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "8641",
+            "title": "Lusus serius, das ist: Lustiges doch ernsthafftes Spiel",
+            "author": "Maier, Michael",
+            "year": 1625,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": null,
+            "shelf_mark": "R",
+            "ustc_sn": 2132303,
+            "_normTitle": "lusus serius das ist lustiges doch ernsthafftes spiel",
+            "_normAuthor": "maier michael"
+          },
+          "score": 9,
+          "titleShared": [
+            "lusus",
+            "serius"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1912167",
+        "title": "Neu eingerichtetes Lexicon medico-chymicum oder chymisches Lexicon ...",
+        "author": "Hellwig, Christoph von",
+        "year": 1711,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1912167"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1912676",
+        "title": "Themis Aurea, das ist von den Gesetzen und Ordnungen der löblichen Fraternitet R. C. Ein aussführlicher Tractat und Bericht, darinnen gründlichen erwiesen wird, dass dieselbige Gesetz nicht allein in Warheit beständtig, sondern auch an sich selbst dem gemeinen und privat Nutzen nohtwendig, nützlich und erspriesslich seynd",
+        "author": "Maier, Michael",
+        "year": 1618,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1912676"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14153",
+            "title": "Themis aurea, das ist, von den Gesetzen, und Ordnungen der löblichen Fraternitet R.C",
+            "author": "Maier, Michael",
+            "year": 1618,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": "Hoffmann, Nikolaus I",
+            "shelf_mark": "R",
+            "ustc_sn": 2004727,
+            "_normTitle": "themis aurea das ist von den gesetzen und ordnungen der loblichen fraternitet r c",
+            "_normAuthor": "maier michael"
+          },
+          "score": 19,
+          "titleShared": [
+            "themis",
+            "aurea",
+            "gesetzen",
+            "ordnungen",
+            "loblichen",
+            "fraternitet"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14154",
+            "title": "Themis aurea, hoc est, de legibus Fraternitatis R.C",
+            "author": "Maier, Michael",
+            "year": 1618,
+            "place": "Frankfurt",
+            "publisher": "Hoffmann, Nikolaus I|Jennis, Lukas",
+            "printer": null,
+            "shelf_mark": "R",
+            "ustc_sn": 2108939,
+            "_normTitle": "themis aurea hoc est de legibus fraternitatis r c",
+            "_normAuthor": "maier michael"
+          },
+          "score": 11,
+          "titleShared": [
+            "themis",
+            "aurea"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14155",
+            "title": "Themis aurea, hoc est, De legibus Fraternitatis R.C",
+            "author": "Maier, Michael",
+            "year": 1624,
+            "place": "Frankfurt",
+            "publisher": "[Jennis, Lukas]",
+            "printer": null,
+            "shelf_mark": null,
+            "ustc_sn": 2108939,
+            "_normTitle": "themis aurea hoc est de legibus fraternitatis r c",
+            "_normAuthor": "maier michael"
+          },
+          "score": 9,
+          "titleShared": [
+            "themis",
+            "aurea"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1912930",
+        "title": "Alchymia Andreae Libavii, recognita, emendata, et aucta; tum dogmatibus &amp; experimentis nonnullis ... : tum commentario medico physico chymico ...",
+        "author": "Libavius, Andreas",
+        "year": 1606,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1912930"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1913791",
+        "title": "Fortunii Liceti Genuensis... De mundi &amp; hominis analogia",
+        "author": "Liceti, Fortunio",
+        "year": 1635,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1913791"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1913978",
+        "title": "Fortunii Liceti Genuensis ... De rationalis animae varia propensione ad corpus libri duo. ...",
+        "author": "Liceti, Fortunio",
+        "year": 1634,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1913978"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1914129",
+        "title": "Fortunii Liceti Genuensis ... Ulysses apud Circen, sive de quadruplici transformatione ...",
+        "author": "Liceti, Fortunio",
+        "year": 1636,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1914129"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1914200",
+        "title": "Fortunii Liceti Genuensis ... De anima subiecto corpori nil tribuente, deque seminis vita, &amp; efficientia primaria in formatione faetus ...",
+        "author": "Liceti, Fortunio",
+        "year": 1631,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1914200"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1914274",
+        "title": "D. Joh. Gottlob Krügers Träume",
+        "author": "Krüger, Johann Gottlob",
+        "year": 1758,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1914274"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1915083",
+        "title": "Ausserlesenster Curiositäten merck-würdiger Traum-Tempel nebst seinen denk-würdigen Neben-Zimmern von allerhand sonderbaren Träumen ...",
+        "author": "Männling, Johann Christoph",
+        "year": 1714,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1915083"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1915690",
+        "title": "Lexicon alchemiae sive dictionarium alchemisticum, cum obscuriorum verborum, &amp; rerum hermeticarum, tum Theophrast-Paracelsicarum phrasium, planam explicationem continens",
+        "author": "Ruland, Martin",
+        "year": 1612,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1915690"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "8293",
+            "title": "Lexicon alchemiae",
+            "author": "Ruland sr., Martin",
+            "year": 1612,
+            "place": "Frankfurt",
+            "publisher": "Palthenius, Zacharias",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2027415,
+            "_normTitle": "lexicon alchemiae",
+            "_normAuthor": "ruland sr martin"
+          },
+          "score": 11,
+          "titleShared": [
+            "lexicon",
+            "alchemiae"
+          ],
+          "authorShared": [
+            "ruland",
+            "martin"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1916280",
+        "title": "Symbola aureae mensae duodecim nationum. Hoc est, Hermaea seu Mercurii festa ab heroibus duodenis selectis, artis chymicae usu, sapientia &amp; authoritate paribus celebrata, ad Pyrgopolynicen seu adversarium illum tot annis iactabundum, virgini chemiae iniuriam argumentis tam vitiosis, quam convitiis argutis inferentem, confundendum &amp; exarmandum, artifices vero optime de ea meritos suo honori &amp; famae restituendum ... opus ... utilissimum, 12. libris explicatum &amp; traditum, figuris cupro incisis passim adiectis",
+        "author": "Maier, Michael",
+        "year": 1617,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1916280"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13870",
+            "title": "Symbola aureae mensae duodecim nationum",
+            "author": "Maier, Michael",
+            "year": 1617,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": "Humm, Anton",
+            "shelf_mark": "A",
+            "ustc_sn": 2095599,
+            "_normTitle": "symbola aureae mensae duodecim nationum",
+            "_normAuthor": "maier michael"
+          },
+          "score": 17,
+          "titleShared": [
+            "symbola",
+            "aureae",
+            "mensae",
+            "duodecim",
+            "nationum"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1916979",
+        "title": "Speculum imaginum veritatis occultae, exhibens symbola, emblemata, hieroglyphica, aenigmata, omni tam materiae, quam forma varietate ...",
+        "author": "Masen, Jacob",
+        "year": 1714,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1916979"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1918265",
+        "title": "Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam pertinentium thesaurus instructissimus: quo non tantum artis auriferae ... verum etiam tractatus omnes virorum ... ad quorum omnium illustrationem additae sunt quamplurimae figurae aeneae. Tomus primus [-secundus]",
+        "author": "Manget, Jean-Jacques",
+        "year": 1702,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1918265"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1918267",
+        "title": "Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam pertinentium thesaurus instructissimus: quo non tantum artis auriferae ... verum etiam tractatus omnes virorum ... ad quorum omnium illustrationem additae sunt quamplurimae figurae aeneae. Tomus primus [-secundus] / Tomus primus.",
+        "author": "[s.n.]",
+        "year": 1702,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1918267"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1919276",
+        "title": "Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam pertinentium thesaurus instructissimus: quo non tantum artis auriferae ... verum etiam tractatus omnes virorum ... ad quorum omnium illustrationem additae sunt quamplurimae figurae aeneae. Tomus primus [-secundus] / Tomus secundus.",
+        "author": "[s.n.]",
+        "year": 1702,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1919276"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1930930",
+        "title": "Templum naturae historicum, Henrici Kornmanni ex Kirchaina Chattorum; in quo, de natura et miraculis quatuor elementorum; ignis, aeris, aquae terrae, ita disseritur ... Opus cuiusvis status hominibus perquam utile. In quatuor partes tributum",
+        "author": "Kornmann, Heinrich",
+        "year": 1611,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1930930"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1931279",
+        "title": "De circulo physico, quadrato hoc est, auro, eiusque virtute medicinali, sub duro cortice instar nuclei latente; an &amp; qualis inde petenda sit, tractatus haud inutilis",
+        "author": "Maier, Michael",
+        "year": 1616,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1931279"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "23359",
+            "title": "De circulo physico, quadrato: hoc est, auro, eius que virtute medicinali",
+            "author": "Maier, Michael",
+            "year": 1616,
+            "place": "Oppenheim",
+            "publisher": "Jennis, Lukas",
+            "printer": "Galler, Hieronymus",
+            "shelf_mark": "A",
+            "ustc_sn": 2136239,
+            "_normTitle": "circulo physico quadrato hoc est auro eius que virtute medicinali",
+            "_normAuthor": "maier michael"
+          },
+          "score": 17,
+          "titleShared": [
+            "circulo",
+            "physico",
+            "quadrato",
+            "virtute",
+            "medicinali"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "2746",
+            "title": "De circulo physico, quadrato",
+            "author": "Maier, Michael",
+            "year": 1616,
+            "place": "Oppenheim|Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": "Galler, Hieronymus",
+            "shelf_mark": "A",
+            "ustc_sn": 2136239,
+            "_normTitle": "circulo physico quadrato",
+            "_normAuthor": "maier michael"
+          },
+          "score": 13,
+          "titleShared": [
+            "circulo",
+            "physico",
+            "quadrato"
+          ],
+          "authorShared": [
+            "maier",
+            "michael"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1931373",
+        "title": "Pretiosa margarita novella de thesauro, ac pretiosissimo philosophorum lapide : artis huius divinae typus, et methodus: collectanea ex Arnaldo, Rhaymundo, Rhasi, Alberto, et Michaele Scoto",
+        "author": "Lacinius, Janus",
+        "year": 1546,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1931373"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11617",
+            "title": "Pretiosa margarita novella de thesauro, ac pretiosissimo philosophorum lapide",
+            "author": "[Bonus, Petrus]",
+            "year": 1546,
+            "place": "Venice",
+            "publisher": "Manutius, sons of Aldus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 837068,
+            "_normTitle": "pretiosa margarita novella de thesauro ac pretiosissimo philosophorum lapide",
+            "_normAuthor": "bonus petrus"
+          },
+          "score": 17,
+          "titleShared": [
+            "pretiosa",
+            "margarita",
+            "novella",
+            "thesauro",
+            "pretiosissimo",
+            "philosophorum",
+            "lapide"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1931868",
+        "title": "La  lumière sortant par soi-mesme des ténèbres ou veritable théorie de la pierre des philosophes, écrite en vers italiens, avec un commentaire ...",
+        "author": "Tachenius, Otto",
+        "year": 1693,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1931868"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "8633",
+            "title": "La lumiere sortant par soi-mesme des tenebres",
+            "author": "[Crasselame, Marc-Antonio]",
+            "year": 1693,
+            "place": "Paris",
+            "publisher": "Houry, Laurent d'",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6123713,
+            "_normTitle": "lumiere sortant par soi mesme des tenebres",
+            "_normAuthor": "crasselame marc antonio"
+          },
+          "score": 11,
+          "titleShared": [
+            "lumiere",
+            "sortant",
+            "mesme",
+            "tenebres"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "8634",
+            "title": "La lumiere sortant par soy même des tenebres",
+            "author": "[Crasselame, Marc-Antonio]",
+            "year": 1687,
+            "place": "Paris",
+            "publisher": "Houry, Laurent d'",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6123713,
+            "_normTitle": "lumiere sortant par soy meme des tenebres",
+            "_normAuthor": "crasselame marc antonio"
+          },
+          "score": 7,
+          "titleShared": [
+            "lumiere",
+            "sortant",
+            "tenebres"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1932283",
+        "title": "Traité historique et dogmatique sur les apparitions, les visions &amp; les révélations particulières : avec des observations sur les dissertations du R. P. Dom Calmet ... sur les apparitions et les revenans",
+        "author": "Lenglet Du Fresnoy, Nicolas",
+        "year": 1751,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1932283"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1932286",
+        "title": "Traité historique et dogmatique sur les apparitions, les visions &amp; les révélations particulières : avec des observations sur les dissertations du R. P. Dom Calmet ... sur les apparitions et les revenans / Tome premier.",
+        "author": "[s.n.]",
+        "year": 1751,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1932286"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1932752",
+        "title": "Traité historique et dogmatique sur les apparitions, les visions &amp; les révélations particulières : avec des observations sur les dissertations du R. P. Dom Calmet ... sur les apparitions et les revenans / Tome second.",
+        "author": "[s.n.]",
+        "year": 1751,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1932752"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1933224",
+        "title": "Michaelis Maieri viatorium, hoc est, de montibus planetarum septem, seu metallorum",
+        "author": "Maier, Michael",
+        "year": 1651,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1933224"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1933462",
+        "title": "Codicillus seu vade mecum Raymundi Lulli ... in quo fontes alchimicae artis ac philosophiae reconditioris uberrime traduntur",
+        "author": "Lullus, Raimundus",
+        "year": 1651,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1933462"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2874",
+            "title": "Codicillus seu vade mecum",
+            "author": "Lull, Ramón",
+            "year": 1651,
+            "place": "Rouen",
+            "publisher": "Berthelin, Jean",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6117197,
+            "_normTitle": "codicillus seu vade mecum",
+            "_normAuthor": "lull ramon"
+          },
+          "score": 7,
+          "titleShared": [
+            "codicillus",
+            "mecum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1997066",
+        "title": "Die Philosophie der Alten wiederkommend in der güldenen Zeit : worinnen von den unsichtbaren Anfängen des spiritus rectoris oder bildenden Geists in den Pflanzen ... gehandelt wird",
+        "author": "Oetinger, Friedrich Christoph",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1997066"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1997455",
+        "title": "Matthiae Untzeri ... anatomia mercurii Spagirica seu de hydrargyri natura, proprietate, viribus atque usu, libri duo",
+        "author": "Untzer, Matthias",
+        "year": 1620,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1997455"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1997770",
+        "title": "Matthiae Untzeri ... de sulphure tractatus",
+        "author": "Untzer, Matthias",
+        "year": 1620,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1997770"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1997900",
+        "title": "Matthiae Untzeri ... physiologia salis seu, de salis natura eiusque prima origine, differentiis, proprietate atque usu. Commentatio philosopho-medica ...",
+        "author": "Untzer, Matthias",
+        "year": 1625,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1997900"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1998096",
+        "title": "Troumbüchlin : darinn warhafftig auss natürlichen Ursachen auch der alten Philosophen und Weissagern der Heyden langwirigem Brauch und fleissiger Nachtrachtung erklärt und aussgelegt werden ...",
+        "author": "Ryff, Walther Hermann",
+        "year": 1555,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1998096"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1998397",
+        "title": "Medicina metallorum, das ist, gründliche Wissenschafft, die geringen Metalle zu reinigen und zu verbessern, durch welche nicht allein diejenige Materie, vermittelst welcher die Natur und die Kunst des Chymici, Gold und Silber hervor bringet ... entdecket wird, sondern welche auch klärlich weiset, wie vermittelst dieser Materie ... die unschätzbare transmutatio metallorum zu Wege zu bringen sey ...",
+        "author": "[s.n.]",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1998397"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1998918",
+        "title": "Tractatus theologo-philosophicus, in libros tres distributus, quorum I. de vita. II. de morte. III. de resurrectione : cui inseruntur nonnulla sapientiae veteris, Adami infortunio superstitis, fragmenta: ex profundiori sacrarum literarum sensu &amp; lumine, atque ex limpidiori &amp; liquidiori saniorum philosophorum fonte hausta atque collecta, fratribusque a Cruce Rosea dictis, dedicata",
+        "author": "Fludd, Robert",
+        "year": 1617,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1998918"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14577",
+            "title": "Tractatus theologo-philosophicus",
+            "author": "[Fludd, Robert]",
+            "year": 1617,
+            "place": "Oppenheim",
+            "publisher": "Bry, Johann Theodor de",
+            "printer": "Galler, Hieronymus",
+            "shelf_mark": "R",
+            "ustc_sn": 2056477,
+            "_normTitle": "tractatus theologo philosophicus",
+            "_normAuthor": "fludd robert"
+          },
+          "score": 13,
+          "titleShared": [
+            "tractatus",
+            "theologo",
+            "philosophicus"
+          ],
+          "authorShared": [
+            "fludd",
+            "robert"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1999061",
+        "title": "Des  berühmten Philosophi Nicolai Flamelli chymische Werke : als Das güldene Kleinod der hieroglyphischen Figuren ; Das Kleinod der Philosophiae ; Summarium philosophicum ; Die grosse Erklärung des Steins der Weisen zur Verwandelung aller Metallen ; Schatz der Philosophiae",
+        "author": "N.",
+        "year": 1751,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1999061"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "1999381",
+        "title": "Eines scharfsinnigen Chymici hinterlassene Gedanken von Verbesserung der Metallen oder naturgegründete und experimentirte Metallurgie",
+        "author": "[s.n.]",
+        "year": 1757,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1999381"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "12686",
+            "title": "Eines scharfsinnigen Chymici hinterlassene Gedanken",
+            "author": "anonymous",
+            "year": 1757,
+            "place": "Hermannstadt|Nuremberg",
+            "publisher": "Bauer, Georg",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "eines scharfsinnigen chymici hinterlassene gedanken",
+            "_normAuthor": "anonymous"
+          },
+          "score": 13,
+          "titleShared": [
+            "eines",
+            "scharfsinnigen",
+            "chymici",
+            "hinterlassene",
+            "gedanken"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "1999423",
+        "title": "Della tramutatione metallica sogni tre : nel primo de quali si tratta della falsa tramutatione sofistica: nel secondo della utile tramutatione detta reale usuale: nel terzo della divina tramutatione detta reale filosofica. Aggiontovi di nuovo la concordanza de filosofi, &amp; loro prattica ... Con un copioso indice per ciascun sogno de gli auttori, &amp; dell'opera c'hanno sopra di ciò trattato",
+        "author": "Nazari, Giovanni Battista",
+        "year": 1599,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/1999423"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14668",
+            "title": "Della tramutatione metallica sogni tre",
+            "author": "Nazari, Giovanni Battista",
+            "year": 1599,
+            "place": "Brescia",
+            "publisher": "Marchetti, Pietro Maria",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 844354,
+            "_normTitle": "della tramutatione metallica sogni tre",
+            "_normAuthor": "nazari giovanni battista"
+          },
+          "score": 17,
+          "titleShared": [
+            "della",
+            "tramutatione",
+            "metallica",
+            "sogni"
+          ],
+          "authorShared": [
+            "nazari",
+            "giovanni",
+            "battista"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2032045",
+        "title": "Ioannis Danielis Mylii ... Opus medico-chymicum : continens tres tractatus sive basilicas: quorum prior inscribitur basilica medica, secundus basilica chymica, tertius basilica philosophica",
+        "author": "Mylius Johann Daniel",
+        "year": 1618,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2032045"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2032531",
+        "title": "Pandora, das ist die edlest Gab Gottes oder der werde und heilsame Stein der Weysen, mit welchem die alten Philosophi, auch Theophrastus Paracelsus, die unvollkommene Metallen durch Gewalt des Fewrs verbessert ... Ein guldener Schatz, welcher durch einen Liebhaber dieser Kunst ... errettet ist worden ...",
+        "author": "Reusner, Hieronymus",
+        "year": 1588,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2032531"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "10782",
+            "title": "Pandora: das ist, die edlest Gab Gottes",
+            "author": "[Reusner, Hieronymus]",
+            "year": 1588,
+            "place": "Basel",
+            "publisher": "Henricpetri, Sebastian",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 605024,
+            "_normTitle": "pandora das ist die edlest gab gottes",
+            "_normAuthor": "reusner hieronymus"
+          },
+          "score": 13,
+          "titleShared": [
+            "pandora",
+            "edlest",
+            "gottes"
+          ],
+          "authorShared": [
+            "reusner",
+            "hieronymus"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "23327",
+            "title": "Pandora: das ist, die edlest Gab Gottes",
+            "author": "[Reusner, Hieronymus]",
+            "year": 1598,
+            "place": "Basel",
+            "publisher": "Henricpetri, Sebastian",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 605023,
+            "_normTitle": "pandora das ist die edlest gab gottes",
+            "_normAuthor": "reusner hieronymus"
+          },
+          "score": 11,
+          "titleShared": [
+            "pandora",
+            "edlest",
+            "gottes"
+          ],
+          "authorShared": [
+            "reusner",
+            "hieronymus"
+          ],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "10783",
+            "title": "Pandora, das ist Die edleste Gab Gottes",
+            "author": "[Reusner, Hieronymus]",
+            "year": 1582,
+            "place": "Basel",
+            "publisher": "Apiarius, Samuel",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 605024,
+            "_normTitle": "pandora das ist die edleste gab gottes",
+            "_normAuthor": "reusner hieronymus"
+          },
+          "score": 9,
+          "titleShared": [
+            "pandora",
+            "gottes"
+          ],
+          "authorShared": [
+            "reusner",
+            "hieronymus"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2032880",
+        "title": "Les vrayes centuries et propheties de maistre Michel Nostradamus ou se void representé tout ce, qui s'est passé tant en France, Espagne, Italie, Alemagne, Angleterre, qu'autres parties du monde",
+        "author": "Nostradamus",
+        "year": 1689,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2032880"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2033174",
+        "title": "Das  Kleinot der Philosophie oder das Original der Begierde ... : ein fürtrefflich Werck, in welchem verfasset ist die Ordenung und die Manier, welche der vorgenandte Flamell in der Composition des Wercks der Natur gehalten hat, welche unter seinen hieroglyphischen Figuren sind verstecket. Aus einem alten M. S",
+        "author": "N.",
+        "year": 1672,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2033174"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "21570",
+            "title": "Das Kleinot der Philosophie",
+            "author": "Flamel, Nicolas",
+            "year": 1672,
+            "place": "n.p.",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6076475,
+            "_normTitle": "kleinot der philosophie",
+            "_normAuthor": "flamel nicolas"
+          },
+          "score": 7,
+          "titleShared": [
+            "kleinot",
+            "philosophie"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "7800",
+            "title": "Das Kleinot der Philosophie",
+            "author": "Flamel, Nicolas",
+            "year": 1669,
+            "place": "n.p.",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6076475,
+            "_normTitle": "kleinot der philosophie",
+            "_normAuthor": "flamel nicolas"
+          },
+          "score": 5,
+          "titleShared": [
+            "kleinot",
+            "philosophie"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2033255",
+        "title": "Sancta veritas hermetica, seu concordantia philosophorum, consistens in sale et sole vel mercurio et sulphure, das ist die ehemals excerpirte und darauf mit eigener Hand experimentirte Sonnen-klare Wahrheit der Philosophen Schrifften",
+        "author": "Naxagoras, Ehrd de",
+        "year": 1712,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2033255"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "12649",
+            "title": "Sancta veritas hermetica, seu concordantia philosophorum consistens in sale et sole vel mercurio et sulphure, das ist: Die ehemahls excerpirte und darauf mit eigener Hand experimentirte Sonnen-klare Wahrheit der philosophischen Schrifften",
+            "author": "Naxagoras, Ehrd de",
+            "year": 1712,
+            "place": "Breslau",
+            "publisher": "Steck, widow of Johann Georg",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "sancta veritas hermetica seu concordantia philosophorum consistens in sale et sole vel mercurio et sulphure das ist die ehemahls excerpirte und darauf mit eigener hand experimentirte sonnen klare wahrheit der philosophischen schrifften",
+            "_normAuthor": "naxagoras ehrd de"
+          },
+          "score": 39,
+          "titleShared": [
+            "sancta",
+            "veritas",
+            "hermetica",
+            "concordantia",
+            "philosophorum",
+            "consistens",
+            "mercurio",
+            "sulphure",
+            "excerpirte",
+            "darauf",
+            "eigener",
+            "experimentirte",
+            "sonnen",
+            "klare",
+            "wahrheit",
+            "schrifften"
+          ],
+          "authorShared": [
+            "naxagoras",
+            "ehrd"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2034213",
+        "title": "Mercurii Trismegisti Pimandras utraque lingua restitutus",
+        "author": "Hermes",
+        "year": 1574,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2034213"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2034361",
+        "title": "Ars transmutationis metallicae cum Leonis X. pontificis maximi ... decemvirorum Venetorum edicto",
+        "author": "Panteo, Giovanni Agostino",
+        "year": 1519,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2034361"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1010",
+            "title": "Ars transmutationis metallicae",
+            "author": "Pantheo, Giovanni Agostino",
+            "year": 1518,
+            "place": "Venice",
+            "publisher": "Tacuinus de Tridino, Joannes",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 846517,
+            "_normTitle": "ars transmutationis metallicae",
+            "_normAuthor": "pantheo giovanni agostino"
+          },
+          "score": 10,
+          "titleShared": [
+            "transmutationis",
+            "metallicae"
+          ],
+          "authorShared": [
+            "giovanni",
+            "agostino"
+          ],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2034455",
+        "title": "Poème philosophic de la verité de la phisique mineralle ...",
+        "author": "Nuisement, Clovis Hesteau",
+        "year": 1620,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2034455"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11436",
+            "title": "Poeme philosophic de la verite de la phisique mineralle",
+            "author": "Nuysement, Jacques de",
+            "year": 1620,
+            "place": "Parijs",
+            "publisher": "Perier, Jeremie| Buisard, Abdias",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 1510181,
+            "_normTitle": "poeme philosophic de la verite de la phisique mineralle",
+            "_normAuthor": "nuysement jacques de"
+          },
+          "score": 13,
+          "titleShared": [
+            "poeme",
+            "philosophic",
+            "verite",
+            "phisique",
+            "mineralle"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2034549",
+        "title": "Oracula magica Zoroastris cum scholiis Plethonis et Pselli nunc primum editi ...",
+        "author": "Opsopäus, Johannes",
+        "year": 1607,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2034549"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "10628",
+            "title": "Oracula magica",
+            "author": "Zoroaster",
+            "year": 1607,
+            "place": "Paris",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6016715,
+            "_normTitle": "oracula magica",
+            "_normAuthor": "zoroaster"
+          },
+          "score": 7,
+          "titleShared": [
+            "oracula",
+            "magica"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "10629",
+            "title": "Oracula magica",
+            "author": "Zoroaster",
+            "year": 1599,
+            "place": "Paris",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6016715,
+            "_normTitle": "oracula magica",
+            "_normAuthor": "zoroaster"
+          },
+          "score": 5,
+          "titleShared": [
+            "oracula",
+            "magica"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2034699",
+        "title": "Oracula metrica Iovis, Apollinis, Hecates, Serapidis, et aliorum deorum ac vatum tam virorum quam feminarum : item Astrampsychi oneirocreticon",
+        "author": "Opsopäus, Johannes",
+        "year": 1607,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2034699"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "21283",
+            "title": "Oracula metrica Jovis, Apollonis, Hecates, Serapidis. Astrampsychi oneirocriticon",
+            "author": null,
+            "year": 1607,
+            "place": "Paris",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 158514,
+            "_normTitle": "oracula metrica jovis apollonis hecates serapidis astrampsychi oneirocriticon",
+            "_normAuthor": ""
+          },
+          "score": 13,
+          "titleShared": [
+            "oracula",
+            "metrica",
+            "hecates",
+            "serapidis",
+            "astrampsychi"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2034845",
+        "title": "Hermou tou Trismegistou Poimandres. Asklepiou horoi pros Ammona Basilea = : Mercurii Trismegisti Poemander, seu de potestate ac sapientia divina. Aesculapii definitiones ad Ammonem regem ...",
+        "author": "Hermes",
+        "year": 1554,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2034845"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2035096",
+        "title": "Nicholas Flammel, his exposition of the hieroglyphicall figures which he caused to bee painted upon an arch in St. Innocents church-yard, in Paris : together with the secret booke of Artephius, and the epistle of Iohn Pontanus concerning both the theoricke and the practicke of the philosophers stone",
+        "author": "Orandus, Eirenaeus",
+        "year": 1624,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2035096"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4769",
+            "title": "Nicholas Flammel his exposition of the hieroglyphical figures which he caused to be painted upon an arch in St. Innocents church yard in Paris: concerning both the theory and practise of the philosophers stone",
+            "author": "Flamel, Nicolas",
+            "year": null,
+            "place": "Bath|[1889]",
+            "publisher": null,
+            "printer": null,
+            "shelf_mark": "Alch F|V",
+            "ustc_sn": null,
+            "_normTitle": "nicholas flammel his exposition of the hieroglyphical figures which he caused to be painted upon an arch in st innocents church yard in paris concerning both the theory and practise of the philosophers stone",
+            "_normAuthor": "flamel nicolas"
+          },
+          "score": 26,
+          "titleShared": [
+            "nicholas",
+            "flammel",
+            "exposition",
+            "figures",
+            "which",
+            "caused",
+            "painted",
+            "innocents",
+            "church",
+            "paris",
+            "concerning",
+            "philosophers",
+            "stone"
+          ],
+          "authorShared": [],
+          "yearScore": 0
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2035372",
+        "title": "Opera nuper in lucem prodeuntia : Liber gratie spiritualis visionum &amp; revelationum beate Methildis virginis devotissime ad fidelium instructionem. Evangelium beati Nichodemi de passione Christi ac descensu eius ad inferos testimonio Charini &amp; Leutii resurrectorum. Epistola Lentuli ad Romanos de persona &amp; effigie &amp; moribus Christi, que sola comperta est in annalibus Romanorum. Visio mirabilis Ysaie prophete, que tam divinae trinitatis archana quam generis humani redemptionem manifestat adversus Hebraicam caliginem. Visio sancti Alberti episcopi Agrippinensis de octo regulis vite humane meritoriis a Christo sibi in missa revelatis. Preclarum Erithree Sibille vaticinium ab excidio Troiano usque ad seculi consumationem in orthodoxe fidei testimonium",
+        "author": "Mechthild",
+        "year": 1522,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2035372"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2035719",
+        "title": "Pauli principis de la Scala et Hun ... primi tomi miscellaneorum, de rerum caussis &amp; successibus atque secretiori methodo ibidem expressa effigies ac exemplar, nimirum vaticiniorum &amp; imaginum Ioachimi abbatis Florensis Calabriae, &amp; Anselmi episcopi Marsichani, super statu summorum pontificum Rhomanae ecclesiae, contra falsam, iniquam, vanam, confictam &amp; seditiosam cuiusdam pseudomagi, quae nuper nomine Theophrasti Paracelsi in lucem prodiit, pseudomagicam expositionem vera, &amp; certa, &amp; indubitata| explanatio",
+        "author": "Joachim",
+        "year": 1570,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2035719"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2040154",
+        "title": "Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und bewehrten philosophi und medici Philippi Theophrasti Bombast von Hohenheim ...",
+        "author": "Huser, Johannes",
+        "year": 1589,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2040154"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2056",
+            "title": "Erster (-zehender) Theil der Bücher und Schrifften",
+            "author": "Paracelsus, Theophrastus",
+            "year": 1589,
+            "place": "Basel",
+            "publisher": null,
+            "printer": "Waldkirch, Konrad von",
+            "shelf_mark": "H",
+            "ustc_sn": 604886,
+            "_normTitle": "erster zehender theil der bucher und schrifften",
+            "_normAuthor": "paracelsus theophrastus"
+          },
+          "score": 13,
+          "titleShared": [
+            "erster",
+            "zehender",
+            "theil",
+            "bucher",
+            "schrifften"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2040156",
+        "title": "Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und bewehrten philosophi und medici Philippi Theophrasti Bombast von Hohenheim ... / [Erster bis sechster Theil.]",
+        "author": "[s.n.]",
+        "year": 1589,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2040156"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2056",
+            "title": "Erster (-zehender) Theil der Bücher und Schrifften",
+            "author": "Paracelsus, Theophrastus",
+            "year": 1589,
+            "place": "Basel",
+            "publisher": null,
+            "printer": "Waldkirch, Konrad von",
+            "shelf_mark": "H",
+            "ustc_sn": 604886,
+            "_normTitle": "erster zehender theil der bucher und schrifften",
+            "_normAuthor": "paracelsus theophrastus"
+          },
+          "score": 13,
+          "titleShared": [
+            "erster",
+            "zehender",
+            "theil",
+            "bucher",
+            "schrifften"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2042289",
+        "title": "Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und bewehrten philosophi und medici Philippi Theophrasti Bombast von Hohenheim ... / [Siebender bis zehender Theil.]",
+        "author": "[s.n.]",
+        "year": 1589,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2042289"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2056",
+            "title": "Erster (-zehender) Theil der Bücher und Schrifften",
+            "author": "Paracelsus, Theophrastus",
+            "year": 1589,
+            "place": "Basel",
+            "publisher": null,
+            "printer": "Waldkirch, Konrad von",
+            "shelf_mark": "H",
+            "ustc_sn": 604886,
+            "_normTitle": "erster zehender theil der bucher und schrifften",
+            "_normAuthor": "paracelsus theophrastus"
+          },
+          "score": 13,
+          "titleShared": [
+            "erster",
+            "zehender",
+            "theil",
+            "bucher",
+            "schrifften"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044320",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Aureus tractatus de philosophorum lapide",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044320"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044398",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Aureum seculum redivivum, quod nunc iterum apparuit suaviter floruit, &amp; odoriferum aureumque semen peperit",
+        "author": "Mynsicht, Adrian von",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044398"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044424",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Hydrolithus sophicus seu aquarium sapientum, hoc est opusculum chymicum, in quo via monstratur, materia nominatur, &amp; processus describitur, quomodo videlicet ad universalem tincturam perveniendum, hactenus nondum visum ...",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044424"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044502",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Demonstratio naturae, quam errantibus chymicis facit, dum de sophista et stolido spiratore carbonario conqueritur",
+        "author": "Jean",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044502"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044544",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Via veritatis unicae, hoc est: elegans, perutile et praestans opusculum viam veritatis aperiens",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044544"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044572",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Gloria mundi, alias, paradysi tabula, hoc est: vera priscae scientiae descriptio, quam Adam ab ipso deo didicit: Noe, Abraham et Salomo, tamquam summorum divinorum donorum unum, usurparunt, omneis sapientes, omnibus temporibus, pro totius mundi thesauro habuerunt, &amp; solis piis post sese reliquerunt, nimirum de lapide philosophicorum",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044572"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044680",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / De lapide philosophico tractatus eximius, a Germanico quodam philosopho A. C. M CCCCXXIII subsequente titulo factus et conscriptus ...",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044680"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044704",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / De lapide philosophico per breve opusculum, quod ab ignoto aliquo Germanico philosopho, pene ante ducentos annos, conscriptum &amp; liber alze nuncupatum fuit, nunc vero in lucem editum",
+        "author": "[s.n.]",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044704"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044724",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Lambsprinck ... antiqui libellus de lapide philosophicorum",
+        "author": "Barnaud, Nicolas",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044724"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044766",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Tripus aureus, hoc est, tres tractatus chymici selectissimi ... : 1. Practica cum duodecim clavibus et appendice. De magno lapide antiquorum sapientum",
+        "author": "Maier, Michael",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044766"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2044945",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Novum lumen chemicum e naturae fonte et manuali experientia depromptum : cui accessit tractatus de sulphure",
+        "author": "Se̜dziwój, Michał",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2044945"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2045052",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Introitus apertus ad occlusum regis palatium",
+        "author": "Cureau de La Chambre, Marin",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2045052"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2045112",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Subtilis allegoria super secreta chymiae perspicuae utilitatis et iucundae meditationis",
+        "author": "Maier, Michael",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2045112"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2045158",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Philalethae tractatus tres : Metallorum metamorphosis ; Brevis manuductio ad rubinum coelestem ; Fons chymicae veritatis",
+        "author": "Cureau de La Chambre, Marin",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2045158"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2045238",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum / Iohannis Friderici Helvetii vitulus aureus : quem mundus adorat &amp; orat, in quo tractatur de rarissimo naturae miraculo transmutandi metalla ...",
+        "author": "Helvetius, Johann Friedrich",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2045238"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 10,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2092629",
+        "title": "Johann Jacob Schlierbachs ... practischer Versuch und Vorstellung, vom Nutzen und Schaden des Aderlassens ...",
+        "author": "Schlierbach, Johann Jakob",
+        "year": 1748,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2092629"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2100640",
+        "title": "Friderici Esaiae a Pufendorf religio gentium arcana",
+        "author": "Pufendorf, Friedrich Esaias von",
+        "year": 1773,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2100640"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2088764",
+        "title": "De magia. De observatione somniorum, et de divinatione astrologica, libri tres ...",
+        "author": "Perera, Benet",
+        "year": 1598,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2088764"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "8688",
+            "title": "De magia. De observatione somniorum et de divinatione astrologica, libri tres",
+            "author": "Pererius, Benedictus",
+            "year": 1598,
+            "place": "Cologne",
+            "publisher": "Gymnich, Johann",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 628686,
+            "_normTitle": "magia de observatione somniorum et de divinatione astrologica libri tres",
+            "_normAuthor": "pererius benedictus"
+          },
+          "score": 15,
+          "titleShared": [
+            "magia",
+            "observatione",
+            "somniorum",
+            "divinatione",
+            "astrologica",
+            "libri"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2089025",
+        "title": "Reconditorium ac reclusorium opulentiae sapientiaeque numinis mundi magni, cui deditur in titulum chymica vannus, obtenta quidem &amp; erecta auspice mortale coepto ...",
+        "author": "[s.n.]",
+        "year": 1666,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2089025"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2641",
+            "title": "Reconditorium ac reclusorium opulentiae sapientiaeque numinis magni, cui deditur in titulum chymica vannus",
+            "author": "anonymous",
+            "year": 1666,
+            "place": "Amsterdam",
+            "publisher": "Janssonius van Waesberge, Johannes I|Weyerstraten, Elizaeus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "reconditorium ac reclusorium opulentiae sapientiaeque numinis magni cui deditur in titulum chymica vannus",
+            "_normAuthor": "anonymous"
+          },
+          "score": 23,
+          "titleShared": [
+            "reconditorium",
+            "reclusorium",
+            "opulentiae",
+            "sapientiaeque",
+            "numinis",
+            "magni",
+            "deditur",
+            "titulum",
+            "chymica",
+            "vannus"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2091347",
+        "title": "Tripus chimicus Sendivogianus, dreyfaches chimisches Kleinod. Das ist zwölff Tractätlin von dem philosophischen Stain der alten Weisen ...",
+        "author": "Se̜dziwój, Michał",
+        "year": 1628,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2091347"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14784",
+            "title": "Tripus chimicus Sendivogianus, dreyfaches chimisches Kleinod",
+            "author": "Sendivogius, Michael",
+            "year": 1628,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Lazarus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "tripus chimicus sendivogianus dreyfaches chimisches kleinod",
+            "_normAuthor": "sendivogius michael"
+          },
+          "score": 15,
+          "titleShared": [
+            "tripus",
+            "chimicus",
+            "sendivogianus",
+            "dreyfaches",
+            "chimisches",
+            "kleinod"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2091553",
+        "title": "Gebri summa perfectio, das ist deß ... arabischen Philosophi Geber Büchlin von der gebenedeyten und allerhöchsten Vollkommenheit der allgemainen Artzeney, so wol für die metallischen als auch menschliche Cörper in ihr höchstes Wesen und vollkommenen Grad zubringen ...",
+        "author": "Starkey, George",
+        "year": 1625,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2091553"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2091873",
+        "title": "Elucidarii Christophori Parisiensis ander Theil so unlangst von einem fürnemen Philosopho ubersehen und mit Theophrasti und anderer newen Philosophen Testimoniis illustriret : beneben zweyen künstlichen Tractätlein Raymundi Lulli ... : als vade mecum Lullianum und Eröffnung des Testaments Raymundi Lullii",
+        "author": "Christophorus",
+        "year": 1610,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2091873"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2092966",
+        "title": "Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, avec une explication des hiéroglyphes, et de la guerre de Troye",
+        "author": "Pernety, Antoine Joseph",
+        "year": 1758,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2092966"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4792",
+            "title": "Les fables égyptiennes et grecques",
+            "author": "Pernety, Antoine-Joseph",
+            "year": 1758,
+            "place": "Paris",
+            "publisher": "Bauche",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "fables egyptiennes et grecques",
+            "_normAuthor": "pernety antoine joseph"
+          },
+          "score": 15,
+          "titleShared": [
+            "fables",
+            "egyptiennes",
+            "grecques"
+          ],
+          "authorShared": [
+            "pernety",
+            "antoine",
+            "joseph"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2093584",
+        "title": "Dictionnaire mytho-hermétique, dans lequel on trouve les allégories fabuleuses des poètes, les métaphores, les énigmes et les termes barbares des philosophes hermétiques expliqués",
+        "author": "Pernety, Antoine Joseph",
+        "year": 1758,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2093584"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3617",
+            "title": "Dictionnaire mytho-hermétique",
+            "author": "Pernety, Antoine-Joseph",
+            "year": 1758,
+            "place": "Paris",
+            "publisher": "Bauche",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "dictionnaire mytho hermetique",
+            "_normAuthor": "pernety antoine joseph"
+          },
+          "score": 15,
+          "titleShared": [
+            "dictionnaire",
+            "mytho",
+            "hermetique"
+          ],
+          "authorShared": [
+            "pernety",
+            "antoine",
+            "joseph"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2094179",
+        "title": "Rosarium novum olympicum et benedictum ...",
+        "author": "Figulus, Benedictus",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2094179"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "12383",
+            "title": "Rosarium novum olympicum et benedictum. Das ist: ein newer gebenedeyter philosophischer Rosengart",
+            "author": "Figulus, Benedictus",
+            "year": 1608,
+            "place": "Basel",
+            "publisher": "Figulus, Benedictus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2509219,
+            "_normTitle": "rosarium novum olympicum et benedictum das ist ein newer gebenedeyter philosophischer rosengart",
+            "_normAuthor": "figulus benedictus"
+          },
+          "score": 15,
+          "titleShared": [
+            "rosarium",
+            "novum",
+            "olympicum",
+            "benedictum"
+          ],
+          "authorShared": [
+            "figulus",
+            "benedictus"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2094421",
+        "title": "Sophia, das ist die holdseelige ewige Jungfrau der göttlichen Weisheit oder wunderbahre geistliche Entdeck- und Offenbahrungen so die theure Weisheit einer heiligen Seele gegeben ...",
+        "author": "Pordage, John",
+        "year": 1699,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2094421"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13399",
+            "title": "Sophia: das ist, die holdseelige ewige Jungfrau der goettlichen Weisheit",
+            "author": "Pordage, John",
+            "year": 1699,
+            "place": "Amsterdam",
+            "publisher": "z.n.",
+            "printer": null,
+            "shelf_mark": "M",
+            "ustc_sn": 1836250,
+            "_normTitle": "sophia das ist die holdseelige ewige jungfrau der goettlichen weisheit",
+            "_normAuthor": "pordage john"
+          },
+          "score": 17,
+          "titleShared": [
+            "sophia",
+            "holdseelige",
+            "ewige",
+            "jungfrau",
+            "weisheit"
+          ],
+          "authorShared": [
+            "pordage",
+            "john"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2094732",
+        "title": "Opera omnia Ioannis Pici, Mirandulae concordiaeque comitis, theologorum &amp; philosophorum ... principis: viri, sive linguarum, sive rerum, &amp; humanarum &amp; divinarum, cognitionem spectes, doctrina &amp; ingenio admirando ...",
+        "author": "Pico della Mirandola, Giovanni Francesco",
+        "year": 1557,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2094732"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "10528",
+            "title": "Opera omnia quae extant",
+            "author": "Dionysius Areopagita",
+            "year": 1557,
+            "place": "Cologne",
+            "publisher": "Birckmann, heirs of Arnold",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 151875,
+            "_normTitle": "opera omnia quae extant",
+            "_normAuthor": "dionysius areopagita"
+          },
+          "score": 7,
+          "titleShared": [
+            "opera",
+            "omnia"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "19490",
+            "title": "Opera omnia quae extant",
+            "author": "Dionysius Areopagita",
+            "year": 1556,
+            "place": "Paris",
+            "publisher": null,
+            "printer": "Vascosan, Michel de",
+            "shelf_mark": "H folio",
+            "ustc_sn": 151875,
+            "_normTitle": "opera omnia quae extant",
+            "_normAuthor": "dionysius areopagita"
+          },
+          "score": 6,
+          "titleShared": [
+            "opera",
+            "omnia"
+          ],
+          "authorShared": [],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2095703",
+        "title": "De vitis, sectis, et dogmatibus omnium haereticorum, qui ab orbe condito, ad nostra usque tempora, &amp; veterum &amp; recentium authorum monimentis proditi sunt, elenchus alphabeticus ...",
+        "author": "Du Préau, Gabriel",
+        "year": 1569,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2095703"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2101073",
+        "title": "Raymundi Lulli doctissimi et celeberrimi philosophi liber, qui codicillus, seu vade mecum inscribitur, in quo fontes alchimicae artis et reconditioris philosophiae traduntur, ante hac nunquam impressus",
+        "author": "Lullus, Raimundus",
+        "year": 1563,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2101073"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2101356",
+        "title": "Compendium alchimiae Ioannis Garlandii Angli philosophi doctissimi ... : adiecimus eiusdem compendii per Arnoldum de Villanova explicationem",
+        "author": "Hortulanus",
+        "year": 1560,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2101356"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3039",
+            "title": "Compendium alchimiae",
+            "author": "Johannes de Garlandia",
+            "year": 1560,
+            "place": "Basel",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 831859,
+            "_normTitle": "compendium alchimiae",
+            "_normAuthor": "johannes de garlandia"
+          },
+          "score": 7,
+          "titleShared": [
+            "compendium",
+            "alchimiae"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2101555",
+        "title": "Commentarius de praecipuis generibus divinationum, in quo a prophetiis autoritate divina traditis &amp; a physicis coniecturis, discernuntur artes et imposturae diabolicae, atque observationes natae ex superstitione et cum hac coniunctae ...",
+        "author": "Peucer, Kaspar",
+        "year": 1560,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2101555"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "2994",
+            "title": "Commentarius de praecipuis generibus divinationum",
+            "author": "Peucer, Caspar",
+            "year": 1560,
+            "place": "Wittenberg",
+            "publisher": null,
+            "printer": "Krafft, Johann",
+            "shelf_mark": "H",
+            "ustc_sn": 622891,
+            "_normTitle": "commentarius de praecipuis generibus divinationum",
+            "_normAuthor": "peucer caspar"
+          },
+          "score": 13,
+          "titleShared": [
+            "commentarius",
+            "praecipuis",
+            "generibus",
+            "divinationum"
+          ],
+          "authorShared": [
+            "peucer"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2102482",
+        "title": "La  théorie des songes",
+        "author": "Richard, Jérôme",
+        "year": 1766,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2102482"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2102847",
+        "title": "Roger Bachon de l'admirable pouvoir et puissance de l'art &amp; de nature, ou est traicté de la pièrre philosophale",
+        "author": "Bacon, Roger",
+        "year": 1629,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2102847"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2102930",
+        "title": "Raimundi Lulli ... de secretis naturae sive quinta essentia libri duo : his accesserunt Alberti Magni ... de mineralibus &amp; rebus metallicis libri quinque",
+        "author": "Lullus, Raimundus",
+        "year": 1541,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2102930"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2103342",
+        "title": "Opusculum Raymundinum de auditu kabbalisitico sive ad omnes scientias introductorium [quod videtur esse introductorium ad sapientiam kabbalam regulatum et ... positum, perfecteque correptum a Petro Maynardo ...]",
+        "author": "Lullus, Raimundus",
+        "year": 1518,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2103342"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2103458",
+        "title": "Summa omnium haeresum et catalogus schismaticorum, haereticorum, et idolatrarum",
+        "author": "Medici, Sebastiano",
+        "year": 1581,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2103458"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2104280",
+        "title": "Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[-alter]",
+        "author": "Philo",
+        "year": 1561,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2104280"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2104282",
+        "title": "Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[-alter] / Tomus prior.",
+        "author": "[s.n.]",
+        "year": 1561,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2104282"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2104857",
+        "title": "Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[-alter] / Tomus alter.",
+        "author": "[s.n.]",
+        "year": 1561,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2104857"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2105363",
+        "title": "Rodolphi Goclenii uranoscopiae, chiroscopiae, metoposcopiae, et ophtalmoscopiae, contemplatio, qua probatur, divinationem ex astris, lineisque manuum, fronte, facie &amp; oculis nec impiam esse nec superstitiosam",
+        "author": "Goclenius, Rudolph",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2105363"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2206664",
+        "title": "Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, avec une explication des hiéroglyphes, et de la guerre de Troye / Tome second.",
+        "author": "[s.n.]",
+        "year": 1758,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2206664"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4792",
+            "title": "Les fables égyptiennes et grecques",
+            "author": "Pernety, Antoine-Joseph",
+            "year": 1758,
+            "place": "Paris",
+            "publisher": "Bauche",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "fables egyptiennes et grecques",
+            "_normAuthor": "pernety antoine joseph"
+          },
+          "score": 9,
+          "titleShared": [
+            "fables",
+            "egyptiennes",
+            "grecques"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2208774",
+        "title": "Christiani Thomasii ... Tractatio iuridica de iure circa somnum et somnia, vom Recht des Schlaffs und der Träume",
+        "author": "Thomasius, Christian",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2208774"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2216450",
+        "title": "Der  Todten-Tantz, wie derselbe in der weitberühmten Stadt Basel, als ein Spiegel menschlicher Beschaffenheit, ganz künstlich mit lebendigen Farben gemahlet, nicht ohne nützliche Verwunderung zu sehen ist",
+        "author": "[s.n.]",
+        "year": 1796,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2216450"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2216552",
+        "title": "Viridarium chymicum figuris cupro incisis adornatum, et poeticis picturis illustratum. Ita ut non tantum oculorum et animi recreationem suppeditet, sed et profundiorem rerum naturalium considerationem excitet, adhaec forma sua oblonga amicorum albo inservire queat",
+        "author": "Stoltzius von Stoltzenberg, Daniel",
+        "year": 1624,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2216552"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15455",
+            "title": "[Viridarium chymicum]",
+            "author": "Stoltzius von Stoltzenberg, Daniel",
+            "year": 1624,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2045651,
+            "_normTitle": "viridarium chymicum",
+            "_normAuthor": "stoltzius von stoltzenberg daniel"
+          },
+          "score": 13,
+          "titleShared": [
+            "viridarium",
+            "chymicum"
+          ],
+          "authorShared": [
+            "stoltzius",
+            "stoltzenberg",
+            "daniel"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2217010",
+        "title": "Reverendi P. Petri Thyraei ... De daemoniacis liber unus in quo daemonum obsidentium conditio; obsessorum hominum status ... explicantur ...",
+        "author": "Thyraeus, Petrus",
+        "year": 1594,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2217010"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2217160",
+        "title": "Reverendi P. Petri Thyraei ... De variis tam spirituum quam vivorum hominum prodigiosis apparitionibus, et nocturnis infestationibus libri tres ...",
+        "author": "Thyraeus, Petrus",
+        "year": 1594,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2217160"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2208876",
+        "title": "Theatrum chemicum Britannicum : containing severall poeticall pieces of our famous english philosophers, who have written the hermetique mysteries in their owne ancient language. The first part",
+        "author": "Ashmole, Elias",
+        "year": 1652,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2208876"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 27,
+          "titleShared": [
+            "theatrum",
+            "chemicum",
+            "britannicum",
+            "containing",
+            "severall",
+            "poeticall",
+            "pieces",
+            "famous",
+            "english",
+            "philosophers"
+          ],
+          "authorShared": [
+            "ashmole",
+            "elias"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2209402",
+        "title": "Quinta essentia, das ist, die höchste Subtilitet, Krafft und Wirckung beyder der fürtrefflichsten und menschlichem Geschlecht am nützlichsten Künsten der Medicin und Alchemy. Auch wie nahe diese beyde mit Sipschafft gefreund und verwandt sind ...",
+        "author": "Thurneysser zum Thurn, Leonhardt",
+        "year": 1574,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2209402"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "11915",
+            "title": "Quinta essentia das ist die höchste Subtilitet, Kraft, und Wirkung, beider der furtrefelichisten (und menschlichem gschlecht den nutzlichisten) Könsten der Medicina, und Alchemia",
+            "author": "Thurneisser zum Thurn, Leonhard",
+            "year": 1570,
+            "place": "Münster",
+            "publisher": "Ossenbrügge, Johann| Thurneisser zum Thurn, Leonhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2814451,
+            "_normTitle": "quinta essentia das ist die hochste subtilitet kraft und wirkung beider der furtrefelichisten und menschlichem gschlecht den nutzlichisten konsten der medicina und alchemia",
+            "_normAuthor": "thurneisser zum thurn leonhard"
+          },
+          "score": 13,
+          "titleShared": [
+            "quinta",
+            "essentia",
+            "hochste",
+            "subtilitet",
+            "menschlichem"
+          ],
+          "authorShared": [
+            "thurn"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2209634",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum]",
+        "author": "[s.n.]",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2209634"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2209636",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen primum.",
+        "author": "[s.n.]",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2209636"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2210470",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen secundum.",
+        "author": "[s.n.]",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2210470"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2284847",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium]",
+        "author": "[s.n.]",
+        "year": 1602,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2284847"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14138",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1602,
+            "place": "Oberursel",
+            "publisher": "Zetzner, Lazarus",
+            "printer": "Sutor, Cornelius",
+            "shelf_mark": "A",
+            "ustc_sn": 2078431,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2284849",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium] / Volumen primum.",
+        "author": "[s.n.]",
+        "year": 1602,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2284849"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14138",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1602,
+            "place": "Oberursel",
+            "publisher": "Zetzner, Lazarus",
+            "printer": "Sutor, Cornelius",
+            "shelf_mark": "A",
+            "ustc_sn": 2078431,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2282207",
+        "title": "Historische Wunder-Beschreibung von der sogenannten schönen Melusina, Königs Helmas in Albanien Tochter, welche eine Sirene und Meer-Wunder gewesen, und ihrer Hervorkunft aus dem in Frankreich gelegenen Berg Adelon, auch was sich allda sehr seltsam und merkwürdiges mit ihr zugetragen",
+        "author": "[s.n.]",
+        "year": null,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2282207"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2282411",
+        "title": "Armamentarium ecclesiasticum : complectens arma spiritualia fortissima ad insultus diabolicos elidendos, &amp; feliciter superandos ... pars prima [- secunda]",
+        "author": "Stoiber, Ubald",
+        "year": 1757,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2282411"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2283178",
+        "title": "D. Jacobi Theodori Tabernaemontani neu vollkommen Kräuter-Buch darinnen uber 3000 Kräuter mit schönen und kunstlichen Figuren, auch deren Underscheid und Würckung sammt ihren Namen in mancherley Sprachen beschrieben : erstlichen durch Casparum Bauhinum ... mit vielen neuen Figuren nutzlichen Artzneyen und anderem mit sonderem Fleiss gebesseret : zum Andern durch Hieronymum Bauhinum ... mit sehr nutzlichen Marginalien, Synonimis, neuen Registeren und anderem vermehrt : und nun zum vierdten Mahl aufs fleissigst übersehen an unzahlbaren Orten absonderlich verbessert ...",
+        "author": "Theodorus, Jacobus",
+        "year": 1731,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2283178"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2285791",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium] / Volumen secundum.",
+        "author": "[s.n.]",
+        "year": 1602,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2285791"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14138",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1602,
+            "place": "Oberursel",
+            "publisher": "Zetzner, Lazarus",
+            "printer": "Sutor, Cornelius",
+            "shelf_mark": "A",
+            "ustc_sn": 2078431,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2286442",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium] / Volumen tertium.",
+        "author": "[s.n.]",
+        "year": 1602,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2286442"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14138",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1602,
+            "place": "Oberursel",
+            "publisher": "Zetzner, Lazarus",
+            "printer": "Sutor, Cornelius",
+            "shelf_mark": "A",
+            "ustc_sn": 2078431,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2287453",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in quatuor partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- quartum]",
+        "author": "[s.n.]",
+        "year": 1613,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2287453"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14139",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1613,
+            "place": "Strassburg",
+            "publisher": "Zetzner, Lazarus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2045257,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2287455",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in quatuor partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- quartum] / Volumen quartum.",
+        "author": "[s.n.]",
+        "year": 1613,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2287455"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14139",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1613,
+            "place": "Strassburg",
+            "publisher": "Zetzner, Lazarus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2045257,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2288648",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in quatuor partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- quartum] / Volumen quintum.",
+        "author": "[s.n.]",
+        "year": 1613,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2288648"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14139",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1613,
+            "place": "Strassburg",
+            "publisher": "Zetzner, Lazarus",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2045257,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2289743",
+        "title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden",
+        "author": "Roth-Scholtz, Friedrich",
+        "year": 1728,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2289743"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3528",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1728,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 15,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [
+            "roth",
+            "scholtz",
+            "friedrich"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "22907",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1733,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 13,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [
+            "roth",
+            "scholtz",
+            "friedrich"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2289745",
+        "title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden / Erster Theil.",
+        "author": "[s.n.]",
+        "year": 1728,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2289745"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3528",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1728,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 9,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "22907",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1733,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 7,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2290896",
+        "title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden / Zweyter Theil.",
+        "author": "[s.n.]",
+        "year": 1728,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2290896"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3528",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1728,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 9,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "22907",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1733,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 7,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2291876",
+        "title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden / Dritter Theil.",
+        "author": "[s.n.]",
+        "year": 1728,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2291876"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3528",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1728,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 9,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "22907",
+            "title": "Deutsches theatrum chemicum",
+            "author": "Roth-Scholtz, Friedrich",
+            "year": 1733,
+            "place": "Nuremberg",
+            "publisher": "Felsecker, Adam Jonathan",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "deutsches theatrum chemicum",
+            "_normAuthor": "roth scholtz friedrich"
+          },
+          "score": 7,
+          "titleShared": [
+            "deutsches",
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2299474",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen tertium.",
+        "author": "[s.n.]",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2299474"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2300360",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen quartum.",
+        "author": "[s.n.]",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2300360"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2301444",
+        "title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen sextum.",
+        "author": "[s.n.]",
+        "year": 1659,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2301444"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14140",
+            "title": "Theatrum chemicum",
+            "author": "anonymous",
+            "year": 1659,
+            "place": "Strassburg",
+            "publisher": "Zetzner, heirs of Eberhard",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "theatrum chemicum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 7,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14143",
+            "title": "Theatrum chemicum Britannicum. Containing severall poeticall pieces of our famous english philosophers",
+            "author": "Ashmole, Elias",
+            "year": 1652,
+            "place": "London",
+            "publisher": "Brookes, Nathaniel",
+            "printer": "Grismond, John",
+            "shelf_mark": "A",
+            "ustc_sn": 2024727,
+            "_normTitle": "theatrum chemicum britannicum containing severall poeticall pieces of our famous english philosophers",
+            "_normAuthor": "ashmole elias"
+          },
+          "score": 5,
+          "titleShared": [
+            "theatrum",
+            "chemicum"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2479864",
+        "title": "Herrn Georgii von Welling opus mago-cabbalisticum et theosophicum : darinnen der Ursprung, Natur, Eigenschafften und Gebrauch des Saltzes, Schwefels und Mercurii, in dreyen Theilen beschrieben ... : deme noch beygefüget ein Tractätlein von der göttlichen Weissheit und ein besonderer Anhang etlicher sehr rar- und kostbahrer chymischer Piecen ...",
+        "author": "Welling, Georg von",
+        "year": 1735,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2479864"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2480555",
+        "title": "Veterum sophorum sigilla et imagines magicae, sive sculpturae lapidum et gemmarum secundum nomen dei tetragrammaton, cum signatura planetarum et iuxta certos coeli tractus et constellationes, ad stupendos et mirandos effectus producendos. Additur vera eas conficiendi ratio &amp; pro acuenda memoria ac ingenio erectio signaturae Mercurii stupenda ...",
+        "author": "Trithemius, Johannes",
+        "year": 1612,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2480555"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2497883",
+        "title": "Sebastiani Wirdig ... Nova medicina spirituum : curiosa scientia et doctrina, unanimiter hucusque neglecta, et a nemine merito exculta, medicis tamen et physicis utilissima ...",
+        "author": "Wirdig, Sebastian",
+        "year": 1673,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2497883"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2498465",
+        "title": "Trois traitez de la philosophie naturelle non encore imprimez ... : scavoir le secret livre du ... philosophe Artephius traitant de l'art occulte et transmutation metallique ... ; plus les figures hierogliphiques",
+        "author": "Artephius",
+        "year": 1612,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2498465"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "14826",
+            "title": "Trois traitez de la philosophie naturelle. De l'art occulte. Figures hierogliphiques. Le vray livre",
+            "author": "Artephius|Flamel, Nicolas|Synesius",
+            "year": 1612,
+            "place": "Paris",
+            "publisher": "Marette, Guillaume",
+            "printer": null,
+            "shelf_mark": "A|geplaatst onder Arnauld",
+            "ustc_sn": 6026651,
+            "_normTitle": "trois traitez de la philosophie naturelle de l art occulte figures hierogliphiques le vray livre",
+            "_normAuthor": "artephius flamel nicolas synesius"
+          },
+          "score": 21,
+          "titleShared": [
+            "trois",
+            "traitez",
+            "philosophie",
+            "naturelle",
+            "livre",
+            "occulte",
+            "figures",
+            "hierogliphiques"
+          ],
+          "authorShared": [
+            "artephius"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14824",
+            "title": "Trois traitez de la philosophie naturelle   De l'art occulte. Figures hieropliphiques. Le vray livre",
+            "author": "Artephius|Flamel, Nicolas|Synesius",
+            "year": 1612,
+            "place": "Paris",
+            "publisher": "Guillemot, widow of Matthieu| Thiboust, Samuel",
+            "printer": null,
+            "shelf_mark": "A|geplaatst onder Arnauld",
+            "ustc_sn": 6026651,
+            "_normTitle": "trois traitez de la philosophie naturelle de l art occulte figures hieropliphiques le vray livre",
+            "_normAuthor": "artephius flamel nicolas synesius"
+          },
+          "score": 19,
+          "titleShared": [
+            "trois",
+            "traitez",
+            "philosophie",
+            "naturelle",
+            "livre",
+            "occulte",
+            "figures"
+          ],
+          "authorShared": [
+            "artephius"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "14827",
+            "title": "Trois traitez de la philosophie naturelle. La turbe des philosophes. La parole delaissee. Les douzes portes de l'alchimie",
+            "author": "anonymous|Bernhardus Trevisanus",
+            "year": 1618,
+            "place": "[Paris]",
+            "publisher": "[Sara, J.]",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6019840,
+            "_normTitle": "trois traitez de la philosophie naturelle la turbe des philosophes la parole delaissee les douzes portes de l alchimie",
+            "_normAuthor": "anonymous bernhardus trevisanus"
+          },
+          "score": 9,
+          "titleShared": [
+            "trois",
+            "traitez",
+            "philosophie",
+            "naturelle"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2498584",
+        "title": "De chemia senioris antiquissimi philosophi, libellus, ut brevis, ita artem discentibus, et exercentibus, utilissimus, et vere aureus, nunc primum in lucem aeditus",
+        "author": "Ibn-Umail, Muḥammad",
+        "year": 1560,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2498584"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2653452",
+        "title": "Unterhaltungen aus der Naturgeschichte",
+        "author": "Wilhelm, Gottlieb Tobias",
+        "year": 1792,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2653452"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2573984",
+        "title": "[Divers traitez de la philosophie naturelle]",
+        "author": "Bernardus",
+        "year": 1672,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2573984"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "3742",
+            "title": "Divers traitez de la philosophie naturelle. La turbe des philosophes. La parole delaissée. Les deux traitez. Le tres-ancien duel des chevaliers",
+            "author": "Bernhardus Trevisanus|Drebbel, Cornelius",
+            "year": 1672,
+            "place": "Paris",
+            "publisher": "Houry, Jean d'",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 6087654,
+            "_normTitle": "divers traitez de la philosophie naturelle la turbe des philosophes la parole delaissee les deux traitez le tres ancien duel des chevaliers",
+            "_normAuthor": "bernhardus trevisanus drebbel cornelius"
+          },
+          "score": 11,
+          "titleShared": [
+            "divers",
+            "traitez",
+            "philosophie",
+            "naturelle"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2574308",
+        "title": "Des  Herrn Bernhardi, Grafen von der Marck und Tervis chymische Schrifften von dem gebenedeyten Stein der Weisen",
+        "author": "Bernardus",
+        "year": 1746,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2574308"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2574819",
+        "title": "Splendor lucis, oder Glantz des Lichts, pars I : enthaltend eine kurtze physico-cabalistische Auslegung des grösten Natur-Geheimnuss : insgemein lapis philosophorum genannt",
+        "author": "Sonnenfels, Alois von",
+        "year": 1745,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2574819"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2575066",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil",
+        "author": "Walch, Christian Wilhelm Franz",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2575066"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2575068",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Erster Theil.",
+        "author": "[s.n.]",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2575068"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2575920",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Zweiter Theil.",
+        "author": "[s.n.]",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2575920"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2576642",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Dritter Theil.",
+        "author": "[s.n.]",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2576642"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2577372",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Vierter Theil.",
+        "author": "[s.n.]",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2577372"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2578238",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Fünfter Theil.",
+        "author": "[s.n.]",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2578238"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2579200",
+        "title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Sechster Theil.",
+        "author": "[s.n.]",
+        "year": 1762,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2579200"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2580278",
+        "title": "Amphitheatrum aeternae providentiae divino-magicum, christiano-physicum nec non astrologo-catholicum adversus veteres philosophos, atheos, epicureos, peripateticos et stoicos : autore Iulio Caesare Vanino",
+        "author": "Vanini, Giulio Cesare",
+        "year": 1615,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2580278"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "563",
+            "title": "Amphitheatrum aeternae providentiae divino-magicum",
+            "author": "Vanini, Giulio Cesare",
+            "year": 1615,
+            "place": "Lyon",
+            "publisher": "Harsy, widow of Antoine de",
+            "printer": null,
+            "shelf_mark": "H",
+            "ustc_sn": 6901994,
+            "_normTitle": "amphitheatrum aeternae providentiae divino magicum",
+            "_normAuthor": "vanini giulio cesare"
+          },
+          "score": 19,
+          "titleShared": [
+            "amphitheatrum",
+            "aeternae",
+            "providentiae",
+            "divino",
+            "magicum"
+          ],
+          "authorShared": [
+            "vanini",
+            "giulio",
+            "cesare"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "565",
+            "title": "Amphitheatrum sapientiae aeternae",
+            "author": "Khunrath, Heinrich",
+            "year": 1609,
+            "place": "Hanau",
+            "publisher": "Antonius, Wilhelm",
+            "printer": null,
+            "shelf_mark": "A folio",
+            "ustc_sn": 2106102,
+            "_normTitle": "amphitheatrum sapientiae aeternae",
+            "_normAuthor": "khunrath heinrich"
+          },
+          "score": 5,
+          "titleShared": [
+            "amphitheatrum",
+            "aeternae"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        },
+        {
+          "bph": {
+            "ubn": "564",
+            "title": "Amphitheatrum sapientiae aeternae",
+            "author": "Khunrath, Heinrich",
+            "year": 1608,
+            "place": "Magdeburg|Hanau",
+            "publisher": "Braun, Levin",
+            "printer": "Antonius, Wilhelm",
+            "shelf_mark": "A folio",
+            "ustc_sn": 2106102,
+            "_normTitle": "amphitheatrum sapientiae aeternae",
+            "_normAuthor": "khunrath heinrich"
+          },
+          "score": 5,
+          "titleShared": [
+            "amphitheatrum",
+            "aeternae"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2580659",
+        "title": "Von der hermetischenn Philosophia das ist von dem gebenedeiten Stain der Weisen der hocherfahrnen und fürtrefflichen Philosophen Herren Bernhardi Graven von der Marck und Tervis ein Buch : item dicta Alani, darinn alles hell und klar an Tag geben wirdt ... ex libris doctoris Hernici Wolffii ...",
+        "author": "Bernardus",
+        "year": 1574,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2580659"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "22821",
+            "title": "Von der hermetischenn Philosophia, das ist, von dem gebenedeiten Stain der Weisen  Dicta Alani",
+            "author": "Bernhardus Trevisanus|[Alanus de Insulis]",
+            "year": 1574,
+            "place": "Strasburg",
+            "publisher": "Müller, Christian II",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 703334,
+            "_normTitle": "von der hermetischenn philosophia das ist von dem gebenedeiten stain der weisen dicta alani",
+            "_normAuthor": "bernhardus trevisanus alanus de insulis"
+          },
+          "score": 17,
+          "titleShared": [
+            "hermetischenn",
+            "philosophia",
+            "gebenedeiten",
+            "stain",
+            "weisen",
+            "dicta",
+            "alani"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "6494",
+            "title": "Von der hermetischenn Philosophia. Dicta Alani",
+            "author": "Bernhardus Trevisanus|[Alanus de Insulis]",
+            "year": 1582,
+            "place": "Strasburg",
+            "publisher": "Müller, heirs of Christian II",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 703334,
+            "_normTitle": "von der hermetischenn philosophia dicta alani",
+            "_normAuthor": "bernhardus trevisanus alanus de insulis"
+          },
+          "score": 9,
+          "titleShared": [
+            "hermetischenn",
+            "philosophia",
+            "dicta",
+            "alani"
+          ],
+          "authorShared": [],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2580882",
+        "title": "Wasserstein der Weysen, das ist ein chymisch Tractätlein, darin der Weg gezeiget, die Materia genennet und der Process beschrieben wird, zu dem hohen Geheymnuss der universal Tinctur zukommen vor disem niemalen gesehen ...",
+        "author": "Siebmacher, Johann",
+        "year": 1619,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2580882"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "15752",
+            "title": "Wasserstein der Weysen. Via veritatis",
+            "author": "[Siebmacher, Johann Ambrosius]|Meung, Jean de",
+            "year": 1619,
+            "place": "Frankfurt",
+            "publisher": "Jennis, Lukas",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "wasserstein der weysen via veritatis",
+            "_normAuthor": "siebmacher johann ambrosius meung jean de"
+          },
+          "score": 11,
+          "titleShared": [
+            "wasserstein",
+            "weysen"
+          ],
+          "authorShared": [
+            "siebmacher",
+            "johann"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "2581167",
+        "title": "Disquisitionis historicae &amp; theologicae de visionibus quae primis quatuor post Christi &amp; apostolorum excessum seculis, christianis quibusdam contigisse dicuntur, pars posterior",
+        "author": "Zimmermann, Johannes Jakob",
+        "year": 1738,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2581167"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2581257",
+        "title": "De triplici regione claustralium et spirituali exercitio monachorum ...",
+        "author": "Trithemius, Johannes",
+        "year": 1498,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2581257"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2581467",
+        "title": "The  displaying of supposed witchcraft ...",
+        "author": "Webster, John",
+        "year": 1677,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2581467"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2623923",
+        "title": "Unterhaltungen aus der Naturgeschichte / 3 Die  Amphibien",
+        "author": "Wilhelm, Gottlieb Tobias",
+        "year": 1794,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2623923"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2623925",
+        "title": "Unterhaltungen aus der Naturgeschichte / [Textband.]",
+        "author": "[s.n.]",
+        "year": 1792,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2623925"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2624281",
+        "title": "Unterhaltungen aus der Naturgeschichte / [Tafelband.]",
+        "author": "[s.n.]",
+        "year": 1792,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2624281"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2834337",
+        "title": "Sancti Ephraem Syri, patris et scriptoris ecclesiae antiquissimi et dignissimi, opera omnia quotquot in insignioribus Italiae bibliothecis, praecipue Romanis Graece inveniri potuerunt in tres tomos digesta",
+        "author": "Ephraem",
+        "year": 1616,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2834337"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2835281",
+        "title": "Origenis opera omnia et quae eius nomine circumferuntur",
+        "author": "Origenes",
+        "year": 1743,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2835281"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2835283",
+        "title": "Origenis opera omnia et quae eius nomine circumferuntur / Tomus primus.",
+        "author": "[s.n.]",
+        "year": 1743,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2835283"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2835828",
+        "title": "Origenis opera omnia et quae eius nomine circumferuntur / Tomus secundus.",
+        "author": "[s.n.]",
+        "year": 1743,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2835828"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2836526",
+        "title": "Origenis opera omnia et quae eius nomine circumferuntur / Tomus tertius.",
+        "author": "[s.n.]",
+        "year": 1743,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2836526"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2840942",
+        "title": "Divi Caecilii Cypriani episcopi Carthaginensis et martyris opera iam quartum accuratiori vigilantia a mendis repurgata, per Desiderium Erasmum Roterodamum : accessit liber eiusdem apprime pius ad Fortunatum de duplici martyrio, antehac nunquam excusus",
+        "author": "Cyprianus, Thascius Caecilius",
+        "year": 1540,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2840942"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2841544",
+        "title": "Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus illustrantur, tomus primus, in quo universus sancti textus, et Georgii Pachymerae paraphrasis Graece et Latine, cum adnotationibus Balt. Corderii... continentur, omnia studio ... eiusdem Balthasaris Corderii ... tomus II, in quo S. Maximi scholia, Pachymerae paraphrasis in epistolas, et authores varii qui aut vitam S. Dionysii descripserunt, aut dignitatem ipsius areopagiticam asseruerunt, continentur, opera ... Petri Lansselii et Balthasaris Corderii : accessit nunc primum Areopagitae defensio adversus haereticum calvinistam, per... D. Ioannem de Chaumont",
+        "author": "Dionysius",
+        "year": 1644,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2841544"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2841546",
+        "title": "Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus illustrantur, tomus primus, in quo universus sancti textus, et Georgii Pachymerae paraphrasis Graece et Latine, cum adnotationibus Balt. Corderii... continentur, omnia studio ... eiusdem Balthasaris Corderii ... tomus II, in quo S. Maximi scholia, Pachymerae paraphrasis in epistolas, et authores varii qui aut vitam S. Dionysii descripserunt, aut dignitatem ipsius areopagiticam asseruerunt, continentur, opera ... Petri Lansselii et Balthasaris Corderii : accessit nunc primum Areopagitae defensio adversus haereticum calvinistam, per... D. Ioannem de Chaumont / Tomus primus.",
+        "author": "[s.n.]",
+        "year": 1644,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2841546"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2842318",
+        "title": "Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus illustrantur, tomus primus, in quo universus sancti textus, et Georgii Pachymerae paraphrasis Graece et Latine, cum adnotationibus Balt. Corderii... continentur, omnia studio ... eiusdem Balthasaris Corderii ... tomus II, in quo S. Maximi scholia, Pachymerae paraphrasis in epistolas, et authores varii qui aut vitam S. Dionysii descripserunt, aut dignitatem ipsius areopagiticam asseruerunt, continentur, opera ... Petri Lansselii et Balthasaris Corderii : accessit nunc primum Areopagitae defensio adversus haereticum calvinistam, per... D. Ioannem de Chaumont / Tomus II.",
+        "author": "[s.n.]",
+        "year": 1644,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2842318"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2843210",
+        "title": "Origenis Adamantii, eximii scripturarum interpretis, opera, quae quidem extant omnia, per ... Erasmum Roterodamum partim versa, &amp; vigilanter recognita, partim ab aliis ... translata ... cum praefatione de vita, phrasi, docendi ratione, &amp; operibus illius: adiectis epistola Beati Rhenani nuncupatoria, quae pleraque de vita obituque ipsius Erasmi cognitu digna continet: tum indice copiosissimo",
+        "author": "Origenes",
+        "year": 1557,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2843210"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2847304",
+        "title": "Saducismus triumphatus or full and plain evidence concerning witches and apparitions. In two parts. The first treating of their possibility. The second of their real existence : the advantages whereof above the former, the reader may understand out of H. More's account prefixed thereunto ... : with two authentick, but wonderful stories of certain swedish witches ...",
+        "author": "Glanvill, Joseph",
+        "year": 1682,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2847304"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2848084",
+        "title": "Divi Eucherii episcopi Lugdunensis commentarii in genesim, &amp; in libros regum ...",
+        "author": "Eucherius Lugdunensis",
+        "year": 1564,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2848084"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2848502",
+        "title": "D. Aurelii Augustini Hipponensis episcopi liber de haeresibus, ad Quodvultdeum : accessit operi quadruplex index ... In calce operis addita est arbor hæreseon ... ; additus est præterea tractatus de ecclesia ...",
+        "author": "Augustinus, Aurelius",
+        "year": 1576,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2848502"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2849222",
+        "title": "Opera Dionysii veteris et nove translationis etiam novissime ipsius Marsilii Ficini cum commentariis Hugonis, Alberti, Thome, Ambrosii oratoris Linconiensis et Vercellensis. Veteris translationis. De celesti hierarchia cum commento Hugonis et Alberti. De ecclesiastica hierarchia. De divinis nominibus cum commento beati Thome. De mystica theologia. Undecim epistole Dionysii. Extractio Vercellensis super predictos quattuor libros et super epistolam ad Titum. Nove translationis. De celesti hierarchia cum scholiis sive commento Ambrosii oratoris. De ecclesiastica hierarchia cum commento Ambrosii. De divinis nominibus cum commento Ambrosii oratoris. De mystica theologia cum commento Ambrosii. ... Novissime translationis Marsilii. De mystica theologia cum commento Marsilii Ficini. De divinis nominibus cum commento Marsilii Ficini ...",
+        "author": "Albertus",
+        "year": 1502,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2849222"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2868823",
+        "title": "Sancti Iustini philosophi et martyris opera : Graecus textus multis in locis correctus et Latina Ioannis Langi versio passim emendata: tum varians lectio, emendationum coniecturae, et res Indices seorsim in fine additi. Ab initio praemissa veterum de Iustino elogia, ordinis et censurae ratio .... Athenagorae Atheniensis philosophi christiani apologia vel legatio pro christianis. eiusdem de resurrectione mortuorum. Theophili patriarchae Antiocheni contra christianae religionis calumniatores ad autolycum libri tres. Tatiani Affyrii oratio ad Graecos, quod nihil eorum quibus Graeci gloriantur studiorum apud ipsos natum, sed omnia a barbaris inventa sint. Hermiae philosophi gentilium philosophorum irrisio",
+        "author": "Iustinus",
+        "year": 1615,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2868823"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2869717",
+        "title": "Missale Constantiense ad Romani formam &amp; normam revocatum, atque a ... Clemente VIII. approbatum ... Ioan. Georgii, episcopi Constantiensis, &amp; domini Augiae Maioris, &amp;c. auctoritate &amp; iussu editum",
+        "author": "[s.n.]",
+        "year": 1603,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2869717"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "2870409",
+        "title": "Meditationes divi Augustini episcopi Hipponenis ... Soliloquia animae ad deum ... Manuale ... Enchiridion de fide, spe et caritate ... De triplici habitaculo ... Scala paradisi ... De duodecim abusionum gradibus ... De beata vita ... De assumptione beatae Mariae virginis ... De divinatione daemonum ... De honestate mulierum ... De cura agenda pro mortuis ... De vera et falsa poenitentia ... De cordis contritione ... De contemptu mundi ... De convenientia decem preceptorum ... De cognitione verae vitae ... Confessiones ... De doctrina christiana ... De fide ad Petrum ... De vita et moribus clericorum ... De vera religione ...",
+        "author": "Augustinus, Aurelius",
+        "year": 1484,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/2870409"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3178659",
+        "title": "Recueil précieux de la maçonnerie adonhiramite ...",
+        "author": "Guillemain de Saint-Victor, Louis",
+        "year": 1786,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3178659"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "18471",
+            "title": "Recueil précieux de la maçonnerie adonhiramite",
+            "author": "[Guillemain de Saint-Victor, Louis]",
+            "year": 1786,
+            "place": "[Paris]  \"Philadelphie\"",
+            "publisher": "Philarethe",
+            "printer": null,
+            "shelf_mark": "Rv",
+            "ustc_sn": null,
+            "_normTitle": "recueil precieux de la maconnerie adonhiramite",
+            "_normAuthor": "guillemain de saint victor louis"
+          },
+          "score": 19,
+          "titleShared": [
+            "recueil",
+            "precieux",
+            "maconnerie",
+            "adonhiramite"
+          ],
+          "authorShared": [
+            "guillemain",
+            "saint",
+            "victor",
+            "louis"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "12038",
+            "title": "Recueil précieux de la maçonnerie adonhiramite",
+            "author": "[Guillemain de Saint-Victor, Louis]",
+            "year": 1787,
+            "place": "[Paris]  \"Philadelphie\"",
+            "publisher": "Philarethe",
+            "printer": null,
+            "shelf_mark": "Rv",
+            "ustc_sn": null,
+            "_normTitle": "recueil precieux de la maconnerie adonhiramite",
+            "_normAuthor": "guillemain de saint victor louis"
+          },
+          "score": 18,
+          "titleShared": [
+            "recueil",
+            "precieux",
+            "maconnerie",
+            "adonhiramite"
+          ],
+          "authorShared": [
+            "guillemain",
+            "saint",
+            "victor",
+            "louis"
+          ],
+          "yearScore": 2
+        },
+        {
+          "bph": {
+            "ubn": "17116",
+            "title": "Recueil précieux de la maçonnerie adonhiramite",
+            "author": "[Guillemain de Saint-Victor, Louis]",
+            "year": 1789,
+            "place": "[Paris] \"Philadelphie\"",
+            "publisher": null,
+            "printer": null,
+            "shelf_mark": "Rv",
+            "ustc_sn": null,
+            "_normTitle": "recueil precieux de la maconnerie adonhiramite",
+            "_normAuthor": "guillemain de saint victor louis"
+          },
+          "score": 17,
+          "titleShared": [
+            "recueil",
+            "precieux",
+            "maconnerie",
+            "adonhiramite"
+          ],
+          "authorShared": [
+            "guillemain",
+            "saint",
+            "victor",
+            "louis"
+          ],
+          "yearScore": 1
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "3179095",
+        "title": "Georgii Riplaei ... chymische Schrifften : darinnen vom dem gebenedeyten Stein der Weisen und desselben kunstreichen Praeparation gründlich gehandelt wird ...",
+        "author": "Riplaeus, Georgius",
+        "year": 1717,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3179095"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3179210",
+        "title": "Artephii, des uhralten Philosophi, geheimer Haupt-Schlüssel zu dem verborgenen Stein der Weisen",
+        "author": "Artephius",
+        "year": 1717,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3179210"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3179266",
+        "title": "Das eröffnete philosophische Vatter-Hertz an seinen Sohn, welches er, wegen hohen Alters, nicht länger wolte vor ihm verschlossen halten, sondern zeigete und erklärte demselben alle das, was zu der völligen Composition und Bereitung des Steins der Weisen vonnöthen war ...",
+        "author": "[s.n.]",
+        "year": 1717,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3179266"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3179372",
+        "title": "Rosarium philosophorum. Secunda pars alchimiae de lapide philosophico vero modo praeparando, continens exactam eius scientiae progressionem. Cum figuris rei perfectionem ostendentibus",
+        "author": "[s.n.]",
+        "year": 1550,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3179372"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "22827",
+            "title": "Rosarium philosophorum",
+            "author": null,
+            "year": 1550,
+            "place": "Frankfurt",
+            "publisher": null,
+            "printer": "Jacob, Cyriacus",
+            "shelf_mark": "A",
+            "ustc_sn": 800925,
+            "_normTitle": "rosarium philosophorum",
+            "_normAuthor": ""
+          },
+          "score": 7,
+          "titleShared": [
+            "rosarium",
+            "philosophorum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "3259145",
+        "title": "Sibylliakoi Chrēsmoi ... = : Sibyllina oracula ex veteribus codicibus emendata, ac restituta et commentariis diversorum illustrata",
+        "author": "Opsopäus, Johannes",
+        "year": 1689,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3259145"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3260134",
+        "title": "A  Suggestive Inquiry into the Hermetic Mystery : with a Dissertation on the more Celebrated of the Alchemical Philosophers ...",
+        "author": "Atwood, Mary Anne",
+        "year": 1920,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3260134"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "13799",
+            "title": "A suggestive inquiry into the hermetic mystery with a dissertation on the more celebrated of the alchemical philosophers being an attempt towards the recovery of the ancient experiment of nature",
+            "author": "Atwood, Mary Anne",
+            "year": 1920,
+            "place": "Belfast",
+            "publisher": null,
+            "printer": null,
+            "shelf_mark": "Alch  A|IX",
+            "ustc_sn": null,
+            "_normTitle": "suggestive inquiry into the hermetic mystery with a dissertation on the more celebrated of the alchemical philosophers being an attempt towards the recovery of the ancient experiment of nature",
+            "_normAuthor": "atwood mary anne"
+          },
+          "score": 25,
+          "titleShared": [
+            "suggestive",
+            "inquiry",
+            "hermetic",
+            "mystery",
+            "dissertation",
+            "celebrated",
+            "alchemical",
+            "philosophers"
+          ],
+          "authorShared": [
+            "atwood",
+            "mary",
+            "anne"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "13801",
+            "title": "A suggestive inquiry into the hermetic mystery with a dissertation on the more celebrated of the alchemical philosophers being an attempt towards the recovery of the ancient experiment of nature",
+            "author": "Atwood, Mary Anne",
+            "year": 1918,
+            "place": "Belfast",
+            "publisher": null,
+            "printer": null,
+            "shelf_mark": "Alch A|IX",
+            "ustc_sn": null,
+            "_normTitle": "suggestive inquiry into the hermetic mystery with a dissertation on the more celebrated of the alchemical philosophers being an attempt towards the recovery of the ancient experiment of nature",
+            "_normAuthor": "atwood mary anne"
+          },
+          "score": 24,
+          "titleShared": [
+            "suggestive",
+            "inquiry",
+            "hermetic",
+            "mystery",
+            "dissertation",
+            "celebrated",
+            "alchemical",
+            "philosophers"
+          ],
+          "authorShared": [
+            "atwood",
+            "mary",
+            "anne"
+          ],
+          "yearScore": 2
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "3260848",
+        "title": "Johannis Ticinensis, eines böhmischen Priesters Anthonii de Abbatia, eines in der Kunst erfahrnen Mönchs und Edoardi Kellaei eines welt-berühmten Engeländers vortreffliche und aussführliche chymische Bücher ...",
+        "author": "Tetzen, Johann von",
+        "year": 1691,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3260848"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3261015",
+        "title": "XL. questions concerning the soule",
+        "author": "Walther, Balthasar",
+        "year": 1647,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3261015"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3261245",
+        "title": "Variorum in Europa itinerum deliciae : seu, ex variis manu-scriptis selectiora tantum inscriptionum maxime recentium monumenta : quibus passim in Italia et Germania, Helvetia et Bohemia ... : templa, arae, scholae, bibliothecae ... &amp;c. conspicua sunt",
+        "author": "Chyträus, Nathan",
+        "year": 1599,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3261245"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3261933",
+        "title": "Ioannis Danielis Mylii ... Philosophia reformata : continens libros binos. I. Liber in septem partes divisus est. ... II. Liber continet authoritates Philosophorum",
+        "author": "Mylius Johann Daniel",
+        "year": 1622,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3261933"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3262728",
+        "title": "Geheime Unterredungen zwischen zweyen vertrauten Freunden, einem Theologo philosophizante und Philosopho theologizante, von Magia naturali, deren Ursprung und Principiis, wo bewiesen wird, dass dieselbe eine natürliche, nützliche und zulässige Wissenschafft sey",
+        "author": "[s.n.]",
+        "year": 1722,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3262728"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3262927",
+        "title": "Jakob Lupius ... Grosses und sonderbares Traumbuch, darinnen die nächtlichen Gesichte und Träume der Menschen nicht allein nach den Grundsätzen der uralten berühmten Araber, Egyptier, und anderer Rabbinen deutlich erkläret und ausgeleget, sondern auch mit den fleissigen und langwierigen Observationen des Apomasaris, Cardani, Artemidori, Serenii und anderer grossen Weltweisen bestätiget worden",
+        "author": "Lupius, Jakob",
+        "year": 1763,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3262927"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3263194",
+        "title": "Curieuse und ganz neue Art zu Punctiren",
+        "author": "[s.n.]",
+        "year": 1754,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3263194"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3263300",
+        "title": "Fasciculus unterschiedlicher alten raren und wahren philosophischen Schrifften vom Stein der Weisen ...",
+        "author": "Hellwig, Christoph von",
+        "year": 1719,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3263300"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "4853",
+            "title": "Fasciculus unterschiedlicher alten raren und wahren philosophischen Schrifften",
+            "author": "Hellwig, Christoph von",
+            "year": 1719,
+            "place": "Leipzig  Bremen",
+            "publisher": "Grimm, Johann Andreas",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": null,
+            "_normTitle": "fasciculus unterschiedlicher alten raren und wahren philosophischen schrifften",
+            "_normAuthor": "hellwig christoph von"
+          },
+          "score": 21,
+          "titleShared": [
+            "fasciculus",
+            "unterschiedlicher",
+            "alten",
+            "raren",
+            "wahren",
+            "philosophischen",
+            "schrifften"
+          ],
+          "authorShared": [
+            "hellwig",
+            "christoph"
+          ],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "3303197",
+        "title": "Pedanii Dioscoridis ... de medica materia libri sex ... : his accessit, praeter pharmacorum simplicium catalogum, copiosus omnium ferme medelarum sive curationum index",
+        "author": "Dioscorides",
+        "year": 1554,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3303197"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3303914",
+        "title": "Complementum artis exorcisticae. Cui simile numquam visum est: cum litaniis, benedictionibus, &amp; doctrinis novis, exorcismis efficacissimis, ac remediis copiosis in maleficiatis expertis",
+        "author": "Visconti, Zaccaria",
+        "year": 1618,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3303914"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3304392",
+        "title": "Ge. Henr. Nievpoort ... Rituum qui olim apud Romanos obtinuerunt succincta explicatio ad intelligentiam veterum auctorum facili methodo conscripta : accedunt ... Ioanne Matthiae Gesneri prolusio. atque Caroli Ferdinandi Hommelii de tribunali praetoris liber singularis",
+        "author": "Nieupoort, Guillaume Henri",
+        "year": 1784,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3304392"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3305017",
+        "title": "Mundus Symbolicus, in emblematum universitate formatus, explicatus, et tam sacris, quam profanis eruditionibus ac sententiis illustratus",
+        "author": "Picinelli, Filippo",
+        "year": 1681,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3305017"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3331183",
+        "title": "Malleus maleficarum",
+        "author": "Sprenger, Jakob",
+        "year": 1511,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3331183"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3331759",
+        "title": "M. Tullii Ciceronis opera omnia, praeter hactenus vulgatam Dionysii Lambini editionem ; accesserunt D. Gothofredi,... note",
+        "author": "Cicero, Marcus Tullius",
+        "year": 1588,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3331759"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3333261",
+        "title": "L' histoire du monde de C. Pline second ...",
+        "author": "Plinius Caecilius Secundus, Gaius",
+        "year": 1625,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3333261"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3334867",
+        "title": "Sanctarum autoritatum veterum catholicae ecclesiae patrum libri quatuor. In usum omnium pietatis amantium ... : quibus accessit breve evangeliorum monotessaron",
+        "author": "Bonaventura",
+        "year": 1559,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3334867"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3335469",
+        "title": "Q. Septimii Florentis Tertulliani Carthaginiensis presbyteri, Opera quae hactenus reperiri potuerunt omnia : Iam postremum, ad exemplaria manuscripta collatione facta, quam accuratiss. recognita, aliquot etiam libris auctiora nunc primum in capita, &amp; certo ordine, habita quantum fieri potuit temporum ratione, in quinque tomos distincta. : Cum Jacobi Pamelii ... argumentis &amp; adnotationibus toti operi interiectis, quibus tum loci obscuriores explicantur, tum quicquid ad antiquitatem ecclesiasticam spectat, illustratur. Ab eodem Pamelio recens adiecta Tertulliani vita, scripturarum citatarum index locupletiss. aliaque prolegomena. : Accessere &amp; loci ex coniectura Latini Latinii Viterbiensis restituti, &amp; erudita in lib. De Pallio Joannis Mercerii antecessoris Bituricensis commentaria. Catalogum totius operis inveniet lector post epistolas dedicatorias, &amp; in singulis tomis praefatiunculas de librorum ordine",
+        "author": "Tertullianus, Quintus Septimius Florens",
+        "year": 1608,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3335469"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3464221",
+        "title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses",
+        "author": "Picart, Bernard",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3464221"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3464223",
+        "title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses / [Volume I.]",
+        "author": "[s.n.]",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3464223"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3465080",
+        "title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses / [Volume II.]",
+        "author": "[s.n.]",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3465080"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3465906",
+        "title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses / [Volume III.]",
+        "author": "[s.n.]",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3465906"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3472441",
+        "title": "Cérémonies et coutumes religieuses des peuples idolatres : avec une explication historique, &amp; quelques dissertations curieuses",
+        "author": "Picard, Bernard",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3472441"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3472443",
+        "title": "Cérémonies et coutumes religieuses des peuples idolatres : avec une explication historique, &amp; quelques dissertations curieuses / Tome premier.",
+        "author": "[s.n.]",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3472443"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3472963",
+        "title": "Cérémonies et coutumes religieuses des peuples idolatres : avec une explication historique, &amp; quelques dissertations curieuses / Tome second.",
+        "author": "[s.n.]",
+        "year": 1723,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3472963"
+      },
+      "matches": []
+    },
+    {
+      "jung": {
+        "erara_id": "3476871",
+        "title": "Superstitions anciennes et modernes, préjugés vulgaires qui ont induit les peuples à des usages &amp; à des pratiques contraires à la religion",
+        "author": "Le Brun, Pierre",
+        "year": 1733,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/3476871"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "22967",
+            "title": "Superstitions anciennes et modernes",
+            "author": "[Picard, Bernhard]",
+            "year": 1733,
+            "place": "Amsterdam",
+            "publisher": "Bernard, Jean Frédéric",
+            "printer": null,
+            "shelf_mark": "E folio",
+            "ustc_sn": null,
+            "_normTitle": "superstitions anciennes et modernes",
+            "_normAuthor": "picard bernhard"
+          },
+          "score": 9,
+          "titleShared": [
+            "superstitions",
+            "anciennes",
+            "modernes"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "5582889",
+        "title": "Musaeum hermeticum reformatum et amplificatum, omnes sopho-spagyricae artis discipulos fidelissime erudiens, quo pacto summa illa veraque lapidis philosophici medicina, qua res omnes qualemcunque defectum patientes, instaurantur, inveniri &amp; haberi queat : continens tractatus chimicos XXI. Praestantissimos, quorum nomina &amp; seriem versa pagella indicabit; in gratiam filiorum doctrinae, quibus Germanicum idioma ignotum est, Latina lingua ornatum",
+        "author": "[s.n.]",
+        "year": 1678,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/5582889"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "9452",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 11,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "9453",
+            "title": "Musaeum hermeticum reformatum et amplificatum",
+            "author": "anonymous",
+            "year": 1678,
+            "place": "Frankfurt",
+            "publisher": "Sand, Hermann von",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 2566621,
+            "_normTitle": "musaeum hermeticum reformatum et amplificatum",
+            "_normAuthor": "anonymous"
+          },
+          "score": 11,
+          "titleShared": [
+            "musaeum",
+            "hermeticum",
+            "reformatum",
+            "amplificatum"
+          ],
+          "authorShared": [],
+          "yearScore": 3
+        }
+      ]
+    },
+    {
+      "jung": {
+        "erara_id": "10335151",
+        "title": "Aureum vellus oder Guldin Schatz und Kunstkammer: darinnen der aller fürnemisten ... Auctorum Schrifften und Bücher auss dem gar uralten Schatz der uberblibnen verborgnen ... Reliquien und Monumenten der Aegyptiorum, Arabum, Chaldaeorum &amp; Assyriorum Königen und Weysen",
+        "author": "Trismosin, Salomon",
+        "year": 1598,
+        "source_url": "https://www.e-rara.ch/content/titleinfo/10335151"
+      },
+      "matches": [
+        {
+          "bph": {
+            "ubn": "1205",
+            "title": "Aureum vellus oder guldin Schatz und Kunstkammer",
+            "author": "Trissmosin, Salomon",
+            "year": 1598,
+            "place": "Rorschach",
+            "publisher": "n.n.",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 614838,
+            "_normTitle": "aureum vellus oder guldin schatz und kunstkammer",
+            "_normAuthor": "trissmosin salomon"
+          },
+          "score": 15,
+          "titleShared": [
+            "aureum",
+            "vellus",
+            "guldin",
+            "schatz",
+            "kunstkammer"
+          ],
+          "authorShared": [
+            "salomon"
+          ],
+          "yearScore": 3
+        },
+        {
+          "bph": {
+            "ubn": "1203",
+            "title": "Aureum vellus, oder güldin Schatz und Kunstkammer",
+            "author": "Trissmosin, Salomon",
+            "year": 1599,
+            "place": "[Leipzig]",
+            "publisher": "[Grosse, Henning I]",
+            "printer": null,
+            "shelf_mark": "A",
+            "ustc_sn": 614110,
+            "_normTitle": "aureum vellus oder guldin schatz und kunstkammer",
+            "_normAuthor": "trissmosin salomon"
+          },
+          "score": 14,
+          "titleShared": [
+            "aureum",
+            "vellus",
+            "guldin",
+            "schatz",
+            "kunstkammer"
+          ],
+          "authorShared": [
+            "salomon"
+          ],
+          "yearScore": 2
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/docs/jung-bph-alignment-2026-05-22.md
+++ b/.claude/docs/jung-bph-alignment-2026-05-22.md
@@ -1,0 +1,216 @@
+# Jung Küsnacht ↔ BPH alignment (2026-05-22)
+
+Of the **345** works in Jung's personal library at Küsnacht (e-rara OAI set `cgj` — held by Stiftung der Werke von C.G. Jung, Zürich), which also exist in the BPH catalogue?
+
+Match heuristic: shared significant words in title + author surname overlap + year proximity (≤10 years). Highest-scoring BPH candidate shown per Jung title.
+
+## Summary
+
+- Jung works: **345**
+- Also present in BPH (candidate match): **151**
+- Jung-only (no BPH match found): 194
+
+Coverage: **43.8%** of Jung's Küsnacht library is also bibliographically represented in BPH.
+
+## Works present in both libraries (151)
+
+| Year | Author | Jung title (Küsnacht) | BPH match (UBN / title) | Score |
+|---|---|---|---|--:|
+| 1503 | Petrus | Hexastichon Sebastiani Brant in memorabiles evangelistarum f | [6532](https://bph.sourcelibrary.org/catalog/6532) Hexastichon Sebastiani Brant in memorabiles evange | 16 |
+| 1519 | Panteo, Giovanni Agostino | Ars transmutationis metallicae cum Leonis X. pontificis maxi | [1010](https://bph.sourcelibrary.org/catalog/1010) Ars transmutationis metallicae | 10 |
+| 1546 | Lacinius, Janus | Pretiosa margarita novella de thesauro, ac pretiosissimo phi | [11617](https://bph.sourcelibrary.org/catalog/11617) Pretiosa margarita novella de thesauro, ac pretios | 17 |
+| 1547 | Postel, Guillaume | De nativitate mediatoris ultima, nunc futura, et toti orbi t | [22898](https://bph.sourcelibrary.org/catalog/22898) De nativitate mediatoris ultima | 13 |
+| 1548 | Bracesco, Giovanni | De alchemia dialogi II. quorum prior, genuinam librorum Gebr | [241](https://bph.sourcelibrary.org/catalog/241) De alchemia dialogi duo. Sententia. Lignum vitae | 11 |
+| 1550 | [s.n.] | De alchimia opuscula complura veterum philosophorum, quorum  | [363](https://bph.sourcelibrary.org/catalog/363) De alchimia opuscula complura | 9 |
+| 1550 | [s.n.] | Rosarium philosophorum. Secunda pars alchimiae de lapide phi | [22827](https://bph.sourcelibrary.org/catalog/22827) Rosarium philosophorum | 7 |
+| 1557 | Pico della Mirandola, Giovanni | Opera omnia Ioannis Pici, Mirandulae concordiaeque comitis,  | [10528](https://bph.sourcelibrary.org/catalog/10528) Opera omnia quae extant | 7 |
+| 1560 | Hortulanus | Compendium alchimiae Ioannis Garlandii Angli philosophi doct | [3039](https://bph.sourcelibrary.org/catalog/3039) Compendium alchimiae | 7 |
+| 1560 | Peucer, Kaspar | Commentarius de praecipuis generibus divinationum, in quo a  | [2994](https://bph.sourcelibrary.org/catalog/2994) Commentarius de praecipuis generibus divinationum | 13 |
+| 1566 | Hermes | Ars chemica, quod sit licita recte exercentibus, probationes | [997](https://bph.sourcelibrary.org/catalog/997) Ars chemica. Septem tractatus. Tabula smaragdina.  | 27 |
+| 1574 | Thurneysser zum Thurn, Leonhar | Quinta essentia, das ist, die höchste Subtilitet, Krafft und | [11915](https://bph.sourcelibrary.org/catalog/11915) Quinta essentia das ist die höchste Subtilitet, Kr | 13 |
+| 1574 | Bernardus | Von der hermetischenn Philosophia das ist von dem gebenedeit | [22821](https://bph.sourcelibrary.org/catalog/22821) Von der hermetischenn Philosophia, das ist, von de | 17 |
+| 1588 | Reusner, Hieronymus | Pandora, das ist die edlest Gab Gottes oder der werde und he | [10782](https://bph.sourcelibrary.org/catalog/10782) Pandora: das ist, die edlest Gab Gottes | 13 |
+| 1589 | Huser, Johannes | Erster [- zehender] Theil der Bücher und Schrifften des edle | [2056](https://bph.sourcelibrary.org/catalog/2056) Erster (-zehender) Theil der Bücher und Schrifften | 13 |
+| 1589 | [s.n.] | Erster [- zehender] Theil der Bücher und Schrifften des edle | [2056](https://bph.sourcelibrary.org/catalog/2056) Erster (-zehender) Theil der Bücher und Schrifften | 13 |
+| 1589 | [s.n.] | Erster [- zehender] Theil der Bücher und Schrifften des edle | [2056](https://bph.sourcelibrary.org/catalog/2056) Erster (-zehender) Theil der Bücher und Schrifften | 13 |
+| 1593 | [s.n.] | Artis auriferae quam chemiam vocant, volumen primum [- secun | [1051](https://bph.sourcelibrary.org/catalog/1051) Artis auriferae, quam chemiam vocant, volumen priu | 15 |
+| 1597 | Khunrath, Heinrich | Von hylealischen das ist pri-materialischen catholischen ode | [6914](https://bph.sourcelibrary.org/catalog/6914) Von hylealischen, das ist, Pri-materialischen cath | 19 |
+| 1598 | Perera, Benet | De magia. De observatione somniorum, et de divinatione astro | [8688](https://bph.sourcelibrary.org/catalog/8688) De magia. De observatione somniorum et de divinati | 15 |
+| 1598 | Trismosin, Salomon | Aureum vellus oder Guldin Schatz und Kunstkammer: darinnen d | [1205](https://bph.sourcelibrary.org/catalog/1205) Aureum vellus oder guldin Schatz und Kunstkammer | 15 |
+| 1599 | Nazari, Giovanni Battista | Della tramutatione metallica sogni tre : nel primo de quali  | [14668](https://bph.sourcelibrary.org/catalog/14668) Della tramutatione metallica sogni tre | 17 |
+| 1600 | Trismosin, Salomon | Aurei Velleris oder der güldin Schatz und Kunstkammer. Tract | [1187](https://bph.sourcelibrary.org/catalog/1187) Aurei velleris oder der güldin Schatz und Kunstkam | 17 |
+| 1600 | Béroalde de Verville, François | Le  tableau des riches inventions couvertes du voile des fei | [13977](https://bph.sourcelibrary.org/catalog/13977) Le tableau des riches inventions qui sont represen | 15 |
+| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14138](https://bph.sourcelibrary.org/catalog/14138) Theatrum chemicum | 7 |
+| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14138](https://bph.sourcelibrary.org/catalog/14138) Theatrum chemicum | 7 |
+| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14138](https://bph.sourcelibrary.org/catalog/14138) Theatrum chemicum | 7 |
+| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14138](https://bph.sourcelibrary.org/catalog/14138) Theatrum chemicum | 7 |
+| 1607 | Opsopäus, Johannes | Oracula magica Zoroastris cum scholiis Plethonis et Pselli n | [10628](https://bph.sourcelibrary.org/catalog/10628) Oracula magica | 7 |
+| 1607 | Opsopäus, Johannes | Oracula metrica Iovis, Apollinis, Hecates, Serapidis, et ali | [21283](https://bph.sourcelibrary.org/catalog/21283) Oracula metrica Jovis, Apollonis, Hecates, Serapid | 13 |
+| 1608 | Meisner, Lorenz | Gemma gemmarum alchimistarum oder Erleuterung der parabolisc | [5383](https://bph.sourcelibrary.org/catalog/5383) Gemma gemmarum alchimistarum. Oder Erleuterung der | 27 |
+| 1608 | [s.n.] | Gemma gemmarum alchimistarum oder Erleuterung der parabolisc | [5383](https://bph.sourcelibrary.org/catalog/5383) Gemma gemmarum alchimistarum. Oder Erleuterung der | 25 |
+| 1608 | [s.n.] | Gemma gemmarum alchimistarum oder Erleuterung der parabolisc | [5383](https://bph.sourcelibrary.org/catalog/5383) Gemma gemmarum alchimistarum. Oder Erleuterung der | 25 |
+| 1608 | Reinhart, Hans Christoph | Das  Valete: uber den Tractat der Arcanorum Basilii Valentin | [15151](https://bph.sourcelibrary.org/catalog/15151) Das Valete: Uber den Tractat der Arcanorum Basilii | 15 |
+| 1608 | Figulus, Benedictus | Rosarium novum olympicum et benedictum ... | [12383](https://bph.sourcelibrary.org/catalog/12383) Rosarium novum olympicum et benedictum. Das ist: e | 15 |
+| 1609 | Khunrath, Heinrich | Amphitheatrum sapientiae aeternae, solius verae, christiano- | [565](https://bph.sourcelibrary.org/catalog/565) Amphitheatrum sapientiae aeternae | 13 |
+| 1611 | Thölde, Johann | Triumph Wagen Antimonii fratris Basilii Valentini ... allen  | [14801](https://bph.sourcelibrary.org/catalog/14801) Triumph Wagen antimonii | 9 |
+| 1612 | Ruland, Martin | Lexicon alchemiae sive dictionarium alchemisticum, cum obscu | [8293](https://bph.sourcelibrary.org/catalog/8293) Lexicon alchemiae | 11 |
+| 1612 | Artephius | Trois traitez de la philosophie naturelle non encore imprime | [14826](https://bph.sourcelibrary.org/catalog/14826) Trois traitez de la philosophie naturelle. De l'ar | 21 |
+| 1613 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14139](https://bph.sourcelibrary.org/catalog/14139) Theatrum chemicum | 7 |
+| 1613 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14139](https://bph.sourcelibrary.org/catalog/14139) Theatrum chemicum | 7 |
+| 1613 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14139](https://bph.sourcelibrary.org/catalog/14139) Theatrum chemicum | 7 |
+| 1614 | Maier, Michael | Arcana arcanissima hoc est hieroglyphica Aegyptio-Graeca, vu | [918](https://bph.sourcelibrary.org/catalog/918) Arcana arcanissima hoc est hieroglyphica Aegyptio- | 17 |
+| 1615 | Boissard, Jean Jacques | Tractatus posthumus Jani Jacobi Boissardi ... De divinatione | [14571](https://bph.sourcelibrary.org/catalog/14571) Tractatus posthumus, sive Ulysses. Una cum annexis | 5 |
+| 1615 | Vanini, Giulio Cesare | Amphitheatrum aeternae providentiae divino-magicum, christia | [563](https://bph.sourcelibrary.org/catalog/563) Amphitheatrum aeternae providentiae divino-magicum | 19 |
+| 1616 | Maier, Michael | Lusus serius, quo Hermes sive Mercurius rex mundanorum omniu | [8640](https://bph.sourcelibrary.org/catalog/8640) Lusus serius | 11 |
+| 1616 | Maier, Michael | De circulo physico, quadrato hoc est, auro, eiusque virtute  | [23359](https://bph.sourcelibrary.org/catalog/23359) De circulo physico, quadrato: hoc est, auro, eius  | 17 |
+| 1617 | Fludd, Robert | Utriusque cosmi maioris scilicet et minoris metaphysica, phy | [15137](https://bph.sourcelibrary.org/catalog/15137) Utriusque cosmi maioris scilicet minoris metaphysi | 27 |
+| 1617 | Maier, Michael | Atalanta fugiens, hoc est, emblemata nova de secretis natura | [1112](https://bph.sourcelibrary.org/catalog/1112) Atalanta fugiens | 10 |
+| 1617 | Maier, Michael | Symbola aureae mensae duodecim nationum. Hoc est, Hermaea se | [13870](https://bph.sourcelibrary.org/catalog/13870) Symbola aureae mensae duodecim nationum | 17 |
+| 1617 | Fludd, Robert | Tractatus theologo-philosophicus, in libros tres distributus | [14577](https://bph.sourcelibrary.org/catalog/14577) Tractatus theologo-philosophicus | 13 |
+| 1618 | Maier, Michael | Themis Aurea, das ist von den Gesetzen und Ordnungen der löb | [14153](https://bph.sourcelibrary.org/catalog/14153) Themis aurea, das ist, von den Gesetzen, und Ordnu | 19 |
+| 1619 | Siebmacher, Johann | Wasserstein der Weysen, das ist ein chymisch Tractätlein, da | [15752](https://bph.sourcelibrary.org/catalog/15752) Wasserstein der Weysen. Via veritatis | 11 |
+| 1620 | Mögling, Daniel | Prodromus Rhodo-Stauroticus, Parergi philosophici. Das ist:  | [11687](https://bph.sourcelibrary.org/catalog/11687) Prodromus rhodo-stauroticus, parergi philosophici. | 35 |
+| 1620 | Nuisement, Clovis Hesteau | Poème philosophic de la verité de la phisique mineralle ... | [11436](https://bph.sourcelibrary.org/catalog/11436) Poeme philosophic de la verite de la phisique mine | 13 |
+| 1623 | Caussin, Nicolas | De symbolica Aegyptiorum sapientia : in qua symbola, parabol | [13882](https://bph.sourcelibrary.org/catalog/13882) De symbolica aegyptiorum sapientia | 9 |
+| 1623 | Caussin, Nicolas | Polyhistor symbolicus, electorum symbolorum &amp; parabolaru | [21004](https://bph.sourcelibrary.org/catalog/21004) Polyhistor symbolicus | 7 |
+| 1624 | Orandus, Eirenaeus | Nicholas Flammel, his exposition of the hieroglyphicall figu | [4769](https://bph.sourcelibrary.org/catalog/4769) Nicholas Flammel his exposition of the hieroglyphi | 26 |
+| 1624 | Stoltzius von Stoltzenberg, Da | Viridarium chymicum figuris cupro incisis adornatum, et poet | [15455](https://bph.sourcelibrary.org/catalog/15455) [Viridarium chymicum] | 13 |
+| 1625 | Jamsthaler, Herbrandt | Viatorium spagyricum. Das ist ein gebenedeyter spagyrischer  | [15370](https://bph.sourcelibrary.org/catalog/15370) Viatorium spagyricum. Das ist: ein gebenedeyter sp | 17 |
+| 1628 | Se̜dziwój, Michał | Tripus chimicus Sendivogianus, dreyfaches chimisches Kleinod | [14784](https://bph.sourcelibrary.org/catalog/14784) Tripus chimicus Sendivogianus, dreyfaches chimisch | 15 |
+| 1630 | Nortonus, Samuel | Saturnus saturatus dissolutus, et coelo restitutus, seu modu | [12674](https://bph.sourcelibrary.org/catalog/12674) Saturnus saturatus | 9 |
+| 1650 | Vaughan, Thomas | Anima magica abscondita, or a discourse of the universall sp | [644](https://bph.sourcelibrary.org/catalog/644) Anima magica abscondita; or a discourse of the uni | 21 |
+| 1650 | Vaughan, Thomas | Anthroposophia Theomagica or a Discourse of the Nature of Ma | [691](https://bph.sourcelibrary.org/catalog/691) Anthroposophia theomagica; or a discourse of the n | 21 |
+| 1651 | Lullus, Raimundus | Codicillus seu vade mecum Raymundi Lulli ... in quo fontes a | [2874](https://bph.sourcelibrary.org/catalog/2874) Codicillus seu vade mecum | 7 |
+| 1652 | Ashmole, Elias | Theatrum chemicum Britannicum : containing severall poetical | [14143](https://bph.sourcelibrary.org/catalog/14143) Theatrum chemicum Britannicum. Containing severall | 27 |
+| 1653 | Espagnet, Jean d' | Enchiridion physicae restitutae, in quo verus naturae concen | [4215](https://bph.sourcelibrary.org/catalog/4215) Enchiridion physicae restitutae. Arcanum hermetica | 17 |
+| 1653 | Glauber, Johann Rudolph | Miraculum mundi, sive plena perfectaque descriptio admirabil | [9277](https://bph.sourcelibrary.org/catalog/9277) Miraculum mundi, oder aussführliche Beschreibung d | 13 |
+| 1653 | Glauber, Johann Rudolph | Miraculum mundi, sive plena perfectaque descriptio admirabil | [9277](https://bph.sourcelibrary.org/catalog/9277) Miraculum mundi, oder aussführliche Beschreibung d | 13 |
+| 1658 | Glauber, Johann Rudolph | Tractatus de natura Salium oder aussfürliche Beschreibung de | [14556](https://bph.sourcelibrary.org/catalog/14556) Tractatus de natura salium. Oder aussfürliche Besc | 27 |
+| 1658 | Glauber, Johann Rudolph | Miraculi mundi continuatio : in qua tota natura denudatur, & | [9274](https://bph.sourcelibrary.org/catalog/9274) Miraculi mundi continuatio. Darinnen die gantze Na | 14 |
+| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14140](https://bph.sourcelibrary.org/catalog/14140) Theatrum chemicum | 7 |
+| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14140](https://bph.sourcelibrary.org/catalog/14140) Theatrum chemicum | 7 |
+| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14140](https://bph.sourcelibrary.org/catalog/14140) Theatrum chemicum | 7 |
+| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14140](https://bph.sourcelibrary.org/catalog/14140) Theatrum chemicum | 7 |
+| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14140](https://bph.sourcelibrary.org/catalog/14140) Theatrum chemicum | 7 |
+| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus  | [14140](https://bph.sourcelibrary.org/catalog/14140) Theatrum chemicum | 7 |
+| 1666 | [s.n.] | Reconditorium ac reclusorium opulentiae sapientiaeque numini | [2641](https://bph.sourcelibrary.org/catalog/2641) Reconditorium ac reclusorium opulentiae sapientiae | 23 |
+| 1672 | N. | Das  Kleinot der Philosophie oder das Original der Begierde  | [21570](https://bph.sourcelibrary.org/catalog/21570) Das Kleinot der Philosophie | 7 |
+| 1672 | Bernardus | [Divers traitez de la philosophie naturelle] | [3742](https://bph.sourcelibrary.org/catalog/3742) Divers traitez de la philosophie naturelle. La tur | 11 |
+| 1673 | Lange, Johann | Chymisches Zwey-Blat, das ist zwey vortreffliche chymische T | [2720](https://bph.sourcelibrary.org/catalog/2720) Chymisches Zwey-Blat. Das ist zwey vortreffliche c | 25 |
+| 1675 | Balduin, Christian Adolf | Aurum superius &amp; inferius aurae superioris &amp; inferio | [1238](https://bph.sourcelibrary.org/catalog/1238) Aurum superius et inferius | 9 |
+| 1675 | Balduin, Christian Adolf | Phosphorus hermeticus sive magnes luminaris | [11259](https://bph.sourcelibrary.org/catalog/11259) Phosphorus hermeticus | 7 |
+| 1677 | [s.n.] | Kabbala denudata, seu, doctrina Hebraeorum transcendentalis  | [7623](https://bph.sourcelibrary.org/catalog/7623) Kabbala denudata seu doctrina hebraeorum transende | 17 |
+| 1677 | [s.n.] | Kabbala denudata, seu, doctrina Hebraeorum transcendentalis  | [7623](https://bph.sourcelibrary.org/catalog/7623) Kabbala denudata seu doctrina hebraeorum transende | 17 |
+| 1677 | Knorr von Rosenroth, Christian | Kabbala denudata, seu, doctrina Hebraeorum transcendentalis  | [7623](https://bph.sourcelibrary.org/catalog/7623) Kabbala denudata seu doctrina hebraeorum transende | 17 |
+| 1677 | Bacon, Roger | Vier chymische Tractätlein: I. Lucens lux in tenebris, das i | [15415](https://bph.sourcelibrary.org/catalog/15415) Vier chymische Tractätlein. Lucens lux in tenebris | 41 |
+| 1677 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Mynsicht, Adrian von | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Jean | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Barnaud, Nicolas | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Maier, Michael | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Se̜dziwój, Michał | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Cureau de La Chambre, Marin | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Maier, Michael | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Cureau de La Chambre, Marin | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1677 | Helvetius, Johann Friedrich | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 10 |
+| 1678 | Eyquem du Martineau, Mathurin | Le  pilote de l'onde vive, ou le secret du flux et reflux de | [11307](https://bph.sourcelibrary.org/catalog/11307) Le pilote de l'onde vive | 11 |
+| 1678 | [s.n.] | Musaeum hermeticum reformatum et amplificatum, omnes sopho-s | [9452](https://bph.sourcelibrary.org/catalog/9452) Musaeum hermeticum reformatum et amplificatum | 11 |
+| 1682 | Böhme, Jakob | Von der Menschwerdung Jesu Christi, wie das ewige Wort sey M | [9137](https://bph.sourcelibrary.org/catalog/9137) Von der Menschwerdung Jesu Christi | 7 |
+| 1682 | Walther, Balthasar | Viertzig Fragen von der Seelen Urstand, Essentz, Wesen, Natu | [15431](https://bph.sourcelibrary.org/catalog/15431) Viertzig Fragen von der Seelen Urstand | 11 |
+| 1682 | Böhme, Jakob | De signatura rerum, das ist: von der Gebuhrt und Bezeichnung | [13236](https://bph.sourcelibrary.org/catalog/13236) De signatura rerum, das ist: Von der Gebuhrt und B | 15 |
+| 1682 | Böhme, Jakob | Der  Weeg zu Christo: verfasset in neun Büchlein. Das 1. Von | [15804](https://bph.sourcelibrary.org/catalog/15804) Der Weeg zu Christo | 5 |
+| 1684 | Helmont, Franciscus Mercurius  | Adumbratio Kabbalae Christianae id est Syncatabasis Hebraiza | [17042](https://bph.sourcelibrary.org/catalog/17042) Adumbratio kabbalae Christianae id est syncatabasi | 19 |
+| 1686 | Coenders van Helpen, Barent | Escalier des sages ou la philosophie des anciens | [4476](https://bph.sourcelibrary.org/catalog/4476) Escalier des sages | 9 |
+| 1693 | Tachenius, Otto | La  lumière sortant par soi-mesme des ténèbres ou veritable  | [8633](https://bph.sourcelibrary.org/catalog/8633) La lumiere sortant par soi-mesme des tenebres | 11 |
+| 1699 | Pordage, John | Sophia, das ist die holdseelige ewige Jungfrau der göttliche | [13399](https://bph.sourcelibrary.org/catalog/13399) Sophia: das ist, die holdseelige ewige Jungfrau de | 17 |
+| 1702 | Bosch, Jacob | Symbolographia sive de arte symbolica sermones septem : quib | [13923](https://bph.sourcelibrary.org/catalog/13923) Symbolographia sive de arte symbolica | 11 |
+| 1706 | [s.n.] | Drey curieuse chymische Tractätlein. Das erste betitult güld | [3887](https://bph.sourcelibrary.org/catalog/3887) Drey curieuse chymische Tractätlein. Güldene Rose. | 17 |
+| 1706 | Chrysander, Alitophilus | Aureum seculum patefactum oder die eröffnete güldene Zeit .. | [1196](https://bph.sourcelibrary.org/catalog/1196) Aureum seculum patefactum: oder, Die eröffnete gül | 15 |
+| 1707 | [s.n.] | Der hermetische Triumph oder der siegende philosophische Ste | [6491](https://bph.sourcelibrary.org/catalog/6491) Der hermetische Triumph oder der siegende philosop | 13 |
+| 1712 | Naxagoras, Ehrd de | Sancta veritas hermetica, seu concordantia philosophorum, co | [12649](https://bph.sourcelibrary.org/catalog/12649) Sancta veritas hermetica, seu concordantia philoso | 39 |
+| 1719 | Hellwig, Christoph von | Fasciculus unterschiedlicher alten raren und wahren philosop | [4853](https://bph.sourcelibrary.org/catalog/4853) Fasciculus unterschiedlicher alten raren und wahre | 21 |
+| 1723 | Kirchweger, Anton Joseph | Aurea catena Homeri oder eine Beschreibung von dem Ursprung  | [1174](https://bph.sourcelibrary.org/catalog/1174) Aurea Catena Homeri. Das ist: eine Beschreibung vo | 19 |
+| 1728 | Roth-Scholtz, Friedrich | Deutsches theatrum chemicum, auf welchem der berühmtesten Ph | [3528](https://bph.sourcelibrary.org/catalog/3528) Deutsches theatrum chemicum | 15 |
+| 1728 | [s.n.] | Deutsches theatrum chemicum, auf welchem der berühmtesten Ph | [3528](https://bph.sourcelibrary.org/catalog/3528) Deutsches theatrum chemicum | 9 |
+| 1728 | [s.n.] | Deutsches theatrum chemicum, auf welchem der berühmtesten Ph | [3528](https://bph.sourcelibrary.org/catalog/3528) Deutsches theatrum chemicum | 9 |
+| 1728 | [s.n.] | Deutsches theatrum chemicum, auf welchem der berühmtesten Ph | [3528](https://bph.sourcelibrary.org/catalog/3528) Deutsches theatrum chemicum | 9 |
+| 1730 | Böhme, Jakob | Quaestiones theosophicae oder Betrachtung göttlicher Offenba | [11853](https://bph.sourcelibrary.org/catalog/11853) Quaestiones theosophicae, oder Betrachtung göttlic | 15 |
+| 1730 | Böhme, Jakob | De vita et scriptis Jacobi Böhmii oder ausführlich erläutert | [15508](https://bph.sourcelibrary.org/catalog/15508) De vita et scriptis Jacobi Boehmii oder ausfuehrli | 11 |
+| 1730 | Böhme, Jakob | Epistolae theosophicae oder theosophische Send-Briefe | [4360](https://bph.sourcelibrary.org/catalog/4360) Epistolae theosophicae, oder theosophische Send-Br | 11 |
+| 1731 | Walch, Johannes | Geheimniss der Natur des grossen und kleinen Bauers, in welc | [5291](https://bph.sourcelibrary.org/catalog/5291) Geheimniss der Natur des grossen und kleinen Bauer | 13 |
+| 1733 | Le Brun, Pierre | Superstitions anciennes et modernes, préjugés vulgaires qui  | [22967](https://bph.sourcelibrary.org/catalog/22967) Superstitions anciennes et modernes | 9 |
+| 1734 | Fictuld, Hermann | Das edele Perlein und theurer Schatz der himmlischen Weishei | [4001](https://bph.sourcelibrary.org/catalog/4001) Das edele Perlein und theurer Schatz der himmlisch | 19 |
+| 1740 | Fictuld, Hermann | Der längst gewünschte und versprochene chymisch-philosophisc | [8021](https://bph.sourcelibrary.org/catalog/8021) Der längst gewünschte und versprochene chymisch-ph | 21 |
+| 1741 | Maugin de Richebourg, Jean | Bibliothèque des philosophes chimiques | [1698](https://bph.sourcelibrary.org/catalog/1698) Bibliotheque des philosophes chimiques | 15 |
+| 1741 | [s.n.] | Bibliothèque des philosophes chimiques / Tome premier. | [1699](https://bph.sourcelibrary.org/catalog/1699) Bibliothèque des philosophes chimiques | 9 |
+| 1741 | [s.n.] | Bibliothèque des philosophes chimiques / Tome second. | [1699](https://bph.sourcelibrary.org/catalog/1699) Bibliothèque des philosophes chimiques | 9 |
+| 1741 | [s.n.] | Bibliothèque des philosophes chimiques / Tome troisième. | [1699](https://bph.sourcelibrary.org/catalog/1699) Bibliothèque des philosophes chimiques | 9 |
+| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un cat | [6638](https://bph.sourcelibrary.org/catalog/6638) Histoire de la philosophie hermetique | 8 |
+| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un cat | [6638](https://bph.sourcelibrary.org/catalog/6638) Histoire de la philosophie hermetique | 8 |
+| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un cat | [6638](https://bph.sourcelibrary.org/catalog/6638) Histoire de la philosophie hermetique | 8 |
+| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un cat | [6638](https://bph.sourcelibrary.org/catalog/6638) Histoire de la philosophie hermetique | 8 |
+| 1749 | Fictuld, Hermann | Azoth et ignis, das ist, das wahre elementarische Wasser und | [1323](https://bph.sourcelibrary.org/catalog/1323) Azoth et Ignis, Das ist, das wahre elementarische  | 27 |
+| 1752 | L.C.S | Hermaphroditisches Sonn- und Monds-Kind, das ist des Sohns d | [6399](https://bph.sourcelibrary.org/catalog/6399) Hermaphroditisches Sonn- und Monds-Kind | 7 |
+| 1754 | Fictuld, Hermann | Hermann Fictulds Abhandlung von der Alchymie und derselben G | [65](https://bph.sourcelibrary.org/catalog/65) Hermann Fictulds Abhandlung von der Alchymie, und  | 19 |
+| 1757 | [s.n.] | Eines scharfsinnigen Chymici hinterlassene Gedanken von Verb | [12686](https://bph.sourcelibrary.org/catalog/12686) Eines scharfsinnigen Chymici hinterlassene Gedanke | 13 |
+| 1758 | [s.n.] | Les  fables egyptiennes et grecques dévoilées &amp; réduites | [4792](https://bph.sourcelibrary.org/catalog/4792) Les fables égyptiennes et grecques | 9 |
+| 1758 | Pernety, Antoine Joseph | Les  fables egyptiennes et grecques dévoilées &amp; réduites | [4792](https://bph.sourcelibrary.org/catalog/4792) Les fables égyptiennes et grecques | 15 |
+| 1758 | Pernety, Antoine Joseph | Dictionnaire mytho-hermétique, dans lequel on trouve les all | [3617](https://bph.sourcelibrary.org/catalog/3617) Dictionnaire mytho-hermétique | 15 |
+| 1758 | [s.n.] | Les  fables egyptiennes et grecques dévoilées &amp; réduites | [4792](https://bph.sourcelibrary.org/catalog/4792) Les fables égyptiennes et grecques | 9 |
+| 1770 | [s.n.] | Das  Geheimniss der hermetischen Philosophie, in welchem die | [5290](https://bph.sourcelibrary.org/catalog/5290) Das Geheimniss der hermetischen Philosophie | 9 |
+| 1770 | Oetinger, Friedrich Christoph | Das  Geheimniss von dem Salz, als dem edelsten Wesen der höc | [5284](https://bph.sourcelibrary.org/catalog/5284) Das Geheimniss von dem Salz | 5 |
+| 1782 | Birkholz, Adam Michael | Der  Compass der Weisen ... | [3028](https://bph.sourcelibrary.org/catalog/3028) Der Compass der Weisen, von einem Mitverwandten de | 7 |
+| 1786 | Guillemain de Saint-Victor, Lo | Recueil précieux de la maçonnerie adonhiramite ... | [18471](https://bph.sourcelibrary.org/catalog/18471) Recueil précieux de la maçonnerie adonhiramite | 19 |
+| 1920 | Atwood, Mary Anne | A  Suggestive Inquiry into the Hermetic Mystery : with a Dis | [13799](https://bph.sourcelibrary.org/catalog/13799) A suggestive inquiry into the hermetic mystery wit | 25 |
+
+## In Jung's library but not in BPH (194, first 30 shown)
+
+| Year | Author | Title | e-rara |
+|---|---|---|---|
+| 1481 | Albertus | [De anima. De intellectu] | [1350065](https://www.e-rara.ch/content/titleinfo/1350065) |
+| 1484 | Augustinus, Aurelius | Meditationes divi Augustini episcopi Hipponenis ... Soliloquia animae  | [2870409](https://www.e-rara.ch/content/titleinfo/2870409) |
+| 1489 | Isidorus | Liber ethymologiarum Isidori Hyspalensis episcopi | [1837195](https://www.e-rara.ch/content/titleinfo/1837195) |
+| 1495 | [s.n.] | In disem teütschen kalender vindet man gar hübsch nach einander die zw | [1607901](https://www.e-rara.ch/content/titleinfo/1607901) |
+| 1497 | Iamblichus | Index eor um, quae hoc in libro habentur De mysteriis Aegyptiorum, Cha | [1833657](https://www.e-rara.ch/content/titleinfo/1833657) |
+| 1498 | Trithemius, Johannes | De triplici regione claustralium et spirituali exercitio monachorum .. | [2581257](https://www.e-rara.ch/content/titleinfo/2581257) |
+| 1501 | Apuleius | [Commentarii a Philippo Beroaldo conditi in asinum aureum Lucii Apulei | [1388711](https://www.e-rara.ch/content/titleinfo/1388711) |
+| 1502 | Albertus | Opera Dionysii veteris et nove translationis etiam novissime ipsius Ma | [2849222](https://www.e-rara.ch/content/titleinfo/2849222) |
+| 1511 | Sprenger, Jakob | Malleus maleficarum | [3331183](https://www.e-rara.ch/content/titleinfo/3331183) |
+| 1513 | Johannes | Iohannis Saresberiensis policraticus de nugis curialium et vestigiis p | [1835136](https://www.e-rara.ch/content/titleinfo/1835136) |
+| 1514 | Albertus | Alberti Magni philosophie naturalis isagoge: sive introductiones: emen | [1192211](https://www.e-rara.ch/content/titleinfo/1192211) |
+| 1518 | Lullus, Raimundus | Opusculum Raymundinum de auditu kabbalisitico sive ad omnes scientias  | [2103342](https://www.e-rara.ch/content/titleinfo/2103342) |
+| 1522 | Erasmus, Desiderius | Arnobii Afri ... commentarii ... In omnes psalmos, sermone Latino, sed | [1684589](https://www.e-rara.ch/content/titleinfo/1684589) |
+| 1522 | Mechthild | Opera nuper in lucem prodeuntia : Liber gratie spiritualis visionum &a | [2035372](https://www.e-rara.ch/content/titleinfo/2035372) |
+| 1523 | Johannes | Divi Ioannis Chrysostomi Psegmata quaedam | [1684152](https://www.e-rara.ch/content/titleinfo/1684152) |
+| 1528 | Achillini, Alessandro | Secreta secretorum Aristotelis | [1349506](https://www.e-rara.ch/content/titleinfo/1349506) |
+| 1529 | Bernardus de Lutzemburgo | Catalogus haereticorum omnium pene qui ad haec usque tempora passim li | [1605508](https://www.e-rara.ch/content/titleinfo/1605508) |
+| 1533 | Agrippa von Nettesheim, Heinri | Henrici Cornelii Agrippae ... De occulta philosophia libri tres | [1343192](https://www.e-rara.ch/content/titleinfo/1343192) |
+| 1539 | Cornarius, Janus | Artemidori ... De somniorum interpretatione, libri quinque | [1342698](https://www.e-rara.ch/content/titleinfo/1342698) |
+| 1540 | Cyprianus, Thascius Caecilius | Divi Caecilii Cypriani episcopi Carthaginensis et martyris opera iam q | [2840942](https://www.e-rara.ch/content/titleinfo/2840942) |
+| 1541 | Ǧābir Ibn-Ḥaiyān | In hoc vo lumine De alchemia continentur haec .... : De investigatione | [1719033](https://www.e-rara.ch/content/titleinfo/1719033) |
+| 1541 | Lullus, Raimundus | Raimundi Lulli ... de secretis naturae sive quinta essentia libri duo  | [2102930](https://www.e-rara.ch/content/titleinfo/2102930) |
+| 1542 | Aetios | Aetii medici Graeci contractae ex veteribus medicinae tetrabiblos : ho | [1530278](https://www.e-rara.ch/content/titleinfo/1530278) |
+| 1543 | Epiphanius | D. Epiphanii Episcopi Constantiae Cypri, contra octoaginta haereses op | [1720269](https://www.e-rara.ch/content/titleinfo/1720269) |
+| 1545 | Ǧābir Ibn-Ḥaiyān | Alchemiae Gebri Arabis philosophi solertissimi, libri, cum reliquis, u | [1342369](https://www.e-rara.ch/content/titleinfo/1342369) |
+| 1554 | Hermes | Hermou tou Trismegistou Poimandres. Asklepiou horoi pros Ammona Basile | [2034845](https://www.e-rara.ch/content/titleinfo/2034845) |
+| 1554 | Dioscorides | Pedanii Dioscoridis ... de medica materia libri sex ... : his accessit | [3303197](https://www.e-rara.ch/content/titleinfo/3303197) |
+| 1555 | Ryff, Walther Hermann | Troumbüchlin : darinn warhafftig auss natürlichen Ursachen auch der al | [1998096](https://www.e-rara.ch/content/titleinfo/1998096) |
+| 1557 | Origenes | Origenis Adamantii, eximii scripturarum interpretis, opera, quae quide | [2843210](https://www.e-rara.ch/content/titleinfo/2843210) |
+| 1559 | Bonaventura | Sanctarum autoritatum veterum catholicae ecclesiae patrum libri quatuo | [3334867](https://www.e-rara.ch/content/titleinfo/3334867) |
+| _...and 164 more_ | | | |
+
+## Method note
+
+This is a fuzzy bibliographic match, not a UBN-level identity check. The score combines:
+- Shared significant title words (≥5 letters), weighted ×2
+- Shared author tokens (≥4 letters), weighted ×2
+- Year proximity (3 pts for same year, 2 for ≤2 years, 1 for ≤10 years)
+
+Different editions of the same work (e.g. *Theatrum chemicum* 1602 in Zürich and 1659 in BPH) count as a match because the bibliographic connection is what Jozef's question asked about.
+
+The matches table is sorted by year and shows the highest-scoring BPH candidate per Jung work. False positives are possible at the long-tail (low score) end — review with Paul before publishing.

--- a/scripts/jung-bph-alignment.mjs
+++ b/scripts/jung-bph-alignment.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+/**
+ * Jung Küsnacht ↔ BPH bibliographic alignment.
+ *
+ * Of the 345 works in Jung's personal library at Küsnacht (e-rara OAI set
+ * "cgj"), which ones also exist in BPH's catalogue (Supabase bph_works)?
+ *
+ * Jozef Ritman asked for this on 2026-05-21: "establish a meaningful
+ * connection between the collections of the Embassy of the Free Mind
+ * and Jung's library in Switzerland."
+ *
+ * This is a READ-ONLY analysis. Outputs a markdown report.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/jung-bph-alignment.mjs
+ *
+ * Output:
+ *   .claude/docs/jung-bph-alignment-YYYY-MM-DD.md
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const OAI_BASE = 'https://www.e-rara.ch/oai';
+const OAI_SET = process.env.OAI_SET || 'cgj';
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+
+if (!SUPABASE_KEY) {
+  console.error('SUPABASE_ANON_KEY or SUPABASE_SERVICE_ROLE_KEY required');
+  process.exit(1);
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// ── Normalization (consistent across both sides) ─────────────────────────
+
+function normalize(s) {
+  return (s || '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/^(the|a|an|der|die|das|de|le|la|les|il|lo|gli|i|el|los|las|een|het|sancti|sanctus|sancto)\s+/i, '')
+    .replace(/\[s\.n\.\]|\[s\.l\.\]|\[s\. n\.\]|\[s\. l\.\]/gi, '')
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Surname-extracting normalizer: "Boccalini, Trajano" -> "boccalini"
+function normSurname(author) {
+  const a = normalize(author);
+  if (!a) return '';
+  const parts = a.split(/[, ]/).filter(Boolean);
+  // For "lastname, firstname" form, first part is the surname
+  // For "firstname lastname" form, last part is the surname
+  // Heuristic: e-rara seems to use the natural "firstname lastname [year-year]" form
+  // BPH uses "Lastname, Firstname". So matching is hard.
+  // Safest: build a set of all words and require one significant word matches.
+  return parts.filter(p => p.length >= 4).join(' ');
+}
+
+function tokens(s, minLen = 4) {
+  return normalize(s).split(' ').filter(w => w.length >= minLen);
+}
+
+// ── OAI-PMH harvest ──────────────────────────────────────────────────────
+
+function parseRecords(xml) {
+  const records = [];
+  const recordRegex = /<record>([\s\S]*?)<\/record>/g;
+  let m;
+  while ((m = recordRegex.exec(xml)) !== null) {
+    const r = m[1];
+    if (r.includes('status="deleted"')) continue;
+    const idMatch = r.match(/<identifier>oai:www\.e-rara\.ch:(\d+)<\/identifier>/);
+    if (!idMatch) continue;
+    const id = idMatch[1];
+    const get = (tag) => {
+      const x = r.match(new RegExp(`<dc:${tag}>([^<]*)<\\/dc:${tag}>`));
+      return x ? x[1].trim() : null;
+    };
+    const date = get('date');
+    const yearMatch = date && date.match(/(\d{4})/);
+    records.push({
+      erara_id: id,
+      title: get('title') || '',
+      author: get('creator') || '',
+      year: yearMatch ? parseInt(yearMatch[1]) : null,
+      source_url: `https://www.e-rara.ch/content/titleinfo/${id}`,
+    });
+  }
+  const tokenMatch = xml.match(/<resumptionToken[^>]*>([^<]*)<\/resumptionToken>/);
+  return { records, resumptionToken: tokenMatch?.[1]?.trim() || null };
+}
+
+async function harvestCgj() {
+  console.log(`Harvesting e-rara OAI set "${OAI_SET}"...`);
+  let url = `${OAI_BASE}?verb=ListRecords&metadataPrefix=oai_dc&set=${OAI_SET}`;
+  const all = [];
+  while (url) {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'SourceLibrary/1.0 (Jung-BPH alignment)' },
+      signal: AbortSignal.timeout(60000),
+    });
+    if (!res.ok) {
+      console.error(`OAI ${res.status}, retrying`);
+      await sleep(5000);
+      continue;
+    }
+    const xml = await res.text();
+    const { records, resumptionToken } = parseRecords(xml);
+    all.push(...records);
+    url = resumptionToken
+      ? `${OAI_BASE}?verb=ListRecords&resumptionToken=${encodeURIComponent(resumptionToken)}`
+      : null;
+    await sleep(1000);
+  }
+  console.log(`  ${all.length} cgj records`);
+  return all;
+}
+
+// ── BPH pull ─────────────────────────────────────────────────────────────
+
+async function pullBphCatalogue(supa) {
+  console.log('Pulling BPH catalogue (bph_works)...');
+  const all = [];
+  const PAGE = 1000;
+  let from = 0;
+  while (true) {
+    const { data, error } = await supa
+      .from('bph_works')
+      .select('ubn, title, author, year, place, publisher, printer, shelf_mark, ustc_sn')
+      .range(from, from + PAGE - 1);
+    if (error) {
+      console.error('Supabase error:', error.message);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < PAGE) break;
+    from += PAGE;
+    process.stdout.write(`  ${all.length}…\r`);
+  }
+  console.log(`  ${all.length} BPH works`);
+  return all;
+}
+
+// ── Matching ─────────────────────────────────────────────────────────────
+
+function buildBphIndex(bph) {
+  // Index by normalized title (first 4+ chars) for fast scan, then refine by author/year.
+  const byTitleStart = new Map();
+  for (const b of bph) {
+    const t = normalize(b.title);
+    if (t.length < 6) continue;
+    const key = t.slice(0, 12); // first 12 chars of normalized title
+    if (!byTitleStart.has(key)) byTitleStart.set(key, []);
+    byTitleStart.get(key).push({ ...b, _normTitle: t, _normAuthor: normalize(b.author) });
+  }
+  return byTitleStart;
+}
+
+function findMatches(record, byTitleStart) {
+  const normT = normalize(record.title);
+  if (normT.length < 6) return [];
+  const key = normT.slice(0, 12);
+  const candidates = byTitleStart.get(key) || [];
+  if (candidates.length === 0) return [];
+
+  const recTokens = new Set(tokens(record.title, 5));
+  const recAuthorTokens = new Set(tokens(record.author, 4));
+  const matches = [];
+
+  for (const c of candidates) {
+    const cTokens = new Set(tokens(c.title, 5));
+    // Title token overlap — share at least 2 significant 5+ letter words
+    const titleShared = [...recTokens].filter(t => cTokens.has(t));
+    if (titleShared.length < 2 && recTokens.size > 1 && cTokens.size > 1) continue;
+    if (titleShared.length === 0) continue;
+
+    // Year proximity (within 5 years, or both unknown)
+    let yearScore = 0;
+    if (record.year && c.year) {
+      const diff = Math.abs(record.year - c.year);
+      if (diff > 10) continue;
+      yearScore = diff === 0 ? 3 : diff <= 2 ? 2 : 1;
+    }
+
+    // Author surname overlap
+    const cAuthorTokens = new Set(tokens(c.author, 4));
+    const authorShared = [...recAuthorTokens].filter(t => cAuthorTokens.has(t));
+    const authorScore = authorShared.length;
+
+    const score = titleShared.length * 2 + yearScore + authorScore * 2;
+    matches.push({ bph: c, score, titleShared, authorShared, yearScore });
+  }
+
+  matches.sort((a, b) => b.score - a.score);
+  return matches.slice(0, 3);
+}
+
+// ── Report ───────────────────────────────────────────────────────────────
+
+function writeReport(jung, results) {
+  const today = new Date().toISOString().slice(0, 10);
+  const baseDir = path.join(process.cwd(), '.claude/docs');
+  fs.mkdirSync(baseDir, { recursive: true });
+
+  const matched = results.filter(r => r.matches.length > 0);
+  const notInBph = results.filter(r => r.matches.length === 0);
+
+  const lines = [];
+  lines.push(`# Jung Küsnacht ↔ BPH alignment (${today})`);
+  lines.push('');
+  lines.push(`Of the **${jung.length}** works in Jung's personal library at Küsnacht (e-rara OAI set \`${OAI_SET}\` — held by Stiftung der Werke von C.G. Jung, Zürich), which also exist in the BPH catalogue?`);
+  lines.push('');
+  lines.push(`Match heuristic: shared significant words in title + author surname overlap + year proximity (≤10 years). Highest-scoring BPH candidate shown per Jung title.`);
+  lines.push('');
+  lines.push(`## Summary`);
+  lines.push('');
+  lines.push(`- Jung works: **${jung.length}**`);
+  lines.push(`- Also present in BPH (candidate match): **${matched.length}**`);
+  lines.push(`- Jung-only (no BPH match found): ${notInBph.length}`);
+  lines.push('');
+  lines.push(`Coverage: **${(matched.length / jung.length * 100).toFixed(1)}%** of Jung's Küsnacht library is also bibliographically represented in BPH.`);
+  lines.push('');
+
+  lines.push(`## Works present in both libraries (${matched.length})`);
+  lines.push('');
+  lines.push('| Year | Author | Jung title (Küsnacht) | BPH match (UBN / title) | Score |');
+  lines.push('|---|---|---|---|--:|');
+  for (const r of matched.sort((a, b) => (a.jung.year || 9999) - (b.jung.year || 9999))) {
+    const best = r.matches[0];
+    const t = (r.jung.title || '').slice(0, 60).replace(/\|/g, '\\|');
+    const a = (r.jung.author || '').slice(0, 30).replace(/\|/g, '\\|');
+    const bphT = (best.bph.title || '').slice(0, 50).replace(/\|/g, '\\|');
+    const ubn = best.bph.ubn || '';
+    lines.push(`| ${r.jung.year || '–'} | ${a} | ${t} | [${ubn}](https://bph.sourcelibrary.org/catalog/${ubn}) ${bphT} | ${best.score} |`);
+  }
+  lines.push('');
+
+  // Top 30 not in BPH (could be opportunities for acquisition / scholarly connections)
+  lines.push(`## In Jung's library but not in BPH (${notInBph.length}, first 30 shown)`);
+  lines.push('');
+  lines.push('| Year | Author | Title | e-rara |');
+  lines.push('|---|---|---|---|');
+  for (const r of notInBph.sort((a, b) => (a.jung.year || 9999) - (b.jung.year || 9999)).slice(0, 30)) {
+    const t = (r.jung.title || '').slice(0, 70).replace(/\|/g, '\\|');
+    const a = (r.jung.author || '').slice(0, 30).replace(/\|/g, '\\|');
+    lines.push(`| ${r.jung.year || '–'} | ${a} | ${t} | [${r.jung.erara_id}](${r.jung.source_url}) |`);
+  }
+  if (notInBph.length > 30) lines.push(`| _...and ${notInBph.length - 30} more_ | | | |`);
+  lines.push('');
+
+  lines.push(`## Method note`);
+  lines.push('');
+  lines.push(`This is a fuzzy bibliographic match, not a UBN-level identity check. The score combines:`);
+  lines.push(`- Shared significant title words (≥5 letters), weighted ×2`);
+  lines.push(`- Shared author tokens (≥4 letters), weighted ×2`);
+  lines.push(`- Year proximity (3 pts for same year, 2 for ≤2 years, 1 for ≤10 years)`);
+  lines.push('');
+  lines.push(`Different editions of the same work (e.g. *Theatrum chemicum* 1602 in Zürich and 1659 in BPH) count as a match because the bibliographic connection is what Jozef's question asked about.`);
+  lines.push('');
+  lines.push(`The matches table is sorted by year and shows the highest-scoring BPH candidate per Jung work. False positives are possible at the long-tail (low score) end — review with Paul before publishing.`);
+
+  const mdPath = path.join(baseDir, `jung-bph-alignment-${today}.md`);
+  fs.writeFileSync(mdPath, lines.join('\n'));
+  console.log(`Wrote ${mdPath}`);
+
+  const jsonPath = path.join(baseDir, `jung-bph-alignment-${today}.json`);
+  fs.writeFileSync(jsonPath, JSON.stringify({
+    generated_at: new Date().toISOString(),
+    oai_set: OAI_SET,
+    jung_count: jung.length,
+    matched_count: matched.length,
+    not_in_bph_count: notInBph.length,
+    results,
+  }, null, 2));
+  console.log(`Wrote ${jsonPath}`);
+
+  return { matched, notInBph, mdPath, jsonPath };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+async function main() {
+  const t0 = Date.now();
+  const supa = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+  const [jung, bph] = await Promise.all([
+    harvestCgj(),
+    pullBphCatalogue(supa),
+  ]);
+
+  console.log('\nBuilding BPH title index...');
+  const byTitleStart = buildBphIndex(bph);
+  console.log(`  ${byTitleStart.size} title-prefix buckets`);
+
+  console.log('\nMatching...');
+  const results = jung.map(j => ({ jung: j, matches: findMatches(j, byTitleStart) }));
+
+  const matched = results.filter(r => r.matches.length > 0);
+  console.log(`  ${matched.length} of ${jung.length} have BPH matches`);
+
+  writeReport(jung, results);
+
+  const mins = ((Date.now() - t0) / 60000).toFixed(1);
+  console.log(`\nDone in ${mins} min.`);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Direct response to Jozef's actual question on the #1922 thread: "establish a meaningful connection between the collections of the Embassy of the Free Mind and Jung's library in Switzerland."

## Result

**151 of 345 (43.8%) of Jung's Küsnacht library has a candidate match in the BPH catalogue.**

Looking at the matched list, this is a strong overlap — Khunrath's *Amphitheatrum sapientiae aeternae* (1609), Maier's *Atalanta fugiens* (1617) / *Themis aurea* (1618) / *Symbola aureae mensae* (1617), Fludd's *Utriusque cosmi* (1617), Vanini's *Amphitheatrum aeternae providentiae* (1615), Trismosin's *Aureum vellus* (1598/1600), Bracesco, Hortulanus, Khunrath *Von hylealischen* (1597), four volumes of *Theatrum chemicum* (1602)… these are the bibliographic backbone Jung and the BPH share.

## What this PR contains

- \`scripts/jung-bph-alignment.mjs\` — runnable read-only analysis. Harvests the cgj OAI set and queries Supabase \`bph_works\`. No writes, no schema changes.
- \`.claude/docs/jung-bph-alignment-2026-05-22.md\` — human-readable report Jozef can use directly.
- \`.claude/docs/jung-bph-alignment-2026-05-22.json\` — full data including match scores.

## Method

Fuzzy bibliographic match scored by:
- Shared significant title words (≥5 letters), weighted ×2
- Shared author tokens (≥4 letters), weighted ×2
- Year proximity (3 pts same year, 2 ≤2 years, 1 ≤10 years)

Highest-scoring BPH candidate per Jung work. Different editions of the same work (1602 Zürich Theatrum chemicum ↔ 1659 BPH Theatrum chemicum) intentionally count as a match because the *bibliographic* connection is what the question asked about.

## Caveats

- False positives possible at low score (5–7). Quick scan suggests these are real most of the time but Paul should sanity-check before any public publishing.
- The 4 Jung volumes of \`Theatrum chemicum\` 1602 all map to one BPH UBN (14138) because BPH catalogs the multi-volume work as one bibliographic entity. That's correct, just looks like duplication in the table.

## Follow-up (not in this PR)

A \`/collections/jung-resonances\` landing page surfacing the 151 matched BPH books with a side-link "also in Jung's Küsnacht library" → e-rara. That UI work is queued after Paul's editor (#1921 P1/P2) lands so we have the categoriser tools in place.

## Test plan

- [x] Script runs end-to-end (~50s)
- [x] Sanity check: top matches in the report are real bibliographic pairs (Khunrath, Maier, Fludd, etc.)
- [x] Read-only — no DB writes
- [x] DCO sign-off on commit