### PR TITLE
Include MCP get_book fields (summary, page counts) in nav projection

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -31,10 +31,15 @@ export const GET = withApiAuth(async (
     // Use secondary reads for public GETs; admin full-view still reads primary for freshness
     const db = includeFull ? await getDb() : await getReadDb();
 
-    // Book projection: nav mode only needs fields the reader uses
+    // Book projection: nav mode keeps it light but still includes the
+    // small fields the MCP get_book tool exposes (summary, page counts,
+    // categories, year) — without these, MCP returns a book card with
+    // null pages and no summary.
     const bookProjection = pagesMode === 'nav' ? {
       _id: 0, id: 1, slug: 1, title: 1, display_title: 1, author: 1,
-      published: 1, language: 1, doi: 1,
+      published: 1, year: 1, language: 1, doi: 1,
+      pages_count: 1, pages_translated: 1,
+      categories: 1, reading_summary: 1,
       chapters: 1,
     } : undefined;
 


### PR DESCRIPTION
## Summary

Follow-up to #1995. The MCP `get_book` tool calls `/api/books/[id]?pages=nav` and tries to surface `pages_count`, `pages_translated`, `year`, `categories`, and `reading_summary` — but the `nav` projection didn't include those, so MCP returned a book card with null page counts and no summary.

The tool description in `route.ts` promises "AI-generated summary, chapter list, edition metadata, DOI, and page counts" — so reviewers (and real users) would see the gap immediately.

Adds the missing fields to the `nav` projection. All are small — one number, short string, short array, one prose blob. The page-viewer caller that originally drove `nav` ignores them.

## Test plan

- [ ] After deploy: `curl -X POST sourcelibrary.org/api/mcp ... get_book` returns a populated `pages_count`, `reading_summary`, `categories`, `year`
- [ ] Page viewer (`/book/[slug]/page/[pageId]`) still loads fine (nav callers ignore the added fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)