### PR TITLE
BPH cataloguer panel — edit Supabase bph_works (#1921 P2)

### DIFF
--- a/src/app/api/catalog/bph/[ubn]/edit/route.ts
+++ b/src/app/api/catalog/bph/[ubn]/edit/route.ts
@@ -1,0 +1,212 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import { supabase, supabaseAdmin } from '@/lib/supabase';
+import { logAuditEvent } from '@/lib/audit-logger';
+import { withBphLibrarianAuth } from '@/lib/auth-helpers';
+
+/**
+ * POST /api/catalog/bph/[ubn]/edit
+ *
+ * BPH cataloguer panel write endpoint. Updates Supabase `bph_works` for the
+ * given UBN with librarian-edited fields. Auth-gated to BPH-tenant editors
+ * (or global admins) — see withBphLibrarianAuth.
+ *
+ * Atlas `books` is NOT touched. Surfacing edits back to the digitised
+ * book document is a separate sync problem (see #1921 P3 / out-of-scope notes).
+ *
+ * Audit trail: writes to the Mongo `audit_log` collection via logAuditEvent,
+ * with the per-field before/after diff and the actor email. We deliberately
+ * reuse the existing audit pipeline instead of creating a new `bph_works_audit`
+ * Supabase table for v1 — Mongo `audit_log` is already the canonical history
+ * surface and we want one place to read from when auditing librarian edits.
+ *
+ * The resource being edited (`bph_works.ubn`) is BPH by definition, so the
+ * tenant lockdown invariant is satisfied at the data layer — there's no path
+ * by which this route could mutate another tenant's catalogue.
+ *
+ * See issue #1921 P2.
+ */
+
+export const dynamic = 'force-dynamic';
+
+// Allowed librarian-editable fields. Anything else in the request body is
+// silently dropped. Adding a new field requires (a) confirming the column
+// exists in `bph_works`, (b) deciding the type contract, (c) adding it here.
+const ALLOWED_FIELDS = [
+  // Bibliographic identity
+  'title',
+  'parallel_title',
+  'uniform_title',
+  'author',
+  'variant_author',
+  'pseudonym',
+  'editor',
+  'variant_editor',
+  // Impressum
+  'place',
+  'printer',
+  'publisher',
+  'variant_printer',
+  'variant_publisher',
+  'year',
+  // Physical
+  'bibliographic_format',
+  'binding',
+  'bound_with',
+  'shelf_mark',
+  'state_shelf_mark',
+  'present_location',
+  'object_size_cm',
+  'number_of_copies',
+  // Content
+  'keywords',
+  'language',
+  'series_title',
+  'volume_title',
+  'bibliography',
+  'remarks',
+  'provenance',
+] as const;
+type EditableField = (typeof ALLOWED_FIELDS)[number];
+
+const INTEGER_FIELDS = new Set<EditableField>(['year', 'number_of_copies']);
+
+interface EditBody {
+  [k: string]: unknown;
+}
+
+function coerceField(field: EditableField, raw: unknown): { ok: true; value: string | number | null } | { ok: false; reason: string } {
+  // Treat undefined as "do not change" — caller filters first; here we only
+  // see fields that were explicitly present in the request body.
+  if (raw === null) return { ok: true, value: null };
+
+  if (INTEGER_FIELDS.has(field)) {
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      if (trimmed === '') return { ok: true, value: null };
+      const n = Number(trimmed);
+      if (!Number.isFinite(n) || !Number.isInteger(n)) return { ok: false, reason: `${field} must be an integer` };
+      return { ok: true, value: n };
+    }
+    if (typeof raw === 'number') {
+      if (!Number.isFinite(raw) || !Number.isInteger(raw)) return { ok: false, reason: `${field} must be an integer` };
+      return { ok: true, value: raw };
+    }
+    return { ok: false, reason: `${field} must be an integer or string` };
+  }
+
+  if (typeof raw !== 'string') return { ok: false, reason: `${field} must be a string` };
+  const trimmed = raw.trim();
+  // Empty string normalizes to NULL — easier for librarians who clear a field.
+  return { ok: true, value: trimmed === '' ? null : trimmed };
+}
+
+export const POST = withBphLibrarianAuth(async (request: NextRequest, session, context) => {
+  const { ubn } = await context.params as { ubn: string };
+  if (!ubn) {
+    return NextResponse.json({ error: 'Missing ubn' }, { status: 400 });
+  }
+
+  if (!supabaseAdmin) {
+    return NextResponse.json(
+      { error: 'Service unavailable — SUPABASE_SERVICE_ROLE_KEY not configured' },
+      { status: 503 }
+    );
+  }
+
+  let body: EditBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  // Fetch the existing row first (read via the anon client — same row that
+  // the public catalogue page would show). 404 if it doesn't exist; we don't
+  // create new bph_works rows from the editor.
+  const existingFields = ALLOWED_FIELDS.join(', ');
+  const { data: existing, error: fetchError } = await supabase
+    .from('bph_works')
+    .select(`ubn, ${existingFields}`)
+    .eq('ubn', ubn)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error('[bph-edit] Failed to fetch existing row:', fetchError);
+    return NextResponse.json({ error: 'Failed to fetch existing record' }, { status: 500 });
+  }
+  if (!existing) {
+    return NextResponse.json({ error: `No BPH catalogue entry for UBN ${ubn}` }, { status: 404 });
+  }
+
+  // Build the update set + diff.
+  const updates: Record<string, string | number | null> = {};
+  const changes: Record<string, { before: unknown; after: unknown }> = {};
+
+  const existingRow = existing as unknown as Record<string, unknown>;
+  for (const field of ALLOWED_FIELDS) {
+    if (!(field in body)) continue;
+    const result = coerceField(field, body[field]);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.reason }, { status: 400 });
+    }
+    const before = existingRow[field] ?? null;
+    const after = result.value;
+    // Skip no-ops so we don't pollute the audit trail.
+    if (before === after) continue;
+    // Treat null/empty-string equivalents as no-ops too.
+    if ((before === null || before === '') && (after === null || after === '')) continue;
+    updates[field] = after;
+    changes[field] = { before, after };
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ ok: true, updated: [], message: 'No changes' });
+  }
+
+  // Persist via the service-role client (anon writes are blocked by RLS).
+  const { data: updated, error: updateError } = await supabaseAdmin
+    .from('bph_works')
+    .update(updates)
+    .eq('ubn', ubn)
+    .select(`ubn, ${existingFields}`)
+    .maybeSingle();
+
+  if (updateError || !updated) {
+    console.error('[bph-edit] Update failed:', updateError);
+    return NextResponse.json({ error: 'Failed to update record' }, { status: 500 });
+  }
+
+  // Audit trail (non-blocking). The book_id field is repurposed for the BPH
+  // UBN here — see logAuditEvent comments; the field is typed string and the
+  // history surfacing already handles non-Mongo ids.
+  const actorEmail = session.user?.email || 'unknown';
+  logAuditEvent({
+    action: 'book_metadata_updated',
+    book_id: `bph:${ubn}`,
+    book_title: (existingRow.title as string | null | undefined) || undefined,
+    actor: actorEmail,
+    triggered_by: 'manual',
+    metadata: {
+      source: 'bph_cataloguer_panel',
+      ubn,
+      fields_changed: Object.keys(changes),
+      changes,
+    },
+  });
+
+  // Revalidate the catalogue detail pages (server-rendered, ISR-friendly).
+  try {
+    revalidatePath(`/embed/[tenant]/catalog/${ubn}`, 'page');
+    revalidatePath(`/catalog/${ubn}`, 'page');
+  } catch {
+    // revalidatePath is best-effort; failures shouldn't fail the request.
+  }
+
+  return NextResponse.json({
+    ok: true,
+    ubn,
+    updated: Object.keys(changes),
+    work: updated,
+  });
+});

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -7,6 +7,7 @@ import { tenantBookUrl } from '@/lib/slugify';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import { getPartnerBySlug } from '@/lib/library-partners';
 import GenericCatalogEntry, { generateGenericMetadata } from './GenericCatalogEntry';
