### PR TITLE
Memory layer cleanup: fix CLAUDE.md paths + refresh stale claims in <repo>/memory/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,16 +79,14 @@ Source: `src/lib/auth.ts` (cookies block). See `.claude/docs/auth-tenant-cookies
 - **Dead code cleanup:** GitHub issue #258 (closed) — most cleaned up, some camera components may remain. Note: rithmomachia is a live feature (`/rithmomachia`), not dead code.
 
 ## Domain Context
-Memory is organized hierarchically: `MEMORY.md` (top-level, always loaded) → `_index-*.md` section indexes → individual topic files. Load the relevant section index for your task — don't read all of them.
 
 Detect the work domain from the user's prompt and load the right context automatically:
 - **System overview / "where does X live?":** read `.claude/docs/system-map.md`
-- **Pipeline/cron/Lambda/OCR/translation:** read `memory/_index-pipeline.md` + `memory/_index-safety.md` (or `/pipeline-context`)
-- **UI/frontend/navigation:** read `memory/_index-product.md` (or `/ui-context`)
-- **Data fixes/maintenance/stuck books:** read `memory/_index-safety.md` + `memory/_index-content.md` (or `/maintenance`)
-- **Search/embeddings:** read `memory/_index-search.md`
-- **Import/curation:** read `memory/_index-content.md` (or `/curator`, `/library-curator`)
-- **Deploy/infra:** read `memory/_index-infrastructure.md`
+- **Pipeline/cron/Lambda/OCR/translation:** read `memory/pipeline-ops.md` (or `/pipeline-context`)
+- **UI/frontend/navigation:** read `memory/ui-navigation.md` (or `/ui-context`)
+- **Data fixes/maintenance/stuck books:** read `memory/data-quality.md` (or `/maintenance`)
+- **MCP server/CLI:** read `memory/mcp-server.md`
+- **Book acquisition / curation:** `/curator` or `/library-curator`
 - **Quality auditing:** `/qa-audit`
 - **Batch processing:** `/batch-translate`
 - **Handoffs:** `.claude/handoffs/` (read by date/topic)
@@ -98,7 +96,7 @@ Detect the work domain from the user's prompt and load the right context automat
 - **After fixing a non-trivial bug**, proactively update the relevant memory file following the `/lesson` workflow. Don't wait to be asked.
 - When reading memory files, flag anything that contradicts the current codebase and fix it.
 - Memory entries with dates >14 days old: verify before trusting stats/counts.
-- **When adding new memory files**, add them to the appropriate `_index-*.md` section index (not directly to MEMORY.md). Keep MEMORY.md under 100 lines.
+- **Two memory systems:** `<repo>/memory/` (committed, team-shared, flat files listed above) is loaded by skills like `/pipeline-context`. Claude Code auto-memory (per-machine, gitignored, lives in `~/.claude/projects/<project>/memory/`) is managed by Claude across sessions and has its own `MEMORY.md` + `_index-*.md` hierarchy. The `/lesson` workflow writes to repo memory.
 
 ## Compaction Instructions
 When compacting (`/compact`), ALWAYS preserve:

--- a/memory/data-quality.md
+++ b/memory/data-quality.md
@@ -2,12 +2,11 @@
 
 Known data issues, maintenance patterns, and quality rules. For thumbnail fixes, see `.claude/docs/thumbnails.md`.
 
-## Active Issues
+## Current Issues
 
-- **Orphaned pages (2026-03-16):** ~58K pages with ~164 book_ids that don't match any book. Issue #215.
-- **False-positive page splits (2026-03-14):** 123K sliver pages across 657 books. Issue #182 (closed, tracked under #264).
-- **Gallery images missing thumbnails (2026-03-10):** 48.5% of gallery images lack thumbnail/extracted URLs. Issue #148.
-- **Cover quality (2026-03-18):** Digitizer inserts, bad covers, unarchived books. Issue #251.
+For current data-quality issues, run `gh issue list --label data-quality --state open` — pinning specific issue numbers here goes stale fast (the four originally listed here — #215, #182, #148, #251 — are all closed as of April 2026).
+
+Tracked under the auto-memory entry [[project-stale-bph-issues-2026-05]] (snapshot 2026-05-15): seven BPH-specific issues where PRs shipped partial fixes but issue bodies read as done — verify residual work before closing.
 
 ## id vs _id Distinction (CRITICAL)
 
@@ -15,7 +14,7 @@ App uses `book.id` (not `_id`) for all lookups. Pages' `book_id` matches `book.i
 
 ## Page Count Caches
 
