### PR TITLE
fix(pages-grid): sharp thumbnails for landscape (pecha) pages

### DIFF
--- a/src/components/book/BookPagesSection.tsx
+++ b/src/components/book/BookPagesSection.tsx
@@ -7,7 +7,7 @@ import type { JobType, Job } from '@/lib/types/job';
 import type { ActionType } from './ProcessingPanel';
 import { prompts as promptsApi, jobs, books } from '@/lib/api-client';
 import { queueBooks } from '@/lib/api-client/queues';
-import { getPageThumbUrl } from '@/lib/utils';
+import { getPageGridUrl } from '@/lib/utils';
 import { buildCoverUpdate } from '@/lib/cover-fields';
 import JobStatusBanner from './JobStatusBanner';
 import PagesGrid from './PagesGrid';
@@ -479,7 +479,7 @@ export default function BookPagesSection({ bookId, bookTitle, pages: initialPage
     }
   };
 
-  const getImageUrl = (page: Page) => getPageThumbUrl(page);
+  const getImageUrl = (page: Page) => getPageGridUrl(page);
 
   return (
     <div className="space-y-6">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -217,6 +217,26 @@ export function getPageDisplayUrl(page: Record<string, any>, width = 1200, quali
 }
 
 /**
+ * Pick a grid thumbnail URL appropriate to the page's aspect ratio.
+ * Landscape pages (e.g. Bhutanese pecha folios at 1200x800) blur when
+ * forced into a portrait cell with `object-cover` — the 150px thumb
+ * gets upscaled to fit the cell's height before being cropped to width.
+ * For those pages we serve a 400px variant through the /api/image proxy
+ * (Cloudflare-cached); portrait pages keep the existing 150px thumb.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getPageGridUrl(page: Record<string, any>): string | null {
+  const w = page.image_width;
+  const h = page.image_height;
+  const isLandscape = typeof w === 'number' && typeof h === 'number' && h > 0 && w / h > 1.2;
+  if (!isLandscape) return getPageThumbUrl(page);
+
+  const baseUrl = page.archived_photo || page.photo_original || page.photo;
+  if (!baseUrl || isArchiveFailed(baseUrl)) return getPageThumbUrl(page);
+  return `/api/image?url=${encodeURIComponent(baseUrl)}&w=400&q=70`;
+}
+
+/**
  * Get the best thumbnail (150px) URL for a page.
  * Prefers pre-rendered thumbnail from R2 CDN.
  */


### PR DESCRIPTION
## Summary
Book detail pages show 24 cells of `aspect-[3/4]` portrait, with `object-cover`. For pages that are intrinsically landscape — Bhutanese pecha folios at 1200×800 — the source `-thumb.jpg` (150×100) gets height-fit into the portrait cell, which means upscaling 1.6× before the crop, then losing the sides. Result: 1,325 books with completely unreadable manuscript thumbnails.

Diagnosed by measuring:
- `0001-thumb.jpg`: 150×100, 2.4 KB
- Cell: ~120×160 (3:4 portrait)
- Fit-to-height of a 1.5 landscape source → 240×160 → cropped to 120×160 → ~1.6× upscale of an already-tiny thumb

Fix: a new `getPageGridUrl(page)` helper in `src/lib/utils.ts` that detects landscape pages from `image_width / image_height > 1.2` (already populated on every bhutan page) and routes them through the existing `/api/image?url=…&w=400&q=70` proxy. ~25-40 KB per cell, Cloudflare-cached. Portrait pages keep the existing 150 px direct-from-R2 thumb, so codex books (BPH and others) see zero bandwidth change.

`BookPagesSection.tsx` switches its `getImageUrl` from `getPageThumbUrl` to `getPageGridUrl`.

## Test plan
- [ ] Preview deploy green
- [ ] `https://bhutan.sourcelibrary.org/book/<any>` — page grid renders sharp, readable manuscript folios
- [ ] BPH book page grid (`bph.sourcelibrary.org/book/<any>`) still uses the small thumb (no regression in bandwidth or rendering)
- [ ] `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)