### PR TITLE
Auth: share session cookie across *.sourcelibrary.org subdomains

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -143,6 +143,17 @@ if (process.env.RESEND_API_KEY) {
   }));
 }
 
+// Share the session cookie across every *.sourcelibrary.org subdomain
+// (production only — Vercel previews stay host-scoped because they live on
+// *.vercel.app, and localhost dev needs host-only too). Without this each
+// subdomain (sourcelibrary.org, bph.sourcelibrary.org, future kloss/jung
+// tenants) holds its own session and users have to sign in N times.
+// Roles still gate per-tenant via tenant_memberships — sharing identity does
+// not share permissions.
+const SHARE_SUBDOMAIN_COOKIE = process.env.VERCEL_ENV === 'production';
+const SECURE_COOKIE = process.env.NODE_ENV === 'production';
+const SHARED_COOKIE_DOMAIN = '.sourcelibrary.org';
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers,
   adapter: MongoDBAdapter(clientPromise, { databaseName: dbName }),
@@ -150,6 +161,33 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   session: {
     strategy: 'jwt',
   },
+  cookies: SHARE_SUBDOMAIN_COOKIE ? {
+    sessionToken: {
+      name: '__Secure-authjs.session-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: true,
+        domain: SHARED_COOKIE_DOMAIN,
+      },
+    },
+    callbackUrl: {
+      name: '__Secure-authjs.callback-url',
+      options: {
+        sameSite: 'lax',
+        path: '/',
+        secure: true,
+        domain: SHARED_COOKIE_DOMAIN,
+      },
+    },
+    // csrfToken keeps its NextAuth default: the `__Host-` prefix forbids
+    // a `domain` attribute, and each subdomain hits its own /api/auth/*
+    // routes, so a per-host CSRF cookie is fine.
+  } : undefined,
+  // Silences a warning about not detecting an explicit secure-flag setting
+  // when running behind Vercel's proxy.
+  useSecureCookies: SECURE_COOKIE,
   pages: {
     signIn: '/auth/signin',
     error: '/auth/error',


### PR DESCRIPTION
Configures NextAuth so a single sign-in carries across sourcelibrary.org and every `*.sourcelibrary.org` tenant subdomain (bph.sourcelibrary.org today; kloss/jung later). Without this, each subdomain holds its own session.

## Change

Sets `cookies.sessionToken.options.domain` and `cookies.callbackUrl.options.domain` to `.sourcelibrary.org` when `VERCEL_ENV === 'production'`. CSRF token keeps its NextAuth default (`__Host-` prefix forbids a `domain` attribute, and each subdomain hits its own `/api/auth/*` routes — per-host CSRF is fine).

## Scope safety

- **Gated on production only.** Vercel preview deploys live on `*.vercel.app` and localhost dev needs host-only — both bypass this and stay default.
- **Identity is shared, permissions are not.** Role checks still run via `tenant_memberships` lookups per-tenant — a user signed in on the parent site doesn't get elevated rights on any tenant just by visiting it.

## After this deploys

A user signs in on `sourcelibrary.org` → visits `bph.sourcelibrary.org` → already signed in, sees their EmbedUserMenu populated correctly, gets the `bph_librarian` Edit button if their membership grants it (per-tenant gate stays intact).

Existing sessions: the new `__Secure-authjs.*` cookie names match NextAuth's production defaults, so any current session cookie should be readable. Worst-case rollback is a sign-out-once redo — no data loss possible.

## Test plan

- [x] tsc clean
- [ ] Vercel preview build green
- [ ] After merge: sign in once on `sourcelibrary.org`, visit `bph.sourcelibrary.org/catalog`, confirm session carries (no Sign in pill)
- [x] DCO signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)