### PR TITLE
BPH: bibliographic header + catalogue default + held filter (Paul feedback)

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -630,20 +630,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
 
             {/* Details */}
             <div className="flex-1 text-center sm:text-left">
-              <h1 className="text-2xl sm:text-3xl font-serif font-bold break-words">{book.display_title || book.title}</h1>
-              {book.display_title && book.title !== book.display_title && (
-                <p className="text-stone-400 mt-1 italic text-sm sm:text-base">{book.title}</p>
-              )}
-              {/* Byline: prefer author; fall back to "edited by {editor}" for
-                  magazines / edited volumes / anthologies where the catalogue
-                  has no single author. When both fields are present, show
-                  author with the editor as a secondary credit. See
-                  src/lib/byline.ts for the case-insensitive "Unknown"
-                  placeholder rules shared with cards and citations. */}
+              {/* Bibliographic citation order (Paul Dijstelberge, BPH feedback):
+                  author leads, then title, then impressum. The h1 stays on
+                  title for SEO and visual hierarchy; author renders as the
+                  eyebrow above it. See src/lib/byline.ts for "Unknown" rules. */}
               {(() => {
                 const heroByline = getEffectiveByline(book);
                 return (
-                  <p className="text-lg sm:text-xl text-stone-300 mt-2">
+                  <p className="text-base sm:text-lg text-stone-300 mb-1">
                     {heroByline.role === 'author' ? (
                       embedPolicy.enableBookCollectionNavigation && authorUrl(book.author) ? (
                         <Link href={authorUrl(book.author)!} className="hover:text-white transition-colors">
@@ -654,9 +648,27 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                       <span>edited by <AuthorName author={heroByline.editor} /></span>
                     ) : <AuthorName author={book.author} />}
                     {heroByline.role === 'author' && heroByline.editor && (
-                      <span className="text-stone-400 text-base"> · edited by <AuthorName author={heroByline.editor} /></span>
+                      <span className="text-stone-400 text-sm"> · edited by <AuthorName author={heroByline.editor} /></span>
                     )}
                   </p>
+                );
+              })()}
+              <h1 className="text-2xl sm:text-3xl font-serif font-bold break-words">{book.display_title || book.title}</h1>
+              {book.display_title && book.title !== book.display_title && (
+                <p className="text-stone-400 mt-1 italic text-sm sm:text-base">{book.title}</p>
+              )}
+              {/* Impressum: "Place: Publisher, Year" — same library-card
+                  format as BphCatalogBrowser.formatImpressum so the book page
+                  and catalogue rows line up. */}
+              {(() => {
+                const place = book.place_published?.trim();
+                const publisher = book.publisher?.trim();
+                const year = book.published ? String(book.published).trim() : '';
+                const placePub = [place, publisher].filter(Boolean).join(': ');
+                const impressum = [placePub, year].filter(Boolean).join(', ');
+                if (!impressum) return null;
+                return (
+                  <p className="text-stone-300 mt-2 text-sm sm:text-base">{impressum}</p>
                 );
               })()}
 
@@ -693,27 +705,26 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     ))}
                   </div>
                 )}
