### PR TITLE
Fix /api/books/[id] 404 on non-tenant requests (MCP get_book broken)

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -24,9 +24,9 @@ export const GET = withApiAuth(async (
     const pagesMode = searchParams.get('pages') || 'default'; // 'nav' for minimal, 'default' for standard
     const { id: tenantId, slug: tenantSlug } = getTenantContextFromRequest(request);
 
-    if (!tenantId) {
-      return NextResponse.json({ error: 'Book not found' }, { status: 404 });
-    }
+    // No tenant header → main-site request → serve from the global catalog
+    // (findBookByIdOrSlug skips the tenant filter when tenantId is undefined).
+    // Tenant header present → /api/[tenant]/books/[id] semantics → tenant-scoped lookup.
 
     // Use secondary reads for public GETs; admin full-view still reads primary for freshness
     const db = includeFull ? await getDb() : await getReadDb();
@@ -38,7 +38,7 @@ export const GET = withApiAuth(async (
       chapters: 1,
     } : undefined;
 
-    const result = await findBookByIdOrSlug(db, id, bookProjection || undefined, tenantId, tenantSlug ?? undefined);
+    const result = await findBookByIdOrSlug(db, id, bookProjection || undefined, tenantId ?? undefined, tenantSlug ?? undefined);
     if (!result) {
       return NextResponse.json({ error: 'Book not found' }, { status: 404 });
     }
@@ -77,8 +77,10 @@ export const GET = withApiAuth(async (
     const bookId = (book.id || book._id?.toString()) as string;
     const pageOffset = parseInt(searchParams.get('pageOffset') || '0');
     const pageLimit = parseInt(searchParams.get('pageLimit') || '0'); // 0 = all (backwards-compat)
+    const pageFilter: Record<string, unknown> = { book_id: bookId, page_number: { $gte: 0 } };
+    if (tenantId) pageFilter.tenantId = tenantId;
     let cursor = db.collection('pages')
-      .find({ book_id: bookId, tenantId, page_number: { $gte: 0 } })
+      .find(pageFilter)
       .project(projection)
       .sort({ page_number: 1 });
     if (pageOffset > 0) cursor = cursor.skip(pageOffset);


### PR DESCRIPTION
## Summary

`/api/books/[id]` has been 404ing every non-tenant request since #f39f2656 ("API layer tenant scoping", merged 2026-04-21). The route was guarded with `if (!tenantId) return 404`, but `tenantId` only gets set when the request comes through a tenant subdomain (proxy injects `x-tenant-id`). Requests to bare `sourcelibrary.org` — including every MCP `get_book` call — never have this header and have been failing for over a month.

The sibling routes `/api/books/[id]/text` and `/api/books/[id]/quote` don't have the guard, which is why the MCP "search → read → quote" workflow was partly working: search_library would return a book_id, get_book would silently error, but get_book_text and get_quote would succeed. Confusing but not totally dead.

## Fix

- Remove the early 404 in `GET /api/books/[id]`.
- Pass `tenantId ?? undefined` to `findBookByIdOrSlug` (already handles undefined: skips the tenant filter).
- Make the pages-query tenant filter conditional: only apply when tenantId is set.

When the request comes through a tenant subdomain, behavior is unchanged: book and pages queries are still tenant-scoped.

## Found by

End-to-end smoke testing the MCP ahead of the Anthropic Connectors Directory re-submission. A reviewer would have caught this on their first `get_book` call.

## Test plan

- [ ] After deploy, `curl https://sourcelibrary.org/api/books/<any-valid-id>` returns the book, not 404
- [ ] Re-run the MCP e2e smoke: `get_book` on a result from `search_library` should return title + chapters + summary
- [ ] BPH subdomain still works: `curl https://bph.sourcelibrary.org/api/books/<bph-book-id>` returns the book; non-BPH book IDs still 404 from that subdomain

🤖 Generated with [Claude Code](https://claude.com/claude-code)