### PR TITLE
RLS lockdown Phase 4: anon SELECT-only for entities + embeddings (#1981)

### DIFF
--- a/scripts/migration/rls-lockdown-phase4-readonly.sql
+++ b/scripts/migration/rls-lockdown-phase4-readonly.sql
@@ -1,0 +1,125 @@
+-- RLS lockdown Phase 4 — public catalog (read-only via anon) (2026-05-25)
+--
+-- Closes the read-only catalog half of issue #1981. Four tables hold
+-- catalog data that's intentionally public (entities, embeddings — they
+-- power the encyclopedia, semantic search, image similarity), but were
+-- previously *also* writable via the anon key, which is wrong.
+--
+-- The pattern here is different from Phase 1/2 (PII / telemetry):
+--
+--   Phase 1/2 → service-role only, anon has NO access
+--   Phase 4   → anon SELECT-only, INSERT/UPDATE/DELETE revoked from anon
+--
+-- Tables in scope:
+--
+--   * entities (856,539 rows) — author/place/concept authority records,
+--     read by /encyclopedia, /explore, author detail pages, etc.
+--   * book_embeddings — semantic search index (gemini-embedding-2,
+--     768-dim), read by /api/search/semantic and /api/search/unified.
+--   * artwork_embeddings — artwork semantic embeddings.
+--   * clip_embeddings (101,981 rows) — CLIP image embeddings, read by
+--     /api/identify and /api/gallery/similar.
+--
+-- All four are written exclusively by service-role workers
+--   scripts/workers/sync-entities.mjs
+--   scripts/workers/enrich-worker.mjs  (book_embeddings)
+--   scripts/migration/backfill-book-embeddings.mjs
+--   (artwork_embeddings + clip_embeddings: backfill scripts under
+--    scripts/, all using SUPABASE_SERVICE_ROLE_KEY)
+-- — unaffected by this migration.
+--
+-- No application-code changes needed: the server-rendered pages
+-- already read via anon supabase, and the anon SELECT policy keeps
+-- that path working.
+--
+-- This migration is additive and idempotent.
+
+BEGIN;
+
+-- Common pattern, applied uniformly to all four tables:
+--   1. ENABLE ROW LEVEL SECURITY
+--   2. service_role policy: FOR ALL (writers continue to work)
+--   3. anon + authenticated policies: FOR SELECT (catalog reads continue)
+--   4. REVOKE INSERT/UPDATE/DELETE from public/authenticated/anon
+--      (belt-and-braces — RLS policies are the primary control,
+--       but explicit GRANT-level revoke costs nothing).
+
+-- ───────────────────── entities ─────────────────────
+ALTER TABLE entities ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS entities_service_all ON entities;
+CREATE POLICY entities_service_all ON entities FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS entities_anon_select ON entities;
+CREATE POLICY entities_anon_select ON entities FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS entities_auth_select ON entities;
+CREATE POLICY entities_auth_select ON entities FOR SELECT TO authenticated USING (true);
+
+REVOKE INSERT, UPDATE, DELETE ON entities FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE ON entities FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON entities FROM anon;
+
+-- ───────────────────── book_embeddings ─────────────────────
+ALTER TABLE book_embeddings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS book_embeddings_service_all ON book_embeddings;
+CREATE POLICY book_embeddings_service_all ON book_embeddings FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS book_embeddings_anon_select ON book_embeddings;
+CREATE POLICY book_embeddings_anon_select ON book_embeddings FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS book_embeddings_auth_select ON book_embeddings;
+CREATE POLICY book_embeddings_auth_select ON book_embeddings FOR SELECT TO authenticated USING (true);
+
+REVOKE INSERT, UPDATE, DELETE ON book_embeddings FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE ON book_embeddings FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON book_embeddings FROM anon;
+
+-- ───────────────────── artwork_embeddings ─────────────────────
+ALTER TABLE artwork_embeddings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS artwork_embeddings_service_all ON artwork_embeddings;
+CREATE POLICY artwork_embeddings_service_all ON artwork_embeddings FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS artwork_embeddings_anon_select ON artwork_embeddings;
+CREATE POLICY artwork_embeddings_anon_select ON artwork_embeddings FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS artwork_embeddings_auth_select ON artwork_embeddings;
+CREATE POLICY artwork_embeddings_auth_select ON artwork_embeddings FOR SELECT TO authenticated USING (true);
+
+REVOKE INSERT, UPDATE, DELETE ON artwork_embeddings FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE ON artwork_embeddings FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON artwork_embeddings FROM anon;
+
+-- ───────────────────── clip_embeddings ─────────────────────
+ALTER TABLE clip_embeddings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS clip_embeddings_service_all ON clip_embeddings;
+CREATE POLICY clip_embeddings_service_all ON clip_embeddings FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS clip_embeddings_anon_select ON clip_embeddings;
+CREATE POLICY clip_embeddings_anon_select ON clip_embeddings FOR SELECT TO anon USING (true);
+
+DROP POLICY IF EXISTS clip_embeddings_auth_select ON clip_embeddings;
+CREATE POLICY clip_embeddings_auth_select ON clip_embeddings FOR SELECT TO authenticated USING (true);
+
+REVOKE INSERT, UPDATE, DELETE ON clip_embeddings FROM PUBLIC;
+REVOKE INSERT, UPDATE, DELETE ON clip_embeddings FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON clip_embeddings FROM anon;
+
+COMMIT;
+
+-- ───────────────────── Post-flight verification ─────────────────────
+--
+-- Anon SELECT should still return rows for catalog reads:
+--   curl -sS "$SUPABASE_URL/rest/v1/entities?select=id,name,type&limit=2" \
+--     -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY"
+--   -- expect: 200 with rows
+--
+-- Anon INSERT should be denied:
+--   curl -sS -X POST "$SUPABASE_URL/rest/v1/entities" \
+--     -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+--     -H "Content-Type: application/json" \
+--     -d '{"id":"probe-deleteme","name":"probe","type":"person"}'
+--   -- expect: 401 / 42501 permission denied


