### PR TITLE
Jung Library: backfill null contributing_library on new imports

### DIFF
--- a/.claude/docs/jung-library-crossref-2026-05-22.json
+++ b/.claude/docs/jung-library-crossref-2026-05-22.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-05-22T07:42:13.780Z",
+  "generated_at": "2026-05-22T10:15:29.293Z",
   "oai_set": "cgj",
   "contributing_library": "Stiftung der Werke von C.G. Jung (Zürich)",
   "summary": {
     "total": 345,
-    "byEraraId": 284,
+    "byEraraId": 340,
     "byTitleAuthor": 1,
-    "newCount": 60
+    "newCount": 4
   },
   "records": [
     {
@@ -34,7 +34,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1171064",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1171064/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008daf717292950966438",
+      "existing_title": "Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque theologica : opus antiquissimae philosophiae barbaricae variis speciminibus refertissimum ... / [Tomus primus.]",
+      "existing_visible": false
     },
     {
       "erara_id": "1172145",
@@ -46,7 +49,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1172145",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1172145/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008e4f717292950966872",
+      "existing_title": "Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque theologica : opus antiquissimae philosophiae barbaricae variis speciminibus refertissimum ... / Tomus secundus.",
+      "existing_visible": false
     },
     {
       "erara_id": "1190973",
@@ -373,7 +379,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1386545",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1386545/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008e8f717292950966e31",
+      "existing_title": "Bibliothèque des philosophes chimiques / Tome premier.",
+      "existing_visible": false
     },
     {
       "erara_id": "1387143",
@@ -385,7 +394,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1387143",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1387143/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008eef717292950967088",
+      "existing_title": "Bibliothèque des philosophes chimiques / Tome second.",
+      "existing_visible": false
     },
     {
       "erara_id": "1387726",
@@ -397,7 +409,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1387726",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1387726/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008f3f7172929509672d0",
+      "existing_title": "Bibliothèque des philosophes chimiques / Tome troisième.",
+      "existing_visible": false
     },
     {
       "erara_id": "1388324",
@@ -754,7 +769,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1529971",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1529971/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008f9f717292950967524",
+      "existing_title": "Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii, der zwölff Schlüssel von dem Stein der uhralten Weisen und desselben aussdrücklichen unnd warhafften Praeparation ... : item Ausslegung Rythmorum Basilii von der Materia des Steins der Philosophen ... / Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii.",
+      "existing_visible": false
     },
     {
       "erara_id": "1530085",
@@ -766,7 +784,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1530085",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1530085/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1008fef717292950967597",
+      "existing_title": "Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophischen Schrifften Fratris Basilii, der zwölff Schlüssel von dem Stein der uhralten Weisen und desselben aussdrücklichen unnd warhafften Praeparation ... : item Ausslegung Rythmorum Basilii von der Materia des Steins der Philosophen ... / Gründliche Ausslegung und warhafftige Erklerung der rythmorum Fratris Basilii Valentini Monachi.",
+      "existing_visible": false
     },
     {
       "erara_id": "1530175",
@@ -853,7 +874,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1557942",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1557942/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100903f7172929509675f0",
+      "existing_title": "Lucii Apuleii ... Opera / Tomus I.",
+      "existing_visible": false
     },
     {
       "erara_id": "1558300",
@@ -865,7 +889,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1558300",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1558300/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10090bf717292950967757",
+      "existing_title": "Lucii Apuleii ... Opera / Tomus II.",
+      "existing_visible": false
     },
     {
       "erara_id": "1558622",
@@ -967,7 +994,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2206662",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2206662/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100911f717292950967898",
+      "existing_title": "Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, avec une explication des hiéroglyphes, et de la guerre de Troye / Tome premier.",
+      "existing_visible": false
     },
     {
       "erara_id": "1604772",
@@ -1129,7 +1159,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1606983",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1606983/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100917f717292950967b00",
+      "existing_title": "An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the Soul is evinced from the Principles of Reason and Philosophy / Volume I.",
+      "existing_visible": false
     },
     {
       "erara_id": "1607437",
@@ -1141,7 +1174,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1607437",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1607437/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10091ff717292950967cc7",
+      "existing_title": "An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the Soul is evinced from the Principles of Reason and Philosophy / Volume II.",
+      "existing_visible": false
     },
     {
       "erara_id": "1607901",
@@ -1840,7 +1876,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1831696",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1831696/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10092af717292950967e96",
+      "existing_title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ... / 1",
+      "existing_visible": false
     },
     {
       "erara_id": "1832242",
@@ -1852,7 +1891,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1832242",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1832242/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10092ff7172929509680b9",
+      "existing_title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ... / 2",
+      "existing_visible": false
     },
     {
       "erara_id": "1832773",
@@ -1864,7 +1906,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1832773",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1832773/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100939f7172929509682cb",
+      "existing_title": "Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des écrivains de cette science ... / 3",
+      "existing_visible": false
     },
     {
       "erara_id": "1833247",
@@ -2416,7 +2461,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1918267",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1918267/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10093ff7172929509684a4",
+      "existing_title": "Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam pertinentium thesaurus instructissimus: quo non tantum artis auriferae ... verum etiam tractatus omnes virorum ... ad quorum omnium illustrationem additae sunt quamplurimae figurae aeneae. Tomus primus [-secundus] / Tomus primus.",
+      "existing_visible": false
     },
     {
       "erara_id": "1919276",
@@ -2428,7 +2476,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1919276",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1919276/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100946f717292950968898",
+      "existing_title": "Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam pertinentium thesaurus instructissimus: quo non tantum artis auriferae ... verum etiam tractatus omnes virorum ... ad quorum omnium illustrationem additae sunt quamplurimae figurae aeneae. Tomus primus [-secundus] / Tomus secundus.",
+      "existing_visible": false
     },
     {
       "erara_id": "1930930",
@@ -2515,7 +2566,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1932286",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1932286/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10094bf717292950968c67",
+      "existing_title": "Traité historique et dogmatique sur les apparitions, les visions &amp; les révélations particulières : avec des observations sur les dissertations du R. P. Dom Calmet ... sur les apparitions et les revenans / Tome premier.",
+      "existing_visible": false
     },
     {
       "erara_id": "1932752",
@@ -2527,7 +2581,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/1932752",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/1932752/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100951f717292950968e3a",
+      "existing_title": "Traité historique et dogmatique sur les apparitions, les visions &amp; les révélations particulières : avec des observations sur les dissertations du R. P. Dom Calmet ... sur les apparitions et les revenans / Tome second.",
+      "existing_visible": false
     },
     {
       "erara_id": "1933224",
@@ -2941,7 +2998,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2040156",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2040156/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100962f717292950969011",
+      "existing_title": "Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und bewehrten philosophi und medici Philippi Theophrasti Bombast von Hohenheim ... / [Erster bis sechster Theil.]",
+      "existing_visible": false
     },
     {
       "erara_id": "2042289",
@@ -2953,7 +3013,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2042289",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2042289/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100969f717292950969869",
+      "existing_title": "Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und bewehrten philosophi und medici Philippi Theophrasti Bombast von Hohenheim ... / [Siebender bis zehender Theil.]",
+      "existing_visible": false
     },
     {
       "erara_id": "2044320",
@@ -3520,7 +3583,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2104282",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2104282/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100970f71729295096a059",
+      "existing_title": "Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[-alter] / Tomus prior.",
+      "existing_visible": false
     },
     {
       "erara_id": "2104857",
@@ -3532,7 +3598,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2104857",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2104857/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100977f71729295096a299",
+      "existing_title": "Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[-alter] / Tomus alter.",
+      "existing_visible": false
     },
     {
       "erara_id": "2105363",
@@ -3559,7 +3628,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2206664",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2206664/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100980f71729295096a492",
+      "existing_title": "Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, avec une explication des hiéroglyphes, et de la guerre de Troye / Tome second.",
+      "existing_visible": false
     },
     {
       "erara_id": "2208774",
@@ -3691,7 +3763,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2209636",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2209636/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100987f71729295096a71b",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen primum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2210470",
@@ -3703,7 +3778,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2210470",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2210470/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10098ef71729295096aa5e",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen secundum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2284847",
@@ -3730,7 +3808,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2284849",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2284849/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a10099af71729295096ac97",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium] / Volumen primum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2282207",
@@ -3742,7 +3823,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2282207",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2282207/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009a5f71729295096b046",
+      "existing_title": "Historische Wunder-Beschreibung von der sogenannten schönen Melusina, Königs Helmas in Albanien Tochter, welche eine Sirene und Meer-Wunder gewesen, und ihrer Hervorkunft aus dem in Frankreich gelegenen Berg Adelon, auch was sich allda sehr seltsam und merkwürdiges mit ihr zugetragen",
+      "existing_visible": false
     },
     {
       "erara_id": "2282411",
@@ -3784,7 +3868,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2285791",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2285791/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009aef71729295096b10f",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium] / Volumen secundum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2286442",
@@ -3796,7 +3883,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2286442",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2286442/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009bbf71729295096b39b",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in tres partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- tertium] / Volumen tertium.",
+      "existing_visible": false
     },
     {
       "erara_id": "2287453",
@@ -3823,7 +3913,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2287455",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2287455/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009c3f71729295096b78b",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in quatuor partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- quartum] / Volumen quartum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2288648",
@@ -3835,7 +3928,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2288648",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2288648/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009c9f71729295096bc35",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in quatuor partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- quartum] / Volumen quintum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2289743",
@@ -3862,7 +3958,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2289745",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2289745/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009d0f71729295096c07a",
+      "existing_title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden / Erster Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2290896",
@@ -3874,7 +3973,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2290896",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2290896/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009d6f71729295096c4dc",
+      "existing_title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden / Zweyter Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2291876",
@@ -3886,7 +3988,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2291876",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2291876/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009dcf71729295096c8b2",
+      "existing_title": "Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchymisten Schrifften, die von dem Stein der Weisen, von Verwandlung der schlechten Metalle in bessere ... handeln ... vorgestellet werden / Dritter Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2299474",
@@ -3898,7 +4003,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2299474",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2299474/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009e2f71729295096ccb0",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen tertium.",
+      "existing_visible": false
     },
     {
       "erara_id": "2300360",
@@ -3910,7 +4018,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2300360",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2300360/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009edf71729295096d027",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen quartum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2301444",
@@ -3922,7 +4033,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2301444",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2301444/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a1009fbf71729295096d465",
+      "existing_title": "Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidis philosophici antiquitate, veritate, iure, praestantia, &amp; operationibus, continens: in gratiam verae chemiae, et medicinae chemicae studiosorum ... congestum, et in sex partes seu volumina digestum; singulis voluminibus, suo auctorum et librorum catalogo primis pagellis: rerum vero &amp; verborum indice postremis annexo. Volumen primum [- sextum] / Volumen sextum.",
+      "existing_visible": false
     },
     {
       "erara_id": "2479864",
@@ -4084,7 +4198,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2575068",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2575068/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a03f71729295096d7a9",
+      "existing_title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Erster Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2575920",
@@ -4096,7 +4213,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2575920",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2575920/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a11f71729295096dafe",
+      "existing_title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Zweiter Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2576642",
@@ -4108,7 +4228,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2576642",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2576642/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a1cf71729295096ddd1",
+      "existing_title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Dritter Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2577372",
@@ -4120,7 +4243,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2577372",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2577372/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a22f71729295096e0ac",
+      "existing_title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Vierter Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2578238",
@@ -4132,7 +4258,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2578238",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2578238/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a2af71729295096e40f",
+      "existing_title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Fünfter Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2579200",
@@ -4144,7 +4273,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2579200",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2579200/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a33f71729295096e7d2",
+      "existing_title": "Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Kezerein, Spaltungen und Religionsstreitigkeiten, bis auf die Zeiten der Reformation. Erster [- sechster] Theil / Sechster Theil.",
+      "existing_visible": false
     },
     {
       "erara_id": "2580278",
@@ -4258,7 +4390,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2623925",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2623925/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a3cf71729295096ec06",
+      "existing_title": "Unterhaltungen aus der Naturgeschichte / [Textband.]",
+      "existing_visible": false
     },
     {
       "erara_id": "2624281",
@@ -4270,7 +4405,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2624281",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2624281/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a41f71729295096ed6b",
+      "existing_title": "Unterhaltungen aus der Naturgeschichte / [Tafelband.]",
+      "existing_visible": false
     },
     {
       "erara_id": "2834337",
@@ -4312,7 +4450,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2835283",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2835283/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a46f71729295096edcb",
+      "existing_title": "Origenis opera omnia et quae eius nomine circumferuntur / Tomus primus.",
+      "existing_visible": false
     },
     {
       "erara_id": "2835828",
@@ -4324,7 +4465,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2835828",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2835828/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a4bf71729295096efeb",
+      "existing_title": "Origenis opera omnia et quae eius nomine circumferuntur / Tomus secundus.",
+      "existing_visible": false
     },
     {
       "erara_id": "2836526",
@@ -4336,7 +4480,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2836526",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2836526/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a50f71729295096f2a6",
+      "existing_title": "Origenis opera omnia et quae eius nomine circumferuntur / Tomus tertius.",
+      "existing_visible": false
     },
     {
       "erara_id": "2840942",
@@ -4378,7 +4525,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2841546",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2841546/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a55f71729295096f531",
+      "existing_title": "Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus illustrantur, tomus primus, in quo universus sancti textus, et Georgii Pachymerae paraphrasis Graece et Latine, cum adnotationibus Balt. Corderii... continentur, omnia studio ... eiusdem Balthasaris Corderii ... tomus II, in quo S. Maximi scholia, Pachymerae paraphrasis in epistolas, et authores varii qui aut vitam S. Dionysii descripserunt, aut dignitatem ipsius areopagiticam asseruerunt, continentur, opera ... Petri Lansselii et Balthasaris Corderii : accessit nunc primum Areopagitae defensio adversus haereticum calvinistam, per... D. Ioannem de Chaumont / Tomus primus.",
+      "existing_visible": false
     },
     {
       "erara_id": "2842318",
@@ -4390,7 +4540,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/2842318",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/2842318/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a5cf71729295096f838",
+      "existing_title": "Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus illustrantur, tomus primus, in quo universus sancti textus, et Georgii Pachymerae paraphrasis Graece et Latine, cum adnotationibus Balt. Corderii... continentur, omnia studio ... eiusdem Balthasaris Corderii ... tomus II, in quo S. Maximi scholia, Pachymerae paraphrasis in epistolas, et authores varii qui aut vitam S. Dionysii descripserunt, aut dignitatem ipsius areopagiticam asseruerunt, continentur, opera ... Petri Lansselii et Balthasaris Corderii : accessit nunc primum Areopagitae defensio adversus haereticum calvinistam, per... D. Ioannem de Chaumont / Tomus II.",
+      "existing_visible": false
     },
     {
       "erara_id": "2843210",
@@ -4894,7 +5047,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/3464223",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/3464223/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a6df71729295096fbb2",
+      "existing_title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses / [Volume I.]",
+      "existing_visible": false
     },
     {
       "erara_id": "3465080",
@@ -4906,7 +5062,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/3465080",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/3465080/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a73f71729295096ff0c",
+      "existing_title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses / [Volume II.]",
+      "existing_visible": false
     },
     {
       "erara_id": "3465906",
@@ -4918,7 +5077,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/3465906",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/3465906/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a78f717292950970249",
+      "existing_title": "Cérémonies et coutumes religieuses de tous les peuples du monde : avec une explication historique, &amp; quelques dissertations curieuses / [Volume III.]",
+      "existing_visible": false
     },
     {
       "erara_id": "3472441",
@@ -4945,7 +5107,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/3472443",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/3472443/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a83f717292950970467",
+      "existing_title": "Cérémonies et coutumes religieuses des peuples idolatres : avec une explication historique, &amp; quelques dissertations curieuses / Tome premier.",
+      "existing_visible": false
     },
     {
       "erara_id": "3472963",
@@ -4957,7 +5122,10 @@
       "rights": "PDM 1.0",
       "source_url": "https://www.e-rara.ch/content/titleinfo/3472963",
       "manifest_url": "https://www.e-rara.ch/i3f/v21/3472963/manifest",
-      "match_type": "new"
+      "match_type": "erara_id",
+      "existing_book_id": "6a100a94f71729295097066f",
+      "existing_title": "Cérémonies et coutumes religieuses des peuples idolatres : avec une explication historique, &amp; quelques dissertations curieuses / Tome second.",
+      "existing_visible": false
     },
     {
       "erara_id": "3476871",

--- a/.claude/docs/jung-library-crossref-2026-05-22.md
+++ b/.claude/docs/jung-library-crossref-2026-05-22.md
@@ -5,74 +5,18 @@ Source: e-rara OAI-PMH set `cgj` → Stiftung der Werke von C.G. Jung (Zürich)
 ## Summary
 
 - Total records harvested: **345**
-- Already in our database (erara_id match): **284**
+- Already in our database (erara_id match): **340**
 - Already in our database (title/author match, different source): **1**
-- New to our library: **60**
+- New to our library: **4**
 
-## New books (60) — would import on `--import`
+## New books (4) — would import on `--import`
 
 | Year | Author | Title | e-rara |
 |---|---|---|---|
 | 1522 | Mechthild | Opera nuper in lucem prodeuntia : Liber gratie spiritualis visionum &amp; revela | [2035372](https://www.e-rara.ch/content/titleinfo/2035372) |
-| 1561 | [s.n.] | Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[ | [2104282](https://www.e-rara.ch/content/titleinfo/2104282) |
-| 1561 | [s.n.] | Philonis Judaei ... operum, quotquot ad hunc diem haberi potuerunt, tomus prior[ | [2104857](https://www.e-rara.ch/content/titleinfo/2104857) |
-| 1589 | [s.n.] | Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und | [2040156](https://www.e-rara.ch/content/titleinfo/2040156) |
-| 1589 | [s.n.] | Erster [- zehender] Theil der Bücher und Schrifften des edlen, hochgelehrten und | [2042289](https://www.e-rara.ch/content/titleinfo/2042289) |
-| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2284849](https://www.e-rara.ch/content/titleinfo/2284849) |
-| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2285791](https://www.e-rara.ch/content/titleinfo/2285791) |
-| 1602 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2286442](https://www.e-rara.ch/content/titleinfo/2286442) |
-| 1608 | [s.n.] | Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophisc | [1529971](https://www.e-rara.ch/content/titleinfo/1529971) |
-| 1608 | [s.n.] | Gemma gemmarum alchimistarum oder Erleuterung der parabolischen und philosophisc | [1530085](https://www.e-rara.ch/content/titleinfo/1530085) |
-| 1613 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2287455](https://www.e-rara.ch/content/titleinfo/2287455) |
-| 1613 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2288648](https://www.e-rara.ch/content/titleinfo/2288648) |
-| 1644 | [s.n.] | Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus  | [2841546](https://www.e-rara.ch/content/titleinfo/2841546) |
-| 1644 | [s.n.] | Sancti Dionysii Areopagitae operum omnium quae extant, et commentariorum quibus  | [2842318](https://www.e-rara.ch/content/titleinfo/2842318) |
 | 1650 | Vaughan, Thomas | Anthroposophia Theomagica or a Discourse of the Nature of Man and his State afte | [1705641](https://www.e-rara.ch/content/titleinfo/1705641) |
-| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2209636](https://www.e-rara.ch/content/titleinfo/2209636) |
-| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2210470](https://www.e-rara.ch/content/titleinfo/2210470) |
-| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2299474](https://www.e-rara.ch/content/titleinfo/2299474) |
-| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2300360](https://www.e-rara.ch/content/titleinfo/2300360) |
-| 1659 | [s.n.] | Theatrum chemicum, praecipuos selectorum auctorum tractatus de chemiae et lapidi | [2301444](https://www.e-rara.ch/content/titleinfo/2301444) |
-| 1677 | [s.n.] | Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque | [1171064](https://www.e-rara.ch/content/titleinfo/1171064) |
-| 1677 | [s.n.] | Kabbala denudata, seu, doctrina Hebraeorum transcendentalis et metaphysica atque | [1172145](https://www.e-rara.ch/content/titleinfo/1172145) |
 | 1677 | Webster, John | The  displaying of supposed witchcraft ... | [2581467](https://www.e-rara.ch/content/titleinfo/2581467) |
-| 1702 | [s.n.] | Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam perti | [1918267](https://www.e-rara.ch/content/titleinfo/1918267) |
-| 1702 | [s.n.] | Jo. Jacobi Mangeti ... Bibliotheca chemica curiosa, seu rerum ad alchemiam perti | [1919276](https://www.e-rara.ch/content/titleinfo/1919276) |
-| 1723 | [s.n.] | Cérémonies et coutumes religieuses de tous les peuples du monde : avec une expli | [3464223](https://www.e-rara.ch/content/titleinfo/3464223) |
-| 1723 | [s.n.] | Cérémonies et coutumes religieuses de tous les peuples du monde : avec une expli | [3465080](https://www.e-rara.ch/content/titleinfo/3465080) |
-| 1723 | [s.n.] | Cérémonies et coutumes religieuses de tous les peuples du monde : avec une expli | [3465906](https://www.e-rara.ch/content/titleinfo/3465906) |
-| 1723 | [s.n.] | Cérémonies et coutumes religieuses des peuples idolatres : avec une explication  | [3472443](https://www.e-rara.ch/content/titleinfo/3472443) |
-| 1723 | [s.n.] | Cérémonies et coutumes religieuses des peuples idolatres : avec une explication  | [3472963](https://www.e-rara.ch/content/titleinfo/3472963) |
-| 1728 | [s.n.] | Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchym | [2289745](https://www.e-rara.ch/content/titleinfo/2289745) |
-| 1728 | [s.n.] | Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchym | [2290896](https://www.e-rara.ch/content/titleinfo/2290896) |
-| 1728 | [s.n.] | Deutsches theatrum chemicum, auf welchem der berühmtesten Philosophen und Alchym | [2291876](https://www.e-rara.ch/content/titleinfo/2291876) |
-| 1741 | [s.n.] | Bibliothèque des philosophes chimiques / Tome premier. | [1386545](https://www.e-rara.ch/content/titleinfo/1386545) |
-| 1741 | [s.n.] | Bibliothèque des philosophes chimiques / Tome second. | [1387143](https://www.e-rara.ch/content/titleinfo/1387143) |
-| 1741 | [s.n.] | Bibliothèque des philosophes chimiques / Tome troisième. | [1387726](https://www.e-rara.ch/content/titleinfo/1387726) |
-| 1743 | [s.n.] | Origenis opera omnia et quae eius nomine circumferuntur / Tomus primus. | [2835283](https://www.e-rara.ch/content/titleinfo/2835283) |
-| 1743 | [s.n.] | Origenis opera omnia et quae eius nomine circumferuntur / Tomus secundus. | [2835828](https://www.e-rara.ch/content/titleinfo/2835828) |
-| 1743 | [s.n.] | Origenis opera omnia et quae eius nomine circumferuntur / Tomus tertius. | [2836526](https://www.e-rara.ch/content/titleinfo/2836526) |
-| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des  | [1831696](https://www.e-rara.ch/content/titleinfo/1831696) |
-| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des  | [1832242](https://www.e-rara.ch/content/titleinfo/1832242) |
-| 1744 | [s.n.] | Histoire de la philosophie hermétique : accompagnée d'un catalogue raisonné des  | [1832773](https://www.e-rara.ch/content/titleinfo/1832773) |
-| 1745 | [s.n.] | An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the | [1606983](https://www.e-rara.ch/content/titleinfo/1606983) |
-| 1745 | [s.n.] | An  Enquiry into the Nature of the Human Soul : wherein the Immateriality of the | [1607437](https://www.e-rara.ch/content/titleinfo/1607437) |
-| 1751 | [s.n.] | Traité historique et dogmatique sur les apparitions, les visions &amp; les révél | [1932286](https://www.e-rara.ch/content/titleinfo/1932286) |
-| 1751 | [s.n.] | Traité historique et dogmatique sur les apparitions, les visions &amp; les révél | [1932752](https://www.e-rara.ch/content/titleinfo/1932752) |
-| 1758 | [s.n.] | Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, a | [2206662](https://www.e-rara.ch/content/titleinfo/2206662) |
-| 1758 | [s.n.] | Les  fables egyptiennes et grecques dévoilées &amp; réduites au même principe, a | [2206664](https://www.e-rara.ch/content/titleinfo/2206664) |
-| 1762 | [s.n.] | Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Keze | [2575068](https://www.e-rara.ch/content/titleinfo/2575068) |
-| 1762 | [s.n.] | Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Keze | [2575920](https://www.e-rara.ch/content/titleinfo/2575920) |
-| 1762 | [s.n.] | Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Keze | [2576642](https://www.e-rara.ch/content/titleinfo/2576642) |
-| 1762 | [s.n.] | Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Keze | [2577372](https://www.e-rara.ch/content/titleinfo/2577372) |
-| 1762 | [s.n.] | Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Keze | [2578238](https://www.e-rara.ch/content/titleinfo/2578238) |
-| 1762 | [s.n.] | Christian Wilhelm Franz Walchs ... Entwurf einer vollständigen Historie der Keze | [2579200](https://www.e-rara.ch/content/titleinfo/2579200) |
-| 1778 | [s.n.] | Lucii Apuleii ... Opera / Tomus I. | [1557942](https://www.e-rara.ch/content/titleinfo/1557942) |
-| 1778 | [s.n.] | Lucii Apuleii ... Opera / Tomus II. | [1558300](https://www.e-rara.ch/content/titleinfo/1558300) |
 | 1786 | Guillemain de Saint-Victor, Louis | Recueil précieux de la maçonnerie adonhiramite ... | [3178659](https://www.e-rara.ch/content/titleinfo/3178659) |
-| 1792 | [s.n.] | Unterhaltungen aus der Naturgeschichte / [Textband.] | [2623925](https://www.e-rara.ch/content/titleinfo/2623925) |
-| 1792 | [s.n.] | Unterhaltungen aus der Naturgeschichte / [Tafelband.] | [2624281](https://www.e-rara.ch/content/titleinfo/2624281) |
-| – | [s.n.] | Historische Wunder-Beschreibung von der sogenannten schönen Melusina, Königs Hel | [2282207](https://www.e-rara.ch/content/titleinfo/2282207) |
 
 ## Title/author overlap (1) — physical/conceptual matches in other libraries
 
@@ -80,11 +24,13 @@ Source: e-rara OAI-PMH set `cgj` → Stiftung der Werke von C.G. Jung (Zürich)
 |---|---|---|---|
 | 1653 | Glauber, Johann Rudolph | Miraculum mundi, sive plena perfectaque descriptio admirabil | [Miraculum mundi, sive plena perfectaque descriptio admirabil](https://sourcelibrary.org/book/69bd9ee4f6d63c919747d604) (e-rara) |
 
-## Already imported (284) — e-rara IDs already in our DB
+## Already imported (340) — e-rara IDs already in our DB
 
 | Title | Existing book |
 |---|---|
 | Triumph Wagen Antimonii fratris Basilii Valentini ... allen  | [69bd9dee6120d54bd037a1ae](https://sourcelibrary.org/book/69bd9dee6120d54bd037a1ae) |
+| Kabbala denudata, seu, doctrina Hebraeorum transcendentalis  | [6a1008daf717292950966438](https://sourcelibrary.org/book/6a1008daf717292950966438) |
+| Kabbala denudata, seu, doctrina Hebraeorum transcendentalis  | [6a1008e4f717292950966872](https://sourcelibrary.org/book/6a1008e4f717292950966872) |
 | Aurea catena Homeri oder eine Beschreibung von dem Ursprung  | [69bda050f6d63c9197485ed9](https://sourcelibrary.org/book/69bda050f6d63c9197485ed9) |
 | Alberti Magni philosophie naturalis isagoge: sive introducti | [69bd9c826120d54bd036f86b](https://sourcelibrary.org/book/69bd9c826120d54bd036f86b) |
 | Kabbala denudata, seu, doctrina Hebraeorum transcendentalis  | [69bd9f4bf6d63c91974800b0](https://sourcelibrary.org/book/69bd9f4bf6d63c91974800b0) |
@@ -106,6 +52,9 @@ Source: e-rara OAI-PMH set `cgj` → Stiftung der Werke von C.G. Jung (Zürich)
 | [De anima. De intellectu] | [69bd9c50f105648cca08b68c](https://sourcelibrary.org/book/69bd9c50f105648cca08b68c) |
 | Mutus liber, in quo tamen tota philosophia hermetica, figuri | [69bd9f4ff6d63c9197480aa6](https://sourcelibrary.org/book/69bd9f4ff6d63c9197480aa6) |
 | Bibliothèque des philosophes chimiques | [69bda0acf6d63c919748958e](https://sourcelibrary.org/book/69bda0acf6d63c919748958e) |
+| Bibliothèque des philosophes chimiques / Tome premier. | [6a1008e8f717292950966e31](https://sourcelibrary.org/book/6a1008e8f717292950966e31) |
+| Bibliothèque des philosophes chimiques / Tome second. | [6a1008eef717292950967088](https://sourcelibrary.org/book/6a1008eef717292950967088) |
+| Bibliothèque des philosophes chimiques / Tome troisième. | [6a1008f3f7172929509672d0](https://sourcelibrary.org/book/6a1008f3f7172929509672d0) |
 | Bedencken über Esaiae Stiefels Büchlein: von dreyerley Zusta | [69bd9fb2f6d63c9197481c0b](https://sourcelibrary.org/book/69bd9fb2f6d63c9197481c0b) |
 | [Commentarii a Philippo Beroaldo conditi in asinum aureum Lu | [69bd9c6b6120d54bd036ecd0](https://sourcelibrary.org/book/69bd9c6b6120d54bd036ecd0) |
 | Ulyssis Aldrovandi ... serpentum et draconum historiae libri | [69bd9eaef6d63c919747befa](https://sourcelibrary.org/book/69bd9eaef6d63c919747befa) |
@@ -129,9 +78,4 @@ Source: e-rara OAI-PMH set `cgj` → Stiftung der Werke von C.G. Jung (Zürich)
 | Sal, lumen, et spiritus mundi philosophici or the dawning of | [69bd9ef7f6d63c919747da66](https://sourcelibrary.org/book/69bd9ef7f6d63c919747da66) |
 | Alberti Magni, de secretis mulierum libellus, scholiis auctu | [69bd9d726120d54bd0376d18](https://sourcelibrary.org/book/69bd9d726120d54bd0376d18) |
 | Gemma gemmarum alchimistarum oder Erleuterung der parabolisc | [69bd9dcd6120d54bd0379764](https://sourcelibrary.org/book/69bd9dcd6120d54bd0379764) |
-| Das  Valete: uber den Tractat der Arcanorum Basilii Valentin | [69bd9dd16120d54bd037982d](https://sourcelibrary.org/book/69bd9dd16120d54bd037982d) |
-| Aetii medici Graeci contractae ex veteribus medicinae tetrab | [69bd9cba6120d54bd0370923](https://sourcelibrary.org/book/69bd9cba6120d54bd0370923) |
-| Andreae Alciati emblemata cum commentariis Claudii Minois I. | [69bd9f13f6d63c919747ef3b](https://sourcelibrary.org/book/69bd9f13f6d63c919747ef3b) |
-| Antonii van Dale ... Dissertationes de origine ac progressu  | [69bd9ff3f6d63c9197483331](https://sourcelibrary.org/book/69bd9ff3f6d63c9197483331) |
-| Lucii Apuleii ... Opera | [69bda131f6d63c919748e9d3](https://sourcelibrary.org/book/69bda131f6d63c919748e9d3) |
-| _...and 234 more_ | |
+| _...and 290 more_ | |

--- a/scripts/import-jung-library.mjs
+++ b/scripts/import-jung-library.mjs
@@ -393,6 +393,7 @@ async function runImport(newRecords) {
 const CONTRIBUTING_LIBRARY_VARIANTS = [
   'Stiftung der Werke von C.G.Jung',           // no space — needs normalization
   'Stiftung der Werke von C.G. Jung',          // missing (Zürich) — canonical adds it
+  'e-rara (Swiss libraries)',                  // generic pre-enrichment label
 ];
 
 async function backfillCategory(db, records) {
@@ -408,9 +409,14 @@ async function backfillCategory(db, records) {
   const needsCategory = existing.filter(b =>
     !Array.isArray(b.categories) || !b.categories.includes(CATEGORY_TAG)
   );
+  // Every Jung Küsnacht book should carry the canonical Stiftung label.
+  // Fix when missing entirely, or when it's one of the known variants we
+  // want to normalize away from.
   const needsLibFix = existing.filter(b => {
     const cl = b.image_source?.contributing_library;
-    return cl && cl !== CONTRIBUTING_LIBRARY && CONTRIBUTING_LIBRARY_VARIANTS.some(v => cl === v || cl.startsWith(v));
+    if (!cl) return true;                                  // null/missing
+    if (cl === CONTRIBUTING_LIBRARY) return false;         // already canonical
+    return CONTRIBUTING_LIBRARY_VARIANTS.some(v => cl === v || cl.startsWith(v));
   });
 
   console.log(`  Need category tag: ${needsCategory.length}`);


### PR DESCRIPTION
Small fix. The 56 books imported in #1924 came in with no `contributing_library` set — the import API leaves it empty and the existing enrich script only matches `'e-rara (Swiss libraries)'` (the generic pre-enrichment label), so the null rows were stranded.

Extends `--backfill-category` to treat null/missing OR the generic label as candidates for the canonical `'Stiftung der Werke von C.G. Jung (Zürich)'` tag.

Live run today: 57 books normalized (matched = modified = 57). All 340 Jung Küsnacht books in our DB now carry the canonical Stiftung label.

🤖 DCO signed.