+import BphCatalogueEditButton from '@/components/book/BphCatalogueEditButton';
 
 // Catalogue entry routing
 // - BPH (providerKey === 'bph'): legacy `bph_works` table + bespoke fields
@@ -315,6 +316,13 @@ export default async function CatalogEntryPage({ params }: Props) {
           {work.year && <span className="tabular-nums">{work.year}</span>}
           {work.place && <span>{work.place}</span>}
           {work.language && <span className="text-muted">{work.language}</span>}
+        </div>
+
+        {/* Cataloguer edit affordance — gated by AuthCheck inside the button.
+            Visible only to BPH librarians + global admins. Writes Supabase
+            bph_works directly (see #1921 P2). */}
+        <div className="mb-6">
+          <BphCatalogueEditButton work={work} variant="header" />
         </div>
 
         {/* Source Library digital edition (when available) */}

--- a/src/components/auth/AuthCheck.tsx
+++ b/src/components/auth/AuthCheck.tsx
@@ -5,8 +5,16 @@ import { useStableSession } from '@/hooks/useStableSession';
 interface AuthCheckProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
-  /** Require a specific role. 'admin' = admin only. 'inner_circle' = admin or inner_circle. Default: any authenticated user. */
-  role?: 'admin' | 'inner_circle' | 'reader';
+  /**
+   * Require a specific role.
+   * - 'admin'         — admin or superadmin (global only)
+   * - 'inner_circle'  — editor-equivalent (global OR tenant membership)
+   * - 'reader'        — any authenticated user
+   * - 'bph_librarian' — editor on the BPH tenant OR global admin. Used to gate
+   *   the BPH cataloguer panel. The underlying check is tenant-scoped (not a
+   *   new global role) but the name makes the intent obvious at the callsite.
+   */
+  role?: 'admin' | 'inner_circle' | 'reader' | 'bph_librarian';
 }
 
 // Mirrors ROLE_LEVEL in src/lib/auth.ts, with legacy aliases (inner_circle, curator)
