### PR TITLE
Fix BPH sign-in: route /auth and /account links to main host

### DIFF
--- a/src/components/embed/EmbedUserMenu.tsx
+++ b/src/components/embed/EmbedUserMenu.tsx
@@ -2,9 +2,37 @@
 
 import { signOut } from 'next-auth/react';
 import { useStableSession } from '@/hooks/useStableSession';
-import Link from 'next/link';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Settings } from 'lucide-react';
+
+// On tenant subdomains, /auth/* and /account are caught by the proxy.ts
+// rewrite (it sends every non-/embed/, non-/api/, non-/_next/ path to
+// /embed/<tenant>), so the link silently lands on the tenant homepage —
+// from the user's POV "nothing happens". Route those off to the main
+// host instead. Cookies are shared on .sourcelibrary.org so the session
+// carries back (see CLAUDE.md "Authentication across subdomains").
+function isTenantSubdomain(host: string): boolean {
+  return host.endsWith('.sourcelibrary.org') && host !== 'sourcelibrary.org';
+}
+
+function navigateToSignIn() {
+  if (typeof window === 'undefined') return;
+  if (isTenantSubdomain(window.location.hostname)) {
+    const callbackUrl = encodeURIComponent(window.location.href);
+    window.location.assign(`https://sourcelibrary.org/auth/signin?callbackUrl=${callbackUrl}`);
+  } else {
+    window.location.assign('/auth/signin');
+  }
+}
+
+function navigateToAccount() {
+  if (typeof window === 'undefined') return;
+  if (isTenantSubdomain(window.location.hostname)) {
+    window.location.assign('https://sourcelibrary.org/account');
+  } else {
+    window.location.assign('/account');
+  }
+}
 
 /**
  * Floating top-right control for embed/tenant pages.
@@ -162,13 +190,16 @@ export default function EmbedUserMenu() {
                 <div className="text-xs text-muted truncate">Signed in as</div>
                 <div className="text-sm font-medium text-primary truncate">{name}</div>
               </div>
-              <Link
-                href="/account"
-                className="block px-3 py-2 text-sm text-secondary hover:bg-cream/60"
-                onClick={() => setIsOpen(false)}
+              <button
+                type="button"
+                onClick={() => {
+                  setIsOpen(false);
+                  navigateToAccount();
+                }}
+                className="block w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60"
               >
                 Account
-              </Link>
+              </button>
               <button
                 onClick={() => signOut({ callbackUrl: '/' })}
                 className="block w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60 border-t border-border-light/60"
@@ -177,13 +208,16 @@ export default function EmbedUserMenu() {
               </button>
             </>
           ) : (
-            <Link
-              href="/auth/signin"
-              className="block px-3 py-2 text-sm text-secondary hover:bg-cream/60"
-              onClick={() => setIsOpen(false)}
+            <button
+              type="button"
+              onClick={() => {
+                setIsOpen(false);
+                navigateToSignIn();
+              }}
+              className="block w-full text-left px-3 py-2 text-sm text-secondary hover:bg-cream/60"
             >
               Sign in
-            </Link>
+            </button>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

Paul reported clicking **Sign in** on `bph.sourcelibrary.org` did nothing. The page just reloaded to the BPH homepage.

Root cause: `src/proxy.ts:363-413` rewrites every path on a tenant subdomain (anything not `/embed/`, `/api/`, `/_next/`) to `/embed/<tenant>`. So a relative `/auth/signin` link from `EmbedUserMenu` resolved to `bph.sourcelibrary.org/auth/signin` → rewritten to `/embed/bph` (BPH home) before the auth route ever rendered. Same bug for `/account`.

## Fix

`EmbedUserMenu` now navigates **Sign in** and **Account** through `https://sourcelibrary.org` via JS (`window.location.assign`) when on a tenant subdomain. This uses the cross-subdomain cookie sharing set up in #1943 (09ddc137): sign in once on the main host, session carries back to BPH via the `.sourcelibrary.org` cookie. Sign in passes a `callbackUrl` so the user returns to whatever BPH page they came from.

Buttons replace `Link` so the runtime host check doesn't cause hydration mismatches.

## Lockdown invariant note

This intentionally crosses subdomains (briefly) for the auth flow. No rendered anchor `<a href>` points off-subdomain, so `scripts/audit-bph-leaks.mjs` still passes. The cross-subdomain trip is exactly what #1943 was set up to support — partner branding stays on `bph.sourcelibrary.org` for all content; only the auth utility flow visits the main host.

## Test plan

- [ ] On the Vercel preview, switch the host to `bph.sourcelibrary.org` (or test the EmbedUserMenu on any tenant subdomain preview).
- [ ] Click the gear icon top-right, then **Sign in** — should land on `sourcelibrary.org/auth/signin?callbackUrl=...`.
- [ ] Complete sign-in; should redirect back to the original BPH page with avatar showing in the menu.
- [ ] Open the menu, click **Account** — should land on `sourcelibrary.org/account`.
- [ ] Click **Sign out** — should land on BPH home (unchanged behavior).
- [ ] On `sourcelibrary.org` (non-tenant host), Sign in / Account stay relative (no main-host prefix needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)