### PR DESCRIPTION
## SQL-only PR — no code changes

The SQL migration was **applied to production on 2026-05-25** before this PR. No application code needs to change: the public site already reads via the anon client, and the new anon SELECT policy keeps that working. The change is purely in what anon is *not* allowed to do (INSERT/UPDATE/DELETE).

## What this closes

Phase 4 of #1981 — public catalog tables that were anon-readable *and* anon-writable. Anyone with the public JS bundle's anon key could mutate the encyclopedia, the semantic search index, or the visual similarity index.

| Table | Rows | Read by | Written by |
|---|---|---|---|
| \`entities\` | 856,539 | encyclopedia, explore, author pages, MCP server | \`scripts/workers/sync-entities.mjs\` (service-role) |
| \`book_embeddings\` | semantic vectors | \`/api/search/semantic\`, \`/api/search/unified\` | \`scripts/workers/enrich-worker.mjs\` + backfill (service-role) |
| \`artwork_embeddings\` | semantic vectors | \`/api/search/unified\`, \`src/lib/semantic-search.ts\` | backfill scripts (service-role) |
| \`clip_embeddings\` | 101,981 | \`/api/identify\`, \`/api/gallery/similar\` | backfill scripts (service-role) |

After this PR: each table has \`ENABLE ROW LEVEL SECURITY\` plus three policies — service_role FOR ALL, anon FOR SELECT, authenticated FOR SELECT. INSERT/UPDATE/DELETE are revoked from anon/authenticated/public at the GRANT level as belt-and-braces.

## Pattern difference from Phase 1 (#1997) and Phase 2 (#2001)

Phase 1 + 2 locked down PII / telemetry — anon has *no* access. Phase 4 locks down public catalog — anon has *read* access but no write access. The catalog is genuinely public per the product, but writes should be exclusively the workers' job.

## Verification

\`\`\`bash
# Anon SELECT should still return rows
for tbl in entities book_embeddings artwork_embeddings clip_embeddings ; do
  curl -sS -o /dev/null -w "$tbl: HTTP %{http_code}\n" \
    "$SUPABASE_URL/rest/v1/$tbl?select=*&limit=1" \
    -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY"
done
# All 4 returned HTTP 200 ✓

# Anon INSERT should be denied
curl -sS -X POST "$SUPABASE_URL/rest/v1/entities" \
  -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
  -H "Content-Type: application/json" \
  -d '{"id":"probe-deleteme","name":"probe","type":"person"}'
# Returned: HTTP 401 "permission denied for table entities" ✓
\`\`\`

## What's left in #1981

Only **Phase 3** remains: \`library_catalog_records\` — needs tenant-aware RLS (not just service-role lockdown — the catalog IS public per-tenant, but cross-tenant reads must be blocked per CLAUDE.md's tenant invariants). Bigger design work, separate PR with a design proposal before code.

## References

- Tracker: #1981
- Sibling PRs: #1997 (Phase 1, merged), #2001 (Phase 2, merged today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)