@@ -57,6 +65,18 @@ export function AuthCheck({ children, fallback = null, role }: AuthCheckProps) {
 
   if (role === 'inner_circle' && level < ROLE_LEVEL.editor) {
     return <>{fallback}</>;
+  }
+
+  // BPH cataloguer panel: tenant-scoped editor on BPH, OR global admin/superadmin.
+  // We check tenantSlug explicitly because a `tenantRole = 'editor'` set on a
+  // different tenant must not unlock BPH writes.
+  if (role === 'bph_librarian') {
+    const tenantSlug = user.tenantSlug;
+    const isBphEditor = tenantSlug === 'bph' && (ROLE_LEVEL[user.tenantRole] ?? 0) >= ROLE_LEVEL.editor;
+    const isGlobalAdmin = globalLevel >= ROLE_LEVEL.admin;
+    if (!isBphEditor && !isGlobalAdmin) {
+      return <>{fallback}</>;
+    }
   }
 
   return <>{children}</>;

--- a/src/components/book/BphCatalogueEditButton.tsx
+++ b/src/components/book/BphCatalogueEditButton.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { AuthCheck } from '@/components/auth/AuthCheck';
+import BphCatalogueEditModal, { type BphWorkEditable } from './BphCatalogueEditModal';
+
+/**
+ * Client wrapper that adds an "Edit cataloguer fields" button to a server-
+ * rendered BPH catalogue view. Visible only to users with `bph_librarian`
+ * rights (BPH-tenant editor or global admin). Opens the modal that writes
+ * Supabase `bph_works`.
+ *
+ * Kept as a thin shell so the server component (BphCatalogueRecord) doesn't
+ * need to become client-side.
+ */
+export default function BphCatalogueEditButton({ work, variant = 'inline' }: {
+  work: BphWorkEditable;
+  /** 'inline' for the inline catalogue record (book detail page),
+   *  'header' for the standalone catalogue detail page. */
+  variant?: 'inline' | 'header';
+}) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  // Slightly different styling per surface so the inline (dark) and header
+  // (light) backgrounds both stay legible.
+  const buttonCls =
+    variant === 'header'
+      ? 'inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md border border-accent-rust/40 text-accent-rust hover:bg-accent-rust/10 transition-colors'
+      : 'inline-flex items-center gap-1.5 text-sm text-accent-gold hover:text-accent-gold transition-colors';
+
+  return (
+    <AuthCheck role="bph_librarian">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={buttonCls}
+        title="Edit BPH catalogue fields (Supabase bph_works)"
+      >
+        <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+        Edit cataloguer fields
+      </button>
+
+      {open && (
+        <BphCatalogueEditModal
+          work={work}
+          onClose={() => setOpen(false)}
+          onSave={() => {
+            // Re-fetch the server component data so the updated values show
+            // without a full reload.
+            router.refresh();
+          }}
+        />
+      )}
+    </AuthCheck>
+  );
+}