-                {(book.published || book.source_work_dates?.length) && (
+                {/* Calendar chip carries composition / translation dates that
+                    enrich the plain print year shown in the impressum line above.
+                    Skip the chip when there's no source_work_dates to add — the
+                    print year alone is already in the impressum. */}
+                {book.source_work_dates?.length ? (
                   <div className="flex items-center gap-2">
                     <Calendar className="w-4 h-4" />
-                    {book.source_work_dates?.length ? (
-                      <span>
-                        {book.source_work_dates.find(l => l.type === 'composition')
-                          ? `${book.source_work_dates.find(l => l.type === 'composition')!.author || ''} ${book.source_work_dates.find(l => l.type === 'composition')!.date_display}`.trim()
-                          : ''}
-                        {book.source_work_dates.find(l => l.type === 'composition') && book.published
-                          ? <span className="text-stone-500"> · published {book.published}</span>
-                          : ''}
-                        {!book.source_work_dates.find(l => l.type === 'composition') && book.source_work_dates.find(l => l.type === 'translation')
-                          ? `${book.source_work_dates.find(l => l.type === 'translation')!.author || ''} trans. ${book.source_work_dates.find(l => l.type === 'translation')!.date_display}`.trim()
-                          : ''}
-                        {!book.source_work_dates.find(l => l.type === 'composition') && !book.source_work_dates.find(l => l.type === 'translation') && book.published
-                          ? book.published
-                          : ''}
-                      </span>
-                    ) : book.published}
+                    <span>
+                      {book.source_work_dates.find(l => l.type === 'composition')
+                        ? `${book.source_work_dates.find(l => l.type === 'composition')!.author || ''} ${book.source_work_dates.find(l => l.type === 'composition')!.date_display}`.trim()
+                        : ''}
+                      {book.source_work_dates.find(l => l.type === 'composition') && book.published
+                        ? <span className="text-stone-500"> · published {book.published}</span>
+                        : ''}
+                      {!book.source_work_dates.find(l => l.type === 'composition') && book.source_work_dates.find(l => l.type === 'translation')
+                        ? `${book.source_work_dates.find(l => l.type === 'translation')!.author || ''} trans. ${book.source_work_dates.find(l => l.type === 'translation')!.date_display}`.trim()
+                        : ''}
+                    </span>
                   </div>
-                )}
+                ) : null}
                 <div className="flex items-center gap-2">
                   <FileText className="w-4 h-4" />
                   {totalPages} pages

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -202,6 +202,13 @@ export async function GET(req: NextRequest) {
       }
     } else if (digitized === 'sl' && mode === 'new') {
       query = query.not('sl_book_id', 'is', null);
+    } else if (digitized === 'held' && mode === 'new') {
+      // Catalogue entries with a non-null `present_location` are books
+      // physically in the building (Leeszaal, Depot, …). Catalog-only
+      // references and works held elsewhere have null present_location.
+      // Requested by Paul Dijstelberge (BPH) — visitors wanted a way to see
+      // just the volumes they could ask to consult on site.
+      query = query.not('present_location', 'is', null);
     } else if (digitized === 'false') {
       if (mode === 'new') {
         query = query.is('sl_book_id', null).is('ia_identifier', null);

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -57,7 +57,19 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     const language = typeof sp.language === 'string' ? sp.language : '';
     const q = typeof sp.q === 'string' ? sp.q : '';
     const offset = parseInt(typeof sp.offset === 'string' ? sp.offset : '0', 10) || 0;
-    const rawView = typeof sp.view === 'string' ? sp.view : 'books';
+    // Default landing view for unified-catalogue tenants (BPH, Kloss, …):
+    // show the full library catalogue rather than just the digitised subset.
+    // Per Paul Dijstelberge's BPH feedback — a visitor to a library's home
+    // page expects to see the whole collection, with digitised as a filter
+    // they can opt into. Non-unified tenants keep the legacy 'books' default.
+    //
+    // Exception: when the URL already carries a books-grid search (`?q=…`),
+    // honour that by defaulting to 'books' so the strip-redirect below
+    // doesn't silently drop the query.
+    const tenantIsUnified = tenant === 'bph' || !!getPartnerBySlug(tenant)?.hasUnifiedCatalogue;
+    const hasBooksGridQuery = typeof sp.q === 'string' && sp.q !== '';
+    const defaultView = tenantIsUnified && !hasBooksGridQuery ? 'catalog' : 'books';
+    const rawView = typeof sp.view === 'string' ? sp.view : defaultView;
     const view = rawView === 'catalogue' ? 'catalog' : rawView;
     // Display dimension is independent of the view filter. When unset, default
     // matches what the partner mockup leads with: catalog→list, books→grid.

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -97,7 +97,7 @@ interface AdvancedFilters {
   language: string;
   yearFrom: string;
   yearTo: string;
-  digitized: '' | 'true' | 'sl' | 'false';
+  digitized: '' | 'true' | 'sl' | 'false' | 'held';
 }
 
 const EMPTY_ADV: AdvancedFilters = {
@@ -575,6 +575,7 @@ export default function BphCatalogBrowser({
                   className="w-full text-sm border border-border-light rounded-md px-2.5 py-1.5 bg-white text-primary"
                 >
                   <option value="">All books in the library</option>
+                  <option value="held">Physically held at BPH</option>
                   <option value="sl">Digitised on Source Library</option>
                   <option value="true">Digitised anywhere</option>
                   <option value="false">Not yet digitised</option>


### PR DESCRIPTION
## Summary

First batch of fixes from Paul Dijstelberge's BPH curator feedback (2026-05-22 email).

**1. Book page hero — author leads, then title, then impressum**

The current hero rendered `title → author`, which inverts the library catalogue convention Paul referenced. New order:

```
Trajano Boccalini                ← eyebrow (small)
Polityke toet-steen              ← h1 (preserved for SEO)
Amsterdam: Jacobus van Hardenberg, 1695   ← impressum
```

Format mirrors `BphCatalogBrowser.formatImpressum` so book pages and catalogue rows line up. Year is no longer duplicated in the metadata chips below — the Calendar chip now renders only when `source_work_dates` adds composition/translation dates worth showing alongside the print year.

**2. BPH default landing view: catalogue (all 27,706) instead of digitised (2,222)**

Paul: *"The default is now show digitised. Should be: show all."* Changed the `view` default in `/embed/[tenant]/page.tsx` for unified-catalogue tenants (BPH, Kloss, future partners). Non-unified tenants keep the legacy default.

Safety net: if the URL already carries `?q=…` (books-grid search), the default stays `books` so the strip-redirect doesn't silently drop the query.

**3. New filter option: "Physically held at BPH"**

Paul: *"what I miss: show the books actually in the library."* New option in the digitisation dropdown filters by `present_location IS NOT NULL` — the field BPH already uses to track which volumes are in the building (Leeszaal / Depot / …) vs catalog-only references.

## What's deferred

Other items from the same feedback that need separate work:
- Scholar's view toggle (waiting on the user-menu redesign in flight)
- Page-count accuracy (needs a new `pagination` field + admin editing in the cataloguer panel)
- Author thesaurus / title-page-vs-canonical fields (schema change + admin UI)
- Language metadata corrections on 4 specific Boccalini books (data fix, not code)
- Auth sign-in/out on BPH subdomain (you mentioned you're already on this)

## Test plan

- [ ] On the preview deploy, `bph.sourcelibrary.org/` lands on the full catalogue (Show all selected; ~27,706 in counter)
- [ ] `bph.sourcelibrary.org/?q=behme` still searches the books grid (digitised subset) — query not stripped
- [ ] Filter dropdown shows new "Physically held at BPH" option; selecting it returns a subset of the catalogue
- [ ] Open any book detail page (e.g. `/book/polityke-toet-steen`): author renders above title, impressum line appears, year not duplicated in chips
- [ ] Open a book with `source_work_dates` (e.g. a translation): Calendar chip still shows composition + print dates
- [ ] Open a book with no publisher/place/year: impressum line is absent (no empty `: ,`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)