### PR TITLE
Author authority on book hero: variants, dates, VIAF/Wikidata + scans relabel

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense, cache } from 'react';
 import { Metadata } from 'next';
+import { ObjectId } from 'mongodb';
 import { getReadDb } from '@/lib/mongodb';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
@@ -32,6 +33,7 @@ import CategoryPicker from '@/components/ui/CategoryPicker';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import ExpandableGuide from '@/components/book/ExpandableGuide';
 import { AISection } from '@/components/embed/AISection';
+import AuthorAuthority from '@/components/book/AuthorAuthority';
 import { linkEntities, buildEntityList } from '@/lib/link-entities';
 import LikeButton from '@/components/ui/LikeButton';
 import CiteButton from '@/components/ui/CiteButton';
@@ -380,11 +382,37 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
   // Fall back to the catalog book (Supabase) if Atlas fetch failed
   const book = fullBookResult?.book ?? quickBook;
 
-  // Fetch full index data from dedicated collection (keeps book docs small)
-  const bookIndexDoc = await db.collection('book_indexes').findOne(
-    { book_id: bookId },
-    { projection: { _id: 0, book_id: 0 }, maxTimeMS: 5000 }
-  ).catch(() => null);
+  // Author authority record (variants / VIAF / Wikidata) — only when the
+  // book has been linked to an entity. Loaded in parallel with the index
+  // doc; failures are non-fatal (the AuthorAuthority component just doesn't
+  // render). See scripts/enrichment/viaf-author-linking.mjs for how the
+  // link gets set.
+  const authorEntityIdRaw = (book as { author_entity_id?: string }).author_entity_id;
+  const authorEntityId = typeof authorEntityIdRaw === 'string' && ObjectId.isValid(authorEntityIdRaw)
+    ? authorEntityIdRaw
+    : null;
+
+  const [bookIndexDoc, authorEntity] = await Promise.all([
+    db.collection('book_indexes').findOne(
+      { book_id: bookId },
+      { projection: { _id: 0, book_id: 0 }, maxTimeMS: 5000 }
+    ).catch(() => null),
+    authorEntityId
+      ? db.collection('entities').findOne(
+          { _id: new ObjectId(authorEntityId) },
+          {
+            projection: {
+              _id: 0,
+              name: 1, canonical_name: 1, aliases: 1,
+              viaf_id: 1, wikidata_id: 1, lcnaf_id: 1, gnd_id: 1,
+              wikipedia_url: 1,
+              wikidata_birth_date: 1, wikidata_death_date: 1,
+            },
+            maxTimeMS: 3000,
+          }
+        ).catch(() => null)
+      : Promise.resolve(null),
+  ]);
 
   // Merge index data back onto book for rendering (if found in dedicated collection)
   if (bookIndexDoc) {
@@ -428,7 +456,9 @@ async function getBook(id: string, tenantId?: string, tenantSlug?: string): Prom
   const galleryImages = deduplicateByDHash(galleryImagesParsed).slice(0, 8) as GalleryImagePreview[];
   const bookCollections = JSON.parse(JSON.stringify(bookCollectionsRaw)) as BookCollectionPreview[];
 
-  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, matchedBySlug };
+  const serializedEntity = authorEntity ? JSON.parse(JSON.stringify(authorEntity)) : null;
+
+  return { book: serializedBook as Book, pages: serializedPages as Page[], totalBooks, galleryImages, galleryImageCount, bookCollections, matchedBySlug, authorEntity: serializedEntity };
 }
 
 // Skeleton for book info while loading
@@ -491,7 +521,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
     notFound();
   }
 
-  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections } = data;
+  const { book, pages, totalBooks, galleryImages, galleryImageCount, bookCollections, authorEntity } = data;
 
   // Enforce tenant isolation: book must belong to the tenant in the URL.
   // Books are stored with EITHER `tenantId` (UUID) or `tenant_id` (slug) — sometimes both.
@@ -654,6 +684,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   </p>
                 );
               })()}
+              {authorEntity && (
+                <AuthorAuthority entity={authorEntity} bookAuthor={book.author} />
+              )}
               <h1 className="text-2xl sm:text-3xl font-serif font-bold break-words">{book.display_title || book.title}</h1>
               {book.display_title && book.title !== book.display_title && (
                 <p className="text-stone-400 mt-1 italic text-sm sm:text-base">{book.title}</p>
@@ -726,9 +759,18 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     </span>
                   </div>
                 ) : null}
-                <div className="flex items-center gap-2">
+                {/* "scans" rather than "pages": the count is of scanned
+                    images (IIIF canvases — covers, blanks, endpapers
+                    included). Bibliographic pagination ("[8] 240 [12] pp.")
+                    will live in a separate field once curators capture it
+                    per book. Paul Dijstelberge (BPH) flagged this — none
+                    of the displayed page counts matched the real book. */}
+                <div
+                  className="flex items-center gap-2"
+                  title="Scanned images, including covers and blanks. Bibliographic pagination may differ."
+                >
                   <FileText className="w-4 h-4" />
