### PR TITLE
EFM newsletter opt-in checkbox on beta signup

### DIFF
--- a/src/app/[tenant]/admin/email/page.tsx
+++ b/src/app/[tenant]/admin/email/page.tsx
@@ -612,6 +612,10 @@ export default function EmailAdminPage() {
                       <div className="text-xs text-stone-400 mt-1">{source.replace(/_/g, ' ')}</div>
                     </div>
                   ))}
+                  <div className="bg-stone-900 rounded-lg p-4 border border-stone-800 text-center">
+                    <div className="text-2xl font-semibold text-accent-gold">{stats.efm_newsletter_opt_in ?? 0}</div>
+                    <div className="text-xs text-stone-400 mt-1">EFM newsletter opt-in</div>
+                  </div>
                 </div>
 
                 {/* Recent signups */}
@@ -626,6 +630,9 @@ export default function EmailAdminPage() {
                         <div className="flex items-center gap-3 text-xs text-stone-500">
                           <span>{r.source?.replace(/_/g, ' ')}</span>
                           {r.country && <span>{r.country}</span>}
+                          {r.efm_newsletter_opt_in && (
+                            <span className="text-accent-gold" title="Opted into EFM newsletter">EFM</span>
+                          )}
                           <span>{new Date(r.subscribed_at).toLocaleDateString()}</span>
                         </div>
                       </div>

--- a/src/app/[tenant]/beta/page.tsx
+++ b/src/app/[tenant]/beta/page.tsx
@@ -43,14 +43,17 @@ const GALLERY_IMAGES = [
 ];
 
 function EmailForm({
-  email, setEmail, status, errorMsg, onSubmit, variant = 'dark',
+  email, setEmail, efmNewsletter, setEfmNewsletter, status, errorMsg, onSubmit, variant = 'dark', idPrefix,
 }: {
   email: string;
   setEmail: (v: string) => void;
+  efmNewsletter: boolean;
+  setEfmNewsletter: (v: boolean) => void;
   status: 'idle' | 'loading' | 'success' | 'error';
   errorMsg: string;
   onSubmit: (e: React.FormEvent) => void;
   variant?: 'dark' | 'light';
+  idPrefix: string;
 }) {
   if (status === 'success') {
     return (
@@ -91,6 +94,24 @@ function EmailForm({
           {status === 'loading' ? 'Joining...' : 'Get Free Access'}
         </button>
       </form>
+      <label
+        htmlFor={`${idPrefix}-efm-newsletter`}
+        className={`flex items-start gap-2 mt-3 cursor-pointer text-sm font-sans ${
+          variant === 'dark' ? 'text-white/60 hover:text-white/80' : 'text-stone-600 hover:text-stone-800'
+        }`}
+      >
+        <input
+          id={`${idPrefix}-efm-newsletter`}
+          type="checkbox"
+          checked={efmNewsletter}
+          onChange={(e) => setEfmNewsletter(e.target.checked)}
+          disabled={status === 'loading'}
+          className="mt-0.5 h-4 w-4 accent-accent-gold cursor-pointer flex-shrink-0"
+        />
+        <span>
+          Also send me the Embassy of the Free Mind newsletter
+        </span>
+      </label>
       {status === 'error' && (
         <p className="text-red-400 text-sm mt-2 font-sans">
           {errorMsg}
@@ -102,6 +123,7 @@ function EmailForm({
 
 export default function BetaLandingPage() {
   const [email, setEmail] = useState('');
+  const [efmNewsletter, setEfmNewsletter] = useState(false);
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [errorMsg, setErrorMsg] = useState('');
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -122,7 +144,7 @@ export default function BetaLandingPage() {
       const res = await fetch('/api/beta/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email.trim() }),
+        body: JSON.stringify({ email: email.trim(), efmNewsletter }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -219,10 +241,13 @@ export default function BetaLandingPage() {
             <EmailForm
               email={email}
               setEmail={setEmail}
+              efmNewsletter={efmNewsletter}
+              setEfmNewsletter={setEfmNewsletter}
               status={status}
               errorMsg={errorMsg}
               onSubmit={handleSubmit}
               variant="dark"
+              idPrefix="hero"
             />
             <p className="text-white/30 text-xs mt-3 font-sans">
               An initiative of the Embassy of the Free Mind, Amsterdam
@@ -401,10 +426,13 @@ export default function BetaLandingPage() {
             <EmailForm
               email={email}
               setEmail={setEmail}
+              efmNewsletter={efmNewsletter}
+              setEfmNewsletter={setEfmNewsletter}
               status={status}
               errorMsg={errorMsg}
               onSubmit={handleSubmit}
               variant="dark"
+              idPrefix="cta"
             />
           </div>
           <p className="text-white/20 text-xs mt-4 font-sans">

--- a/src/app/api/admin/email/subscribers/route.ts
+++ b/src/app/api/admin/email/subscribers/route.ts
@@ -6,15 +6,16 @@ export const GET = withAdminAuth(async (_request: NextRequest) => {
   const db = await getDb();
   const collection = db.collection('beta_subscribers');
 
-  const [total, bySource, recent] = await Promise.all([
+  const [total, bySource, efmOptIn, recent] = await Promise.all([
     collection.countDocuments(),
     collection.aggregate([
       { $group: { _id: '$source', count: { $sum: 1 } } },
     ]).toArray(),
+    collection.countDocuments({ efm_newsletter_opt_in: true }),
     collection.find()
       .sort({ subscribed_at: -1 })
       .limit(20)
-      .project({ email: 1, source: 1, subscribed_at: 1, country: 1 })
+      .project({ email: 1, source: 1, subscribed_at: 1, country: 1, efm_newsletter_opt_in: 1 })
       .toArray(),
   ]);
 
@@ -29,11 +30,13 @@ export const GET = withAdminAuth(async (_request: NextRequest) => {
     source: r.source || 'unknown',
     subscribed_at: r.subscribed_at?.toISOString() || '',
     country: r.country || undefined,
+    efm_newsletter_opt_in: r.efm_newsletter_opt_in === true,
   }));
 
   return NextResponse.json({
     total,
     by_source: sourceMap,
+    efm_newsletter_opt_in: efmOptIn,
     recent: maskedRecent,
   });
 });

--- a/src/app/api/beta/subscribe/route.ts
+++ b/src/app/api/beta/subscribe/route.ts
@@ -92,6 +92,7 @@ export async function POST(request: NextRequest) {
     const email = body.email;
     const source = body.source;
     const comment = body.comment;
+    const efmNewsletter = body.efmNewsletter === true;
 
     if (!email || typeof email !== 'string') {
       return NextResponse.json({ error: 'Email is required' }, { status: 400 });
@@ -111,6 +112,14 @@ export async function POST(request: NextRequest) {
     // Check for existing subscriber
     const existing = await collection.findOne({ email: normalizedEmail });
     if (existing) {
+      // If they're newly opting into the EFM newsletter, record it without
+      // overwriting a prior opt-in.
+      if (efmNewsletter && !existing.efm_newsletter_opt_in) {
+        await collection.updateOne(
+          { _id: existing._id },
+          { $set: { efm_newsletter_opt_in: true, efm_newsletter_opt_in_at: new Date() } },
+        );
+      }
       return NextResponse.json({ message: 'Already subscribed!', alreadySubscribed: true });
     }
 
@@ -131,7 +140,11 @@ export async function POST(request: NextRequest) {
         : 'beta_landing',
       subscribed_at: new Date(),
       notified: false,
+      efm_newsletter_opt_in: efmNewsletter,
     };
+    if (efmNewsletter) {
+      doc.efm_newsletter_opt_in_at = new Date();
+    }
     if (comment && typeof comment === 'string' && comment.trim()) {
       doc.comment = comment.trim().slice(0, 1000);
     }

--- a/src/lib/api-client/types/email.ts
+++ b/src/lib/api-client/types/email.ts
@@ -29,11 +29,13 @@ export interface EmailDraft {
 export interface SubscriberStats {
   total: number;
   by_source: Record<string, number>;
+  efm_newsletter_opt_in: number;
   recent: Array<{
     email_masked: string;
     source: string;
     subscribed_at: string;
     country?: string;
+    efm_newsletter_opt_in: boolean;
   }>;
 }
 


### PR DESCRIPTION
## Summary
- Adds an optional "Also send me the Embassy of the Free Mind newsletter" checkbox (default unchecked) to both signup forms on `/beta`.
- Persists the opt-in on `beta_subscribers` as `efm_newsletter_opt_in` + `efm_newsletter_opt_in_at`. Re-subscribing later with the box ticked will set the flag without overwriting a prior opt-in.
- `/admin/email` Subscribers tab now shows an "EFM newsletter opt-in" count card and tags opted-in rows in the recent list.
- No live push to an EFM mailing list yet — consent is recorded so we can export when ready.

## Test plan
- [ ] On the `/beta` preview, sign up with the box unchecked → record should have `efm_newsletter_opt_in: false`.
- [ ] Sign up a fresh email with the box checked → record should have `efm_newsletter_opt_in: true` and a timestamp.
- [ ] Submit again with same email + box checked → response is `alreadySubscribed`, doc gets opt-in set.
- [ ] `/admin/email` Subscribers tab shows the new count card and an "EFM" badge on recent rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)