### PR TITLE
BPH catalog editor: restore contributor mode (revert of regression in #1949)

### DIFF
--- a/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/edit/page.tsx
@@ -81,13 +81,17 @@ export default async function EditCatalogEntryPage({ params }: Props) {
   const tenantRole = await effectiveTenantRole(session.user.email, tenant);
   const effectiveRole = ROLE_LEVEL[platformRole] >= ROLE_LEVEL[tenantRole] ? platformRole : tenantRole;
 
-  // PR-C ships editor mode only. PR-D will loosen this to contributor and
-  // route the form's Save through the pending-changes flow instead.
-  if (ROLE_LEVEL[effectiveRole] < ROLE_LEVEL['editor']) {
+  // Contributor and above can reach this page. The API routes Save through
+  // applyWorkRevision for editor+ (direct apply) and into
+  // bph_works_pending_changes for contributor (queued for editor review).
+  // The form learns its mode from the `mode` prop below.
+  if (ROLE_LEVEL[effectiveRole] < ROLE_LEVEL['contributor']) {
     const h = await headers();
     const referer = h.get('referer') || `/catalog/${encodeURIComponent(ubn)}`;
     redirect(referer);
   }
+  const formMode: 'editor' | 'contributor' =
+    ROLE_LEVEL[effectiveRole] >= ROLE_LEVEL['editor'] ? 'editor' : 'contributor';
 
   // Fetch the current row using exactly the whitelisted editable columns.
   // The detail page exists at /catalog/[ubn] — if we can't find the row,
@@ -140,6 +144,7 @@ export default async function EditCatalogEntryPage({ params }: Props) {
           tenant={tenant}
           initial={work}
           editorEmail={session.user.email || ''}
+          mode={formMode}
         />
       </div>
     </div>

--- a/src/components/catalog/BphWorkEditForm.tsx
+++ b/src/components/catalog/BphWorkEditForm.tsx
@@ -28,6 +28,10 @@ interface Props {
   tenant: string;
   initial: Record<string, unknown>;
   editorEmail: string;
+  /** 'editor' → Save applies directly via applyWorkRevision.
+   *  'contributor' → Save queues a row in bph_works_pending_changes for
+   *  editor review. The form UI changes copy but is otherwise identical. */
+  mode: 'editor' | 'contributor';
 }
 
 // Mirrors EDITABLE_BPH_FIELDS in src/lib/bph-catalog.ts, organised into the
@@ -144,7 +148,7 @@ function isUnchanged(orig: unknown, next: unknown): boolean {
   return false;
 }
 
-export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _editorEmail }: Props) {
+export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _editorEmail, mode }: Props) {
   const router = useRouter();
 
   // Form state — one entry per editable field, all strings (number-typed
@@ -165,6 +169,7 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
   const [note, setNote] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [submittedPendingId, setSubmittedPendingId] = useState<string | null>(null);
 
   const changedFields = useMemo(() => {
     const changed: string[] = [];
@@ -223,8 +228,19 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
         setSubmitting(false);
         return;
       }
-      // Redirect back to the detail page. The catalog row is cached by
-      // Next.js; pushing the same route forces a fresh fetch.
+      const body = (await res.json()) as { mode?: 'applied' | 'queued'; pendingId?: string };
+      if (body.mode === 'queued' && body.pendingId) {
+        // Contributor flow: hold on the form, show a clear success banner,
+        // and let the user navigate back when they're ready. Redirecting to
+        // the detail page would land them on the unchanged record with no
+        // signal that their work landed somewhere.
+        setSubmittedPendingId(body.pendingId);
+        setSubmitting(false);
+        return;
+      }
+      // Editor flow: changes are live. Bounce back to the detail page so the
+      // updated values are visible immediately (router.refresh forces a
+      // fresh server-side fetch).
       router.push(`/catalog/${encodeURIComponent(ubn)}`);
       router.refresh();
     } catch (err) {
@@ -233,8 +249,46 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
     }
   };
 
+  if (submittedPendingId) {
+    return (
+      <div className="p-6 rounded-lg border border-accent-gold/50 bg-accent-gold/10">
+        <h2 className="text-lg font-medium text-primary mb-2">Submitted for review</h2>
+        <p className="text-sm text-secondary mb-4">
+          An editor will look at your proposed change and either apply it or leave a note explaining why not. The change isn&rsquo;t live yet — the catalogue entry is unchanged until the editor approves.
+        </p>
+        <p className="text-xs text-muted mb-4 font-mono">Submission ID: {submittedPendingId}</p>
+        <div className="flex flex-wrap gap-2">
+          <a
+            href={`/catalog/${encodeURIComponent(ubn)}`}
+            className="px-3 py-1.5 text-sm rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 transition-colors"
+          >
+            Back to catalogue entry
+          </a>
+          <a
+            href={`/catalog/${encodeURIComponent(ubn)}/edit`}
+            className="px-3 py-1.5 text-sm rounded-md border border-border-light text-secondary hover:bg-warm hover:text-primary transition-colors"
+          >
+            Propose another change
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Mode banner — clarifies what Save will do. Contributor edits queue
+          for editor review; editor edits apply immediately. Both write to
+          the same revision history once approved. */}
+      {mode === 'contributor' && (
+        <div className="p-3 rounded-lg border border-accent-gold/50 bg-accent-gold/10 text-sm text-primary">
+          <p className="font-medium mb-0.5">Your changes will be sent for review</p>
+          <p className="text-xs text-secondary">
+            An editor (Jose or Paul) will see your proposed changes and either apply them or leave a note. You&rsquo;ll be able to track the status from this work&rsquo;s page.
+          </p>
+        </div>
+      )}
+
       {/* Source citation — required, applies to every changed field. */}
       <div className="p-4 bg-white border border-border-light rounded-lg">
         <h2 className="text-xs uppercase tracking-wider text-muted font-medium mb-3">Source for this change</h2>
@@ -382,7 +436,9 @@ export default function BphWorkEditForm({ ubn, tenant, initial, editorEmail: _ed
             disabled={submitting || changedFields.length === 0}
             className="px-4 py-1.5 text-sm rounded-md bg-accent-rust text-white hover:bg-accent-rust/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            {submitting ? 'Saving…' : 'Save changes'}
+            {submitting
+              ? mode === 'contributor' ? 'Submitting…' : 'Saving…'
+              : mode === 'contributor' ? 'Submit for review' : 'Save changes'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

PR #1949 (Author authority via VIAF + Wikidata) accidentally reverted the contributor-mode pieces shipped in PR-D (#1935). The role gate snapped back to editor-only, the form's `mode` prop and queued-response handling were removed, and the "Submitted for review" success panel disappeared.

**Net effect on production:** BPH contributors lose the "Propose a change" flow — clicking the edit affordance redirects them straight back to the catalogue card with no explanation.

## What's restored

- `edit/page.tsx`: role gate loosened from `< 'editor'` back to `< 'contributor'`; `formMode` resolved and threaded through to the form as `mode={formMode}`.
- `BphWorkEditForm.tsx`:
  - `mode: 'editor' | 'contributor'` on Props
  - `submittedPendingId` state
  - queued-vs-applied branching in the submit handler
  - contributor mode banner above the form ("Your changes will be sent for review")
  - "Submitted for review" success panel on contributor submit
  - mode-aware save button label (`Submit for review` vs `Save changes`)

`POST /api/[tenant]/catalog/[ubn]/edit` was untouched by #1949 and already has the editor/contributor branching, so this PR is purely re-wiring the UI to the existing API contract.

## Test plan

- [ ] Sign in as a BPH contributor → visit a catalogue card → click "Propose a change" → form renders with the amber banner and "Submit for review" button.
- [ ] Submit a change → success panel appears with the submission ID; bph_works row is unchanged.
- [ ] Sign in as a BPH editor → same card → edit button reads "Edit catalogue entry"; form has no banner and button reads "Save changes". Save applies immediately and redirects to the catalogue card.
- [ ] Reader role → edit URL still redirects to the referer (catalogue card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)