### PR TITLE
Link book illustrations to their source page

### DIFF
--- a/src/app/[tenant]/book/[id]/guide/page.tsx
+++ b/src/app/[tenant]/book/[id]/guide/page.tsx
@@ -443,11 +443,14 @@ export default function GuidePage({ params }: GuidePageProps) {
                   const imageId = `${item.pageId}-${item.detectionIndex}`;
                   // Use pre-cropped URL if available, fall back to original
                   const displayUrl = item.extractedUrl || item.thumbnailUrl || item.imageUrl;
+                  const pageHref = book
+                    ? `/book/${book.slug || bookId}/page/${item.pageId}`
+                    : `/gallery/image/${imageId}`;
 
                   return (
                     <Link
                       key={imageId}
-                      href={`/gallery/image/${imageId}`}
+                      href={pageHref}
                       className="group relative aspect-square rounded-lg overflow-hidden transition-all hover:shadow-md"
                       style={{ background: 'var(--bg-warm)', border: '1px solid var(--border-light)' }}
                     >

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -1043,10 +1043,14 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   {galleryImages.map((img) => {
                     const src = img.extracted_url || img.thumbnail_url || img.image_url;
                     if (!src) return null;
+                    const pageId = img.id.match(/^(.+)[:\-]\d+$/)?.[1];
+                    const href = pageId
+                      ? `/book/${book.slug || book.id}/page/${pageId}`
+                      : `/gallery/image/${img.id}`;
                     return (
                       <Link
                         key={img.id}
-                        href={`/gallery/image/${img.id}`}
+                        href={href}
                         className="flex-shrink-0 group"
                       >
                         <div className="w-28 h-28 sm:w-36 sm:h-36 rounded-lg overflow-hidden bg-stone-100 border border-stone-200 group-hover:border-accent-rust/40 transition-colors">


### PR DESCRIPTION
## Summary
- On book detail pages, the **Illustrations** strip currently links each thumbnail to `/gallery/image/{id}` — readers expect clicking an illustration to take them to the page of the book it came from, not into the global gallery viewer.
- Extracts the `pageId` from the gallery image id (`{pageId}:{detectionIndex}` or `{pageId}-{detectionIndex}`) and links to `/book/{slug}/page/{pageId}`. Falls back to the gallery URL if the id doesn't match the expected shape.
- Applies the same change to the reading guide's Illustrations panel (`/book/[id]/guide`) for consistency.
- "View All →" is intentionally unchanged — that one belongs in the gallery.

## Files
- \`src/app/[tenant]/book/[id]/page.tsx\` — main book detail page Illustrations row
- \`src/app/[tenant]/book/[id]/guide/page.tsx\` — reading guide Illustrations panel

## Test plan
- [ ] On a preview deploy, open a book with illustrations (e.g. a BPH alchemical title with figures) and click a thumbnail — should land on the reader at the source page, not the gallery viewer
- [ ] Confirm "View All →" still goes to \`/gallery?bookId=...\`
- [ ] Spot-check tenant subdomain (bph.sourcelibrary.org) — relative \`/book/{slug}/page/{pageId}\` href should be rewritten by \`proxy.ts\` and stay on-host (no leak to sourcelibrary.org)
- [ ] Reading guide \`/book/{id}/guide\` Illustrations panel — same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)