### PR TITLE
RLS lockdown Phase 2: lock gemini_usage + pipeline_snapshots to service-role (#1981)

### DIFF
--- a/scripts/migration/rls-lockdown-phase2-telemetry.sql
+++ b/scripts/migration/rls-lockdown-phase2-telemetry.sql
@@ -1,0 +1,79 @@
+-- RLS lockdown Phase 2 — operational telemetry (2026-05-25)
+--
+-- Closes the operational-surveillance half of issue #1981. Two tables are
+-- currently readable via the public anon key:
+--
+--   * gemini_usage (4,669,573 rows): every Gemini API call with model,
+--     tokens, cost, endpoint, type, timestamps. Doesn't include prompt
+--     content, but exposes near-realtime AI spend, pipeline volume, and
+--     internal endpoint structure.
+--
+--   * pipeline_snapshots (21,930 rows): internal pipeline state — job
+--     timings, queue depths, throughput metrics.
+--
+-- Neither table contains end-user PII per se (visitor data lives in
+-- analytics_pageviews, locked down in Phase 1). The risk class here is
+-- operational surveillance and competitive intel: anyone reading our
+-- frontend JS to extract the anon key can monitor our AI spend curve in
+-- real time, observe pipeline throughput, and infer internal process
+-- decisions. Neither should be exposed.
+--
+-- The companion code changes switch the relevant consumers from anon
+-- `supabase` to `supabaseAdmin`:
+--
+--   src/app/api/[tenant]/analytics/pipeline/route.ts
+--   src/app/api/analytics/pipeline/route.ts
+--   src/lib/gemini-logger.ts (fetchUsageRows)
+--   src/lib/book-history.ts (fetchSupabaseUsage)
+--
+-- Writers (the Gemini logger inserts in gemini-logger.ts, the
+-- pipeline_snapshots writes from the pipeline workers) already use the
+-- service-role client — unaffected.
+--
+-- This migration is additive and idempotent — re-running is safe.
+
+BEGIN;
+
+-- ───────────────────── gemini_usage ─────────────────────
+ALTER TABLE gemini_usage ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS gemini_usage_service_all ON gemini_usage;
+CREATE POLICY gemini_usage_service_all
+  ON gemini_usage
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON gemini_usage FROM PUBLIC;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON gemini_usage FROM authenticated;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON gemini_usage FROM anon;
+
+-- ───────────────────── pipeline_snapshots ─────────────────────
+ALTER TABLE pipeline_snapshots ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS pipeline_snapshots_service_all ON pipeline_snapshots;
+CREATE POLICY pipeline_snapshots_service_all
+  ON pipeline_snapshots
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+REVOKE SELECT, INSERT, UPDATE, DELETE ON pipeline_snapshots FROM PUBLIC;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON pipeline_snapshots FROM authenticated;
+REVOKE SELECT, INSERT, UPDATE, DELETE ON pipeline_snapshots FROM anon;
+
+COMMIT;
+
+-- ───────────────────── Post-flight verification ─────────────────────
+--
+-- Anon-key probe (run from a shell, not in SQL editor):
+--   curl -sS "$SUPABASE_URL/rest/v1/gemini_usage?select=*&limit=1" \
+--     -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY"
+--   -- expect: 401 permission denied
+--
+-- Service-role count check:
+--   SELECT relname, relrowsecurity FROM pg_class
+--     WHERE relname IN ('gemini_usage', 'pipeline_snapshots');
+--   -- both should show relrowsecurity = true

--- a/src/app/api/[tenant]/analytics/pipeline/route.ts
+++ b/src/app/api/[tenant]/analytics/pipeline/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { resolveTenantId } from '@/lib/tenant-context';
 import { withAuth } from '@/lib/auth-helpers';
-import { supabase } from '@/lib/supabase';
+import { supabaseAdmin } from '@/lib/supabase';
 
 export const maxDuration = 30;
 
@@ -24,6 +24,12 @@ const CACHE_TTL_MS = 60 * 1000;
  */
 export const GET = withAuth(async (request: NextRequest, session, context) => {
   try {
+    // Uses supabaseAdmin because gemini_usage and pipeline_snapshots are
+    // RLS-locked to service_role only (operational telemetry; see #1981 +
+    // rls-lockdown-phase2-telemetry.sql). Caller already passed withAuth.
+    if (!supabaseAdmin) {
+      return NextResponse.json({ error: 'supabaseAdmin not configured' }, { status: 500 });
+    }
     const { searchParams } = new URL(request.url);
     const hours = Math.min(parseInt(searchParams.get('hours') || '24', 10), 720); // max 30 days
     const { tenant } = await context.params;
@@ -46,7 +52,7 @@ export const GET = withAuth(async (request: NextRequest, session, context) => {
     const [snapshots, cronRuns, needsAttention, recentErrors, recentDecisions, velocityRows] = await Promise.all([
       // 1. Pipeline snapshots from Supabase (fast time-series query)
       // Filter out zero-page snapshots (caused by warehouse migration or orchestrator restarts)
-      supabase
+      supabaseAdmin
         .from('pipeline_snapshots')
         .select('timestamp, funnel, pages, books, active_batch')
         .gte('timestamp', cutoff.toISOString())
@@ -55,7 +61,7 @@ export const GET = withAuth(async (request: NextRequest, session, context) => {
         .then(({ data }) => data || []),
 
       // 2. Recent cron runs from Supabase
-      supabase
+      supabaseAdmin
         .from('cron_runs')
         .select('cron, timestamp, duration_ms, actions, errors, error_count, status')
         .gte('timestamp', cutoff.toISOString())
@@ -78,7 +84,7 @@ export const GET = withAuth(async (request: NextRequest, session, context) => {
         .toArray(),
 
       // 4. Recent errors from Supabase gemini_usage (last 6h)
-      supabase
+      supabaseAdmin
         .from('gemini_usage')
         .select('type, error_category, error_message, timestamp')
         .eq('status', 'failed')
@@ -108,7 +114,7 @@ export const GET = withAuth(async (request: NextRequest, session, context) => {
         }),
 
       // 5. Recent decisions from Supabase cron_runs
-      supabase
+      supabaseAdmin
         .from('cron_runs')
         .select('cron, timestamp, decisions')
         .gte('timestamp', cutoff.toISOString())
@@ -131,7 +137,7 @@ export const GET = withAuth(async (request: NextRequest, session, context) => {
         }),
 
       // 6. Pipeline velocity from materialized view (pre-computed hourly rates)
-      supabase
+      supabaseAdmin
         .from('pipeline_velocity')
         .select('hour, books_complete, pages_translated, pages_ocr, pages_total')
         .gte('hour', cutoff.toISOString())

--- a/src/app/api/analytics/pipeline/route.ts
+++ b/src/app/api/analytics/pipeline/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import { withAuth } from '@/lib/auth-helpers';
-import { supabase } from '@/lib/supabase';
+import { supabaseAdmin } from '@/lib/supabase';
 
 export const maxDuration = 30;
 
@@ -24,6 +24,12 @@ const CACHE_TTL_MS = 60 * 1000;
  */
 export const GET = withAuth(async (request: NextRequest, session) => {
   try {
+    // Uses supabaseAdmin because gemini_usage and pipeline_snapshots are
+    // RLS-locked to service_role only (operational telemetry; see #1981 +
+    // rls-lockdown-phase2-telemetry.sql). Caller already passed withAuth.
+    if (!supabaseAdmin) {
+      return NextResponse.json({ error: 'supabaseAdmin not configured' }, { status: 500 });
+    }
     const { searchParams } = new URL(request.url);
     const hours = Math.min(parseInt(searchParams.get('hours') || '24', 10), 720); // max 30 days
     const { id: tenantId } = getTenantContextFromRequest(request);
@@ -45,7 +51,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
     const [snapshots, cronRuns, needsAttention, recentErrors, recentDecisions, velocityRows] = await Promise.all([
       // 1. Pipeline snapshots from Supabase (fast time-series query)
       // Filter out zero-page snapshots (caused by warehouse migration or orchestrator restarts)
-      supabase
+      supabaseAdmin
         .from('pipeline_snapshots')
         .select('timestamp, funnel, pages, books, active_batch')
         .gte('timestamp', cutoff.toISOString())
@@ -54,7 +60,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
         .then(({ data }) => data || []),
 
       // 2. Recent cron runs from Supabase
-      supabase
+      supabaseAdmin
         .from('cron_runs')
         .select('cron, timestamp, duration_ms, actions, errors, error_count, status')
         .gte('timestamp', cutoff.toISOString())
@@ -77,7 +83,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
         .toArray(),
 
       // 4. Recent errors from Supabase gemini_usage (last 6h)
-      supabase
+      supabaseAdmin
         .from('gemini_usage')
         .select('type, error_category, error_message, timestamp')
         .eq('status', 'failed')
@@ -107,7 +113,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
         }),
 
       // 5. Recent decisions from Supabase cron_runs
-      supabase
+      supabaseAdmin
         .from('cron_runs')
         .select('cron, timestamp, decisions')
         .gte('timestamp', cutoff.toISOString())
@@ -130,7 +136,7 @@ export const GET = withAuth(async (request: NextRequest, session) => {
         }),
 
       // 6. Pipeline velocity from materialized view (pre-computed hourly rates)
-      supabase
+      supabaseAdmin
         .from('pipeline_velocity')
         .select('hour, books_complete, pages_translated, pages_ocr, pages_total')
         .gte('hour', cutoff.toISOString())

--- a/src/lib/book-history.ts
+++ b/src/lib/book-history.ts
@@ -24,7 +24,7 @@
  *   - `audit_log` and `book_metadata_changelog` writers do not stamp `tenantId`.
  */
 import type { Db } from 'mongodb';
-import { supabase, supabaseAdmin } from './supabase';
+import { supabaseAdmin } from './supabase';
 
 export interface HistoryEvent {
   type:
@@ -209,7 +209,11 @@ const SOURCE_LABELS: Record<string, string> = {
 };
 
 async function fetchSupabaseUsage(bookId: string): Promise<UsageRow[]> {
-  const client = supabaseAdmin || supabase;
+  // gemini_usage is RLS-locked to service_role (see #1981); no anon fallback.
+  if (!supabaseAdmin) {
+    throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
+  }
+  const client = supabaseAdmin;
   // Read selected columns; `triggered_by` is optional in case the column hasn't shipped yet.
   const { data, error } = await client
     .from('gemini_usage')

--- a/src/lib/gemini-logger.ts
+++ b/src/lib/gemini-logger.ts
@@ -55,7 +55,7 @@
  */
 
 import { getDb } from './mongodb';
-import { supabaseAdmin, supabase } from './supabase';
+import { supabaseAdmin } from './supabase';
 
 // Pricing per 1M tokens (as of Jan 2025)
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
@@ -357,7 +357,11 @@ export async function getUsageSummary(params: {
   by_type: Record<string, { calls: number; cost: number }>;
   by_model: Record<string, { calls: number; cost: number }>;
 }> {
-  const client = supabaseAdmin || supabase;
+  // gemini_usage is RLS-locked to service_role (see #1981); no anon fallback.
+  if (!supabaseAdmin) {
+    throw new Error('supabaseAdmin not configured — SUPABASE_SERVICE_ROLE_KEY missing');
+  }
+  const client = supabaseAdmin;
 
   // Note: PostgREST defaults to 1000 rows. For book-scoped queries this is fine.
   // For time-range queries across all books, use dashboard_usage view instead.


### PR DESCRIPTION
## ⚠️ Merge ASAP — same pattern as #1997

The SQL migration was **applied to production on 2026-05-25** before this PR. Until the code changes here deploy, the old code reading via anon \`supabase\` will hit 401 on:

- \`/api/analytics/pipeline\` (global pipeline analytics)
- \`/api/[tenant]/analytics/pipeline\` (per-tenant pipeline analytics)
- Anywhere that calls \`fetchUsageRows\` (the gemini-logger time-range reader; primary caller is \`processing-dashboard\` which already uses supabaseAdmin, but the fallback path was exposed)
- Anywhere that calls \`fetchSupabaseUsage\` (the book-history reader; bookwise routes call this)

These are admin / dashboard endpoints with low traffic; brief window of degradation closes on merge + deploy.

## What this closes

Phase 2 of #1981 — operational-surveillance tables exposed via the public anon key.

| Table | Rows | What was exposed | Now |
|---|---|---|---|
| \`gemini_usage\` | 4,695,068 | Per-call model, tokens, cost, type, endpoint, timestamps. **No prompt/response content** (that's a relief) but anyone can monitor AI spend curve + pipeline volume + infer endpoint structure in near-realtime. | service-role only |
| \`pipeline_snapshots\` | 21,930 | Internal pipeline state — job timings, queue depths, throughput. | service-role only |

Verified post-apply: anon-key probe returns \`401 permission denied\` for both. Service-role reads (sync workers + API routes) unaffected (count grew 4.67M → 4.70M between the audit and the verify probe).

## What's in the PR

- **\`scripts/migration/rls-lockdown-phase2-telemetry.sql\`** — idempotent. Same pattern as Phase 1: \`ENABLE ROW LEVEL SECURITY\` + service-role-only policies + \`REVOKE\` belt-and-braces. Already applied to prod.

- **\`src/app/api/[tenant]/analytics/pipeline/route.ts\`** and **\`src/app/api/analytics/pipeline/route.ts\`** — whole-file switch from anon \`supabase\` → \`supabaseAdmin\`. These routes also read \`cron_runs\` + \`dashboard_usage\` (materialized view) — those aren't locked down in this phase but the switch is harmless, and consistent (all reads in the file go through one client now). Both routes wrapped in \`withAuth\` app-side.

- **\`src/lib/gemini-logger.ts\`** (\`fetchUsageRows\`) — removed the \`const client = supabaseAdmin || supabase\` fallback that would silently 401 after the lockdown. Now throws if \`SUPABASE_SERVICE_ROLE_KEY\` is missing. \`supabase\` removed from the import (was only used in the fallback).

- **\`src/lib/book-history.ts\`** (\`fetchSupabaseUsage\`) — same fallback removal + import trim.

## Writers untouched

The Gemini logger's insert/update paths (\`gemini-logger.ts\` lines that handle \`logGeminiCall\` etc.) already used \`supabaseAdmin\`. The pipeline workers that write \`pipeline_snapshots\` also used service-role. No behavior change.

## Verification

\`\`\`bash
curl -sS -w "\nHTTP %{http_code}\n" \
  "$SUPABASE_URL/rest/v1/gemini_usage?select=*&limit=1" \
  -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY"
# Verified 2026-05-25: HTTP 401, {"code":"42501","message":"permission denied for table gemini_usage"}
# Same for pipeline_snapshots ✓
\`\`\`

\`npx tsc --noEmit\` clean (exit 0).

## What's left in #1981

- **Phase 3** — \`library_catalog_records\` — tenant-aware RLS, bigger design (not just service-role lockdown — the catalog *is* public per-tenant).
- **Phase 4** — \`entities\` + embeddings — anon SELECT-only (catalog data) + REVOKE on writes.

## References

- Tracker: #1981
- Sibling PR (Phase 1): #1997 (merged earlier today, same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)