-`pages_count`, `pages_ocr`, `pages_translated` on books are performance caches synced by the `sync-page-counts` cron (6h). Source of truth: `pages` collection. `translation_percent` is never stored — computed at read time.
+`pages_count`, `pages_ocr`, `pages_translated` on books are performance caches. Source of truth: `pages` collection. `translation_percent` is never stored — computed at read time. The old `sync-page-counts` cron has been archived; the endpoint now lives at `/api/admin/sync-page-counts` for manual reruns. Counter sync is the responsibility of any worker that writes to `pages` (see pipeline-ops.md "Critical Rules" — Hetzner workers must call counter sync helpers).
 
 ## Data Provenance Rule
 

--- a/memory/mcp-server.md
+++ b/memory/mcp-server.md
@@ -1,27 +1,34 @@
 # MCP Server
 
-Source Library exposes an MCP server for Claude Code integration, enabling direct database queries and book operations from the CLI.
+Source Library exposes a Model Context Protocol server for Claude Desktop, Claude Code, and other MCP clients. It surfaces search and book-fetch tools backed by the production database.
 
-## Setup
+## Where It Lives
 
-The MCP server is configured in `.claude/settings.json` under `mcpServers`. It runs as a Node.js process using `npx tsx`.
+- **Code:** `mcp-server/` (separate package at the repo root, not under `src/`)
+- **Entry point:** `mcp-server/src/index.ts` (tool list + dispatch)
+- **HTTP transport:** `mcp-server/src/api.ts`
+- **CLI runner:** `mcp-server/src/cli.ts`
+- **Published as:** an npm package; the `mcp-server/README.md` and `mcp-server/CHANGELOG.md` track external versions.
 
 ## Available Tools
 
-- `search_books` — Search by title, author, or query
-- `get_book` — Get full book details by ID or slug
-- `get_page` — Get a specific page with OCR and translation
-- `list_collections` — Browse collections
-- `query_stats` — Database statistics
-- `run_query` — Direct MongoDB queries (admin, read-only)
+Confirmed in `mcp-server/src/index.ts`:
 
-## Key Files
-
-- `src/mcp/server.ts` — MCP server entry point
-- `src/mcp/tools/` — Tool implementations
+- `search_library` — top-level keyword search across books
+- `list_books` — filtered enumeration (collection, author, etc.)
+- `search_translations` — search within translated text
+- `search_within_book` — scoped search inside one book
+- `search_concept` — semantic concept search
+- `search_images` — gallery / artwork search
+- `get_book` — book metadata by id or slug
+- `get_book_text` — full OCR + translation text for a book
+- `get_quote` — single-quote fetch with citation URL
+- `check_duplicate` — pre-import duplicate detection
+- `submit_feedback` — user feedback ingestion
 
 ## Notes
 
-- MCP server uses read-only database access — no writes
-- Queries go through the same `getDb()` connection as the web app
-- Rate limiting applies to MCP calls same as API calls
+- All tools are read-only against the production `bookstore` database except `submit_feedback`, which writes to a feedback collection.
+- The MCP server reuses the same Mongo connection helpers as the web app — rate limiting and the Vercel WAF rules cover it.
+- The remote MCP server (with OAuth) is described in the auto-memory entry `remote-mcp-server.md`.
+- `/api/mcp` on the web side gets heavy crawler attention (~32K bot hits / 30 days as of 2026-05) — kept behind the Vercel Bot Management rules.

--- a/memory/pipeline-ops.md
+++ b/memory/pipeline-ops.md
@@ -2,7 +2,7 @@
 
 Operational reference for pipeline monitoring, debugging, and processing. For full architecture details, see `.claude/docs/pipeline-architecture.md`.
 
-## Where Everything Runs (March 2026)
+## Where Everything Runs (snapshot 2026-05 — verify if older than ~30 days)
 
 | Component | Where | How |
 |-----------|-------|-----|
@@ -28,7 +28,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 | OCR (batch) | `gemini-3-flash-preview` | `gemini-3.1-flash-lite-preview` |
 | Translation | `gemini-3-flash-preview` | `gemini-3.1-flash-lite-preview` |
 | Transliteration | `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite-preview` |
-| Summary/Index | `gemini-3-flash-preview` | `gemini-3-flash-preview` |
+| Summary/Index/Chapters | `gemini-3.1-flash-lite-preview` | `gemini-3.1-flash-lite-preview` |
 
 ## Emergency Controls
 
@@ -53,7 +53,7 @@ Operational reference for pipeline monitoring, debugging, and processing. For fu
 - Any script overwriting `ocr.data` or `translation.data` MUST call `createRevision(pageId, field, jobId?)` first
 - **Never patch Hetzner directly without committing to git.** Local-only patches cause drift that's invisible to other devs and future sessions. Apply fixes in git first, then `git pull` on Hetzner.
 - **Health grading uses DB latency only** (findMs, countMs), not job count. Job count stopped correlating with DB load when translation moved to Hetzner. See lesson 2026-03-30.
