### PR TITLE
fix: batch-collector page_count + CLAUDE.md stack refresh (Q1+Q2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Source: `src/lib/auth.ts` (cookies block). See `.claude/docs/auth-tenant-cookies
 
 ## Stack
 - Next.js 16, MongoDB Atlas, Gemini AI, Vercel deployment
-- Production database: `bookstore` (~17K live books, ~24.5K warehouse), NOT `sourcelibrary_research`
+- Production database: `bookstore`, NOT `sourcelibrary_research`. As of 2026-05-26: ~46K total docs, ~29K `visible: true` (publicly shown), ~15K with `pages_count > 0` (actually processed), ~14K with any OCR. The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking, seeded by `scripts/tmp-write-highlighted-books.mjs`); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
 
 ## AI Models — IMPORTANT
 - Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite-preview` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -600,13 +600,16 @@ async function processOneJob(db, job) {
       }
     );
 
-    // Log to Supabase gemini_usage (non-blocking)
+    // Log to Supabase gemini_usage (non-blocking).
+    // page_count: prefer the batch's own page_count (always populated on batch_jobs).
+    // successCount tracks DB matchedCount which is 0 for re-collected batches.
     logUsageAsync({
       type: job.type || 'ocr',
       mode: 'batch',
       model: job.model,
       book_id: job.book_id,
-      page_count: successCount,
+      page_ids: job.page_ids,
+      page_count: job.page_count || job.page_ids?.length || successCount,
       input_tokens: totalInputTokens,
       output_tokens: totalOutputTokens,
       cost_usd: costUsd,


### PR DESCRIPTION
## Summary

Carbon-audit handoff `.claude/handoffs/2026-05-25-pipeline-data-questions.md` flagged three blocking issues. This PR fixes Q1 + Q2; Q3 (Visual books in OCR) deferred for separate consideration (would need a backfill audit).

### Q1 — `gemini_usage` `type=translation` page-credit ratio of 0.45

**Root cause:** `scripts/workers/batch-collector.mjs:603` logged
```
page_count: successCount
```
where `successCount` is `pages.bulkWrite().matchedCount`. For batches whose results were already collected (re-runs, recovery passes), matchedCount is 0 even though the batch did the Gemini work and tokens/cost are non-zero. Result: **15,940 of 15,942 mode=batch type=translation records have page_count missing or zero** in the live Supabase `gemini_usage` table.

**Fix:** prefer `job.page_count` (always populated on `batch_jobs` — verified across all 1,386 saved + 276 archived translation batches), fall back through `page_ids.length` and lastly `successCount`. Also pass `page_ids` to the logger so its existing fallback works.

**Investigation note — second source of low-pageCount records:** ~526K realtime translation records logged via `worker/hetzner-translate(-batch)` are also missing `page_count`. These are **pre-2026-04-10 historical records** written by the legacy direct-Mongo writer before the supabase-usage-logger migration in #944 added the `page_ids.length` fallback. Active code paths since the migration are correct. A separate backfill could populate `page_count` from `page_ids` on those Mongo docs if the historical numbers matter for analytics, but no active code change is needed.

### Q2 — `tier` field stale; "17K live, 24.5K warehouse" wrong

**Root cause:** `tier` is only used in `src/app/page.tsx:73` for homepage-carousel ranking, and only written by the seed script `scripts/tmp-write-highlighted-books.mjs`. It was never a warehouse/live distinction. The canonical "live books" filter across all public APIs is `visible: true && pages_count > 0`.

**Real counts (queried 2026-05-26):**
- 45,712 total
- 28,572 visible
- 14,977 visible + pages_count > 0 ← canonical "live"
- 14,838 visible + pages_ocr > 0

**Fix:** CLAUDE.md stack block refreshed with accurate counts and a pointer to the canonical filter.

A separate sibling PR (in carbon-sourcelibrary, commit `d5078ad`) replaces the "17,000-book library" framing in the carbon blog with "~29K visible / ~15K processed" / "roughly 15,000 books" / a 15,000 multiplier in PathPicker.

## Out of scope
- Q3 (OCR filter for `language='Visual'`). Recommend a separate PR with a backfill audit script — many of the 14,544 Visual books may already have produced OCR garbage that we'd want to clean up, not just stop generating.
- Backfill of historical `page_count` on Mongo gemini_usage. Optional follow-up.

## Test plan
- [ ] Next batch-collector run logs a `gemini_usage` row with realistic page_count (verify against any `batch_jobs` doc that completes in next 10-min window)
- [ ] Translation page-credit ratio in `gemini_usage_daily` trends back toward 1.0+ over the coming days