### PR TITLE
fix(bhutan): query source_url, not nonexistent iiif_manifest column

### DIFF
--- a/src/lib/books-catalog.ts
+++ b/src/lib/books-catalog.ts
@@ -127,7 +127,7 @@ export async function browseBooks(opts: {
   if (opts.collection) query = query.contains('collections', [opts.collection]);
   if (opts.category) query = query.contains('categories', [opts.category]);
   if (opts.provider) query = query.eq('image_source_provider', opts.provider);
-  if (opts.library === 'bhutan') query = query.ilike('iiif_manifest', '%eap.bl.uk%');
+  if (opts.library === 'bhutan') query = query.ilike('source_url', '%eap.bl.uk%');
   if (opts.firstTranslation) query = query.eq('is_first_translation', true);
   if (opts.yearMin != null) query = query.gte('year', opts.yearMin);
   if (opts.yearMax != null) query = query.lte('year', opts.yearMax);
@@ -403,7 +403,7 @@ export async function searchBooksCatalog(
   if (opts?.category) query = query.contains('categories', [opts.category]);
   if (opts?.firstTranslation) query = query.eq('is_first_translation', true);
   if (opts?.hasTranslation) query = query.gt('pages_translated', 0);
-  if (opts?.library === 'bhutan') query = query.ilike('iiif_manifest', '%eap.bl.uk%');
+  if (opts?.library === 'bhutan') query = query.ilike('source_url', '%eap.bl.uk%');
   else if (opts?.library) query = query.eq('image_source_provider', opts.library);
 
   const { data, error } = await query;


### PR DESCRIPTION
## Summary
- `bhutan.sourcelibrary.org` rendered "0 books from Bhutan Buddhist Manuscripts" even though all 1325 bhutan books exist in Mongo (`tenant_id: bhutan`, `visible: true`, `pages_count > 0`) and are mirrored to Supabase `books_catalog`.
- Root cause: the bhutan filter in `src/lib/books-catalog.ts` (two call sites — `browseBooks` and `searchBooksCatalog`) calls `query.ilike('iiif_manifest', '%eap.bl.uk%')`, but `books_catalog` has no `iiif_manifest` column. Supabase/PostgREST silently returns `null` rather than erroring or returning zero rows, so the page shows the empty state.
- The eap.bl.uk URL is stored on `source_url` (e.g. `https://eap.bl.uk/archive-file/EAP039-1-2-1/manifest`). Switching the column returns the expected 1325 rows.

Verified directly against prod Supabase:
- `ilike('iiif_manifest', '%eap.bl.uk%')` → `count: null`
- `ilike('source_url', '%eap.bl.uk%')` → `count: 1325`
- `+ .eq('visible', true).gt('pages_count', 0)` → `count: 1325`

## Test plan
- [ ] Preview deploy comes up green
- [ ] `https://bhutan.sourcelibrary.org/` shows 1325 books, not 0
- [ ] First page of results renders thumbnails (eap.bl.uk images)
- [ ] `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)