--- a/src/components/book/BphCatalogueEditModal.tsx
+++ b/src/components/book/BphCatalogueEditModal.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { X, Save, Loader2 } from 'lucide-react';
+
+/**
+ * BphCatalogueEditModal — cataloguer panel for Supabase `bph_works`.
+ *
+ * Mirrors BookEditModal in shape (modal overlay, save/cancel) but writes to
+ * a different store (`bph_works` via /api/catalog/bph/[ubn]/edit) and exposes
+ * the BPH-rich field set Paul Dijstelberge asked for in issue #1921 P2.
+ *
+ * Atlas `books` is NOT touched here — see the API route doc-comment. Sync
+ * back to the digitised book document is out of scope for v1.
+ *
+ * Repeatable fields in BPH (e.g. variant_author) live as single text columns
+ * in `bph_works`; the UI uses textareas and the convention "one per line".
+ * Reshaping the table into sub-records is a follow-up (out of scope per
+ * #1921 plan).
+ */
+
+export interface BphWorkEditable {
+  ubn: string;
+  // Bibliographic identity
+  title?: string | null;
+  parallel_title?: string | null;
+  uniform_title?: string | null;
+  author?: string | null;
+  variant_author?: string | null;
+  pseudonym?: string | null;
+  editor?: string | null;
+  variant_editor?: string | null;
+  // Impressum
+  place?: string | null;
+  printer?: string | null;
+  publisher?: string | null;
+  variant_printer?: string | null;
+  variant_publisher?: string | null;
+  year?: number | null;
+  // Physical
+  bibliographic_format?: string | null;
+  binding?: string | null;
+  bound_with?: string | null;
+  shelf_mark?: string | null;
+  state_shelf_mark?: string | null;
+  present_location?: string | null;
+  object_size_cm?: string | null;
+  number_of_copies?: number | null;
+  // Content
+  keywords?: string | null;
+  language?: string | null;
+  series_title?: string | null;
+  volume_title?: string | null;
+  bibliography?: string | null;
+  remarks?: string | null;
+  provenance?: string | null;
+}
+
+interface BphCatalogueEditModalProps {
+  work: BphWorkEditable;
+  onClose: () => void;
+  onSave?: () => void;
+}
+
+export default function BphCatalogueEditModal({ work, onClose, onSave }: BphCatalogueEditModalProps) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedSummary, setSavedSummary] = useState<string | null>(null);
+
+  // Form fields — initialise from the loaded row, treating null as empty so
+  // the input is always controlled.
+  const [title, setTitle] = useState(work.title ?? '');
+  const [parallelTitle, setParallelTitle] = useState(work.parallel_title ?? '');
+  const [uniformTitle, setUniformTitle] = useState(work.uniform_title ?? '');
+  const [author, setAuthor] = useState(work.author ?? '');
+  const [variantAuthor, setVariantAuthor] = useState(work.variant_author ?? '');
+  const [pseudonym, setPseudonym] = useState(work.pseudonym ?? '');
+  const [editor, setEditor] = useState(work.editor ?? '');
+  const [variantEditor, setVariantEditor] = useState(work.variant_editor ?? '');
+
+  const [place, setPlace] = useState(work.place ?? '');
+  const [printer, setPrinter] = useState(work.printer ?? '');
+  const [publisher, setPublisher] = useState(work.publisher ?? '');
+  const [variantPrinter, setVariantPrinter] = useState(work.variant_printer ?? '');
+  const [variantPublisher, setVariantPublisher] = useState(work.variant_publisher ?? '');
+  const [year, setYear] = useState(work.year != null ? String(work.year) : '');
+
+  const [bibliographicFormat, setBibliographicFormat] = useState(work.bibliographic_format ?? '');
+  const [binding, setBinding] = useState(work.binding ?? '');
+  const [boundWith, setBoundWith] = useState(work.bound_with ?? '');
+  const [shelfMark, setShelfMark] = useState(work.shelf_mark ?? '');
+  const [stateShelfMark, setStateShelfMark] = useState(work.state_shelf_mark ?? '');
+  const [presentLocation, setPresentLocation] = useState(work.present_location ?? '');
+  const [objectSizeCm, setObjectSizeCm] = useState(work.object_size_cm ?? '');
+  const [numberOfCopies, setNumberOfCopies] = useState(work.number_of_copies != null ? String(work.number_of_copies) : '');
+
+  const [keywords, setKeywords] = useState(work.keywords ?? '');
+  const [language, setLanguage] = useState(work.language ?? '');
+  const [seriesTitle, setSeriesTitle] = useState(work.series_title ?? '');
+  const [volumeTitle, setVolumeTitle] = useState(work.volume_title ?? '');
+  const [bibliography, setBibliography] = useState(work.bibliography ?? '');
+  const [remarks, setRemarks] = useState(work.remarks ?? '');
+  const [provenance, setProvenance] = useState(work.provenance ?? '');
+
+  // Handle Escape key to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSavedSummary(null);
+
+    try {
+      const payload: Record<string, string | number | null> = {
+        title, parallel_title: parallelTitle, uniform_title: uniformTitle,
+        author, variant_author: variantAuthor, pseudonym,
+        editor, variant_editor: variantEditor,
+        place, printer, publisher,
+        variant_printer: variantPrinter, variant_publisher: variantPublisher,
+        year: year.trim() === '' ? null : year.trim(),
+        bibliographic_format: bibliographicFormat,
+        binding, bound_with: boundWith,
+        shelf_mark: shelfMark, state_shelf_mark: stateShelfMark,
+        present_location: presentLocation,
+        object_size_cm: objectSizeCm,
+        number_of_copies: numberOfCopies.trim() === '' ? null : numberOfCopies.trim(),
+        keywords, language,
+        series_title: seriesTitle, volume_title: volumeTitle,
+        bibliography, remarks, provenance,
+      };
+
+      const res = await fetch(`/api/catalog/bph/${encodeURIComponent(work.ubn)}/edit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data?.error || `HTTP ${res.status}`);
+      }
+
+      const updatedFields: string[] = Array.isArray(data?.updated) ? data.updated : [];
+      if (updatedFields.length === 0) {
+        setSavedSummary('No changes to save.');
+      } else {
+        setSavedSummary(`Updated ${updatedFields.length} field${updatedFields.length === 1 ? '' : 's'}.`);
+      }
+      onSave?.();
+      // Close after a short success blip so the librarian sees confirmation.
+      setTimeout(() => onClose(), 600);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bph-cataloguer-modal-title"
+        className="bg-white rounded-xl shadow-xl max-w-3xl w-full max-h-[92vh] overflow-y-auto"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-stone-200 sticky top-0 bg-white z-10">
+          <div>
+            <h2 id="bph-cataloguer-modal-title" className="text-lg font-semibold text-stone-900">
+              Edit cataloguer fields
+            </h2>
+            <p className="text-xs text-stone-500 mt-0.5">
+              BPH UBN <span className="font-mono">{work.ubn}</span> — writes Supabase <span className="font-mono">bph_works</span>
+            </p>
+          </div>
+          <button onClick={onClose} aria-label="Close dialog" className="p-1 hover:bg-stone-100 rounded">
+            <X className="w-5 h-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-6">
+          {/* 1. Bibliographic identity */}
+          <Section title="Bibliographic identity" subtitle="Preserve title-page spellings in the variant fields.">
+            <Row>
+              <Field2Col label="Short title">
+                <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Year">
+                <input type="text" inputMode="numeric" value={year} onChange={(e) => setYear(e.target.value)} placeholder="e.g. 1695" className={inputCls} />
+              </Field2Col>
+            </Row>
+            <Field label="Full title (transcription)" hint="Long-form title as printed.">
+              <textarea value={parallelTitle} onChange={(e) => setParallelTitle(e.target.value)} rows={2} className={textareaCls} />
+            </Field>
+            <Field label="Variant title">
+              <input type="text" value={uniformTitle} onChange={(e) => setUniformTitle(e.target.value)} className={inputCls} />
+            </Field>
+            <Row>
+              <Field2Col label="Author (canonical)">
+                <input type="text" value={author} onChange={(e) => setAuthor(e.target.value)} className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Author (as on title page)" hint="One per line for multiple variants.">
+                <textarea value={variantAuthor} onChange={(e) => setVariantAuthor(e.target.value)} rows={2} className={textareaCls} />
+              </Field2Col>
+            </Row>
+            <Row>
+              <Field2Col label="Pseudonym">
+                <input type="text" value={pseudonym} onChange={(e) => setPseudonym(e.target.value)} className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Editor / translator">
+                <input type="text" value={editor} onChange={(e) => setEditor(e.target.value)} className={inputCls} />
+              </Field2Col>
+            </Row>
+            <Field label="Editor (as on title page)" hint="One per line for multiple variants.">
+              <textarea value={variantEditor} onChange={(e) => setVariantEditor(e.target.value)} rows={2} className={textareaCls} />
+            </Field>
+          </Section>
+
+          {/* 2. Impressum */}
+          <Section title="Impressum" subtitle="Place, printer, publisher — the imprint statement.">
+            <Row>
+              <Field2Col label="Place">
+                <input type="text" value={place} onChange={(e) => setPlace(e.target.value)} placeholder="e.g. Amsterdam" className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Printer">
+                <input type="text" value={printer} onChange={(e) => setPrinter(e.target.value)} className={inputCls} />
+              </Field2Col>
+            </Row>
+            <Row>
+              <Field2Col label="Publisher">
+                <input type="text" value={publisher} onChange={(e) => setPublisher(e.target.value)} className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Printer (variant)">
+                <input type="text" value={variantPrinter} onChange={(e) => setVariantPrinter(e.target.value)} className={inputCls} />
+              </Field2Col>
+            </Row>
+            <Field label="Publisher (variant)">
+              <input type="text" value={variantPublisher} onChange={(e) => setVariantPublisher(e.target.value)} className={inputCls} />
+            </Field>
+          </Section>
+
+          {/* 3. Physical */}
+          <Section title="Physical" subtitle="Collation formula, binding, location at BPH.">
+            <Field label="Format (collation formula)" hint="e.g. In-4 : A-Ff⁴. Asterisks and other notation are preserved verbatim.">
+              <input type="text" value={bibliographicFormat} onChange={(e) => setBibliographicFormat(e.target.value)} className={inputCls + ' font-mono'} />
+            </Field>
+            <Field label="Binding" hint="Free text — describe the physical binding.">
+              <textarea value={binding} onChange={(e) => setBinding(e.target.value)} rows={2} className={textareaCls} />
+            </Field>
+            <Field label="Bound with">
+              <input type="text" value={boundWith} onChange={(e) => setBoundWith(e.target.value)} className={inputCls} />
+            </Field>
+            <Row>
+              <Field2Col label="Shelf mark">
+                <input type="text" value={shelfMark} onChange={(e) => setShelfMark(e.target.value)} className={inputCls + ' font-mono'} />
+              </Field2Col>
+              <Field2Col label="State Collection shelf mark">
+                <input type="text" value={stateShelfMark} onChange={(e) => setStateShelfMark(e.target.value)} className={inputCls + ' font-mono'} />
+              </Field2Col>
+            </Row>
+            <Row>
+              <Field2Col label="Present location">
+                <input type="text" value={presentLocation} onChange={(e) => setPresentLocation(e.target.value)} className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Object size (cm)">
+                <input type="text" value={objectSizeCm} onChange={(e) => setObjectSizeCm(e.target.value)} className={inputCls} />
+              </Field2Col>
+            </Row>
+            <Field label="Number of copies held">
+              <input type="text" inputMode="numeric" value={numberOfCopies} onChange={(e) => setNumberOfCopies(e.target.value)} className={inputCls} />
+            </Field>
+          </Section>
+
+          {/* 4. Content */}
+          <Section title="Content" subtitle="Keywords, notes, language.">
+            <Field label="Keywords" hint="Comma-separated.">
+              <textarea value={keywords} onChange={(e) => setKeywords(e.target.value)} rows={2} className={textareaCls} />
+            </Field>
+            <Field label="Language">
+              <input type="text" value={language} onChange={(e) => setLanguage(e.target.value)} placeholder="e.g. Dutch" className={inputCls} />
+            </Field>
+            <Row>
+              <Field2Col label="Series title">
+                <input type="text" value={seriesTitle} onChange={(e) => setSeriesTitle(e.target.value)} className={inputCls} />
+              </Field2Col>
+              <Field2Col label="Volume title">
+                <input type="text" value={volumeTitle} onChange={(e) => setVolumeTitle(e.target.value)} className={inputCls} />
+              </Field2Col>
+            </Row>
+            <Field label="Bibliography">
+              <textarea value={bibliography} onChange={(e) => setBibliography(e.target.value)} rows={2} className={textareaCls} />
+            </Field>
+            <Field label="Remarks (notes)" hint="Multiple notes — one per line.">
+              <textarea value={remarks} onChange={(e) => setRemarks(e.target.value)} rows={3} className={textareaCls} />
+            </Field>
+            <Field label="Provenance / collection">
+              <input type="text" value={provenance} onChange={(e) => setProvenance(e.target.value)} className={inputCls} />
+            </Field>
+          </Section>
+
+          {error && (
+            <div role="alert" className="p-3 bg-red-50 text-red-700 rounded-lg text-sm">
+              {error}
+            </div>
+          )}
+          {savedSummary && !error && (
+            <div role="status" className="p-3 bg-emerald-50 text-emerald-800 rounded-lg text-sm">
+              {savedSummary}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 p-4 border-t border-stone-200 bg-stone-50 sticky bottom-0">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-stone-700 hover:bg-stone-200 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-2 px-4 py-2 bg-accent-rust text-white rounded-lg hover:bg-accent-rust/90 disabled:opacity-50 transition-colors"
+          >
+            {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+            Save changes
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- small layout helpers (kept local so the modal is self-contained) ----------
+
+const inputCls =
+  'w-full px-3 py-2 border border-stone-300 rounded-lg text-stone-900 focus:outline-none focus:ring-2 focus-visible:ring-accent-rust';
+const textareaCls = inputCls + ' resize-y';
+
+function Section({ title, subtitle, children }: { title: string; subtitle?: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <div className="border-b border-stone-200 pb-1">
+        <h3 className="text-sm font-semibold text-stone-800">{title}</h3>
+        {subtitle && <p className="text-xs text-stone-500">{subtitle}</p>}
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">{children}</div>;
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-sm font-medium text-stone-700 mb-1">{label}</span>
+      {children}
+      {hint && <span className="block text-xs text-stone-500 mt-1">{hint}</span>}
+    </label>
+  );
+}
+
+function Field2Col({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-sm font-medium text-stone-700 mb-1">{label}</span>
+      {children}
+      {hint && <span className="block text-xs text-stone-500 mt-1">{hint}</span>}
+    </label>
+  );
+}

--- a/src/components/book/BphCatalogueRecord.tsx
+++ b/src/components/book/BphCatalogueRecord.tsx
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { ExternalLink } from 'lucide-react';
+import BphCatalogueEditButton from './BphCatalogueEditButton';
 
 /**
  * Inline display of a book's BPH catalogue record, side-loaded from Supabase
@@ -21,8 +22,10 @@ interface FieldProvenance {
 
 interface BphWorkRow {
   ubn: string;
+  title: string | null;
   parallel_title: string | null;
   uniform_title: string | null;
+  author: string | null;
   variant_author: string | null;
   pseudonym: string | null;
   editor: string | null;
@@ -32,6 +35,7 @@ interface BphWorkRow {
   publisher: string | null;
   variant_printer: string | null;
   variant_publisher: string | null;
+  year: number | null;
   shelf_mark: string | null;
   state_shelf_mark: string | null;
   present_location: string | null;
@@ -56,10 +60,10 @@ async function fetchWork(ubn: string): Promise<BphWorkRow | null> {
   const { data } = await supabase
     .from('bph_works')
     .select(`
-      ubn, parallel_title, uniform_title,
-      variant_author, pseudonym, editor, variant_editor,
+      ubn, title, parallel_title, uniform_title,
+      author, variant_author, pseudonym, editor, variant_editor,
       place, printer, publisher, variant_printer, variant_publisher,
-      shelf_mark, state_shelf_mark, present_location,
+      year, shelf_mark, state_shelf_mark, present_location,
       keywords, language, series_title, volume_title,
       bibliography, remarks, number_of_copies, object_size_cm,
       bibliographic_format, binding, bound_with,
@@ -118,6 +122,13 @@ export default async function BphCatalogueRecord({ ubn }: { ubn: string }) {
       </summary>
 
       <div className="mt-3 p-4 bg-stone-800/50 rounded-lg border border-stone-700 space-y-4">
+        {/* Cataloguer edit affordance — only renders for BPH librarians /
+            global admins via AuthCheck inside the button. Keeps the BPH
+            partner panel where the data lives. */}
+        <div className="flex justify-end -mb-2">
+          <BphCatalogueEditButton work={work} variant="inline" />
+        </div>
+
         {(work.parallel_title || work.uniform_title || work.series_title || work.volume_title) && (
           <Section title="Title">
             <Field label="Full title (transcription)" value={work.parallel_title} />

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -254,3 +254,66 @@ export const withInnerCircleAuth = (h: (request: NextRequest, session: Session, 
 // TODO: Remove withCuratorAuth — mapped to 'editor'. Verify each callsite matches
 // this permission level before removing.
 export const withCuratorAuth = (h: (request: NextRequest, session: Session, context?: any) => Promise<NextResponse>) => withAuth(h, { minRole: 'editor' });
+
+/**
+ * BPH librarian auth wrapper.
+ *
+ * Tenant-scoped editor surface for the BPH cataloguer panel — writes Supabase
+ * `bph_works`. A user passes when they are EITHER:
+ *   - an active `editor`-or-higher member of the BPH tenant (memberships row
+ *     with tenantSlug='bph'), OR
+ *   - a global admin / superadmin.
+ *
+ * Unlike `withAuth`, this guard:
+ *   - Refuses the CRON_SECRET bearer path. Cataloguer edits are a human-only
+ *     surface (audit-trail concerns — a librarian must be attributable).
+ *   - Does not depend on the request `x-tenant-id` header, because the
+ *     editor surface may render from a tenant-scoped path OR from the global
+ *     book detail page (where the same BPH catalogue record is inline). The
+ *     resource being edited (`bph_works.ubn`) is BPH by definition.
+ *
+ * See issue #1921 P2.
+ */
+export function withBphLibrarianAuth(
+  handler: (request: NextRequest, session: Session, context?: any) => Promise<NextResponse>,
+): (request: NextRequest, context?: any) => Promise<NextResponse> {
+  return async (request: NextRequest, context?: any) => {
+    const session = await auth();
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'Unauthorized - Authentication required' },
+        { status: 401 }
+      );
+    }
+
+    const globalRole = normalizeRole((session.user as any).role);
+    const isGlobalAdmin = (ROLE_LEVEL[globalRole] ?? 0) >= ROLE_LEVEL['admin'];
+
+    // Resolve BPH tenant id and check membership.
+    let isBphEditor = false;
+    try {
+      const db = await getDb();
+      const bphTenant = await db.collection('tenants').findOne(
+        { slug: 'bph', status: { $ne: 'deleted' } },
+        { projection: { id: 1 } }
+      );
+      if (bphTenant?.id) {
+        const tenantRole = await getTenantMembershipRole(session.user.email, bphTenant.id as string);
+        if (tenantRole && (ROLE_LEVEL[tenantRole] ?? 0) >= ROLE_LEVEL['editor']) {
+          isBphEditor = true;
+        }
+      }
+    } catch {
+      // Fail closed on lookup failure.
+    }
+
+    if (!isGlobalAdmin && !isBphEditor) {
+      return NextResponse.json(
+        { error: 'Forbidden - BPH librarian role required' },
+        { status: 403 }
+      );
+    }
+
+    return handler(request, session, context);
+  };
+}


### PR DESCRIPTION
## Why

Paul Dijstelberge logged into bph.sourcelibrary.org on 2026-05-21 and could only edit the keywords field. The reason: the existing `BookEditModal` writes to Atlas `books` (8 fields). The BPH-rich fields Paul wants — binding, shelfmark, bibliographic_format (collation formula), remarks, variant authors — live in Supabase `bph_works`, which had no editor surface. Issue #1921 plan called this out as the P2 task; P1 shipped today in #1932.

## What

A parallel **BPH cataloguer panel** that writes Supabase `bph_works`. Architecturally separate from `BookEditModal` so the Atlas surface stays lean and Paul gets a tool that matches his mental model.

### Field set rationale

Editable fields (from #1921 P2 spec, mapped to actual `bph_works` columns):
- **Bibliographic identity** — `title`, `parallel_title`, `uniform_title`, `author`, `variant_author`, `pseudonym`, `editor`, `variant_editor`
- **Impressum** — `place`, `printer`, `publisher`, `variant_printer`, `variant_publisher`, `year`
- **Physical** — `bibliographic_format` (collation), `binding`, `bound_with`, `shelf_mark`, `state_shelf_mark`, `present_location`, `object_size_cm`, `number_of_copies`
- **Content** — `keywords`, `language`, `series_title`, `volume_title`, `bibliography`, `remarks`, `provenance`

Repeatable fields in BPH (e.g. `variant_author`) are single text columns in `bph_works`, not sub-records. The UI uses textareas with "one per line" guidance rather than reshaping the table — splitting these into proper sub-records is a follow-up (out of scope for v1).

Read-only on this surface (handled elsewhere or sourced upstream): `ia_identifier`, `ustc_sn`, `sl_book_id`, `field_provenance`, `sl_external_*`.

### Auth model

New `withBphLibrarianAuth` wrapper in `src/lib/auth-helpers.ts`. Passes when the user has:
- Active `editor`-or-higher membership on the **BPH tenant** (memberships row, slug=`bph`), **OR**
- Global `admin` / `superadmin`.

The check is tenant-scoped, not a new global role — this is a librarian surface, not a platform-wide capability. `AuthCheck` gets a matching `bph_librarian` value so the same intent is expressed at the UI callsite (rather than reusing the more permissive `inner_circle`).

Deliberately **no `CRON_SECRET` bypass** — cataloguer edits are a human-only audit-trail surface; a librarian must be attributable.

### Audit trail

Writes a row to the existing Mongo `audit_log` collection via `logAuditEvent` with:
- `action: 'book_metadata_updated'`
- `book_id: 'bph:<ubn>'` (namespaced so it's distinguishable from Atlas edits)
- `actor: session.user.email`
- `metadata.source: 'bph_cataloguer_panel'`
- `metadata.changes: { field: { before, after } }`

Chose `audit_log` over a new `bph_works_audit` Supabase table for v1: it's the canonical history surface already wired into `/api/books/[id]/history`, and one place is easier to read. If/when BPH-specific audit needs diverge we can add a Supabase mirror table.

### Tenant lockdown

- The resource being edited (`bph_works.ubn`) is BPH by definition — no path by which this route could mutate another tenant's catalogue.
- The Edit button uses `AuthCheck role="bph_librarian"` and the role check looks at `tenantSlug === 'bph'` explicitly, so an editor on another tenant cannot accidentally unlock writes.
- No new internal links; the modal stays on-host.

## Where it surfaces

1. **`BphCatalogueRecord.tsx`** (inline catalogue panel on the book detail page) — the Edit button sits at the top of the expanded catalogue record, only rendered for BPH librarians.
2. **`/embed/[tenant]/catalog/[ubn]` page** — header-style Edit button under the metadata line.

Both routes are tenant-aware via `proxy.ts`; the cataloguer panel renders the same on `bph.sourcelibrary.org/catalogue/<ubn>` and the embed path.

## Out of scope (per task description)

- Author thesaurus / VIAF lookup (#1921 P3, separate)
- Backfilling bph_works data (the asterisks bug — needs Paul to identify the book)
- Syncing edits back to Atlas `books` (separate sync problem)
- Jungkamer physical-only ingest (#1922 Phase 2, blocked on this PR)
- Splitting bph_works fields into repeating sub-records (binding-per-copy etc.)

## Test plan

- [ ] BPH-tenant editor (Paul's account) sees the "Edit cataloguer fields" button on `bph.sourcelibrary.org/catalogue/<UBN>` and on the book detail page when the book has a BPH UBN.
- [ ] Reader-only accounts and non-BPH editors do **not** see the button.
- [ ] Editing a field, clicking Save → row in `bph_works` updates, modal closes, page refreshes with new values.
- [ ] `audit_log` row appears with `source: 'bph_cataloguer_panel'`, correct `actor`, before/after diff.
- [ ] Empty string clears a field (stored as NULL).
- [ ] Invalid `year` / `number_of_copies` returns 400 with field-named error.
- [ ] Unauthenticated POST → 401. Authenticated reader → 403. CRON_SECRET bearer → 403 (no bypass).
- [ ] Non-existent UBN → 404.
- [ ] `npx tsc --noEmit` clean (verified locally).
- [ ] BPH subdomain lockdown audit (`scripts/audit-bph-leaks.mjs`) still passes — no new off-subdomain links introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)