### PR TITLE
BPH catalog P1: sign-out on embed, impressum line, filter labels (#1921)

### DIFF
--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { TenantLayoutWrapper } from '@/components/tenant/TenantLayoutWrapper';
 import EmbedResizeReporter from '@/components/embed/EmbedResizeReporter';
 import EmbedNavigationOverlay from '@/components/embed/EmbedNavigationOverlay';
+import EmbedUserMenu from '@/components/embed/EmbedUserMenu';
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -11,12 +12,15 @@ export const metadata: Metadata = {
  * Layout for embed routes. Adds data-embed attribute to hide
  * SiteHeader, GlobalFooter, and other chrome via CSS.
  * The root layout still wraps this — we just signal "embed mode".
+ * EmbedUserMenu is a small floating sign-in / sign-out affordance
+ * because the SiteHeader is stripped on embed pages.
  */
 export default function EmbedLayout({ children }: { children: React.ReactNode }) {
   return (
     <TenantLayoutWrapper>
       <div data-embed="" className="embed-mode">
         {children}
+        <EmbedUserMenu />
         <EmbedResizeReporter />
         <EmbedNavigationOverlay />
       </div>

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+import { useStableSession } from '@/hooks/useStableSession';
+import Link from 'next/link';
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+/**
+ * Minimal user menu for embed/tenant pages.
+ *
+ * The main SiteHeader is intentionally stripped on embed routes so partner
+ * subdomains (e.g. bph.sourcelibrary.org) look like the partner's own site
+ * rather than ours. That left librarians like Paul with no way to sign out
+ * once authenticated. This is a floating top-right control: a sign-in link
+ * for anonymous users, an avatar + dropdown (with Account, Sign out) for
+ * authenticated ones.
+ */
+export default function EmbedUserMenu() {
+  const { data: session, status } = useStableSession();
+  const [isOpen, setIsOpen] = useState(false);
+  const [imgError, setImgError] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const handleImgError = useCallback(() => setImgError(true), []);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  if (status === 'loading') return null;
+
+  const containerCls =
+    'fixed top-3 right-3 z-50 print:hidden';
+
+  if (!session) {
+    return (
+      <div className={containerCls}>
+        <Link
+          href="/auth/signin"
+          className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-white/90 backdrop-blur-sm border border-border-light text-secondary hover:text-primary shadow-sm transition-colors"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  const name = session.user?.name || session.user?.email || 'Account';
+  const initials = session.user?.name
+    ?.split(' ')
+    .map(n => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2) || session.user?.email?.[0]?.toUpperCase() || '?';
+
+  return (
+    <div ref={menuRef} className={containerCls}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-2 py-1 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors"
+        aria-label="Account menu"
+      >
+        {session.user?.image && !imgError ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={session.user.image}
+            alt=""
+            className="w-7 h-7 rounded-full"
+            onError={handleImgError}
+          />
+        ) : (
+          <div className="w-7 h-7 rounded-full bg-accent-rust text-white text-xs font-medium flex items-center justify-center">
+            {initials}
+          </div>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-56 rounded-md bg-white border border-border-light shadow-lg overflow-hidden">
+          <div className="px-3 py-2 border-b border-border-light/60">
+            <div className="text-xs text-muted truncate">Signed in as</div>
+            <div className="text-sm font-medium text-primary truncate">{name}</div>
+          </div>
+          <Link
+            href="/account"
+            className="block px-3 py-2 text-sm text-secondary hover:bg-cream/60"
+            onClick={() => setIsOpen(false)}
+          >
+            Account
+          </Link>
+          <button
+            onClick={() => signOut({ callbackUrl: '/' })}
+            className="block w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60 border-t border-border-light/60"
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -56,6 +56,17 @@ interface BphWork {
 
 /** Human-readable label for an external scan source. Defaults to a Title-Cased
     fallback when we don't have a curated label for a provider yet. */
+/** Library-card-style impressum: "Place: Printer, Year". Picks publisher if no
+    printer; collapses gracefully when fields are null. Matches the order Paul
+    asked for in issue #1921 (author, title, impressum on the short card). */
+function formatImpressum(w: { place?: string | null; printer?: string | null; publisher?: string | null; year?: number | null }): string {
+  const place = w.place?.trim();
+  const agent = w.printer?.trim() || w.publisher?.trim();
+  const year = w.year ? String(w.year) : '';
+  const placeAgent = [place, agent].filter(Boolean).join(': ');
+  return [placeAgent, year].filter(Boolean).join(', ');
+}
+
 function externalSourceLabel(source: string | null | undefined): string {
   if (!source) return 'another archive';
   const map: Record<string, string> = {
@@ -563,10 +574,10 @@ export default function BphCatalogBrowser({
                   onChange={(e) => handleAdvChange('digitized', e.target.value)}
                   className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
                 >
-                  <option value="">All</option>
-                  <option value="sl">On Source Library</option>
+                  <option value="">All books in the library</option>
+                  <option value="sl">Digitised on Source Library</option>
                   <option value="true">Digitised anywhere</option>
-                  <option value="false">Not digitised</option>
+                  <option value="false">Not yet digitised</option>
                 </select>
               </div>
             )}
@@ -668,13 +679,16 @@ export default function BphCatalogBrowser({
                           Read at {externalSourceLabel(external.source)}
                         </a>
                       )}
-                      {/* Mobile: show author + place inline */}
+                      {/* Mobile: show author inline (author column is hidden < sm) */}
                       <div className="text-xs text-muted sm:hidden mt-0.5">
-                        {displayAuthor}{w.place ? ` · ${w.place}` : ''}
+                        {displayAuthor}
                       </div>
-                      {w.printer && (
-                        <div className="text-[11px] text-muted mt-0.5 hidden md:block">
-                          {w.printer}{w.publisher && w.publisher !== w.printer ? ` / ${w.publisher}` : ''}
+                      {/* Impressum line — place, printer/publisher, year — in
+                          the order librarians expect on a short bibliographic
+                          card. Falls back gracefully when fields are missing. */}
+                      {(w.place || w.printer || w.publisher) && (
+                        <div className="text-[11px] text-muted mt-0.5 italic">
+                          {formatImpressum(w)}
                         </div>
                       )}
                     </td>


### PR DESCRIPTION
Three of the four P1 items from Paul's #1921 feedback. The fourth needs more info from Paul before I can act on it.

## Changes

### 1. Sign-out on the BPH (tenant) subdomain — \`EmbedUserMenu\`

**Bug:** Paul reported he couldn't sign out. The site header is intentionally stripped on \`/embed/*\` routes so partner subdomains look like the partner's own site — but that meant authenticated librarians had no menu at all. \`ConditionalSiteHeader\` returns null when \`isEmbedded\`, taking \`UserMenu\` (which has the signOut button) with it.

**Fix:** Add a minimal \`EmbedUserMenu\` floating top-right of every embed page:
- Anonymous → "Sign in" pill linking to \`/auth/signin\`
- Authenticated → avatar + dropdown with Account, Sign out

Rendered once in \`src/app/embed/layout.tsx\` so every BPH page gets it.

### 2. Impressum line on the catalog list card

**Before:** scattered fields — title, then a separate row showing printer/publisher inline, with place hidden in a column on wide screens only.

**After:** single librarian-style line under the title: \`Amsterdam: Hardenberg, 1695\` — exactly the order Paul asked for ("author, title, impressum"). The helper falls back gracefully:
- \`place, printer/publisher, year\` → "Amsterdam: Hardenberg, 1695"
- no place → "Hardenberg, 1695"
- no printer → uses publisher
- no year → just the place/agent

### 3. Filter labels

The digitization dropdown was confusingly labelled:
- \`All\` → "All books in the library"
- \`On Source Library\` → "Digitised on Source Library"
- \`Digitised anywhere\` (unchanged label, fine)
- \`Not digitised\` → "Not yet digitised"

This addresses Paul's note that the default wasn't clearly "show all". The default is already empty (\`""\` = all books); now the label says so explicitly.

### 4. Asterisks rendered as decoration — *NOT* fixed in this PR

Paul's screenshot showed asterisks treated as decoration in a collation formula. I traced his stated example, **Polityke toet-steen** (Boccalini, Amsterdam, Hardenberg, 1695, UBN 11473), and the row has \`bibliographic_format: null\` — no collation data at all. The rendering pipeline (\`BphCatalogueRecord.tsx:161\`) is plain text inside a \`<span>\` with no markdown or sanitization, so asterisks would pass through unchanged if the value were set.

Two possibilities: the screenshot was of a different book, or the asterisks are in a different field (volume_title, remarks). I'll ping Paul for the specific UBN before guessing.

## Test plan

Preview will deploy from this branch. Things to check:
- [ ] **bph.sourcelibrary.org**: when signed in, "Sign out" appears top-right and works
- [ ] **bph.sourcelibrary.org**: when signed out, "Sign in" link appears top-right
- [ ] Catalog rows show "Place: Printer, Year" under the title
- [ ] Filter dropdown labels match the new text
- [ ] tsc clean (verified: \`exit 0\`)
- [x] DCO sign-off

Closes P1 items 1, 2, 3 of #1921. P1 item 4 (asterisks) waiting on Paul. P2 (BPH cataloguer panel) is the next bigger piece.