### PR TITLE
View options menu: scholar toggles for AI intros + reading guide

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -937,7 +937,13 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
       {(() => {
         return (
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            <div className="card p-6">
+            {/* data-view-section="ai-summary": the whole "About This Book"
+                card is hidden when the visitor has scholar mode on (see
+                EmbedUserMenu). Categories are AI-assigned, the prose is
+                generated, and the empty states are meta-commentary about
+                the AI pipeline — none of it belongs on a stripped-down
+                bibliographic page. */}
+            <div className="card p-6" data-view-section="ai-summary">
               <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>About This Book</h2>
 
               {/* Categories */}
@@ -957,7 +963,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     ))}
                   </div>
                   {hasTranslations && (
-                    <ExpandableGuide embedPolicy={embedPolicy} bookId={book.id} detailedSummary={bookSummaryObj?.detailed || bookSummaryObj?.abstract} />
+                    <div data-view-section="reading-guide">
+                      <ExpandableGuide embedPolicy={embedPolicy} bookId={book.id} detailedSummary={bookSummaryObj?.detailed || bookSummaryObj?.abstract} />
+                    </div>
                   )}
                 </>
               ) : hasTranslations ? (

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -8,6 +8,13 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
+// Synchronous cookie reader. Runs during HTML parsing before any of the
+// gated sections render, so toggling the menu options never produces a
+// flash of unstyled content. The CSS rules in globals.css consume the
+// data attributes set here. Kept inline + minified so it ships in the
+// initial HTML payload without needing a separate script request.
+const VIEW_MODE_INIT_SCRIPT = `(function(){var c=document.cookie;if(/(?:^|; )sl_hide_ai=1/.test(c))document.documentElement.dataset.slHideAi='1';if(/(?:^|; )sl_hide_guide=1/.test(c))document.documentElement.dataset.slHideGuide='1';})();`;
+
 /**
  * Layout for embed routes. Adds data-embed attribute to hide
  * SiteHeader, GlobalFooter, and other chrome via CSS.
@@ -18,6 +25,7 @@ export const metadata: Metadata = {
 export default function EmbedLayout({ children }: { children: React.ReactNode }) {
   return (
     <TenantLayoutWrapper>
+      <script dangerouslySetInnerHTML={{ __html: VIEW_MODE_INIT_SCRIPT }} />
       <div data-embed="" className="embed-mode">
         {children}
         <EmbedUserMenu />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -644,3 +644,13 @@ body:has(.embed-mode) [data-site-mode-indicator] {
 body:has(.embed-mode) {
   background: #fafaf8;
 }
+
+/* Scholar view options — toggled from EmbedUserMenu. Cookies are read by an
+   inline script in the embed layout that sets data attributes on <html>
+   before any rendering, so the gated sections never paint when hidden.
+   Apply outside .embed-mode too — root-domain book pages should respect
+   the same preferences. */
+html[data-sl-hide-ai="1"] [data-view-section="ai-summary"],
+html[data-sl-hide-guide="1"] [data-view-section="reading-guide"] {
+  display: none !important;
+}

--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -4,23 +4,63 @@ import { signOut } from 'next-auth/react';
 import { useStableSession } from '@/hooks/useStableSession';
 import Link from 'next/link';
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { Settings } from 'lucide-react';
 
 /**
- * Minimal user menu for embed/tenant pages.
+ * Floating top-right control for embed/tenant pages.
  *
- * The main SiteHeader is intentionally stripped on embed routes so partner
- * subdomains (e.g. bph.sourcelibrary.org) look like the partner's own site
- * rather than ours. That left librarians like Paul with no way to sign out
- * once authenticated. This is a floating top-right control: a sign-in link
- * for anonymous users, an avatar + dropdown (with Account, Sign out) for
- * authenticated ones.
+ * Has two responsibilities:
+ *
+ * 1. View options — cookie-backed toggles that strip AI-generated prose
+ *    and pedagogical helpers from book pages. Requested by Paul Dijstelberge
+ *    (BPH) who finds the default presentation off-putting for scholarly use:
+ *    "Default with bells and whistles, possible to chose without".
+ *
+ * 2. Auth — Sign in link for anonymous visitors, avatar + Account/Sign out
+ *    for authenticated ones. The main SiteHeader is stripped on embed routes
+ *    so partner subdomains (bph.sourcelibrary.org, …) look like the
+ *    partner's own site; this control is the only sign-out affordance.
+ *
+ * Cookies are scoped to the current host (no Domain attr) so each subdomain
+ * keeps independent preferences — a scholar can run BPH in scholar mode
+ * without affecting how sourcelibrary.org renders for them.
  */
+
+const COOKIE_HIDE_AI = 'sl_hide_ai';
+const COOKIE_HIDE_GUIDE = 'sl_hide_guide';
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+function readCookie(name: string): boolean {
+  if (typeof document === 'undefined') return false;
+  const row = document.cookie.split('; ').find(r => r.startsWith(name + '='));
+  return row?.split('=')[1] === '1';
+}
+
+function writeCookie(name: string, on: boolean) {
+  if (typeof document === 'undefined') return;
+  if (on) {
+    document.cookie = `${name}=1; path=/; max-age=${COOKIE_MAX_AGE}; samesite=lax`;
+  } else {
+    document.cookie = `${name}=; path=/; max-age=0; samesite=lax`;
+  }
+}
+
 export default function EmbedUserMenu() {
   const { data: session, status } = useStableSession();
   const [isOpen, setIsOpen] = useState(false);
   const [imgError, setImgError] = useState(false);
+  const [hideAi, setHideAi] = useState(false);
+  const [hideGuide, setHideGuide] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const handleImgError = useCallback(() => setImgError(true), []);
+
+  // Hydrate toggle state from cookies after mount. The server has already
+  // rendered the book page using whatever the cookie said at request time;
+  // this just keeps the checkbox UI in sync.
+  useEffect(() => {
+    setHideAi(readCookie(COOKIE_HIDE_AI));
+    setHideGuide(readCookie(COOKIE_HIDE_GUIDE));
+  }, []);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -34,71 +74,117 @@ export default function EmbedUserMenu() {
 
   if (status === 'loading') return null;
 
-  const containerCls =
-    'fixed top-3 right-3 z-50 print:hidden';
+  // CSS-driven hiding: the inline script in embed/layout.tsx sets data
+  // attributes on <html> at page-load time; the toggle handlers update them
+  // directly so the change is instant. Cookies persist the preference for
+  // the next page load. ISR-cached HTML is identical for all visitors —
+  // only the html dataset (and CSS) differs between scholar and default
+  // views, so cache hit rate stays the same.
+  const toggleHideAi = () => {
+    const next = !hideAi;
+    setHideAi(next);
+    writeCookie(COOKIE_HIDE_AI, next);
+    document.documentElement.dataset.slHideAi = next ? '1' : '';
+  };
 
-  if (!session) {
-    return (
-      <div className={containerCls}>
-        <Link
-          href="/auth/signin"
-          className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-white/90 backdrop-blur-sm border border-border-light text-secondary hover:text-primary shadow-sm transition-colors"
-        >
-          Sign in
-        </Link>
-      </div>
-    );
-  }
+  const toggleHideGuide = () => {
+    const next = !hideGuide;
+    setHideGuide(next);
+    writeCookie(COOKIE_HIDE_GUIDE, next);
+    document.documentElement.dataset.slHideGuide = next ? '1' : '';
+  };
 
-  const name = session.user?.name || session.user?.email || 'Account';
-  const initials = session.user?.name
+  const containerCls = 'fixed top-3 right-3 z-50 print:hidden';
+
+  const name = session?.user?.name || session?.user?.email || 'Account';
+  const initials = session?.user?.name
     ?.split(' ')
     .map(n => n[0])
     .join('')
     .toUpperCase()
-    .slice(0, 2) || session.user?.email?.[0]?.toUpperCase() || '?';
+    .slice(0, 2) || session?.user?.email?.[0]?.toUpperCase() || '?';
 
   return (
     <div ref={menuRef} className={containerCls}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-2 px-2 py-1 rounded-full bg-white/90 backdrop-blur-sm border border-border-light shadow-sm hover:bg-white transition-colors"
-        aria-label="Account menu"
+        aria-label={session ? 'Account & view options' : 'View options'}
       >
-        {session.user?.image && !imgError ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={session.user.image}
-            alt=""
-            className="w-7 h-7 rounded-full"
-            onError={handleImgError}
-          />
+        {session ? (
+          session.user?.image && !imgError ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={session.user.image}
+              alt=""
+              className="w-7 h-7 rounded-full"
+              onError={handleImgError}
+            />
+          ) : (
+            <div className="w-7 h-7 rounded-full bg-accent-rust text-white text-xs font-medium flex items-center justify-center">
+              {initials}
+            </div>
+          )
         ) : (
-          <div className="w-7 h-7 rounded-full bg-accent-rust text-white text-xs font-medium flex items-center justify-center">
-            {initials}
+          <div className="w-7 h-7 rounded-full flex items-center justify-center text-secondary">
+            <Settings className="w-4 h-4" aria-hidden="true" />
           </div>
         )}
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-56 rounded-md bg-white border border-border-light shadow-lg overflow-hidden">
+        <div className="absolute right-0 mt-2 w-64 rounded-md bg-white border border-border-light shadow-lg overflow-hidden">
           <div className="px-3 py-2 border-b border-border-light/60">
-            <div className="text-xs text-muted truncate">Signed in as</div>
-            <div className="text-sm font-medium text-primary truncate">{name}</div>
+            <div className="text-xs text-muted mb-1.5">View</div>
+            <label className="flex items-start gap-2 py-1 cursor-pointer text-sm text-secondary hover:text-primary">
+              <input
+                type="checkbox"
+                checked={hideAi}
+                onChange={toggleHideAi}
+                className="mt-0.5"
+              />
+              <span>Hide AI introductions &amp; summaries</span>
+            </label>
+            <label className="flex items-start gap-2 py-1 cursor-pointer text-sm text-secondary hover:text-primary">
+              <input
+                type="checkbox"
+                checked={hideGuide}
+                onChange={toggleHideGuide}
+                className="mt-0.5"
+              />
+              <span>Hide reading guide &amp; pedagogical helpers</span>
+            </label>
           </div>
-          <Link
-            href="/account"
-            className="block px-3 py-2 text-sm text-secondary hover:bg-cream/60"
-            onClick={() => setIsOpen(false)}
-          >
-            Account
-          </Link>
-          <button
-            onClick={() => signOut({ callbackUrl: '/' })}
-            className="block w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60 border-t border-border-light/60"
-          >
-            Sign out
-          </button>
+
+          {session ? (
+            <>
+              <div className="px-3 py-2 border-b border-border-light/60">
+                <div className="text-xs text-muted truncate">Signed in as</div>
+                <div className="text-sm font-medium text-primary truncate">{name}</div>
+              </div>
+              <Link
+                href="/account"
+                className="block px-3 py-2 text-sm text-secondary hover:bg-cream/60"
+                onClick={() => setIsOpen(false)}
+              >
+                Account
+              </Link>
+              <button
+                onClick={() => signOut({ callbackUrl: '/' })}
+                className="block w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60 border-t border-border-light/60"
+              >
+                Sign out
+              </button>
+            </>
+          ) : (
+            <Link
+              href="/auth/signin"
+              className="block px-3 py-2 text-sm text-secondary hover:bg-cream/60"
+              onClick={() => setIsOpen(false)}
+            >
+              Sign in
+            </Link>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

From Paul Dijstelberge's BPH feedback: *"Default with bells and whistles, possible to chose without."* Adds two toggles to the floating user menu on embed/tenant pages.

**Toggles**
- ☐ Hide AI introductions & summaries → hides the entire "About This Book" card on book pages (header, categories, prose, expandable guide).
- ☐ Hide reading guide & pedagogical helpers → hides just the ExpandableGuide (chapter summaries, quote highlights, illustrations panel).

**Menu UX change**
The floating control now always opens a dropdown — gear icon when signed out, avatar when signed in. The View section sits above the auth section so anonymous scholars can pick scholar mode without needing an account.

**ISR-safe CSS-based hiding**
Cookies are read by an inline script in `embed/layout.tsx` during HTML parsing, before any content renders. The script sets `data-sl-hide-ai` / `data-sl-hide-guide` on `<html>`; CSS rules in `globals.css` then hide elements tagged with `data-view-section="ai-summary"` and `"reading-guide"`. The HTML body is identical for all visitors so the ISR cache (revalidate=86400 on book pages) stays effective. Toggle handlers update the html dataset directly for instant feedback.

**Cookies**
- `sl_hide_ai=1` (1 year, path=/, samesite=lax)
- `sl_hide_guide=1` (same)
- Scoped to current host (no Domain attr) so BPH scholar-mode doesn't bleed onto sourcelibrary.org.

## Test plan

- [ ] Visit a BPH book page (e.g. `bph.sourcelibrary.org/book/polityke-toet-steen`) signed out — gear icon appears top-right; clicking it shows View section + Sign in link.
- [ ] Toggle "Hide AI introductions & summaries": the entire "About This Book" card disappears instantly. Cookie set. Reload the page — card still hidden, no flash.
- [ ] Toggle off: card reappears, cookie cleared.
- [ ] Toggle "Hide reading guide & pedagogical helpers": only the ExpandableGuide hides; summary prose still shows.
- [ ] Signed-in flow: avatar instead of gear icon; View toggles + Account + Sign out all in one dropdown.
- [ ] On sourcelibrary.org (non-embed), the menu doesn't appear (correct — that uses SiteHeader instead).

## What's deferred

- Apply the same toggles to non-embed `/[tenant]/...` routes (the main-site rendering of tenant pages). Currently only embed routes have the menu and the init script.
- Coordinate with the auth/cross-subdomain work in flight (PR #1944 just landed docs; sign-in/out fix is separate) — once cookies are scoped to `.sourcelibrary.org`, we may want the view preferences to share that scope too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)