### PR TITLE
docs: add Mission opener + CLAUDE.md cleanup (follow-up to #1984)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # Claude Code Guidelines for Source Library
 
+## Mission
+Source Library is a digital library of historical primary sources — alchemy, Hermetica, Kabbalah, Rosicrucianism, early modern science, and adjacent traditions — with AI-aided OCR, translation, and curation that make these texts readable and citable. The core experience is *reading and quoting* originals (`/book/...`, shortlinks, DOIs via Zenodo); curation surfaces them through collections, galleries, and editorial pages. Tenant subdomains (BPH/EFM, etc.) host curated subsets as standalone reading rooms for partner institutions.
+
+When making product decisions, lead with: who reads this, what experience are they having, and does this serve the goal of putting primary sources into people's hands. Technical choices flow from that. The CRITICAL sections below are scar tissue from real incidents — read them, but don't mistake them for the point of the project.
+
 ## Development Workflow — CRITICAL
 - **Feature branches off `main`.** One branch per feature/task: `feat/ai-search`, `fix/cover-thumbnails`, etc. No long-running dev branches.
 - **Create a branch via worktree:** Use `EnterWorktree` at session start — it creates an isolated checkout with its own branch. Do NOT `git checkout -b` in the main directory (see Multi-Session Awareness above).
@@ -58,7 +63,7 @@ Tenant subdomains (e.g. `bph.sourcelibrary.org`) MUST be a closed system. Visito
 
 The NextAuth session cookie is set on `.sourcelibrary.org` (with the leading dot) in production, so signing in on `sourcelibrary.org` carries through to every tenant subdomain (`bph.sourcelibrary.org` today, `kloss/jung/...` later) and vice versa. Gated on `VERCEL_ENV === 'production'` — Vercel previews and localhost stay host-scoped.
 
-**Identity shares, permissions do not.** Role checks still run via `memberships` collection lookups per tenant (`auth-helpers.ts:25-50`). A user signed in on the parent site does not inherit any tenant role just by visiting a subdomain; the `withAuth(handler, { minRole })` wrapper (and role-specific shorthands like `withEditorAuth`, `withAdminAuth`) continues to enforce per-tenant gates.
+**Identity shares, permissions do not.** Role checks still run via `memberships` collection lookups per tenant (`getTenantMembershipRole` in `src/lib/auth-helpers.ts`). A user signed in on the parent site does not inherit any tenant role just by visiting a subdomain; the `withAuth(handler, { minRole })` wrapper (and role-specific shorthands like `withEditorAuth`, `withAdminAuth`) continues to enforce per-tenant gates.
 
 **CSRF token stays per-host** (`__Host-` prefix forbids the `domain` attribute, and each subdomain hits its own `/api/auth/*` routes).
 
@@ -96,7 +101,8 @@ Detect the work domain from the user's prompt and load the right context automat
 - **After fixing a non-trivial bug**, proactively update the relevant memory file following the `/lesson` workflow. Don't wait to be asked.
 - When reading memory files, flag anything that contradicts the current codebase and fix it.
 - Memory entries with dates >14 days old: verify before trusting stats/counts.
-- **Two memory systems:** `<repo>/memory/` (committed, team-shared, flat files listed above) is loaded by skills like `/pipeline-context`. Claude Code auto-memory (per-machine, gitignored, lives in `~/.claude/projects/<project>/memory/`) is managed by Claude across sessions and has its own `MEMORY.md` + `_index-*.md` hierarchy. The `/lesson` workflow writes to repo memory.
+- **Two memory systems, in plain terms:** repo memory = *team facts* (committed, shared with collaborators). Auto-memory = *Claude's per-machine notes* about the user (gitignored, private). The `/lesson` workflow writes to repo memory. Locations: `<repo>/memory/` (loaded by skills like `/pipeline-context`); `~/.claude/projects/<project>/memory/` (managed by Claude across sessions, has its own `MEMORY.md` + `_index-*.md` hierarchy).
+- **Every incident handoff ends with a CLAUDE.md check.** When writing a handoff in `.claude/handoffs/`, the last step is: "does CLAUDE.md need a new invariant?" If yes, PR the doc change the same session. Otherwise the lesson lives only in the handoff and decays. Both big CRITICAL sections in this file were written this way.
 
 ## Compaction Instructions
 When compacting (`/compact`), ALWAYS preserve:


### PR DESCRIPTION
## Summary
Acts on the four pieces of org advice that came out of the #1984 staleness audit.

| Change | Why |
|---|---|
| **Add a Mission section at the top** | CLAUDE.md previously opened with three CRITICAL safety sections; a new contributor (or Claude session) read six paragraphs of don'ts before learning what Source Library *is*. Mission now names the goal (readable + citable primary sources), the core experience (reading + quoting), and frames the CRITICAL sections as scar tissue. |
| **Swap \`auth-helpers.ts:25-50\` for the symbol name \`getTenantMembershipRole\`** | Line numbers were 4 of 5 stale refs in the previous PR. Symbols are greppable; line numbers rot. Verified this was the only \`path:line\` ref in the file. |
| **Rewrite the "Two memory systems" bullet** | Old version led with paths and architecture. New version leads with the plain-English distinction (team facts vs Claude's per-machine notes about the user) and puts paths after. |
| **Add "Every incident handoff ends with a CLAUDE.md check"** | Both big CRITICAL sections (Tenant Lockdown, Multi-Session) were written this way after real incidents. Making the pattern explicit instead of cultural so the next incident also produces durable doc. |

## Test plan
- [x] Doc-only diff, no code paths touched
- [x] \`grep -nE '\\.(ts|tsx|js|mjs|py):[0-9]+' CLAUDE.md\` returns no matches (no remaining line-range refs)
- [x] All internal section refs still resolve (Domain Context, Knowledge Maintenance, etc.)

Stacked on #1984 (merged).