-                  {totalPages} pages
+                  {totalPages} scans
                 </div>
                 {embedPolicy.showGalleryImages && imageCount > 0 && (
                   <Link

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -260,7 +260,20 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 interface GalleryImagePreview { id: string; extracted_url?: string; thumbnail_url?: string; image_url?: string; description?: string; type?: string; page_number?: number; gallery_quality?: number; dhash?: string; book_id?: string }
 interface BookCollectionPreview { slug: string; name: string; subtitle?: string; color?: string; book_count?: number; featured_images?: Array<{ extracted_url?: string; thumbnail_url?: string; image_url?: string }> }
 
-async function getBook(id: string, tenantId?: string, tenantSlug?: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean } | null> {
+interface AuthorEntityPreview {
+  name?: string;
+  canonical_name?: string;
+  aliases?: string[];
+  viaf_id?: string;
+  wikidata_id?: string;
+  lcnaf_id?: string;
+  gnd_id?: string;
+  wikipedia_url?: string;
+  wikidata_birth_date?: string;
+  wikidata_death_date?: string;
+}
+
+async function getBook(id: string, tenantId?: string, tenantSlug?: string): Promise<{ book: Book; pages: Page[]; totalBooks: number; galleryImages: GalleryImagePreview[]; galleryImageCount: number; bookCollections: BookCollectionPreview[]; matchedBySlug: boolean; authorEntity: AuthorEntityPreview | null } | null> {
   // Reuse the cached book lookup (shared with generateMetadata — saves a full DB round trip)
   // When Supabase serves the lookup (<50ms), we get the bookId instantly and can start
   // ALL Atlas queries in parallel — including a full book refetch for fields not in the catalog.

--- a/src/components/book/AuthorAuthority.tsx
+++ b/src/components/book/AuthorAuthority.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * Surfaces the author authority record (birth/death dates, variant spellings,
+ * VIAF/Wikidata/LCNAF/Wikipedia links) below the author byline. Renders only
+ * when the book has an `author_entity_id` AND the linked entity has at least
+ * one of dates / aliases / authority IDs.
+ *
+ * Requested by Paul Dijstelberge (BPH) — scholars want to see that the
+ * system actually knows "Tr. Bokkalini" and "Trajano Boccalini" are the
+ * same person, not just take it on faith. The full alias list (incl. non-
+ * Latin scripts) lives on the dedicated /author page; this component is the
+ * inline confidence signal.
+ */
+
+interface AuthorEntity {
+  name?: string;
+  canonical_name?: string;
+  aliases?: string[];
+  viaf_id?: string;
+  wikidata_id?: string;
+  lcnaf_id?: string;
+  gnd_id?: string;
+  wikipedia_url?: string;
+  wikidata_birth_date?: string;
+  wikidata_death_date?: string;
+}
+
+interface Props {
+  entity: AuthorEntity;
+  /** book.author — used to dedupe out the form already visible in the byline. */
+  bookAuthor?: string;
+}
+
+// Skip non-Latin variants in the inline expand so the line stays readable
+// for European-language scholars (the primary BPH audience). The dedicated
+// /author page surfaces the full multi-script alias list.
+function isLatinScript(s: string): boolean {
+  return !/[֐-׿؀-ۿऀ-ॿ一-鿿぀-ヿ㐀-䶿Ͱ-ϿЀ-ӿ]/.test(s);
+}
+
+// Wikidata returns ISO dates ("1556-01-01") or year-only ("1556") or
+// signed-year for BCE ("-0470"). Pull the first integer.
+function formatYear(date?: string): string {
+  if (!date) return '';
+  const match = date.match(/-?\d{1,4}/);
+  if (!match) return '';
+  // Strip leading zeros but keep the sign for BCE
+  const negative = match[0].startsWith('-');
+  const num = match[0].replace(/^-?0+/, '') || '0';
+  return negative ? `${num} BCE` : num;
+}
+
+const INLINE_ALIAS_LIMIT = 5;
+
+export default function AuthorAuthority({ entity, bookAuthor }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  const canonical = entity.canonical_name || entity.name;
+  const birth = formatYear(entity.wikidata_birth_date);
+  const death = formatYear(entity.wikidata_death_date);
+  const dates = birth && death ? `${birth}–${death}` : birth ? `b. ${birth}` : death ? `d. ${death}` : '';
+
+  // Dedupe aliases against the byline (book.author) and the entity's
+  // canonical form so we don't show variants identical to what's already
+  // visible. Comparison is case- and punctuation-insensitive.
+  const norm = (s: string) => s.toLowerCase().replace(/[\s,.\-_'"]+/g, '');
+  const seen = new Set([bookAuthor, canonical].filter(Boolean).map(s => norm(s as string)));
+  const filteredAliases = (entity.aliases || [])
+    .filter(a => a && isLatinScript(a))
+    .filter(a => {
+      const key = norm(a);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+  const inlineAliases = filteredAliases.slice(0, INLINE_ALIAS_LIMIT);
+  const extraAliases = filteredAliases.slice(INLINE_ALIAS_LIMIT);
+  const hasMore = extraAliases.length > 0;
+
+  const authorityLinks = [
+    entity.viaf_id && { label: 'VIAF', href: `https://viaf.org/viaf/${entity.viaf_id}` },
+    entity.wikidata_id && { label: 'Wikidata', href: `https://www.wikidata.org/wiki/${entity.wikidata_id}` },
+    entity.wikipedia_url && { label: 'Wikipedia', href: entity.wikipedia_url },
+    entity.lcnaf_id && { label: 'LC', href: `https://id.loc.gov/authorities/names/${entity.lcnaf_id}.html` },
+    entity.gnd_id && { label: 'GND', href: `https://d-nb.info/gnd/${entity.gnd_id}` },
+  ].filter(Boolean) as { label: string; href: string }[];
+
+  if (!dates && inlineAliases.length === 0 && authorityLinks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-0.5 text-xs text-stone-400 leading-relaxed">
+      {dates && <span>{dates}</span>}
+      {dates && inlineAliases.length > 0 && <span> · </span>}
+      {inlineAliases.length > 0 && (
+        <>
+          <span className="text-stone-500">also </span>
+          {inlineAliases.map((a, i) => (
+            <span key={a}>
+              {i > 0 && <span className="text-stone-500">, </span>}
+              {a}
+            </span>
+          ))}
+          {hasMore && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="ml-1 underline decoration-stone-600 underline-offset-2 hover:text-stone-200"
+            >
+              {expanded ? 'show less' : `+${extraAliases.length} more`}
+            </button>
+          )}
+        </>
+      )}
+      {expanded && hasMore && (
+        <div className="mt-1">
+          {extraAliases.map((a, i) => (
+            <span key={a}>
+              {i > 0 && <span className="text-stone-500">, </span>}
+              {a}
+            </span>
+          ))}
+        </div>
+      )}
+      {authorityLinks.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+          {authorityLinks.map(({ label, href }) => (
+            <a
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-stone-200 transition-colors"
+            >
+              {label}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two BPH curator-feedback fixes on the book page hero.

**1. AuthorAuthority component** (`src/components/book/AuthorAuthority.tsx`)

Surfaces birth/death dates, variant spellings, and authority IDs below the author byline whenever the book has an `author_entity_id` linked to an entity record. For Drebbel that's:

```
Cornelis Drebbel
also Cornelius Drebel · Cornelis Jacobszoon Drebbel
Wikidata
```

For Geber (40+ multi-script aliases), the inline expand shows only Latin-script variants; the dedicated `/author/[name]` page already handles the full list.

Dedupe is case- and punctuation-insensitive against both `book.author` and `entity.canonical_name` so we don't echo what's already in the byline. Authority links: VIAF, Wikidata, Wikipedia, LCNAF, GND — each one rendered only when populated. Returns null when there's nothing meaningful to show.

Server fetch is wired into the existing `Promise.all` alongside the `book_indexes` lookup so it adds no sequential latency. ObjectId conversion is guarded by `ObjectId.isValid` so non-Atlas/non-ObjectId author_entity_id values fall through cleanly.

**2. Scans relabel**

The metadata chip `X pages` → `X scans` with a `title` tooltip:

> Scanned images, including covers and blanks. Bibliographic pagination may differ.

The displayed count is IIIF canvas count (Boccalini's `de-ragguagli-di-parnaso` shows 800 today; Paul says the actual book is 781pp). Until we add a real `pagination` field editable in the cataloguer panel, "pages" is misleading and "scans" is honest. When the pagination field lands, render both: `240 pages · 260 scans`.

## Test plan

- [ ] Book with rich entity (e.g. `/book/tractatus-duo` — Drebbel, has Wikidata + aliases): byline shows aliases caption with Wikidata link.
- [ ] Book with no entity link (any unlinked author, ~45% of BPH): AuthorAuthority renders nothing.
- [ ] Book where canonical_name === book.author: no duplicate name in the alias list.
- [ ] Book with non-Latin aliases (Geber): inline list shows only Latin variants; click "+N more" expands.
- [ ] Every book page metadata strip reads "X scans" (not "X pages"); tooltip on hover explains.
- [ ] Old book pages still render — no regression on Suspense/streaming.

## Notes

- This uses the existing entity graph populated by `scripts/enrichment/viaf-author-linking.mjs`. Authority coverage is sparse for the long tail (617 VIAF, 437 GND, 14,901 with aliases as of today's BPH-targeted run); component is graceful when fields are missing.
- The "as-printed on title page" form Paul described in his email (his field 1.1) is still TBD — needs a schema field + cataloguer-panel UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)