### PR TITLE
Promote 3 reusable backfill scripts to scripts/maintenance/

### DIFF
--- a/scripts/maintenance/backfill-erara-doi.mjs
+++ b/scripts/maintenance/backfill-erara-doi.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Backfill `erara_doi` (and `erara_id` when missing) for e-rara books that
+ * are missing the persistent identifier. The e-rara title page OCR contains
+ * a `Persistent Link: https://doi.org/10.3931/e-rara-XXXXX` marker; we extract
+ * the trailing numeric ID and reconstruct the canonical DOI form, tolerating
+ * common OCR errors in the prefix (e.g. "10.103931" instead of "10.3931").
+ *
+ * Usage:
+ *   node scripts/maintenance/backfill-erara-doi.mjs           # dry-run
+ *   node scripts/maintenance/backfill-erara-doi.mjs --apply
+ *   node scripts/maintenance/backfill-erara-doi.mjs --limit 20
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = (() => {
+  const i = process.argv.indexOf('--limit');
+  return i >= 0 ? parseInt(process.argv[i + 1], 10) : Infinity;
+})();
+const PAGES_PER_BOOK = 5;
+
+// Match either the clean prefix or common OCR variants. The trailing
+// numeric e-rara id is what we care about — reconstruct the DOI canonically.
+const DOI_RX = /10\.\d{4,6}\/e-rara-(\d{3,7})/i;
+// Fallback: a Persistent Link line that might have OCR damage but still
+// contains the bare e-rara id.
+const PLAIN_ID_RX = /e-rara[- ](\d{3,7})/i;
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+const cursor = db.collection('books').find(
+  {
+    'image_source.provider': 'e-rara',
+    $or: [{ erara_doi: { $exists: false } }, { erara_doi: null }],
+  },
+  { projection: { _id: 1, title: 1, erara_id: 1 } }
+);
+
+let scanned = 0, noOcr = 0, noMatch = 0, wouldWrite = 0, written = 0;
+const samples = [];
+
+for await (const book of cursor) {
+  if (scanned >= LIMIT) break;
+  scanned++;
+
+  const bookId = String(book._id);
+  const pages = await db.collection('pages').find(
+    { book_id: bookId, 'ocr.data': { $exists: true, $ne: '' } },
+    { projection: { page_number: 1, 'ocr.data': 1 } }
+  ).sort({ page_number: 1 }).limit(PAGES_PER_BOOK).toArray();
+
+  if (pages.length === 0) { noOcr++; continue; }
+
+  // Look first for the strict DOI pattern across sampled pages
+  let eraraId = null, matchedPage = null, source = null;
+  for (const p of pages) {
+    const m = (p.ocr?.data || '').match(DOI_RX);
+    if (m) { eraraId = m[1]; matchedPage = p.page_number; source = 'doi'; break; }
+  }
+  // Fallback: scan only near a "Persistent Link" hint to reduce false positives
+  if (!eraraId) {
+    for (const p of pages) {
+      const data = p.ocr?.data || '';
+      const hint = data.match(/Persistent Link[^]*?(?=<|$)/i);
+      if (hint) {
+        const m = hint[0].match(PLAIN_ID_RX);
+        if (m) { eraraId = m[1]; matchedPage = p.page_number; source = 'persistent_link'; break; }
+      }
+    }
+  }
+
+  if (!eraraId) { noMatch++; continue; }
+
+  const doi = `10.3931/e-rara-${eraraId}`;
+  wouldWrite++;
+  if (samples.length < 15) samples.push({
+    id: bookId.slice(-8),
+    title: book.title?.slice(0, 55),
+    extracted_id: eraraId,
+    canonical_doi: doi,
+    matched_page: matchedPage,
+    source,
+    existing_erara_id: book.erara_id || null,
+  });
+
+  if (APPLY) {
+    const set = {
+      erara_doi: doi,
+      'image_source.doi': doi,
+      'image_source.source_url': `https://www.e-rara.ch/doi/${doi}`,
+      _erara_doi_backfill: {
+        at: new Date(),
+        source,
+        matched_page: matchedPage,
+      },
+    };
+    if (!book.erara_id) set.erara_id = eraraId;
+    const res = await db.collection('books').updateOne({ _id: book._id }, { $set: set });
+    if (res.modifiedCount > 0) written++;
+  }
+}
+
+console.log(`Scanned: ${scanned}`);
+console.log(`  no OCR pages: ${noOcr}`);
+console.log(`  OCR but no DOI / e-rara id found: ${noMatch}`);
+console.log(`  ${APPLY ? 'wrote' : 'would write'}: ${APPLY ? written : wouldWrite}`);
+
+console.log('\nSample (first 15):');
+for (const s of samples) {
+  console.log(`  ${s.id} p${s.matched_page} (${s.source}) "${s.title}"`);
+  console.log(`    → ${s.canonical_doi}  erara_id: ${s.existing_erara_id ? `(keep ${s.existing_erara_id})` : `(set ${s.extracted_id})`}`);
+}
+
+if (!APPLY) console.log('\nDRY RUN — re-run with --apply to commit.');
+
+await client.close();

