### PR TITLE
chore(archive): ETIMEDOUT failover + auto-unblock cron + r2-snapshot cron

### DIFF
--- a/scripts/workers/archive-auto-unblock.mjs
+++ b/scripts/workers/archive-auto-unblock.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Archive Auto-Unblock Worker
+ *
+ * Clears archive_metadata.blocked on books that hit the 5-strike circuit
+ * breaker with transient failure reasons (network errors, source 5xx,
+ * opj_decompress crashes, fetch failed, etc.) after MIN_AGE_DAYS so they get
+ * another attempt. Auth blocks (HTTP 401/403) are left alone — those need
+ * source rotation, not retry.
+ *
+ * Without this, transient-failure books accumulate forever. 13 books got
+ * blocked over a 4-day window in the May 2026 stuck-archive incident — the
+ * archive-bulk circuit breaker is meant to stop wasteful retries within one
+ * outage, not to permanently quarantine books.
+ *
+ * Run via Hetzner cron (daily is plenty — blocks accumulate slowly):
+ *   set -a; source .env.production.local; set +a; node scripts/workers/archive-auto-unblock.mjs
+ */
+
+import { MongoClient } from 'mongodb';
+
+const MIN_AGE_DAYS = 14;
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+// Reasons that benefit from a retry. Auth (401/403) deliberately omitted.
+const RETRYABLE_REASON_PATTERNS = [
+  /^bulk-archive failed 5x: terminated$/,
+  /^bulk-archive failed 5x: spawnSync /,
+  /^bulk-archive failed 5x: HTTP 5\d\d/,
+  /^bulk-archive failed 5x: fetch failed/,
+  /^bulk-archive failed 5x: This operation was aborted/,
+  /^bulk-archive failed 5x: socket hang up/,
+  /^bulk-archive failed 5x: ECONNRESET/,
+  /^bulk-archive failed 5x: ETIMEDOUT/,
+];
+
+async function unblockCollection(db, name) {
+  const cutoff = new Date(Date.now() - MIN_AGE_DAYS * 24 * 3600e3);
+  const candidates = await db.collection(name).find(
+    {
+      'archive_metadata.blocked': true,
+      'archive_metadata.blocked_at': { $lt: cutoff },
+      'archive_metadata.blocked_reason': { $in: RETRYABLE_REASON_PATTERNS },
+    },
+    { projection: { id: 1, title: 1, 'archive_metadata.blocked_reason': 1 } }
+  ).toArray();
+
+  if (candidates.length === 0) {
+    console.log(`[archive-auto-unblock] ${name}: nothing to unblock (>${MIN_AGE_DAYS}d old, retryable reason)`);
+    return 0;
+  }
+
+  console.log(`[archive-auto-unblock] ${name}: unblocking ${candidates.length} books`);
+  for (const b of candidates.slice(0, 10)) {
+    console.log(`  - ${(b.title || '').slice(0, 60)} | ${b.archive_metadata.blocked_reason}`);
+  }
+  if (candidates.length > 10) console.log(`  ... and ${candidates.length - 10} more`);
+
+  const ids = candidates.map(b => b.id);
+  const result = await db.collection(name).updateMany(
+    { id: { $in: ids } },
+    { $unset: {
+      'archive_metadata.blocked': '',
+      'archive_metadata.blocked_at': '',
+      'archive_metadata.blocked_reason': '',
+      'archive_metadata.bulk_failures': '',
+      'archive_metadata.bulk_last_error': '',
+      'archive_metadata.bulk_last_failed_at': '',
+    }}
+  );
+  return result.modifiedCount;
+}
+
+async function run() {
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  console.log(`[archive-auto-unblock] Starting at ${new Date().toISOString()} (cutoff: ${MIN_AGE_DAYS}d)`);
+
+  const liveUnblocked = await unblockCollection(db, 'books');
+  const warehouseUnblocked = await unblockCollection(db, 'books_warehouse');
+
+  console.log(`[archive-auto-unblock] Done: ${liveUnblocked} live + ${warehouseUnblocked} warehouse unblocked`);
+
+  await client.close();
+}
+
+run().catch(err => { console.error('[archive-auto-unblock] FAILED:', err); process.exit(1); });

