### PR TITLE
fix(archive): skip /full/full/ upgrade for Harvard MPS

### DIFF
--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -108,6 +108,13 @@ export async function rateLimitedFetch(url, opts = {}) {
 export function upgradeToFullRes(url) {
   if (!url || typeof url !== 'string') return url;
   try {
+    // Harvard MPS rate-limits /full/full/ much more aggressively than /full/2000,/
+    // — at 1 req/s the full-res endpoint still 429s out (5 cold-start fails =
+    // circuit breaker, 0 successes). The existing 2000px variant in the photo
+    // field is plenty for archive. Skip the upgrade entirely.
+    if (url.includes('mps.lib.harvard.edu')) {
+      return url;
+    }
     if (url.includes('archive.org') && url.includes('/full/pct:')) {
       return url.replace(/\/full\/pct:\d+\//, '/full/full/');
     }


### PR DESCRIPTION
Follow-up to #1978 (Harvard rate-limit entry).

## What we observed

After #1978 merged and deployed, the next archive-ocr cycle had **4,036 Harvard pages in the candidate pool** but logged this:

\`\`\`
FAIL [mps.lib.harvard.edu]: HTTP 429    (×5)
[mps.lib.harvard.edu] Circuit breaker: 5 failures with 0 successes, skipping domain
Per-domain: ... (mps.lib.harvard.edu absent — 0 ok, all blocked by cold-start circuit)
\`\`\`

Even at 1 req/s Harvard returned 429. The rate isn't the lever — the lever is the URL variant.

## Root cause

\`upgradeToFullRes()\` in \`scripts/lib/iiif-utils.mjs\` rewrites IIIF image URLs from bounded-size variants (\`/full/2000,/\`) to the full-resolution endpoint (\`/full/full/\`). Most providers tolerate that. Harvard's MPS rate-limits the full-res endpoint much more aggressively than the bounded variants — even sub-1/s pacing 429s.

The page records already have \`/full/2000,/\` in their \`photo\` field. A 2000px-wide JPEG (~150-200KB) is ample for archival; we don't need full native resolution from Harvard.

## Change

Add a Harvard-specific early-return in \`upgradeToFullRes()\` so the existing 2000px URL is used unchanged.

## Expected next-cycle effect

- Same 4,036 Harvard pages in the candidate pool
- HTTP 200s instead of 429s
- Harvard appears in the per-domain stats as ok > 0
- 294 Harvard zombie books move from \`archiving\` → \`archive_complete\` as their pages fill in
- pipeline_stalls alert drops accordingly

## Related

- #1978 (Harvard rate limit entry — necessary but not sufficient)
- Same suspicion applies to MDZ (\`digitale-sammlungen.de\`, ~50% failure rate, same upgrade path). Filing separately if this fix proves the hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)