### PR TITLE
Follow-ups: RLS Phase 3 design doc + UBN-collision triage helper

### DIFF
--- a/.claude/docs/rls-phase3-tenant-aware-design.md
+++ b/.claude/docs/rls-phase3-tenant-aware-design.md
@@ -1,0 +1,141 @@
+# RLS Phase 3: `library_catalog_records` lockdown — design (2026-05-25)
+
+**Status:** design proposal for #1981 Phase 3. Not yet implemented.
+
+## The problem
+
+`library_catalog_records` is currently anon-readable via the public anon key. After Phases 1 / 2 / 4 (all merged 2026-05-25), this is the only remaining table in issue #1981 with the original exposure.
+
+Quick anon probe (still 200 as of 2026-05-25 21:39 UTC):
+
+```bash
+curl -sS "$SUPABASE_URL/rest/v1/library_catalog_records?select=*&limit=1" \
+  -H "apikey: $SUPABASE_ANON_KEY" -H "Authorization: Bearer $SUPABASE_ANON_KEY"
+# returns: HTTP 200 + row with full bibliographic + tenant_id
+```
+
+Today only `kloss-collection` data lives here (1,614 rows). The exposure is low-impact while only one tenant is in the table — but the design needs to be settled **before** more tenants (Jung, BPH State, partner libraries from #1878 Phase 6+) start populating it, because once cross-tenant data is there a misfire becomes a real cross-tenant leak.
+
+## Why Phase 3 is different from Phases 1 / 2 / 4
+
+| | Phase 1 (PII) | Phase 2 (telemetry) | Phase 4 (public catalog) | Phase 3 (library_catalog_records) |
+|---|---|---|---|---|
+| Who reads it? | App server only | App server only | Public site (anon) | Public site (anon, **scoped to one tenant per request**) |
+| What goes wrong with anon SELECT? | Visitor PII leak | AI cost surveillance | Anon could mutate the catalog | Anon could read **other tenants'** catalogs |
+| Solution | `service_role`-only | `service_role`-only | anon SELECT + REVOKE writes | (this design) |
+
+Phase 3 is the only one where the legitimate access path is per-tenant: each request needs to read **just that tenant's** rows.
+
+## Constraints from CLAUDE.md
+
+The "Tenant Subdomain Lockdown" section is unambiguous:
+
+> 2. **Every server query touching a tenant page filters by tenant.** When rendered under `/embed/[tenant]/*` or `/[tenant]/*` with a tenant subdomain host, all data fetches must include the tenant constraint. The default for `held_by` / `image_source.provider` (Supabase) and `tenantId` (Atlas) is GLOBAL — explicit filtering is required.
+
+Today every `library_catalog_records` query already complies — they all `.eq('tenant_id', tenant)`. The bug class is "a future query forgets to filter" — solvable in code review, but RLS is the architectural belt-and-braces.
+
+## Consumers (full audit, 2026-05-25)
+
+Every server-side caller of `library_catalog_records`:
+
+| File | Operation | Tenant filter | Client |
+|---|---|---|---|
+| `src/app/api/catalog/[tenant]/route.ts` | SELECT with search/filter | `.eq('tenant_id', tenant)` ✓ | anon `supabase` |
+| `src/app/api/cron/sync-catalog-sl-book-ids/route.ts` | SELECT + UPDATE | (per tenant, looped) | anon `supabase` |
+| `src/lib/tenant-library-loaders.ts` | SELECT count + per-row reads | `.eq('tenant_id', tenantSlug)` ✓ | anon `supabase` |
+| `src/lib/library-partners.ts` | SELECT (catalog-id → sl_book_id map) | `.eq('tenant_id', tenant)` ✓ | anon `supabase` |
+| `src/app/embed/[tenant]/catalog/[ubn]/page.tsx` | SELECT one row | implicit via URL params | anon `supabase` (server-rendered) |
+| `src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx` | renders fetched row | n/a | n/a |
+| `src/app/[tenant]/page.tsx` | server-rendered tenant home | `.eq('tenant_id', tenant)` ✓ | anon `supabase` |
+| `src/components/libraries/CatalogBrowser.tsx` | comment only, fetches via API | n/a (fetches `/api/catalog/[tenant]`) | n/a |
+| `src/components/libraries/SharedLibraryView.tsx` | comment only, fetches via API | n/a | n/a |
+
+**Zero direct client-side queries.** All access is server-rendered or via API routes that already filter by tenant.
+
+Writer: `scripts/migration/backfill-library-catalog-records-from-bph.mjs` or similar (when Kloss / other tenants are imported) — service-role.
+
+## Four options considered
+
+### Option 1: JWT-claim-based RLS — REJECTED
+
+Encode `tenant_id` in the JWT, use `USING (tenant_id = (auth.jwt() ->> 'tenant_id'))`.
+
+**Why this doesn't work for us:** the catalog is publicly accessible without auth. Anonymous visitors browsing `kloss.sourcelibrary.org/catalog` have **no JWT** — the anon key has no embedded claims. Adding "users must sign in to see the catalog" contradicts the product (the catalog is public per-tenant).
+
+A variant — a custom JWT minted per-request by the app with the tenant_id baked in — would require coordinating JWT minting with every server-rendered page. Substantial code change for marginal benefit over Option 2.
+
+### Option 2: Request-header-based RLS — REJECTED
+
+PostgREST exposes incoming HTTP headers to RLS policies via `current_setting('request.headers')::json`. The app sets `X-Tenant-Id` on every catalog read; the policy filters on it.
+
+**Why this doesn't work:** the anon key allows arbitrary direct PostgREST calls. A malicious client can simply omit the header (or set whatever value they want). The policy can't tell "header from app" vs "header from curl". This isn't a security control at all when the client controls the key.
+
+### Option 3: SECURITY DEFINER RPC functions — REJECTED for scope
+
+Define `get_catalog(tenant_text, ...)` and `get_catalog_entry(tenant_text, ubn)` as `SECURITY DEFINER` PL/pgSQL functions; lock the underlying table to `service_role` only; grant `EXECUTE` on the functions to `anon`. The function bodies enforce the tenant filter.
+
+**Why not now:** strongest invariant, but it forces a refactor of 6+ consumer files into RPC calls (`supabase.rpc('get_catalog', { tenant_text: tenant, ... })`). The current ad-hoc query DSL with chained `.eq()`, `.ilike()`, `.or()`, `.range()`, `.order()` is hard to reproduce as a function signature; would need to either pass JSON params or define multiple specialized functions. Worth doing eventually if we add more tenant-aware tables, but disproportionate for one table that already has consistent app-side filtering.
+
+### Option 4: Service-role-only + app-layer filter (Phase 1/2 model) — RECOMMENDED
+
+Lock `library_catalog_records` to `service_role` only — same as `gemini_usage` and `analytics_pageviews`. Switch the 6 consumer files from `supabase` to `supabaseAdmin`. The app-layer `.eq('tenant_id', tenant)` filter remains as the per-request boundary; the DB layer enforces that only the app (not direct anon callers) can read at all.
+
+**Pros:**
+- Same playbook as Phases 1 / 2. Predictable, tested today.
+- Closes the "direct PostgREST with anon key" attack vector entirely.
+- App-layer tenant filter stays as the security boundary (which it already is — every consumer already filters).
+- No client-side regressions: no client code queries this table directly today, and the API route at `/api/catalog/[tenant]` is the canonical access path.
+
+**Cons:**
+- The tenant filter remains a code-review concern (developer must remember to `.eq('tenant_id', tenant)`). RLS doesn't enforce it at the DB level.
+- If we ever need direct anon-readable per-tenant access (e.g., for a static catalog embed on a partner site), we'd need to revisit.
+
+**Mitigation for the code-review concern:** add a CI lint that fails the build if `from('library_catalog_records')` appears anywhere without `.eq('tenant_id', ...)` within the next ~10 lines (or wrap the table access in a helper `loadCatalogRecords(tenant: string, ...)` that bakes the filter in).
+
+## Recommended migration plan
+
+Mirror Phases 1 / 2:
+
+1. **Audit code** (done above): 6 consumer files use `supabase.from('library_catalog_records')`.
+
+2. **SQL migration** (`scripts/migration/rls-lockdown-phase3-catalog.sql`):
+   ```sql
+   BEGIN;
+   ALTER TABLE library_catalog_records ENABLE ROW LEVEL SECURITY;
+   CREATE POLICY library_catalog_records_service_all
+     ON library_catalog_records FOR ALL TO service_role USING (true) WITH CHECK (true);
+   REVOKE SELECT, INSERT, UPDATE, DELETE ON library_catalog_records FROM PUBLIC;
+   REVOKE SELECT, INSERT, UPDATE, DELETE ON library_catalog_records FROM authenticated;
+   REVOKE SELECT, INSERT, UPDATE, DELETE ON library_catalog_records FROM anon;
+   COMMIT;
+   ```
+
+3. **Code changes** (6 files):
+   - `src/app/api/catalog/[tenant]/route.ts` — `supabase` → `supabaseAdmin`, add null guard
+   - `src/app/api/cron/sync-catalog-sl-book-ids/route.ts` — same
+   - `src/lib/tenant-library-loaders.ts` — same
+   - `src/lib/library-partners.ts` — same
+   - `src/app/embed/[tenant]/catalog/[ubn]/page.tsx` — same
+   - `src/app/[tenant]/page.tsx` — same
+
+4. **Optional belt-and-braces:** add a `loadCatalogRecord(supabaseAdmin, tenant, ubn)` helper in `tenant-library-loaders.ts` that bakes in `tenant_id`. Migrate consumers to it over time. (Could be its own follow-up.)
+
+5. **Verify post-apply:**
+   - Anon probe: `library_catalog_records?select=*&limit=1` with anon key returns **401** (was 200).
+   - Per-tenant API still works: `/api/catalog/kloss-collection?limit=5` returns Kloss rows.
+   - Cross-tenant attempt (forge a different tenant param) returns the requested tenant's rows only — same as before; the app's `.eq` filter still enforces.
+
+## Expected effort
+
+~1-2 hours, mirroring Phases 1 / 2 timing. Most of the work is the code switch in 6 files plus null guards; the SQL is ~10 lines.
+
+## Decision
+
+Proposing **Option 4** for implementation. It closes the public exposure cleanly with the same proven pattern, doesn't lock us out of future tenants joining the table, and leaves the application-layer tenant filter as the per-request boundary. If we later want stronger guarantees (e.g., Option 3 RPC functions), we can layer them on without undoing this work.
+
+## References
+
+- Issue #1981 (parent, 4-phase plan)
+- PRs #1997 (Phase 1), #2001 (Phase 2), #2003 (Phase 4)
+- CLAUDE.md "Tenant Subdomain Lockdown — CRITICAL"
+- Constraint discovered: server-side filter pattern is already universal across the 6 consumers; no client-side direct reads

--- a/scripts/maintenance/bph-memorix-ubn-collision-triage.mjs
+++ b/scripts/maintenance/bph-memorix-ubn-collision-triage.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Triage helper for the 167 UBN-collision records logged during the
+ * 2026-05-25 BPH Memorix sync (Step 4 of PR #1975).
+ *
+ * Background:
+ *   Memorix's XML has 163 duplicate UBNs upstream — the same UBN appears
+ *   under two different UUIDs. Our `bph_works.ubn` has UNIQUE (required by
+ *   the FK from bph_works_revisions), so 167 of the 467 "new printed" rows
+ *   would have tripped a unique-constraint violation. Per Derek's call
+ *   during the apply, we skipped them and logged the conflicts to:
+ *
+ *     .claude/docs/bph-memorix-step4-ubn-collisions-2026-05-19.json
+ *
+ *   This script reads that log, pulls the DB title for each conflicting
+ *   row, computes title similarity, and emits a TSV that a librarian
+ *   (Jose / Paul / a curator) can edit to decide per UBN.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/bph-memorix-ubn-collision-triage.mjs \
+ *     > .claude/docs/bph-memorix-ubn-collision-triage.tsv
+ *
+ *   # Then open the TSV in a spreadsheet, fill in the `decision` column
+ *   # (merge / replace / split / leave), and pass to the apply helper
+ *   # (a separate follow-up — not included here, awaits design).
+ *
+ * Output columns (TSV — tab-separated so titles with commas survive):
+ *   ubn                  — the colliding UBN
+ *   xml_uuid             — UUID of the Memorix record we skipped
+ *   db_uuid              — UUID of the existing DB row that won the UBN
+ *   xml_title            — title from the Memorix XML
+ *   db_title             — title currently in bph_works under that UBN
+ *   title_similarity     — 0.0–1.0 (Jaccard over normalized tokens)
+ *   recommendation       — auto-classified: "merge" / "review" / "different"
+ *   decision             — left blank for the librarian
+ *   notes                — left blank for the librarian
+ *
+ * Issue: #1992
+ */
+
+import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    'input': { type: 'string', default: '.claude/docs/bph-memorix-step4-ubn-collisions-2026-05-19.json' },
+    'help': { type: 'boolean', default: false },
+  },
+});
+
+if (args.help) {
+  console.log(readFileSync(import.meta.filename, 'utf8').split('\n').slice(1, 45).join('\n').replace(/^ \* ?/gm, ''));
+  process.exit(0);
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+// ---------- Load the collision log ----------
+const log = JSON.parse(readFileSync(args.input, 'utf8'));
+const collisions = log.collisions;
+process.stderr.write(`Loaded ${collisions.length} collisions from ${args.input}\n`);
+
+// ---------- Fetch DB titles in bulk (chunked uuid IN-list) ----------
+const dbUuids = [...new Set(collisions.map(c => c.existingDbUuid))];
+const titleByUuid = new Map();
+const CHUNK = 100;
+for (let i = 0; i < dbUuids.length; i += CHUNK) {
+  const slice = dbUuids.slice(i, i + CHUNK).map(encodeURIComponent).join(',');
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/bph_works?select=uuid,title,parallel_title,uniform_title&uuid=in.(${slice})`,
+    {
+      headers: {
+        apikey: SUPABASE_KEY,
+        Authorization: `Bearer ${SUPABASE_KEY}`,
+      },
+    }
+  );
+  if (!res.ok) {
+    const txt = await res.text();
+    console.error(`Supabase fetch failed: ${res.status} ${txt.slice(0, 200)}`);
+    process.exit(1);
+  }
+  const rows = await res.json();
+  for (const r of rows) {
+    titleByUuid.set(r.uuid, r.title || r.parallel_title || r.uniform_title || '');
+  }
+  process.stderr.write(`  fetched ${Math.min(i + CHUNK, dbUuids.length)}/${dbUuids.length} db titles\r`);
+}
+process.stderr.write('\n');
+
+// ---------- Title similarity (Jaccard over normalized tokens) ----------
+function normalize(s) {
+  return (s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip diacritics
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ') // strip punctuation
+    .split(/\s+/)
+    .filter(t => t.length >= 2); // drop 1-char fragments + empties
+}
+
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'of', 'in', 'and', 'or', 'on', 'at', 'to', 'for',
+  'with', 'by', 'as', 'is', 'das', 'der', 'die', 'des', 'den', 'dem',
+  'de', 'la', 'le', 'les', 'un', 'une', 'du', 'et', 'en', 'il', 'lo',
+  'van', 'op', 'het', 'om', 'naar', 'uit',
+]);
+
+function jaccard(a, b) {
+  const A = new Set(normalize(a).filter(t => !STOPWORDS.has(t)));
+  const B = new Set(normalize(b).filter(t => !STOPWORDS.has(t)));
+  if (A.size === 0 && B.size === 0) return 1;
+  if (A.size === 0 || B.size === 0) return 0;
+  let inter = 0;
+  for (const t of A) if (B.has(t)) inter++;
+  const union = A.size + B.size - inter;
+  return inter / union;
+}
+
+// Hand-classified thresholds — empirically these capture "same work" cases
+// well in the 91 same-title sample and flag the 76 different-title cases.
+function recommend(sim) {
+  if (sim >= 0.85) return 'merge';      // nearly identical titles
+  if (sim >= 0.55) return 'review';     // shared core tokens, may be same work with expanded title
+  return 'different';                   // disjoint token sets, very likely different works
+}
+
+// ---------- Emit TSV ----------
+const rows = [];
+const counts = { merge: 0, review: 0, different: 0 };
+for (const c of collisions) {
+  const dbTitle = titleByUuid.get(c.existingDbUuid) || '';
+  const sim = jaccard(c.title, dbTitle);
+  const rec = recommend(sim);
+  counts[rec]++;
+  rows.push({
+    ubn: c.ubn,
+    xml_uuid: c.xmlUuid,
+    db_uuid: c.existingDbUuid,
+    xml_title: c.title,
+    db_title: dbTitle,
+    title_similarity: sim.toFixed(2),
+    recommendation: rec,
+    decision: '',
+    notes: '',
+  });
+}
+
+const HEADERS = ['ubn', 'xml_uuid', 'db_uuid', 'xml_title', 'db_title', 'title_similarity', 'recommendation', 'decision', 'notes'];
+console.log(HEADERS.join('\t'));
+// Sort by recommendation (review first so the librarian sees the ambiguous ones)
+// then by similarity ascending within each bucket so the most uncertain land at the top.
+const order = { review: 0, different: 1, merge: 2 };
+rows.sort((a, b) => {
+  const r = order[a.recommendation] - order[b.recommendation];
+  if (r !== 0) return r;
+  return parseFloat(a.title_similarity) - parseFloat(b.title_similarity);
+});
+for (const r of rows) {
+  console.log(HEADERS.map(h => String(r[h]).replace(/\t/g, ' ').replace(/\n/g, ' ')).join('\t'));
+}
+
+// ---------- Summary to stderr (so it doesn't pollute the TSV) ----------
+process.stderr.write(`\nSummary:\n`);
+process.stderr.write(`  recommend MERGE     (sim ≥ 0.85): ${counts.merge}\n`);
+process.stderr.write(`  recommend REVIEW    (0.55 ≤ sim < 0.85): ${counts.review}\n`);
+process.stderr.write(`  recommend DIFFERENT (sim < 0.55): ${counts.different}\n`);
+process.stderr.write(`  total: ${rows.length}\n`);
+process.stderr.write(`\nNext: open the TSV in a spreadsheet, fill the 'decision' column with one of:\n`);
+process.stderr.write(`  merge   — replace the old DB uuid with the XML uuid; keep the existing row\n`);
+process.stderr.write(`  replace — delete the old DB row, insert the XML record fresh\n`);
+process.stderr.write(`  split   — both are valid; needs schema change (drop UNIQUE on ubn)\n`);
+process.stderr.write(`  leave   — DB is correct; XML row is upstream noise, skip the import\n`);


### PR DESCRIPTION
## Two non-deploy artifacts from today's BPH Memorix + RLS lockdown work

### 1. \`.claude/docs/rls-phase3-tenant-aware-design.md\`

Design proposal for the last open phase of #1981 — \`library_catalog_records\`, the only table that's still anon-readable after today's PRs #1997, #2001, #2003 closed Phases 1, 2, and 4.

The doc:

- Audits all 6 server-side consumers of \`library_catalog_records\`. Confirms zero direct client-side queries; the two client components (\`CatalogBrowser\`, \`SharedLibraryView\`) fetch via the \`/api/catalog/[tenant]\` route. All callers already use \`.eq('tenant_id', tenant)\`.
- Evaluates four options for tenant-aware RLS:
  - Option 1 (JWT-claim RLS) — rejected: catalog is public, no per-user JWT
  - Option 2 (request-header RLS) — rejected: anon-key clients control headers
  - Option 3 (SECURITY DEFINER RPC functions) — rejected for scope (forces refactoring the chained \`.eq()\`/\`.ilike()\`/\`.or()\` DSL into function calls)
  - **Option 4 (service-role + app-layer filter)** — recommended: same playbook as Phases 1/2, closes the public exposure cleanly, leaves the app's existing \`.eq('tenant_id', ...)\` as the per-request boundary
- Includes the SQL skeleton (~10 lines) and a 6-file code migration plan (mostly \`supabase\` → \`supabaseAdmin\` with null guards)
- Notes the residual code-review concern (developer must remember to filter; suggests a future helper \`loadCatalogRecord(tenant, ...)\` or a CI lint)

Estimated effort to implement: 1-2 hours, mirroring Phases 1/2 timing. Not implemented in this PR — this is the design.

### 2. \`scripts/maintenance/bph-memorix-ubn-collision-triage.mjs\`

Triage helper for #1992. The 2026-05-25 Memorix sync skipped 167 records due to UBN unique-constraint collisions (Memorix XML had 163 duplicate UBNs upstream). The full log is at \`.claude/docs/bph-memorix-step4-ubn-collisions-2026-05-19.json\` and needs per-UBN librarian decisions.

The helper:

1. Reads the JSON.
2. Pulls the current DB title for each colliding row (bulk fetch via service-role).
3. Computes Jaccard token similarity (stopword-filtered, diacritic-stripped, lowercased) between the XML title and DB title.
4. Emits a TSV with columns: ubn, xml_uuid, db_uuid, xml_title, db_title, title_similarity, recommendation, decision, notes.
5. Auto-classifies into \`merge\` / \`review\` / \`different\` so the librarian can dispatch the easy cases quickly.

**Production test run (2026-05-25):**

| Bucket | Count | Threshold |
|---|---|---|
| merge | 70 | sim ≥ 0.85 — almost certainly same work, librarian glance + bulk approve |
| review | 16 | 0.55 ≤ sim < 0.85 — needs librarian judgment per UBN |
| different | 81 | sim < 0.55 — disjoint token sets, likely actually different works (UBN reuse upstream) |

Output sorted with ambiguous cases (review) first so the hardest ones land at the top.

Usage:

\`\`\`bash
set -a; source .env.production.local; set +a
node scripts/maintenance/bph-memorix-ubn-collision-triage.mjs \\
  > .claude/docs/bph-memorix-ubn-collision-triage.tsv
\`\`\`

The librarian opens the TSV in a spreadsheet, fills in the \`decision\` column (\`merge\` / \`replace\` / \`split\` / \`leave\`), and saves. The apply step (read the filled TSV and execute decisions against \`bph_works\`) is a separate follow-up — not in this PR, awaits the librarian's first pass and a clearer mandate on what \`split\` means schema-wise.

## What this doesn't change

- No production behavior changes (one doc + one script, no consumer code touched).
- No SQL applied to production.
- \`library_catalog_records\` remains anon-readable until Phase 3 is implemented per the design doc.

## References

- Open issues: #1981 (RLS gap, Phase 3 remaining), #1992 (UBN triage)
- Sibling merged today: #1975 (Memorix sync), #1997 (Phase 1), #2001 (Phase 2), #2003 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)