--- a/scripts/workers/archive-bulk.mjs
+++ b/scripts/workers/archive-bulk.mjs
@@ -437,18 +437,39 @@ async function processBook(book, db) {
     console.log(`  [ERROR] ${book.title?.slice(0, 50)}: ${err.message?.slice(0, 100)}`);
     stats.booksFailed++;
 
-    // Mark 401/403 books so we don't retry them every 10 minutes
-    if (err.message?.includes('HTTP 401') || err.message?.includes('HTTP 403')) {
+    const msg = err.message || '';
+    // 401/403: auth at source — can't be fixed by retry, block immediately.
+    // ETIMEDOUT / spawnSync timeouts: opj_decompress hangs on a malformed JP2
+    //   leaf. The whole zip can't be processed by bulk, but archive-ocr can
+    //   still fetch the pages one at a time over HTTP. Same routing as the
+    //   sparse-JP2 case in processBook.
+    // Everything else: transient — record a strike and try again next round.
+    if (msg.includes('HTTP 401') || msg.includes('HTTP 403')) {
       await db.collection(booksCol).updateOne(
         { id: book.id },
         { $set: {
           'archive_metadata.blocked': true,
           'archive_metadata.blocked_at': new Date(),
-          'archive_metadata.blocked_reason': err.message.slice(0, 200),
+          'archive_metadata.blocked_reason': msg.slice(0, 200),
+        }}
+      );
+    } else if (msg.includes('ETIMEDOUT') || msg.includes('spawnSync')) {
+      console.log(`    [FAIL-BOOK] opj_decompress timeout — marking bulk_unsuitable, routing to archive-ocr`);
+      await db.collection(booksCol).updateOne(
+        { id: book.id },
+        { $set: {
+          'archive_metadata.bulk_unsuitable': true,
+          'archive_metadata.bulk_unsuitable_at': new Date(),
+          'archive_metadata.bulk_unsuitable_reason': `opj_decompress timeout: ${msg.slice(0, 160)}`,
+          updated_at: new Date(),
+        }, $unset: {
+          'archive_metadata.bulk_failures': '',
+          'archive_metadata.bulk_last_error': '',
+          'archive_metadata.bulk_last_failed_at': '',
         }}
       );
     } else {
-      await recordBulkFailure(db, book, err.message);
+      await recordBulkFailure(db, book, msg);
     }
   } finally {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}

--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -24,6 +24,12 @@
 # Pipeline health alert (read-only, lightweight)
 0 7 * * * cd /root/sourcelibrary && flock -n /tmp/sl-health.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/pipeline-health-alert.mjs" >> /var/log/sourcelibrary/health-alert.log 2>&1
 
+# R2 coverage snapshot (every 6h — updates the doc /admin/r2-coverage reads)
+30 */6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-r2-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/r2-coverage-snapshot.mjs" >> /var/log/sourcelibrary/r2-snapshot.log 2>&1
+
+# Archive auto-unblock (daily — retry books blocked >14d ago with transient failure reasons; leaves 401/403 auth blocks alone)
+0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-archive-unblock.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/archive-auto-unblock.mjs" >> /var/log/sourcelibrary/archive-auto-unblock.log 2>&1
+
 # ISR cache warming (HTTP revalidation, no DB)
 0 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-warm-authors.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/warm-author-pages.mjs" >> /var/log/sourcelibrary/warm-authors.log 2>&1
 15 5 * * * cd /root/sourcelibrary && flock -n /tmp/sl-prewarm.lock bash -c "set -a; source .env.production.local; set +a; node scripts/maintenance/prewarm-browse.mjs" >> /var/log/sourcelibrary/prewarm-browse.log 2>&1


### PR DESCRIPTION
Three follow-ups to the May 2026 stuck-archive incident (#1909, #1914, #1912).

## 1. ETIMEDOUT failover (archive-bulk.mjs)

\`opj_decompress\` hangs on malformed JP2 leaves and surfaces as \`spawnSync /bin/sh ETIMEDOUT\`. The catch block currently routes those to \`recordBulkFailure\`, which means the book gets re-downloaded 4 more times before the 5-strike circuit blocks it — and once blocked, archive-ocr never picks it up (IA is excluded there).

**5 books are stuck in this state right now**, including the one that originally surfaced the broader regression:

\`\`\`
TARGET book "Theatrum Fungorum oft het Toonsel der Campernoelien":
  archive_metadata.blocked: true
  archive_metadata.blocked_reason: "bulk-archive failed 5x: spawnSync /bin/sh ETIMEDOUT"
  pages_archived: 0  (of 491)
\`\`\`

Treat ETIMEDOUT / spawnSync identically to the sparse-JP2 case from #1914: mark \`bulk_unsuitable\` so archive-bulk skips and archive-ocr's bulk-unsuitable stream takes over via per-page HTTP fetches.

## 2. Auto-unblock cron (scripts/workers/archive-auto-unblock.mjs, new)

13 books got blocked over a 4-day window after the May 20 fixes — all on transient failure modes (terminated, ETIMEDOUT, HTTP 5xx, fetch failed). New daily cron clears \`blocked: true\` for books blocked >14 days ago whose reason matches a retryable pattern. Auth blocks (HTTP 401/403, 89 books) stay blocked — they need source rotation, not retry.

Patterns covered: \`terminated\`, \`spawnSync\`, \`HTTP 5xx\`, \`fetch failed\`, \`aborted\`, \`socket hang up\`, \`ECONNRESET\`, \`ETIMEDOUT\`.

## 3. r2-coverage-snapshot cron entry (crontab.production)

The snapshot worker that backs \`/admin/r2-coverage\` has never been scheduled. The script was added under \"run on demand or via Hetzner cron\" but the cron entry never made it in. Last invocation was a manual run on 2026-05-13; the log file has been 0 bytes for 11 days, and the dashboard shows the 85.5% coverage figure from before the merged fixes (real coverage is now ~91%).

Add a 6-hour cron — coverage changes slowly and the aggregation takes 10-20 min so 4×/day is plenty.

## Sanity-checks

- [x] \`node --check\` both files
- [x] \`scripts/workers/archive-auto-unblock.mjs\` is a single-pass cron that operates on both \`books\` and \`books_warehouse\` collections, no destructive ops beyond \`$unset\` on the block flags.
- [x] Crontab entries use the same \`flock -n /tmp/<name>.lock\` pattern as the surrounding entries.
- [ ] After merge: I'll apply the new crontab lines to the Hetzner crontab (\`crontab.production\` is checked-in reference; actual crontab needs separate \`crontab -e\`).
- [ ] After deploy: next archive-bulk run with an ETIMEDOUT failure should mark the book \`bulk_unsuitable\` (look for \`[FAIL-BOOK] opj_decompress timeout\` in the log). Theatrum Fungorum should appear in archive-ocr's \`bulk-unsuitable IA\` count thereafter.

## Out of scope

- The 5 already-blocked ETIMEDOUT books need a one-off migration to flip \`blocked: true → bulk_unsuitable: true\` so they get picked up immediately. I'll do that as a one-line update on Hetzner post-merge, not in the PR.
- 89 HTTP 401/403 books still need source rotation (#1912). The auto-unblock script deliberately doesn't touch those.
- Throughput tuning (concurrency bumps, page-concurrency bump from 8→12) — separate PR, after we see how this PR settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)