### PR TITLE
Hide Jung Resonances entry points on BPH subdomain

### DIFF
--- a/src/components/libraries/BphUnifiedCatalogue.tsx
+++ b/src/components/libraries/BphUnifiedCatalogue.tsx
@@ -79,30 +79,15 @@ export default function BphUnifiedCatalogue({
   // toggle still routes to list view (allHref forces display=list).
   const effectiveLockDigitized = mode === 'digitized' || display === 'grid';
 
-  // Virtual-collection affordances shown in the catalogue header. Currently
-  // a single link to Jung Resonances; structured as an array so future
-  // resonance views (Kloss, USTC overlaps, etc.) slot in without reflowing.
-  const jungResonancesHref = embedHref(`${basePath}/collections/jung-resonances`);
-
   return (
     <>
-      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="text-2xl sm:text-3xl text-primary font-display">
-            Library Catalogue
-          </h2>
-          <p className="text-sm text-muted mt-1">
-            Complete catalogue of the Bibliotheca Philosophica Hermetica.
-          </p>
-        </div>
-        <Link
-          href={jungResonancesHref}
-          className="shrink-0 inline-flex items-center gap-1.5 text-sm text-secondary hover:text-accent-rust transition-colors mt-1 whitespace-nowrap"
-          title="Books in both BPH and Jung's personal library at Küsnacht"
-        >
-          <span aria-hidden="true">↳</span>
-          Jung Resonances
-        </Link>
+      <div className="mb-6">
+        <h2 className="text-2xl sm:text-3xl text-primary font-display">
+          Library Catalogue
+        </h2>
+        <p className="text-sm text-muted mt-1">
+          Complete catalogue of the Bibliotheca Philosophica Hermetica.
+        </p>
       </div>
 
       <BphCatalogBrowser

--- a/src/components/libraries/SharedLibraryView.tsx
+++ b/src/components/libraries/SharedLibraryView.tsx
@@ -528,43 +528,6 @@ export default function SharedLibraryView({
               </div>
             )}
 
-            {/* Connections / virtual collections — only on the BPH default
-                landing, just below Selected Books. Currently a single card
-                pointing at Jung Resonances; structured as a row so future
-                resonance pages (Kloss ↔ BPH, USTC overlaps, etc.) slot in
-                without reworking the layout. */}
-            {showSelectedBooksRow && (
-              <div className="mb-10">
-                <h2 className="text-2xl sm:text-3xl text-primary font-display mb-1">
-                  Connections
-                </h2>
-                <p className="text-sm text-muted mb-4">
-                  Bibliographic resonances between BPH and other major collections.
-                </p>
-                <div className="grid sm:grid-cols-2 gap-4">
-                  <Link
-                    href={embedHref(`${basePath}/collections/jung-resonances`)}
-                    className="group block rounded-lg border border-border-light bg-white p-5 hover:border-accent-rust/40 hover:shadow-sm transition-all"
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="flex-1 min-w-0">
-                        <p className="text-[10px] uppercase tracking-[0.2em] text-muted mb-1">
-                          Virtual Collection
-                        </p>
-                        <h3 className="text-lg text-primary font-display leading-snug mb-1 group-hover:text-accent-rust transition-colors">
-                          Jung Resonances
-                        </h3>
-                        <p className="text-sm text-secondary leading-relaxed">
-                          151 works from Jung&apos;s personal library at Küsnacht
-                          that are also held in the BPH.
-                        </p>
-                      </div>
-                    </div>
-                  </Link>
-                </div>
-              </div>
-            )}
-
             {/* Library Catalogue heading — only on the default landing
                 (showSelectedBooksRow). The /catalog view uses the unified
                 shell rendered above instead. */}


### PR DESCRIPTION
## Summary
Removes the two surfaces that linked to `/collections/jung-resonances` on bph.sourcelibrary.org:
- The `↳ Jung Resonances` link in the BPH catalogue header (`BphUnifiedCatalogue.tsx`)
- The "Connections" virtual-collection card on the BPH landing page (`SharedLibraryView.tsx`)

The page itself at `/collections/jung-resonances` still exists, so any external/inbound links keep working — this PR only removes the in-product entry points.

## Test plan
- [ ] Visit `bph.sourcelibrary.org` (landing) — no "Connections" section, no Jung Resonances card
- [ ] Visit `bph.sourcelibrary.org/catalog` — catalogue header has just the title + tagline, no `↳ Jung Resonances` link
- [ ] Direct visit to `bph.sourcelibrary.org/collections/jung-resonances` still loads the collection page (so any existing share links don't 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)