### PR TITLE
RLS lockdown Phase 1: lock analytics_pageviews + pending_changes to service-role (#1981)

### DIFF
--- a/scripts/migration/rls-lockdown-phase1-pii.sql
+++ b/scripts/migration/rls-lockdown-phase1-pii.sql
@@ -1,0 +1,90 @@
+-- RLS lockdown Phase 1 — PII tables (2026-05-25)
+--
+-- Closes the GDPR-relevant half of issue #1981. Two tables are currently
+-- readable via the public anon key (which is hardcoded in every served
+-- frontend JS bundle), exposing:
+--
+--   * analytics_pageviews (81k rows): IP, user_agent, country, referrer,
+--     path, timestamp per visitor — personal data under EU GDPR.
+--
+--   * bph_works_pending_changes (0 rows today, but will hold contributor
+--     email + proposed edits as #1877 sees use).
+--
+-- Both should be service-role-only. The app's analytics dashboard and the
+-- contributor-review page have been switched to supabaseAdmin in the same
+-- PR so end-user access still works through the application's auth gate.
+--
+-- This migration is additive and idempotent — re-running is safe.
+--
+-- Companion: src/app/api/analytics/route.ts, src/app/api/[tenant]/analytics/route.ts,
+--            src/app/embed/[tenant]/catalog/review/page.tsx switched to supabaseAdmin.
+--
+-- Verification after apply:
+--   anon-key probe should return 401 / 200 with empty array for both tables.
+--   See scripts/migration/rls-lockdown-phase1-pii.sql header.
+
+BEGIN;
+
+-- ───────────────────── analytics_pageviews ─────────────────────
+ALTER TABLE analytics_pageviews ENABLE ROW LEVEL SECURITY;
+
+-- Service role: full access. The MongoDB→Supabase sync worker
+-- (scripts/workers/supabase-sync.mjs) and the analytics API routes use this.
+DROP POLICY IF EXISTS analytics_pageviews_service_all ON analytics_pageviews;
+CREATE POLICY analytics_pageviews_service_all
+  ON analytics_pageviews
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- No anon / authenticated policies — visitor PII must never be reachable
+-- via end-user keys. Anything that needs aggregated stats goes through
+-- the application's auth-gated API routes.
+
+-- Belt-and-braces grants in case RLS is ever disabled.
+REVOKE SELECT, INSERT, UPDATE, DELETE ON analytics_pageviews FROM PUBLIC;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON analytics_pageviews FROM authenticated;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON analytics_pageviews FROM anon;
+
+-- ───────────────────── bph_works_pending_changes ─────────────────────
+ALTER TABLE bph_works_pending_changes ENABLE ROW LEVEL SECURITY;
+
+-- Service role: full access. The contributor edit/review API routes
+-- (src/app/api/[tenant]/catalog/[ubn]/edit/route.ts and the approve/reject
+-- routes) already use supabaseAdmin. The review page now does too.
+DROP POLICY IF EXISTS bph_works_pending_changes_service_all ON bph_works_pending_changes;
+CREATE POLICY bph_works_pending_changes_service_all
+  ON bph_works_pending_changes
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- No anon / authenticated policies — contributor email + proposed-edit
+-- content is private. Editor reviewers see this content through the
+-- auth-gated /embed/bph/catalog/review page, which goes through
+-- supabaseAdmin server-side.
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON bph_works_pending_changes FROM PUBLIC;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON bph_works_pending_changes FROM authenticated;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON bph_works_pending_changes FROM anon;
+
+COMMIT;
+
+-- ───────────────────── Post-flight verification ─────────────────────
+--
+-- Run as a separate query (NOT in this transaction):
+--
+--   SELECT relname, relrowsecurity FROM pg_class
+--     WHERE relname IN ('analytics_pageviews', 'bph_works_pending_changes');
+--   -- both should show relrowsecurity = true
+--
+--   SELECT polname, polroles::regrole[] FROM pg_policy
+--     WHERE polrelid IN ('analytics_pageviews'::regclass, 'bph_works_pending_changes'::regclass);
+--   -- expect one policy per table, role = service_role
+--
+-- Anon-key probe (run from a shell):
+--   curl -sS "$SUPABASE_URL/rest/v1/analytics_pageviews?select=*&limit=1" \
+--     -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY"
+--   -- expect: [] (empty array) or 401, NOT a row payload

--- a/src/app/api/[tenant]/analytics/route.ts
+++ b/src/app/api/[tenant]/analytics/route.ts
@@ -1,18 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-helpers';
-import { supabase } from '@/lib/supabase';
+import { supabaseAdmin } from '@/lib/supabase';
 import { resolveTenantId } from '@/lib/tenant-context';
 
 // In-memory cache (10 minutes — traffic data changes slowly)
 let cache: { key: string; data: unknown; ts: number } | null = null;
 const CACHE_TTL_MS = 10 * 60 * 1000;
 
-/** Fetch all pageviews from Supabase, paginating through 1000-row pages. */
+/** Fetch all pageviews from Supabase, paginating through 1000-row pages.
+ *  Uses the service-role client because analytics_pageviews is RLS-locked
+ *  to service_role only (visitor PII; see issue #1981 + the
+ *  rls-lockdown-phase1-pii.sql migration). End-user access is gated at
+ *  the app layer via withAuth above. */
 async function fetchAllPageviews(since: string) {
+  if (!supabaseAdmin) throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
   const rows: any[] = [];
   let offset = 0;
   while (true) {
-    const { data } = await supabase
+    const { data } = await supabaseAdmin
       .from('analytics_pageviews')
       .select('path, referrer, country, ip, timestamp')
       .gte('timestamp', since)

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,17 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-helpers';
-import { supabase } from '@/lib/supabase';
+import { supabaseAdmin } from '@/lib/supabase';
 
 // In-memory cache (10 minutes — traffic data changes slowly)
 let cache: { data: unknown; ts: number } | null = null;
 const CACHE_TTL_MS = 10 * 60 * 1000;
 
-/** Fetch all pageviews from Supabase, paginating through 1000-row pages. */
+/** Fetch all pageviews from Supabase, paginating through 1000-row pages.
+ *  Uses the service-role client because analytics_pageviews is RLS-locked
+ *  to service_role only (visitor PII; see issue #1981 + the
+ *  rls-lockdown-phase1-pii.sql migration). End-user access is gated at
+ *  the app layer via withAuth above. */
 async function fetchAllPageviews(since: string) {
+  if (!supabaseAdmin) throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
   const rows: any[] = [];
   let offset = 0;
   while (true) {
-    const { data } = await supabase
+    const { data } = await supabaseAdmin
       .from('analytics_pageviews')
       .select('path, referrer, country, ip, timestamp')
       .gte('timestamp', since)

--- a/src/app/embed/[tenant]/catalog/review/page.tsx
+++ b/src/app/embed/[tenant]/catalog/review/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from 'next/navigation';
 import type { Metadata } from 'next';
-import { supabase } from '@/lib/supabase';
+import { supabaseAdmin } from '@/lib/supabase';
 import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
 import { getDb } from '@/lib/mongodb';
@@ -92,7 +92,15 @@ export default async function CatalogReviewPage({ params }: Props) {
   // Fetch pending rows + titles for each UBN in one go. The bph_works
   // join via Supabase's PostgREST `select` keeps this to a single round trip
   // even though pending rows can include creates with no UBN yet.
-  const { data, error } = await supabase
+  //
+  // Uses supabaseAdmin (service role) because bph_works_pending_changes is
+  // RLS-locked to service_role only (contributor PII; see issue #1981 +
+  // rls-lockdown-phase1-pii.sql). Access on this page is gated above by
+  // session + tenant-role checks.
+  if (!supabaseAdmin) {
+    throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
+  }
+  const { data, error } = await supabaseAdmin
     .from('bph_works_pending_changes')
     .select('id, ubn, change_type, proposer_email, field_changes, note, status, created_at')
     .eq('status', 'pending')
@@ -126,7 +134,7 @@ export default async function CatalogReviewPage({ params }: Props) {
   const ubns = Array.from(new Set(rows.map(r => r.ubn).filter((u): u is string => !!u)));
   const titlesByUbn = new Map<string, string>();
   if (ubns.length > 0) {
-    const { data: works } = await supabase
+    const { data: works } = await supabaseAdmin
       .from('bph_works')
       .select('ubn, title, parallel_title, uniform_title')
       .in('ubn', ubns);


### PR DESCRIPTION
## ⚠️ Merge ASAP — production is degraded

The SQL migration `scripts/migration/rls-lockdown-phase1-pii.sql` was **applied to production on 2026-05-25** alongside this PR. Until the code changes here deploy, the old code reading via anon \`supabase\` will hit 401 on:

- \`/api/analytics\` (analytics dashboard)
- \`/api/[tenant]/analytics\` (per-tenant analytics)
- \`/embed/bph/catalog/review\` (BPH contributor review queue)

These are admin-tool endpoints (low traffic) but the brief window of broken-ness should be closed by merging and deploying.

## What this closes

Phase 1 of #1981 — the GDPR-relevant tables exposed via the public anon key.

| Table | Rows | What was exposed | Now |
|---|---|---|---|
| \`analytics_pageviews\` | 81,187 | IP, user_agent, country, referrer, path, timestamp per visitor (PII under EU GDPR) | service-role only |
| \`bph_works_pending_changes\` | 0 today | will hold contributor email + proposed edits as #1877 sees use | service-role only |

Verified post-apply: \`curl ...rest/v1/<table>?... \` with the anon key returns \`401 permission denied\` for both tables. Service-role reads (sync workers + API routes) unaffected.

## What's in the PR

- **\`scripts/migration/rls-lockdown-phase1-pii.sql\`** — idempotent. \`ENABLE ROW LEVEL SECURITY\` + service-role-only policies + \`REVOKE\` belt-and-braces. Already applied to prod.
- **\`src/app/api/analytics/route.ts\`** — switched from anon \`supabase\` → \`supabaseAdmin\` with null guard. Comment refs #1981.
- **\`src/app/api/[tenant]/analytics/route.ts\`** — same.
- **\`src/app/embed/[tenant]/catalog/review/page.tsx\`** — same. Two reads in this file (pending_changes + bph_works titles for context); both moved to \`supabaseAdmin\`.

Writers (MongoDB→Supabase sync worker + the contributor-edit POST/PATCH routes) already used service-role; unchanged.

## How this is structurally different from app-layer auth

Before: API routes wrapped in \`withAuth\` / pages wrapped in \`auth()\` + role check, then fetched via anon \`supabase\`. The auth check protected the API endpoint; **direct PostgREST access with the same anon key bypassed it entirely**. The anon key is in every served JS bundle, so this was effectively no protection at all.

After: same app-layer auth + the DB layer enforces service-role-only via RLS. The anon key has no access at all to these tables, regardless of where the request comes from.

## Verification

```bash
# Anon-key probe — should be 401 after the SQL applies
curl -sS -w "\nHTTP %{http_code}\n" \
  "$SUPABASE_URL/rest/v1/analytics_pageviews?select=*&limit=1" \
  -H "apikey: $SUPABASE_ANON_KEY" \
  -H "Authorization: Bearer $SUPABASE_ANON_KEY"
# Verified 2026-05-25: HTTP 401, {"code":"42501","message":"permission denied for table analytics_pageviews"}

# Same for bph_works_pending_changes — verified 401 ✓
```

\`npx tsc --noEmit\` passes (exit 0).

## What's NOT in this PR (deferred to follow-ups)

Issue #1981 enumerates 4 phases. This is Phase 1 only:

- **Phase 2** — \`gemini_usage\` (4.67M rows of AI pipeline telemetry, anon-readable), \`pipeline_snapshots\` — operational surveillance class, no PII but exposes cost/volume.
- **Phase 3** — \`library_catalog_records\` — needs tenant-aware RLS (not just service-role lockdown) because the catalog IS public per-tenant. Bigger design work.
- **Phase 4** — \`entities\`, \`book_embeddings\`, \`artwork_embeddings\`, \`clip_embeddings\` — anon SELECT-only (public catalog) + revoke writes.

## References

- Tracker: #1981
- Discovered while applying #1975 (BPH Memorix final sync — Supabase dashboard warned about the new \`bph_work_files\` table missing RLS, which prompted the sweep of all recent CREATE TABLE migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)