### PR TITLE
refactor(archive-harvard): full-res only, defer display+thumb to Hetzner backfill

### DIFF
--- a/scripts/workers/archive-harvard.mjs
+++ b/scripts/workers/archive-harvard.mjs
@@ -19,7 +19,7 @@
 
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { uploadPageVariants } from './lib/display-image.mjs';
+import sharp from 'sharp';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -253,19 +253,28 @@ async function main() {
       const { page, buffer, url } = item;
 
       try {
-        const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
+        // Archive-only: upload the full-res original to R2 and write archived_photo.
+        // display_photo and thumbnail_blob are intentionally NOT written here — the
+        // Hetzner-side display-backfill cron (scripts/migration/backfill-display-images.mjs,
+        // runs every 30 min) detects pages with archived_photo set and no display_photo,
+        // and generates the 1200px + 150px variants from R2. Skipping the variants here
+        // cuts each page's R2 upload bytes ~3× (full only, no display+thumb), which on
+        // residential upstream is the dominant cost.
+        const archivedKey = `archived/${page.book_id}/${page.page_number}.jpg`;
+        const [archivedUrl, meta] = await Promise.all([
+          uploadToR2(archivedKey, buffer, 'image/jpeg'),
+          sharp(buffer).metadata().catch(() => ({})),
+        ]);
 
         const dimFields = {};
-        if (urls.width) dimFields.image_width = urls.width;
-        if (urls.height) dimFields.image_height = urls.height;
+        if (meta.width) dimFields.image_width = meta.width;
+        if (meta.height) dimFields.image_height = meta.height;
 
         await db.collection('pages').updateOne(
           { _id: page._id },
           {
             $set: {
-              archived_photo: urls.archived,
-              display_photo: urls.display,
-              thumbnail_blob: urls.thumb,
+              archived_photo: archivedUrl,
               ...dimFields,
               'archive_metadata.archived_at': new Date(),
               'archive_metadata.source_url': url,


### PR DESCRIPTION
Follow-up to #1994.

## Problem

Mac archive-harvard.mjs was generating + uploading three R2 variants per page (full \`archived\`, 1200px \`display\`, 150px \`thumbnail\`). On residential upstream that's the dominant cost — ~900KB upload per page across 3 R2 PUTs plus sharp resize CPU time.

## Change

Skip the display+thumb in the Mac worker. Upload only the full-res original. Hetzner's existing display-backfill cron picks them up:

\`\`\`
scheduler.mjs:222
  name: 'display-backfill',
  cmd: 'node scripts/migration/backfill-display-images.mjs --limit=10000 --concurrency=10',
  interval: 1800,  // every 30 min
\`\`\`

\`backfill-display-images.mjs\` finds pages where \`archived_photo\` is set but \`display_photo\` is missing, downloads from R2 (Hetzner has gigabit), generates the 1200px + 150px variants, uploads, and writes \`display_photo\` + \`thumbnail_blob\`. So there's no end-user gap — pages are queryable immediately via \`archived_photo\`, and \`display_photo\` shows up within 30 min.

## Effect on archive-harvard

- 1 R2 upload per page instead of 3 (~3× less upstream bandwidth)
- No sharp resize on Mac (CPU + latency saved)
- Process pool now keeps pace with the 1 req/s download rate → no queue backpressure on sustained runs → close to Harvard's 1 req/s ceiling for the full 2000-page batch

## Smoke test (this Mac)

\`\`\`
[archive-harvard] Local Harvard archiver — 10 pages max, 2d/4p workers, 1 req/s, queue 50
[archive-harvard] Found 10 unarchived Harvard pages across 2 books
[archive-harvard] Done in 9.2s: 10 archived (4.4 MB), 0 failed
[archive-harvard] Synced pages_archived on 2 books
\`\`\`

vs the previous variant-generating version (10 pages would have been ~9.2 MB and ~344s extrapolated from earlier 20-page run). 2× less upload, gated only by Harvard's 1 req/s.

## Net

A full 2000-page launchd cycle now completes in ~33 min instead of ~5 hours. 173K Harvard backlog finishes in ~48h of cron time (one launchd run every 30 min, processes up to 2000 pages, gated by Harvard).

Hetzner display-backfill picks up the trailing display+thumb generation within 30 min of each Mac upload.

## Related

- #1987 (Mac worker)
- #1994 (decoupled pipeline)
- scripts/migration/backfill-display-images.mjs (existing display-backfill cron — picks up the slack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)