### PR TITLE
View options: wrap all AI prose in <AISection> so toggle hides every surface

### DIFF
--- a/src/app/[tenant]/book/[id]/guide/page.tsx
+++ b/src/app/[tenant]/book/[id]/guide/page.tsx
@@ -9,6 +9,7 @@ import SectionsNav from '@/components/layout/SectionsNav';
 import { BookLoader } from '@/components/ui/BookLoader';
 import LikeButton from '@/components/ui/LikeButton';
 import { books, gallery } from '@/lib/api-client';
+import { AISection } from '@/components/embed/AISection';
 
 interface SectionSummary {
   title: string;
@@ -268,13 +269,15 @@ export default function GuidePage({ params }: GuidePageProps) {
 
               {/* Brief Abstract */}
               {(book.index?.bookSummary?.brief || book.reading_summary?.overview) && (
-                <p
-                  className="mt-5 text-lg leading-relaxed"
-                  style={{ color: 'var(--text-secondary)' }}
-                >
-                  {book.index?.bookSummary?.brief ||
-                   (book.reading_summary?.overview && book.reading_summary.overview.split('\n\n')[0]?.slice(0, 300) + (book.reading_summary.overview.length > 300 ? '...' : ''))}
-                </p>
+                <AISection>
+                  <p
+                    className="mt-5 text-lg leading-relaxed"
+                    style={{ color: 'var(--text-secondary)' }}
+                  >
+                    {book.index?.bookSummary?.brief ||
+                     (book.reading_summary?.overview && book.reading_summary.overview.split('\n\n')[0]?.slice(0, 300) + (book.reading_summary.overview.length > 300 ? '...' : ''))}
+                  </p>
+                </AISection>
               )}
 
               {/* Link to Book */}

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -31,6 +31,7 @@ import DublinCoreMeta from '@/components/seo/DublinCoreMeta';
 import CategoryPicker from '@/components/ui/CategoryPicker';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import ExpandableGuide from '@/components/book/ExpandableGuide';
+import { AISection } from '@/components/embed/AISection';
 import { linkEntities, buildEntityList } from '@/lib/link-entities';
 import LikeButton from '@/components/ui/LikeButton';
 import CiteButton from '@/components/ui/CiteButton';
@@ -937,13 +938,12 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
       {(() => {
         return (
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            {/* data-view-section="ai-summary": the whole "About This Book"
-                card is hidden when the visitor has scholar mode on (see
-                EmbedUserMenu). Categories are AI-assigned, the prose is
-                generated, and the empty states are meta-commentary about
-                the AI pipeline — none of it belongs on a stripped-down
-                bibliographic page. */}
-            <div className="card p-6" data-view-section="ai-summary">
+            {/* The whole "About This Book" card is hidden when the visitor
+                has scholar mode on (see EmbedUserMenu). Categories are
+                AI-assigned, the prose is generated, and the empty states
+                are meta-commentary about the AI pipeline — none of it
+                belongs on a stripped-down bibliographic page. */}
+            <AISection className="card p-6">
               <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>About This Book</h2>
 
               {/* Categories */}
@@ -963,9 +963,9 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                     ))}
                   </div>
                   {hasTranslations && (
-                    <div data-view-section="reading-guide">
+                    <AISection kind="reading-guide">
                       <ExpandableGuide embedPolicy={embedPolicy} bookId={book.id} detailedSummary={bookSummaryObj?.detailed || bookSummaryObj?.abstract} />
-                    </div>
+                    </AISection>
                   )}
                 </>
               ) : hasTranslations ? (
@@ -987,7 +987,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   />
                 </p>
               )}
-            </div>
+            </AISection>
 
             {/* Chapters & Sections */}
             {book.chapters?.length ? (

--- a/src/app/[tenant]/categories/[id]/page.tsx
+++ b/src/app/[tenant]/categories/[id]/page.tsx
@@ -11,6 +11,7 @@ import CategorySchema from '@/components/seo/CategorySchema';
 import { tenantBookUrl } from '@/lib/slugify';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { getBookThumbnailUrl } from '@/lib/utils';
+import { AISection } from '@/components/embed/AISection';
 
 interface Book {
   id: string;
@@ -192,9 +193,11 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
                       {book.published && <span>{book.published}</span>}
                     </div>
                     {summaryText && (
-                      <p className="text-sm text-stone-600 mt-3 line-clamp-2">
-                        {summaryText}
-                      </p>
+                      <AISection>
+                        <p className="text-sm text-stone-600 mt-3 line-clamp-2">
+                          {summaryText}
+                        </p>
+                      </AISection>
                     )}
                   </div>
                 </Link>

--- a/src/app/[tenant]/collection-areas/[id]/page.tsx
+++ b/src/app/[tenant]/collection-areas/[id]/page.tsx
@@ -13,6 +13,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { LIBRARY_CATEGORIES } from '@/app/api/categories/route';
 import { notFound } from 'next/navigation';
 import { tenantBookUrl } from '@/lib/slugify';
+import { AISection } from '@/components/embed/AISection';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { getBookThumbnailUrl } from '@/lib/utils';
 
@@ -177,9 +178,11 @@ export default async function CollectionAreaPage({ params }: Props) {
                                             {book.author}
                                         </p>
                                         {summaryText && (
-                                            <p className="text-xs text-secondary mt-2 line-clamp-2">
-                                                {summaryText}
-                                            </p>
+                                            <AISection>
+                                                <p className="text-xs text-secondary mt-2 line-clamp-2">
+                                                    {summaryText}
+                                                </p>
+                                            </AISection>
                                         )}
                                         {book.pages_count && (
                                             <p className="text-xs text-muted mt-2">

--- a/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
@@ -5,6 +5,7 @@ import { getReadDb } from '@/lib/mongodb';
 import { tenantBookUrl } from '@/lib/slugify';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import type { LibraryPartner } from '@/lib/library-partners';
+import { AISection } from '@/components/embed/AISection';
 
 // Generic catalogue detail renderer for tenants whose bibliographic data
 // lives in `library_catalog_records` (set `hasUnifiedCatalogue: true` on
@@ -300,11 +301,13 @@ export default async function GenericCatalogEntry({
                 </dl>
 
                 {slBook.reading_summary?.overview && (
-                  <p className="text-sm text-secondary leading-relaxed mb-4 italic">
-                    {slBook.reading_summary.overview.length > 380
-                      ? slBook.reading_summary.overview.slice(0, 380) + '…'
-                      : slBook.reading_summary.overview}
-                  </p>
+                  <AISection>
+                    <p className="text-sm text-secondary leading-relaxed mb-4 italic">
+                      {slBook.reading_summary.overview.length > 380
+                        ? slBook.reading_summary.overview.slice(0, 380) + '…'
+                        : slBook.reading_summary.overview}
+                    </p>
+                  </AISection>
                 )}
 
                 <a

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -8,6 +8,7 @@ import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
 import { getPartnerBySlug } from '@/lib/library-partners';
 import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
+import { AISection } from '@/components/embed/AISection';
 import GenericCatalogEntry, { generateGenericMetadata } from './GenericCatalogEntry';
 
 // Catalogue entry routing
@@ -488,11 +489,13 @@ export default async function CatalogEntryPage({ params }: Props) {
             </dl>
 
             {slBook.reading_summary?.overview && (
-              <p className="text-sm text-secondary leading-relaxed mb-4 italic">
-                {slBook.reading_summary.overview.length > 380
-                  ? slBook.reading_summary.overview.slice(0, 380) + '…'
-                  : slBook.reading_summary.overview}
-              </p>
+              <AISection>
+                <p className="text-sm text-secondary leading-relaxed mb-4 italic">
+                  {slBook.reading_summary.overview.length > 380
+                    ? slBook.reading_summary.overview.slice(0, 380) + '…'
+                    : slBook.reading_summary.overview}
+                </p>
+              </AISection>
             )}
 
             <a

--- a/src/components/embed/AISection.tsx
+++ b/src/components/embed/AISection.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Wraps AI-generated prose so the "Hide AI introductions & summaries" / "Hide
+ * reading guide" toggles in EmbedUserMenu can hide it via CSS. The toggles
+ * write a cookie; an inline script in embed/layout.tsx reads the cookie on
+ * page load and sets data-sl-hide-ai / data-sl-hide-guide on <html>. The
+ * rules in globals.css then key off this wrapper's data-view-section.
+ *
+ * Use this anywhere AI-generated content renders (book summaries, reading
+ * guides, AI-assigned category prose, etc.). Forgetting to wrap is the
+ * failure mode: the toggle silently misses that surface.
+ */
+interface AISectionProps {
+  kind?: 'ai-summary' | 'reading-guide';
+  className?: string;
+  children: ReactNode;
+}
+
+export function AISection({ kind = 'ai-summary', className, children }: AISectionProps) {
+  return (
+    <div data-view-section={kind} className={className}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The Hide AI introductions toggle (#1950) only tagged the book detail "About This Book" card with `data-view-section="ai-summary"`. Catalogue cards, category grids, collection-area grids, and the guide page rendered AI prose as plain `<p>`, so toggling hid one surface but the next page kept showing AI text.
- Extracts a tiny wrapper component `src/components/embed/AISection.tsx` that emits the `data-view-section` attribute (`ai-summary` or `reading-guide`), and applies it everywhere AI-generated prose renders.
- Forgetting to wrap new AI surfaces is now caught in code review (visible in diff/grep) rather than silently leaking AI content past the toggle.

No CSS or cookie/script changes — the existing architecture (cookie + inline script + `html[data-sl-hide-ai="1"]` selector) is unchanged; this just makes sure every AI-prose surface participates.

## Test plan
- [ ] On `bph.sourcelibrary.org/catalog/{ubn}`, click the gear → Hide AI introductions. The reading-summary blockquote on the BPH catalogue card should disappear.
- [ ] Navigate to another catalogue card without reloading. Its AI summary should also be hidden.
- [ ] Visit `/book/{slug}` — "About This Book" card hides.
- [ ] Visit `/book/{slug}/guide` — brief abstract hides.
- [ ] Visit a category and collection-area grid — per-book AI snippets hide.
- [ ] Untoggle → everything reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)