### PR TITLE
fix(archive): add Harvard MPS to per-domain rate limit table (1/s)

### DIFF
--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -50,6 +50,7 @@ const DOMAIN_RATE_LIMITS = {
   'media.getty.edu':           4,    // Getty Museum IIIF — open access
   'stacks.stanford.edu':       4,   // Stanford Libraries — open access
   'rmda.kulib.kyoto-u.ac.jp':  2,   // Kyoto University — conservative
+  'mps.lib.harvard.edu':       1,   // Harvard MPS — 429s at 2/s on /full/full/ upgrades. 294 books with 882 pages got 3-strike-blocked at 2/s in May 2026 before this entry was added.
   _default:                   2,    // Unknown domains: 2 req/s
 };
 


### PR DESCRIPTION
## Why

Harvard's IIIF endpoint at \`mps.lib.harvard.edu\` returns HTTP 429 at the default 2 req/s. Side effect of the missing entry: **294 books / ~882 pages got blocked** at the per-page 3-strike circuit (\`archive_metadata.failure_count >= 3\`) and have been sitting in \`pipeline_auto.status: archiving\` for ~25 days. These are the bulk of the current \`pipeline_stalls\` alert (401 books total).

Sample page (one of the stuck ones):

\`\`\`
photo:        https://mps.lib.harvard.edu/.../full/2000,/0/default.jpg
last_failure: HTTP 429 at /full/full/0/default.jpg
failure_count: 3
last_failure_at: 2026-05-21
\`\`\`

\`archive-ocr.mjs\` upgrades \`/full/2000,/\` to \`/full/full/\` via \`upgradeToFullRes()\` before fetching, and Harvard rate-limits the full-res endpoint more aggressively than 2/s. The token bucket in \`waitForToken()\` falls back to \`_default: 2\` for Harvard since it's not in the table.

## Change

Add \`mps.lib.harvard.edu: 1\` to \`DOMAIN_RATE_LIMITS\`. Conservative choice — Harvard published no explicit policy. Can be bumped to 2 if logs show clean fetches with no 429 retry pattern.

## Companion DB op (not in this PR)

Reset \`archive_metadata.failure_count\` on the affected 882 Harvard pages so they retry under the new rate limit:

\`\`\`js
db.pages.updateMany(
  { photo: /mps\.lib\.harvard\.edu/, 'archive_metadata.failure_count': { \$gte: 3 }, 'archive_metadata.last_failure_reason': 'HTTP 429' },
  { \$unset: { 'archive_metadata.failure_count': '', 'archive_metadata.last_failure_at': '', 'archive_metadata.last_failure_reason': '', 'archive_metadata.last_failure_source_url': '' } }
)
\`\`\`

This already ran on Hetzner before opening this PR (still streaming as I write).

## Expected effect

- 294 Harvard books move from stuck-archiving → archive_complete over the next few archive-ocr cycles
- pipeline_stalls alert drops from 401 → ~107 (= 401 − 294)
- Combined with the OCR-submit unblock (1,438 books got \`split_checked: true\` earlier today), this drains the deepest stuck pool from the May 2026 incident

## Related

- #1909 (silent no-op + candidate query fix)
- #1914 (bulk→IIIF failover)
- #1967 (ETIMEDOUT failover + auto-unblock + r2-snapshot cron)
- #1968 (throughput tuning)
- #1912 (overall prioritization plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)