-- Summary/Index generation: ALWAYS use `gemini-3-flash-preview` (per CLAUDE.md)
+- Summary/Index/Chapters generation: enrich-worker uses `gemini-3.1-flash-lite-preview` for ALL phases (per CLAUDE.md, verified in `scripts/workers/enrich-worker.mjs`).
 - Stale Vercel connection pools after DB recovery → redeploy to reset
 
 ## Lessons Learned

--- a/memory/ui-navigation.md
+++ b/memory/ui-navigation.md
@@ -23,9 +23,11 @@ Operational reference for frontend work. For design tokens, see `.claude/docs/st
 - `/{tenant}/book/[slug]` — Primary book detail route (root `/book/[slug]` is legacy-redirected by middleware)
 - `/collections/[slug]` — Global collection detail route (shared across all tenants, contains cross-tenant books)
 - `/{tenant}/gallery/image/[id]` — Primary gallery image route (root `/gallery/image/[id]` is legacy-redirected)
-- `/about/*` — Content pages (research, faq, sources, standards, progress)
-- `/admin/*` — Admin dashboard (auth-gated)
-- `/artwork` — Visual art wing (admin-only for now)
+- `/browse`, `/catalog`, `/explore`, `/search` — Discovery surfaces (all global / non-tenant per the 2026-04-29 lesson below)
+- `/librarian`, `/podcast`, `/blog`, `/artwork` — Reading-room features
+- `/about/*` — Content pages (`faq`, `sources`, `research`, `progress`, `by-the-numbers`, `processing`)
+- `/admin/*` — Admin dashboard (auth-gated). Includes `/admin/system-map` for the interactive architecture diagram.
+- `/developers`, `/for-libraries`, `/for-researchers`, `/founding-donors`, `/ficino-society` — Partner / outreach pages
 
 ## Lessons Learned
 


### PR DESCRIPTION
## Summary

Two-commit cleanup of the memory layer after auditing both `CLAUDE.md` and the five flat files in `<repo>/memory/` that skills (`/pipeline-context`, `/maintenance`, `/ui-context`, `/lesson`) load on demand.

### Commit 1 — CLAUDE.md: drop nonexistent `_index-*.md` paths

The **Domain Context** section was rewritten in commit 05fd283f (2026-04-24) to point at `memory/_index-pipeline.md`, `memory/_index-product.md`, `memory/_index-safety.md`, etc. — files that have never existed in this repo's git history. The skills it references all load the actual flat files in `<repo>/memory/` (`pipeline-ops.md`, `ui-navigation.md`, `data-quality.md`, `mcp-server.md`, `lessons-learned.md`). Nothing was broken at runtime — anyone (or any fresh Claude session) reading CLAUDE.md just got sent to files that don't exist.

Knowledge Maintenance now explains the two memory systems (repo flat files vs Claude Code's per-machine auto-memory) so future edits don't conflate them — the `_index-*.md` files DO exist, but in `~/.claude/projects/<project>/memory/`, which is likely how the original confusion happened.

### Commit 2 — `<repo>/memory/` flat-file refresh

Audited each file against current code and GitHub state. Findings + fixes:

| File | Stale claim | Fix |
|---|---|---|
| `pipeline-ops.md` | Summary/Index uses `gemini-3-flash-preview` | enrich-worker uses `gemini-3.1-flash-lite-preview` for ALL phases — verified in `scripts/workers/enrich-worker.mjs`; matches CLAUDE.md |
| `data-quality.md` | Four "Active Issues" listed (#215, #182, #148, #251) | All four CLOSED as of April 2026. Replaced with pointer to `gh issue list` + cross-link to the auto-memory BPH-issues snapshot |
| `data-quality.md` | `sync-page-counts` cron runs every 6h | Cron archived; endpoint is now manual-only at `/api/admin/sync-page-counts`. Counter sync is now the worker's responsibility |
| `ui-navigation.md` | About pages: faq/sources/research/standards/progress | `standards` doesn't exist; missing `by-the-numbers` and `processing`. Also ~10 top-level routes (browse, catalog, explore, librarian, podcast, etc.) were unmentioned |
| `mcp-server.md` | Code at `src/mcp/server.ts`, 6 named tools | Code actually at `mcp-server/` package, 11 real tools verified in `mcp-server/src/index.ts` |
| `lessons-learned.md` | None | Read through, all claims still accurate (historical incident records) |

## Test plan

- [ ] No remaining `memory/_index-*.md` references in CLAUDE.md
- [ ] All paths in updated memory files exist (`scripts/workers/enrich-worker.mjs`, `mcp-server/src/index.ts`, `/api/admin/sync-page-counts`, `src/lib/slugify.ts`)
- [ ] Skills `/pipeline-context`, `/ui-context`, `/maintenance`, `/lesson` continue to work — this PR only changes file contents, not skill config
- [ ] About pages enumerated in ui-navigation.md all exist under `src/app/about/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)