### PR TITLE
UserMenu: show admin links for superadmin too

### DIFF
--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -48,8 +48,12 @@ export default function UserMenu({ variant = 'default' }: UserMenuProps) {
     );
   }
 
-  // Authenticated user: show avatar + dropdown
-  const isAdmin = (session.user as any)?.role === 'admin';
+  // Authenticated user: show avatar + dropdown.
+  // Accept admin OR superadmin — auth.ts assigns 'superadmin' to anyone in
+  // PLATFORM_ADMIN_EMAILS, so a `role === 'admin'` check was hiding the
+  // admin links from the very people who own the platform.
+  const role = (session.user as { role?: string } | undefined)?.role;
+  const isAdmin = role === 'admin' || role === 'superadmin';
   const isMember = (session.user as any)?.membership != null;
 
   const initials = session.user?.name


### PR DESCRIPTION
## Bug

`UserMenu.tsx` line 52 gates the admin block on `role === 'admin'`. Strict equality. But auth.ts only ever assigns `'admin'` to tenant-scoped tenantRole, never to the platform-level `token.role`. The platform-level role is either `'superadmin'` (PLATFORM_ADMIN_EMAILS) or `'reader'`. Result: superadmins see the reader dropdown.

## Fix

`isAdmin = role === 'admin' || role === 'superadmin'`. One-line change.

## Verify after merge

Sign in as Derek on sourcelibrary.org → click your avatar top-right → dropdown should now also include Analytics / Duplicates / API Keys / Feedback below Support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)