### PR TITLE
feat(archive): Harvard MPS Mac-side worker (Hetzner is IP-blocked)

### DIFF
--- a/scripts/workers/archive-harvard.mjs
+++ b/scripts/workers/archive-harvard.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Local Harvard MPS archive worker (runs on Mac, not Hetzner)
+ *
+ * Harvard's MPS (mps.lib.harvard.edu) returns HTTP 429 for every request
+ * from Hetzner IPs (verified 2026-05-25: both IPv4 and IPv6 addresses
+ * blocked at the AWS ELB layer regardless of User-Agent, URL variant, or
+ * pacing). Same pattern as archive-erara/gallica.
+ *
+ * Downloads IIIF pages at the bounded 2000px-wide variant already stored
+ * in pages.photo (NOT /full/full/ — Harvard rate-limits the full-res
+ * endpoint more aggressively even from non-Hetzner IPs), uploads to R2,
+ * updates MongoDB.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/workers/archive-harvard.mjs
+ *   node scripts/workers/archive-harvard.mjs --limit=500 --concurrency=2 --dry-run
+ */
+
+import { MongoClient } from 'mongodb';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { uploadPageVariants } from './lib/display-image.mjs';
+
+const args = process.argv.slice(2);
+const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
+const hasFlag = (name) => args.includes(`--${name}`);
+
+const PAGE_LIMIT = parseInt(getArg('limit') || '2000', 10);
+const CONCURRENCY = parseInt(getArg('concurrency') || '2', 10);
+const RATE_PER_SEC = parseFloat(getArg('rate') || '1');
+const DRY_RUN = hasFlag('dry-run');
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID;
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY;
+const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME || 'sourcelibrary';
+const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || 'https://images.sourcelibrary.org';
+
+if (!MONGODB_URI) { console.error('Missing MONGODB_URI'); process.exit(1); }
+if (!R2_ACCOUNT_ID) { console.error('Missing R2_ACCOUNT_ID'); process.exit(1); }
+
+const USER_AGENT = 'SourceLibrary/1.0 (https://sourcelibrary.org; derek@ancientwisdomtrust.org)';
+
+const r2 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: { accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY },
+});
+
+async function uploadToR2(key, buffer, contentType = 'image/jpeg') {
+  await r2.send(new PutObjectCommand({
+    Bucket: R2_BUCKET_NAME, Key: key, Body: buffer,
+    ContentType: contentType, CacheControl: 'public, max-age=86400, s-maxage=86400',
+  }));
+  return `${R2_PUBLIC_URL}/${key}`;
+}
+
+// Token bucket rate limiter
+let tokens = RATE_PER_SEC;
+let lastRefill = Date.now();
+
+async function waitForToken() {
+  const now = Date.now();
+  const elapsed = (now - lastRefill) / 1000;
+  tokens = Math.min(RATE_PER_SEC, tokens + elapsed * RATE_PER_SEC);
+  lastRefill = now;
+
+  if (tokens < 1) {
+    const waitMs = ((1 - tokens) / RATE_PER_SEC) * 1000;
+    await new Promise(r => setTimeout(r, waitMs));
+    tokens = 0;
+    lastRefill = Date.now();
+  } else {
+    tokens -= 1;
+  }
+}
+
+async function downloadImage(url, maxRetries = 4) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60_000);
+    try {
+      const res = await fetch(url, {
+        signal: controller.signal,
+        headers: { 'User-Agent': USER_AGENT },
+      });
+      if (res.status === 429) {
+        clearTimeout(timeout);
+        const backoff = 5000 * Math.pow(2, attempt); // 5s, 10s, 20s, 40s
+        if (attempt < maxRetries) {
+          await new Promise(r => setTimeout(r, backoff));
+          continue;
+        }
+        throw new Error(`HTTP 429 after ${maxRetries + 1} attempts`);
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buffer = Buffer.from(await res.arrayBuffer());
+      return buffer;
+    } catch (err) {
+      clearTimeout(timeout);
+      if (attempt === maxRetries || !err.message?.includes('429')) throw err;
+    }
+  }
+}
+
+async function main() {
+  const start = Date.now();
+  console.log(`[archive-harvard] Local Harvard archiver — ${PAGE_LIMIT} pages max, ${CONCURRENCY} workers, ${RATE_PER_SEC} req/s`);
+
+  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 5, serverSelectionTimeoutMS: 10000 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  // Check pause
+  const control = await db.collection('system_config').findOne({ _id: 'processing_control' });
+  if (control?.paused) {
+    console.log(`[archive-harvard] Pipeline paused. Exiting.`);
+    await client.close();
+    return;
+  }
+
+  // Find Harvard books with unarchived pages. Books with pages_archived < pages_count
+  // are the ones we still owe work; the $expr lets us skip already-complete books cheaply.
+  const harvardBooks = await db.collection('books')
+    .find({
+      'image_source.provider': 'harvard',
+      pages_count: { $gt: 0 },
+      $expr: { $lt: [{ $ifNull: ['$pages_archived', 0] }, '$pages_count'] },
+      'archive_metadata.blocked': { $ne: true },
+    }, { projection: { id: 1, title: 1, pages_count: 1, pages_archived: 1 } })
+    .limit(1000)
+    .maxTimeMS(30_000)
+    .toArray();
+
+  // Collect unarchived pages with Harvard URLs (pages_book_pagenum_idx makes the per-book lookup fast)
+  const allPages = [];
+  for (const book of harvardBooks) {
+    if (allPages.length >= PAGE_LIMIT) break;
+    const remaining = PAGE_LIMIT - allPages.length;
+    const bookPages = await db.collection('pages')
+      .find({
+        book_id: book.id,
+        photo: { $exists: true, $nin: [null, ''] },
+        $or: [
+          { archived_photo: { $exists: false } },
+          { archived_photo: null },
+          { archived_photo: '' },
+        ],
+        // Skip pages permanently blocked at 3 strikes (broken photo URLs)
+        $and: [{
+          $or: [
+            { 'archive_metadata.failure_count': { $exists: false } },
+            { 'archive_metadata.failure_count': { $lt: 3 } },
+          ],
+        }],
+      }, { projection: { _id: 1, book_id: 1, page_number: 1, photo: 1 } })
+      .limit(remaining)
+      .maxTimeMS(10_000)
+      .toArray()
+      .catch(() => []);
+
+    // Only keep pages that are actually Harvard MPS
+    const harvardPages = bookPages.filter(p => p.photo?.includes('mps.lib.harvard.edu'));
+    if (harvardPages.length > 0) {
+      allPages.push(...harvardPages);
+    }
+  }
+
+  console.log(`[archive-harvard] Found ${allPages.length} unarchived Harvard pages across ${new Set(allPages.map(p => p.book_id)).size} books`);
+
+  if (allPages.length === 0 || DRY_RUN) {
+    if (DRY_RUN && allPages.length > 0) {
+      const byBook = {};
+      for (const p of allPages) byBook[p.book_id] = (byBook[p.book_id] || 0) + 1;
+      console.log(`  Sample: ${Object.entries(byBook).slice(0, 5).map(([b, n]) => `${b}:${n}p`).join(', ')}`);
+    }
+    await client.close();
+    return;
+  }
+
+  // Process pages
+  let idx = 0;
+  let archived = 0;
+  let failed = 0;
+  let totalBytes = 0;
+  let consecutiveFails = 0;
+  const touchedBookIds = new Set();
+
+  async function worker() {
+    while (idx < allPages.length) {
+      // Harvard blocks Hetzner IPs entirely — if we see 20 consecutive failures
+      // from Mac we're probably either offline or Harvard escalated their block.
+      // Better to stop than to burn the failure_count budget on every page.
+      if (consecutiveFails >= 20) {
+        console.log(`  [CIRCUIT BREAKER] 20 consecutive failures — Harvard may be blocking. Stopping.`);
+        break;
+      }
+
+      const i = idx++;
+      if (i >= allPages.length) break;
+      const page = allPages[i];
+
+      await waitForToken();
+
+      // Use the photo URL as-is (already at /full/2000,/). Do NOT upgrade to
+      // /full/full/ — Harvard rate-limits the full-res endpoint aggressively.
+      const url = page.photo;
+
+      try {
+        const buffer = await downloadImage(url);
+        const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
+
+        const dimFields = {};
+        if (urls.width) dimFields.image_width = urls.width;
+        if (urls.height) dimFields.image_height = urls.height;
+
+        await db.collection('pages').updateOne(
+          { _id: page._id },
+          {
+            $set: {
+              archived_photo: urls.archived,
+              display_photo: urls.display,
+              thumbnail_blob: urls.thumb,
+              ...dimFields,
+              'archive_metadata.archived_at': new Date(),
+              'archive_metadata.source_url': url,
+              'archive_metadata.bytes': buffer.byteLength,
+              updated_at: new Date(),
+            },
+            $unset: {
+              'archive_metadata.failure_count': '',
+              'archive_metadata.last_failure_at': '',
+              'archive_metadata.last_failure_reason': '',
+              'archive_metadata.last_failure_source_url': '',
+            },
+          }
+        );
+
+        archived++;
+        totalBytes += buffer.byteLength;
+        touchedBookIds.add(page.book_id);
+        consecutiveFails = 0;
+      } catch (err) {
+        failed++;
+        consecutiveFails++;
+        if (failed <= 5) console.log(`  FAIL page ${page.book_id}/${page.page_number}: ${err.message?.slice(0, 80)}`);
+
+        // Record failure on the page so it eventually circuit-breaks if permanently broken
+        await db.collection('pages').updateOne(
+          { _id: page._id },
+          {
+            $set: {
+              'archive_metadata.last_failure_at': new Date(),
+              'archive_metadata.last_failure_reason': String(err.message || err).slice(0, 200),
+              'archive_metadata.last_failure_source_url': url,
+            },
+            $inc: { 'archive_metadata.failure_count': 1 },
+          }
+        ).catch(() => {});
+      }
+
+      const total = archived + failed;
+      if (total % 50 === 0) {
+        const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+        const mb = (totalBytes / (1024 * 1024)).toFixed(1);
+        const rate = (archived / ((Date.now() - start) / 1000)).toFixed(2);
+        console.log(`  ${total}/${allPages.length} processed, ${archived} archived (${mb} MB), ${failed} failed (${elapsed}s, ${rate}/s)`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, () => worker()));
+
+  const duration = ((Date.now() - start) / 1000).toFixed(1);
+  const mb = (totalBytes / (1024 * 1024)).toFixed(1);
+  console.log(`[archive-harvard] Done in ${duration}s: ${archived} archived (${mb} MB), ${failed} failed`);
+
+  // Sync pages_archived on touched books
+  if (touchedBookIds.size > 0) {
+    let synced = 0;
+    for (const bookId of touchedBookIds) {
+      const archivedCount = await db.collection('pages').countDocuments(
+        { book_id: bookId, archived_photo: { $exists: true, $nin: [null, ''] } },
+        { maxTimeMS: 10000 }
+      ).catch(() => -1);
+      if (archivedCount >= 0) {
+        await db.collection('books').updateOne(
+          { id: bookId },
+          { $set: { pages_archived: archivedCount, updated_at: new Date() } }
+        );
+        synced++;
+      }
+    }
+    console.log(`[archive-harvard] Synced pages_archived on ${synced} books`);
+  }
+
+  // Log run for monitoring
+  await db.collection('cron_runs').insertOne({
+    cron: 'archive-harvard',
+    source: 'local-mac',
+    started_at: new Date(start),
+    finished_at: new Date(),
+    duration_ms: Date.now() - start,
+    status: failed === 0 ? 'success' : 'partial',
+    actions: { archived, failed, bytes: totalBytes, pages_found: allPages.length },
+  });
+
+  await client.close();
+}
+
+main().catch(err => { console.error('[archive-harvard] Fatal:', err); process.exit(1); });

--- a/scripts/workers/archive-ocr.mjs
+++ b/scripts/workers/archive-ocr.mjs
@@ -252,6 +252,7 @@ async function main() {
   // Books move through pipeline stages even if archiving isn't complete.
   // Exclude e-rara (blocked on Hetzner IPs, archived locally via launchd on Mac).
   // Exclude Gallica (429s from Hetzner, archived locally via archive-gallica.mjs on Mac).
+  // Exclude Harvard (mps.lib.harvard.edu blocks Hetzner IPs at the AWS ELB, archive-harvard.mjs on Mac).
   // Exclude IA (handled by archive-bulk.mjs via JP2 zip download, much faster).
   // Prioritize providers that are NOT yet fully archived (IIIF, Cambridge, etc.)
   const PRIORITY_PROVIDERS = ['iiif', 'bsb', 'cambridge', 'vatican', 'loc', 'wellcome', 'heidelberg', 'bl', 'eap', 'met', 'ndl', 'getty', 'stanford', 'darmstadt'];
@@ -282,7 +283,10 @@ async function main() {
       {
         pages_count: { $gt: 0 },
         'archive_metadata.blocked': { $ne: true },
-        'image_source.provider': { $nin: ['e-rara', 'gallica', 'internet_archive', ...PRIORITY_PROVIDERS] },
+        // 'harvard' excluded: mps.lib.harvard.edu HTTP 429s every request from Hetzner
+        // IPs (verified 2026-05-25 at AWS ELB layer, both v4 and v6, all UAs, all paces).
+        // Routed to Mac-side via scripts/workers/archive-harvard.mjs.
+        'image_source.provider': { $nin: ['e-rara', 'gallica', 'internet_archive', 'harvard', ...PRIORITY_PROVIDERS] },
         ...NEEDS_ARCHIVE_EXPR,
       },
       { projection: { id: 1, title: 1, 'image_source.provider': 1 } }


### PR DESCRIPTION
Follow-up to #1978 and #1983 — neither helped because the root cause is IP-based blocking, not rate or URL variant.

## Diagnosis (direct curl from Hetzner)

\`\`\`
$ curl -sI 'https://mps.lib.harvard.edu/.../full/2000,/0/default.jpg'
HTTP/2 429
server: awselb/2.0

$ curl -sI 'https://mps.lib.harvard.edu/.../full/full/0/default.jpg'
HTTP/2 429

$ curl -sI -A 'Mozilla/5.0 ...'
HTTP/2 429

$ curl -4 -sI ...   # IPv4 (46.224.122.120)
HTTP/2 429
$ curl -6 -sI ...   # IPv6 (2a01:4f8:1c19:40ec::1)
HTTP/2 429
\`\`\`

Every variant returns 429. The blocking is at the AWS ELB layer keyed by source IP — Harvard has Hetzner's CIDR blocked outright. Same pattern as e-rara and gallica per the existing exclusion comments.

## Verified from Mac

A residential-IP smoke test from this Mac (5 pages, 1 worker, 1 req/s):

\`\`\`
[archive-harvard] Local Harvard archiver — 5 pages max, 1 workers, 1 req/s
[archive-harvard] Found 5 unarchived Harvard pages across 2 books
[archive-harvard] Done in 65.2s: 5 archived (12.7 MB), 0 failed
[archive-harvard] Synced pages_archived on 2 books
\`\`\`

Mac IP works fine.

## Change

1. **New \`scripts/workers/archive-harvard.mjs\`** — close adaptation of \`archive-gallica.mjs\`. Reads Harvard books with unarchived pages, downloads via the \`/full/2000,/\` bounded variant (does NOT upgrade to \`/full/full/\` — Harvard rate-limits that endpoint aggressively even from non-Hetzner IPs). Uploads to R2, updates MongoDB, syncs \`pages_archived\` on touched books, logs a \`cron_runs\` entry.
2. **\`scripts/workers/archive-ocr.mjs\`** — add \`'harvard'\` to the provider \`$nin\` exclusion list, alongside \`e-rara\`, \`gallica\`, \`internet_archive\`. Stops Hetzner from queuing pages it can't fetch. Updated the exclusion comment block.

## Companion install (not in this PR)

The launchd plist at \`~/Library/LaunchAgents/org.sourcelibrary.archive-harvard.plist\` — same shape as \`archive-gallica.plist\`: 30-min cron, phone-hotspot guard, \`--limit=2000 --concurrency=2 --rate=1\`. I'll install it after merge.

## DB cleanup needed post-deploy (also not in this PR)

Reset \`archive_metadata.failure_count\` on Harvard pages that hit failure_count > 0 from recent Hetzner attempts — they'd otherwise be skipped by the Mac worker's 3-strike check.

## Affected backlog

294 Harvard books / ~882 unarchived pages currently in \`pipeline_auto.status: archiving\`. At 1 req/s the Mac worker can clear ~3,600 pages/hour, so ~15 min of wall-clock work spread across cron runs (30-min interval = 1-2 runs).

## Test plan

- [x] \`node --check\` both files
- [x] Dry-run from Mac: found 20 pages across 7 books, candidate query healthy
- [x] Live test from Mac: 5 pages archived, 0 failed, 65s, no 429s
- [ ] After merge: install plist, \`launchctl bootstrap gui/501 ~/Library/LaunchAgents/org.sourcelibrary.archive-harvard.plist\`
- [ ] After first cron run: confirm pipeline_stalls count drops, Harvard zombie books advance to \`archive_complete\`

## Related

- #1978 (Harvard rate-limit table entry — ineffective, harmless, kept)
- #1983 (skip /full/full/ for Harvard — ineffective, harmless, kept)
- #1912 (overall prioritization plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)