--- a/scripts/maintenance/backfill-language-from-ocr.mjs
+++ b/scripts/maintenance/backfill-language-from-ocr.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Backfill `language` on books where the catalog says "Unknown" but the OCR
+ * already declares a language via `<language>X</language>` tags. Pure data
+ * propagation — no LLM calls, no external requests.
+ *
+ * Strategy per book:
+ *   1. Pull up to N pages (default 5) sorted by page_number
+ *   2. Collect <language> tag values from each page's ocr.data
+ *   3. Pick the majority value (ties go to the first occurrence)
+ *   4. Update books.language; track via _language_backfill for audit/revert
+ *
+ * Books with no OCR or no <language> tag in any sampled page are skipped.
+ *
+ * Usage:
+ *   node scripts/maintenance/backfill-language-from-ocr.mjs            # dry-run
+ *   node scripts/maintenance/backfill-language-from-ocr.mjs --apply
+ *   node scripts/maintenance/backfill-language-from-ocr.mjs --limit 50
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = (() => {
+  const i = process.argv.indexOf('--limit');
+  return i >= 0 ? parseInt(process.argv[i + 1], 10) : Infinity;
+})();
+const PAGES_PER_BOOK = 5;
+
+const LANG_TAG_RX = /<language>([^<]+)<\/language>/g;
+
+const NULL_LANG_VALUES = new Set(['', 'unknown', 'none', 'n/a', 'null', 'undefined']);
+const LANG_CANON = {
+  latin: 'Latin', german: 'German', french: 'French', italian: 'Italian',
+  english: 'English', dutch: 'Dutch', spanish: 'Spanish', greek: 'Greek',
+  hebrew: 'Hebrew', portuguese: 'Portuguese', polish: 'Polish',
+  arabic: 'Arabic', russian: 'Russian', czech: 'Czech', swedish: 'Swedish',
+  danish: 'Danish', norwegian: 'Norwegian', hungarian: 'Hungarian',
+};
+
+/**
+ * Canonicalize a single language string. Returns null for empty / "none" /
+ * "unknown" values. Returns an array if the input is a comma/and-separated
+ * list of multiple languages.
+ */
+function canonicalize(lang) {
+  if (!lang) return null;
+  const t = lang.trim();
+  if (!t) return null;
+  if (NULL_LANG_VALUES.has(t.toLowerCase())) return null;
+
+  // Split multi-language tags like "Latin, German" or "Latin and Greek"
+  if (/[,&]|\band\b/i.test(t)) {
+    const parts = t.split(/[,&]|\band\b/i).map(s => s.trim()).filter(Boolean);
+    const canonized = parts.map(p => canonicalize(p)).filter(x => x != null).flat();
+    return canonized.length === 0 ? null : canonized;
+  }
+
+  const lower = t.toLowerCase();
+  return LANG_CANON[lower] || t.charAt(0).toUpperCase() + t.slice(1);
+}
+
+function majorityVote(values) {
+  if (values.length === 0) return null;
+  const counts = new Map();
+  for (const v of values) counts.set(v, (counts.get(v) || 0) + 1);
+  let bestVal = null, bestCount = 0;
+  for (const [v, c] of counts) {
+    if (c > bestCount) { bestVal = v; bestCount = c; }
+  }
+  return { value: bestVal, count: bestCount, total: values.length, distribution: Object.fromEntries(counts) };
+}
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('bookstore');
+
+// Skip wikimedia_commons and other artwork-only providers — they're single
+// images with no OCR and no meaningful language attribute.
+const cursor = db.collection('books').find(
+  {
+    language: 'Unknown',
+    'image_source.provider': { $nin: ['wikimedia_commons', 'met_openaccess'] },
+  },
+  { projection: { _id: 1, title: 1, 'image_source.provider': 1, pages_count: 1 } }
+);
+
+let scanned = 0, noOcr = 0, noTag = 0, wouldWrite = 0, written = 0;
+const samples = [];
+const langCounts = new Map();
+
+for await (const book of cursor) {
+  if (scanned >= LIMIT) break;
+  scanned++;
+
+  const bookId = String(book._id);
+  const pages = await db.collection('pages').find(
+    { book_id: bookId, 'ocr.data': { $exists: true, $ne: '' } },
+    { projection: { page_number: 1, 'ocr.data': 1 } }
+  ).sort({ page_number: 1 }).limit(PAGES_PER_BOOK).toArray();
+
+  if (pages.length === 0) { noOcr++; continue; }
+
+  const tags = [];
+  for (const p of pages) {
+    const data = p.ocr?.data || '';
+    let m;
+    LANG_TAG_RX.lastIndex = 0;
+    while ((m = LANG_TAG_RX.exec(data)) !== null) {
+      const canon = canonicalize(m[1]);
+      if (!canon) continue;
+      if (Array.isArray(canon)) tags.push(...canon);
+      else tags.push(canon);
+    }
+  }
+
+  if (tags.length === 0) { noTag++; continue; }
+
+  const vote = majorityVote(tags);
+  const proposed = vote.value;
+  wouldWrite++;
+  langCounts.set(proposed, (langCounts.get(proposed) || 0) + 1);
+
+  if (samples.length < 12) samples.push({
+    id: bookId.slice(-8),
+    title: book.title?.slice(0, 60),
+    provider: book.image_source?.provider,
+    proposed,
+    confidence: `${vote.count}/${vote.total}`,
+    distribution: vote.distribution,
+  });
+
+  if (APPLY) {
+    const res = await db.collection('books').updateOne(
+      { _id: book._id },
+      { $set: {
+        language: proposed,
+        _language_backfill: {
+          at: new Date(),
+          source: 'ocr_language_tag',
+          confidence: `${vote.count}/${vote.total}`,
+          distribution: vote.distribution,
+        },
+      }}
+    );
+    if (res.modifiedCount > 0) written++;
+  }
+}
+
+console.log(`Scanned: ${scanned}`);
+console.log(`  no OCR pages: ${noOcr}`);
+console.log(`  OCR but no <language> tag: ${noTag}`);
+console.log(`  ${APPLY ? 'wrote' : 'would write'}: ${APPLY ? written : wouldWrite}`);
+
+console.log('\nLanguages assigned:');
+for (const [l, c] of [...langCounts.entries()].sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${l}: ${c}`);
+}
+
+console.log('\nSample (first 12):');
+for (const s of samples) {
+  console.log(`  [${s.confidence}] ${s.id} (${s.provider || '?'}) ${JSON.stringify(s.title)} → ${s.proposed}`);
+  if (Object.keys(s.distribution).length > 1) console.log(`    distribution: ${JSON.stringify(s.distribution)}`);
+}
+
+if (!APPLY) console.log('\nDRY RUN — re-run with --apply to commit.');
+
+await client.close();

--- a/scripts/maintenance/backfill-sn-authors.mjs
+++ b/scripts/maintenance/backfill-sn-authors.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Backfill author for books where `author === "[s.n.]"` (MARC "no name" sigil
+ * mistakenly stored as a real string by the e-rara importer).
+ *
+ * Usage:
+ *   node scripts/maintenance/backfill-sn-authors.mjs               # dry-run
+ *   node scripts/maintenance/backfill-sn-authors.mjs --apply       # write to DB
+ *   node scripts/maintenance/backfill-sn-authors.mjs --limit 10    # cap LLM calls
+ *
+ * Expects env loaded via:
+ *   set -a; source .env.production.local; set +a
+ */
+
+import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
+import { MongoClient, ObjectId } from 'mongodb';
+
+const MODEL = 'gemini-3.1-flash-lite-preview';
+const APPLY = process.argv.includes('--apply');
+const LIMIT = (() => {
+  const i = process.argv.indexOf('--limit');
+  return i >= 0 ? parseInt(process.argv[i + 1], 10) : Infinity;
+})();
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const GEMINI_KEY = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
+if (!GEMINI_KEY) { console.error('GEMINI_API_KEY / GOOGLE_API_KEY not set'); process.exit(1); }
+
+const SAFETY = [
+  { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+  { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE },
+  { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE },
+  { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+];
+
+const genAI = new GoogleGenerativeAI(GEMINI_KEY);
+const model = genAI.getGenerativeModel({ model: MODEL, safetySettings: SAFETY });
+
+function titleStem(t) {
+  return String(t || '')
+    .replace(/&amp;/g, '&')
+    .replace(/\s*(tom(?:e|us)?|vol(?:ume)?|part(?:e)?|theil|band|deel)[.\s]*[ivxlcdm0-9]+.*$/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+async function extractAuthor({ title, year, language, ocrText }) {
+  const prompt = `You are a bibliographic expert. Given the first pages of a historical book, identify the author named on the title page.
+
+Book metadata:
+- Title: ${title}
+- Year: ${year || 'unknown'}
+- Language: ${language || 'unknown'}
+
+Title-page OCR (first ~3 pages, may include blanks / colophons):
+"""
+${ocrText.slice(0, 6000)}
+"""
+
+Return STRICT JSON with this shape (no markdown, no commentary):
+{
+  "author": "Lastname, Firstname (YYYY-YYYY)" or null,
+  "anonymous": true | false,
+  "confidence": "high" | "medium" | "low",
+  "evidence": "<short quote from OCR that names the author, or 'no author named'>"
+}
+
+Rules:
+- If the title page clearly names an author, return that name in "Lastname, Firstname" format with life dates if you know them.
+- If it's a translation/edition by a known person, the original author goes in "author"; mention the translator/editor in "evidence".
+- If the title page genuinely names no author (treaties, official documents, anonymous polemics, "sine nomine" works), set anonymous: true and author: null.
+- Do NOT guess from title alone. If the OCR is too damaged or doesn't show the title page, return confidence: "low".`;
+
+  const result = await model.generateContent({
+    contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    generationConfig: { responseMimeType: 'application/json', temperature: 0.1 },
+  });
+  const text = result.response.text();
+  return JSON.parse(text);
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db(process.env.MONGODB_DB || 'bookstore');
+
+  const affected = await db.collection('books').find({
+    author: { $in: ['[s.n.]', '[S.N.]', 's.n.', '[s.n]'] },
+  }).project({
+    _id: 1, id: 1, title: 1, published: 1, language: 1, pages_count: 1, categories: 1,
+  }).toArray();
+
+  console.log(`Found ${affected.length} books with [s.n.] author.`);
+
+  // Dedupe by title stem — multi-volume sets get one LLM call
+  const groups = new Map();
+  for (const b of affected) {
+    const stem = titleStem(b.title);
+    if (!groups.has(stem)) groups.set(stem, []);
+    groups.get(stem).push(b);
+  }
+  console.log(`Grouped into ${groups.size} title-stems (multi-volume dedupe).`);
+
+  let llmCalls = 0;
+  let plannedWrites = 0;
+  let skipped = 0;
+  const results = [];
+
+  for (const [stem, books] of groups) {
+    if (llmCalls >= LIMIT) break;
+    const representative = books[0];
+
+    const pages = await db.collection('pages').find({
+      book_id: String(representative._id),
+    }).sort({ page_number: 1 }).limit(8).project({ page_number: 1, 'ocr.data': 1 }).toArray();
+
+    const ocrText = pages.map(p => p?.ocr?.data || '').filter(Boolean).join('\n\n').trim();
+
+    if (!ocrText) {
+      skipped += books.length;
+      results.push({ stem, books: books.map(b => b._id), status: 'no_ocr' });
+      continue;
+    }
+
+    let extracted;
+    try {
+      extracted = await extractAuthor({
+        title: representative.title,
+        year: representative.published,
+        language: representative.language,
+        ocrText,
+      });
+      llmCalls++;
+    } catch (e) {
+      results.push({ stem, books: books.map(b => b._id), status: 'llm_error', error: String(e).slice(0, 200) });
+      continue;
+    }
+
+    const proposed = extracted.anonymous ? null : (extracted.author || null);
+    const status = extracted.anonymous ? 'anonymous_flag' : (proposed ? 'extracted' : 'unparseable');
+
+    for (const b of books) {
+      results.push({
+        bookId: String(b._id),
+        title: b.title,
+        currentAuthor: '[s.n.]',
+        proposedAuthor: proposed,
+        anonymous: extracted.anonymous,
+        confidence: extracted.confidence,
+        evidence: extracted.evidence?.slice(0, 160),
+        status,
+        groupSize: books.length,
+      });
+      if (proposed || extracted.anonymous) plannedWrites++;
+    }
+
+    // Gentle throttle — Gemini Flash Lite handles bursts but be polite
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  // ── Report ──
+  console.log('\n=== DRY-RUN REPORT ===');
+  console.log(`LLM calls: ${llmCalls} | Planned writes: ${plannedWrites} | Skipped (no OCR): ${skipped}`);
+  console.log('\nBy status:');
+  const byStatus = {};
+  for (const r of results) byStatus[r.status] = (byStatus[r.status] || 0) + 1;
+  for (const [s, n] of Object.entries(byStatus)) console.log(`  ${s}: ${n}`);
+
+  console.log('\nFirst 20 proposed changes:');
+  for (const r of results.filter(r => r.bookId).slice(0, 20)) {
+    const tag = r.anonymous ? '[ANON]' : `[${r.confidence?.toUpperCase()}]`;
+    console.log(`  ${tag} ${r.bookId.slice(-8)} ${JSON.stringify(r.title).slice(0, 60)}`);
+    console.log(`    → ${r.anonymous ? 'null + anonymous=true' : r.proposedAuthor}`);
+    if (r.evidence) console.log(`    evidence: ${r.evidence}`);
+  }
+
+  // Write full results to a file so Derek can review the whole set
+  const outPath = '/tmp/sn-backfill-dryrun.json';
+  await import('node:fs').then(fs => fs.promises.writeFile(outPath, JSON.stringify(results, null, 2)));
+  console.log(`\nFull results: ${outPath}`);
+
+  if (APPLY) {
+    console.log('\n=== APPLYING WRITES ===');
+    let written = 0;
+    const now = new Date();
+    for (const r of results) {
+      if (!r.bookId) continue;
+      if (!r.proposedAuthor && !r.anonymous) continue;
+      const update = r.anonymous
+        ? { $set: { author: null, _author_backfill: { at: now, source: MODEL, anonymous: true, evidence: r.evidence, confidence: r.confidence } } }
+        : { $set: { author: r.proposedAuthor, _author_backfill: { at: now, source: MODEL, anonymous: false, evidence: r.evidence, confidence: r.confidence } } };
+      const oid = ObjectId.isValid(r.bookId) ? new ObjectId(r.bookId) : r.bookId;
+      const res = await db.collection('books').updateOne({ _id: oid }, update);
+      if (res.modifiedCount === 0) console.warn(`  WARN: no match for ${r.bookId}`);
+      written++;
+    }
+    console.log(`Wrote ${written} books.`);
+  } else {
+    console.log('\nDRY RUN — no writes. Re-run with --apply to commit.');
+  }
+
+  await client.close();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
Promotes three backfill scripts that were originally written as one-off `_tmp-` cleanup utilities but are parameterized and reusable on any future batch hitting the same data shapes.

- `backfill-sn-authors.mjs` — author extraction for `[s.n.]` MARC sigil
- `backfill-language-from-ocr.mjs` — language propagation from existing OCR
- `backfill-erara-doi.mjs` — persistent DOI capture from e-rara title-page OCR

All default to dry-run, support `--apply` and `--limit`, and stamp a `_*_backfill` provenance field for audit / revert.

Companion to PR #1972 (the e-rara importer fix). These run after that fix to clean historical data; the importer fix prevents the underlying regression from recurring.

## Test plan
- [x] `node --check` on all three — syntax OK
- [x] All three executed at scale during the cleanup session: 92, 318, 353 writes respectively, with provenance markers verified in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)