### PR TITLE
feat(catalogue): dedicated catalogue route for bhutan tenant

### DIFF
--- a/src/app/embed/[tenant]/catalogue/page.tsx
+++ b/src/app/embed/[tenant]/catalogue/page.tsx
@@ -1,0 +1,123 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { supabase } from '@/lib/supabase';
+import { getDb } from '@/lib/mongodb';
+import TenantCatalogueTable, { type CatalogueRow, type CatalogueSort } from '@/components/libraries/TenantCatalogueTable';
+
+interface Props {
+  params: Promise<{ tenant: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+const PAGE_SIZE = 100;
+const VALID_SORTS: ReadonlySet<CatalogueSort> = new Set([
+  'title', 'title_desc',
+  'author', 'author_desc',
+  'pages', 'pages_desc',
+  'translation', 'translation_desc',
+  'ocr', 'ocr_desc',
+  'shelfmark',
+]);
+
+function parseSort(raw: string | undefined): CatalogueSort {
+  if (raw && VALID_SORTS.has(raw as CatalogueSort)) return raw as CatalogueSort;
+  return 'title';
+}
+
+function parsePage(raw: string | undefined): number {
+  const n = Math.max(1, parseInt(raw || '1', 10));
+  return Number.isFinite(n) ? n : 1;
+}
+
+// Supabase column to order by + ascending flag. `pages`, `ocr`, `translation`
+// sort on raw counts (pages_count, pages_ocr, pages_translated) rather than
+// computed percentages — close enough for sort intent and avoids a generated
+// column. `shelfmark` orders by source_url which mirrors the EAP shelfmark
+// embedded in the URL (EAP039-1-2-1 sorts naturally).
+function applySort(query: ReturnType<typeof supabase.from>, sort: CatalogueSort) {
+  switch (sort) {
+    case 'title':           return query.order('sort_title', { ascending: true });
+    case 'title_desc':      return query.order('sort_title', { ascending: false });
+    case 'author':          return query.order('author', { ascending: true, nullsFirst: false });
+    case 'author_desc':     return query.order('author', { ascending: false, nullsFirst: false });
+    case 'pages':           return query.order('pages_count', { ascending: true });
+    case 'pages_desc':      return query.order('pages_count', { ascending: false });
+    case 'translation':     return query.order('pages_translated', { ascending: true });
+    case 'translation_desc':return query.order('pages_translated', { ascending: false });
+    case 'ocr':             return query.order('pages_ocr', { ascending: true });
+    case 'ocr_desc':        return query.order('pages_ocr', { ascending: false });
+    case 'shelfmark':       return query.order('source_url', { ascending: true });
+  }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { tenant } = await params;
+  const db = await getDb();
+  const tenantDoc = await db.collection('tenants').findOne({ slug: tenant });
+  const name = tenantDoc?.name || tenant;
+  return {
+    title: `Catalogue — ${name}`,
+    description: `Full catalogue of manuscripts in the ${name} collection.`,
+  };
+}
+
+export default async function TenantCataloguePage({ params, searchParams }: Props) {
+  const { tenant } = await params;
+  const sp = await searchParams;
+  const sort = parseSort(typeof sp.sort === 'string' ? sp.sort : undefined);
+  const page = parsePage(typeof sp.page === 'string' ? sp.page : undefined);
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const db = await getDb();
+  const tenantDoc = await db.collection('tenants').findOne({ slug: tenant });
+  if (!tenantDoc) notFound();
+
+  // For now this page is only meaningful for tenants whose books are mirrored
+  // to Supabase books_catalog with a parseable shelfmark in source_url. Today
+  // that's bhutan (EAP). When more tenants opt in, generalise the filter via
+  // a tenant.catalogueQuery field rather than branching here.
+  const isBhutan = tenant === 'bhutan';
+  if (!isBhutan) notFound();
+
+  const baseSelect = 'id, slug, title, display_title, author, year, language, pages_count, pages_ocr, pages_translated, source_url';
+  const countQuery = supabase.from('books_catalog').select('id', { count: 'exact', head: true })
+    .ilike('source_url', '%eap.bl.uk%')
+    .eq('visible', true)
+    .gt('pages_count', 0);
+  const dataQueryBase = supabase.from('books_catalog').select(baseSelect)
+    .ilike('source_url', '%eap.bl.uk%')
+    .eq('visible', true)
+    .gt('pages_count', 0)
+    .range(offset, offset + PAGE_SIZE - 1);
+
+  const [{ count, error: countErr }, { data, error: dataErr }] = await Promise.all([
+    countQuery,
+    applySort(dataQueryBase, sort),
+  ]);
+  if (countErr) throw new Error(`catalogue count failed: ${countErr.message}`);
+  if (dataErr) throw new Error(`catalogue fetch failed: ${dataErr.message}`);
+
+  const rows: CatalogueRow[] = (data || []) as unknown as CatalogueRow[];
+  const total = count || 0;
+  const basePath = `/catalogue`;
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-6">
+        <h1 className="text-2xl sm:text-3xl text-primary font-display">Catalogue</h1>
+        <p className="text-sm text-muted mt-1">
+          Complete catalogue of the {tenantDoc.name || tenant} collection. Click any column header to sort.
+        </p>
+      </div>
+
+      <TenantCatalogueTable
+        rows={rows}
+        total={total}
+        page={page}
+        pageSize={PAGE_SIZE}
+        sort={sort}
+        basePath={basePath}
+      />
+    </div>
+  );
+}

--- a/src/app/embed/[tenant]/catalogue/page.tsx
+++ b/src/app/embed/[tenant]/catalogue/page.tsx
@@ -34,7 +34,10 @@ function parsePage(raw: string | undefined): number {
 // computed percentages — close enough for sort intent and avoids a generated
 // column. `shelfmark` orders by source_url which mirrors the EAP shelfmark
 // embedded in the URL (EAP039-1-2-1 sorts naturally).
-function applySort(query: ReturnType<typeof supabase.from>, sort: CatalogueSort) {
+// Matches the type-loose pattern in src/lib/books-catalog.ts:applySort —
+// PostgrestFilterBuilder's generics make a precise signature impractical here.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applySort(query: any, sort: CatalogueSort): any {
   switch (sort) {
     case 'title':           return query.order('sort_title', { ascending: true });
     case 'title_desc':      return query.order('sort_title', { ascending: false });

--- a/src/components/libraries/TenantCatalogueTable.tsx
+++ b/src/components/libraries/TenantCatalogueTable.tsx
@@ -1,0 +1,171 @@
+import Link from 'next/link';
+
+export interface CatalogueRow {
+  id: string;
+  slug: string | null;
+  title: string;
+  display_title: string | null;
+  author: string | null;
+  year: number | null;
+  language: string | null;
+  pages_count: number;
+  pages_ocr: number;
+  pages_translated: number;
+  source_url: string | null;
+}
+
+export type CatalogueSort =
+  | 'title' | 'title_desc'
+  | 'author' | 'author_desc'
+  | 'pages' | 'pages_desc'
+  | 'translation' | 'translation_desc'
+  | 'ocr' | 'ocr_desc'
+  | 'shelfmark';
+
+interface Props {
+  rows: CatalogueRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+  sort: CatalogueSort;
+  /** basePath used to construct column-header links (e.g. "/catalogue"). */
+  basePath: string;
+}
+
+// Extract an EAP shelfmark like "EAP039-1-2-1" from a source_url like
+// "https://eap.bl.uk/archive-file/EAP039-1-2-1/manifest". Returns "" when
+// the pattern doesn't match.
+function eapShelfmark(sourceUrl: string | null): string {
+  if (!sourceUrl) return '';
+  const m = sourceUrl.match(/EAP\d+(?:[-_]\d+)+/i);
+  return m ? m[0] : '';
+}
+
+function pct(num: number, denom: number): string {
+  if (!denom) return '—';
+  return `${Math.round((num / denom) * 100)}%`;
+}
+
+function sortHref(basePath: string, sort: CatalogueSort, current: CatalogueSort, column: 'title' | 'author' | 'pages' | 'translation' | 'ocr' | 'shelfmark'): string {
+  const ascending = column as CatalogueSort;
+  const descending = (`${column}_desc`) as CatalogueSort;
+  const next: CatalogueSort = current === ascending ? descending : ascending;
+  // Sort param only valid for columns with a desc variant; shelfmark has no desc.
+  const isShelfmark = column === 'shelfmark';
+  const params = new URLSearchParams();
+  params.set('sort', isShelfmark ? 'shelfmark' : next);
+  return `${basePath}?${params.toString()}`;
+}
+
+function ArrowIcon({ direction }: { direction: 'asc' | 'desc' | null }) {
+  if (direction === null) return <span aria-hidden className="ml-1 text-stone-300">↕</span>;
+  return <span aria-hidden className="ml-1">{direction === 'asc' ? '↑' : '↓'}</span>;
+}
+
+function arrowFor(column: 'title' | 'author' | 'pages' | 'translation' | 'ocr', current: CatalogueSort): 'asc' | 'desc' | null {
+  if (current === column) return 'asc';
+  if (current === `${column}_desc`) return 'desc';
+  return null;
+}
+
+export default function TenantCatalogueTable({ rows, total, page, pageSize, sort, basePath }: Props) {
+  const start = (page - 1) * pageSize + 1;
+  const end = Math.min(start + rows.length - 1, total);
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const pageHref = (p: number) => {
+    const params = new URLSearchParams();
+    if (sort !== 'title') params.set('sort', sort);
+    if (p !== 1) params.set('page', String(p));
+    const qs = params.toString();
+    return qs ? `${basePath}?${qs}` : basePath;
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm text-muted">
+          Showing <span className="font-medium">{start.toLocaleString()}–{end.toLocaleString()}</span> of <span className="font-medium">{total.toLocaleString()}</span> manuscripts
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-stone-200 bg-white">
+        <table className="w-full text-sm">
+          <thead className="bg-stone-50 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium text-stone-700">
+                <Link href={sortHref(basePath, sort, sort, 'title')} className="inline-flex items-center hover:underline">
+                  Title<ArrowIcon direction={arrowFor('title', sort)} />
+                </Link>
+              </th>
+              <th className="px-3 py-2 font-medium text-stone-700">
+                <Link href={sortHref(basePath, sort, sort, 'author')} className="inline-flex items-center hover:underline">
+                  Monastery / Source<ArrowIcon direction={arrowFor('author', sort)} />
+                </Link>
+              </th>
+              <th className="px-3 py-2 font-medium text-stone-700">
+                <Link href={sortHref(basePath, sort, sort, 'shelfmark')} className="inline-flex items-center hover:underline">
+                  EAP Shelfmark<ArrowIcon direction={sort === 'shelfmark' ? 'asc' : null} />
+                </Link>
+              </th>
+              <th className="px-3 py-2 font-medium text-stone-700 text-right">
+                <Link href={sortHref(basePath, sort, sort, 'pages')} className="inline-flex items-center hover:underline">
+                  Pages<ArrowIcon direction={arrowFor('pages', sort)} />
+                </Link>
+              </th>
+              <th className="px-3 py-2 font-medium text-stone-700 text-right">
+                <Link href={sortHref(basePath, sort, sort, 'ocr')} className="inline-flex items-center hover:underline">
+                  OCR<ArrowIcon direction={arrowFor('ocr', sort)} />
+                </Link>
+              </th>
+              <th className="px-3 py-2 font-medium text-stone-700 text-right">
+                <Link href={sortHref(basePath, sort, sort, 'translation')} className="inline-flex items-center hover:underline">
+                  Translated<ArrowIcon direction={arrowFor('translation', sort)} />
+                </Link>
+              </th>
+              <th className="px-3 py-2 font-medium text-stone-700">Language</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const titleText = row.display_title || row.title;
+              const href = `/book/${row.slug || row.id}`;
+              const shelfmark = eapShelfmark(row.source_url);
+              return (
+                <tr key={row.id} className="border-t border-stone-100 hover:bg-stone-50">
+                  <td className="px-3 py-2">
+                    <Link href={href} className="text-stone-900 hover:underline">{titleText}</Link>
+                  </td>
+                  <td className="px-3 py-2 text-stone-700">{row.author || '—'}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-stone-600">{shelfmark || '—'}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{row.pages_count.toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{pct(row.pages_ocr, row.pages_count)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{pct(row.pages_translated, row.pages_count)}</td>
+                  <td className="px-3 py-2 text-stone-700">{row.language || '—'}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <nav className="mt-4 flex items-center justify-between" aria-label="Pagination">
+          <div className="text-sm text-muted">Page {page} of {totalPages}</div>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Link href={pageHref(page - 1)} className="px-3 py-1 text-sm rounded border border-stone-300 hover:bg-stone-50">
+                ← Previous
+              </Link>
+            )}
+            {page < totalPages && (
+              <Link href={pageHref(page + 1)} className="px-3 py-1 text-sm rounded border border-stone-300 hover:bg-stone-50">
+                Next →
+              </Link>
+            )}
+          </div>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -384,11 +384,21 @@ export async function proxy(request: NextRequest) {
         url.pathname = `/embed/${tenant}${pathname}`;
       }
     } else if (pathname === '/catalogue' || pathname === '/catalog') {
-      // Catalogue page on tenant subdomain — show the full library catalogue
-      // (e.g. all 28k BPH works). `/catalog` kept as legacy alias for any
-      // bookmarks or backlinks; canonical public URL is `/catalogue`.
-      url.pathname = `/embed/${tenant}`;
-      url.searchParams.set('view', 'catalog');
+      // Catalogue page on tenant subdomain.
+      //
+      // Tenants that opt into the dedicated catalogue route (manuscript
+      // collections like bhutan) are routed to `/embed/<tenant>/catalogue`.
+      // Tenants still on the BPH-style `?view=catalog` query param flow
+      // (BPH, kloss, etc.) keep the existing landing-page rewrite — they
+      // render `<UnifiedCatalogue>` / `<BphUnifiedCatalogue>` inside the
+      // landing page based on the query param.
+      const usesDedicatedCatalogue = tenant === 'bhutan';
+      if (usesDedicatedCatalogue) {
+        url.pathname = `/embed/${tenant}/catalogue`;
+      } else {
+        url.pathname = `/embed/${tenant}`;
+        url.searchParams.set('view', 'catalog');
+      }
     } else if (pathname.startsWith('/catalogue/') || pathname.startsWith('/catalog/')) {
       // Catalogue entry detail (e.g. /catalogue/12345 for UBN-keyed BPH works).
       // Both spellings forwarded to the existing `/catalog/[ubn]` route folder.


### PR DESCRIPTION
## Summary
You asked for a "catalog view that has all the metadata from the library" — this is v1: a sortable, paginated table at `bhutan.sourcelibrary.org/catalogue` showing all 1,325 bhutan manuscripts with columns useful for scholarly browsing.

### What's added
- **Route**: `src/app/embed/[tenant]/catalogue/page.tsx` — server-rendered, fetches from Supabase `books_catalog` filtered by `source_url ILIKE '%eap.bl.uk%'` (the bhutan signature, same pattern as the listing query in #1971). Paginated at 100/page.
- **Component**: `src/components/libraries/TenantCatalogueTable.tsx` — sortable column headers (?sort= query param), clickable titles linking to the book reader, EAP shelfmark parsed from `source_url` (e.g. `EAP039-1-2-1`).
- **Proxy split**: `src/proxy.ts` — `/catalogue` on the bhutan subdomain routes to the dedicated `/embed/bhutan/catalogue` page. BPH and other tenants on the existing `?view=catalog` flow keep their behavior (BphUnifiedCatalogue still renders inside the landing page).

### Columns
| Title | Monastery / Source | EAP Shelfmark | Pages | OCR | Translated | Language |

Sort by title (default), author, shelfmark, pages, OCR %, translation %. Header clicks toggle asc/desc.

### Scope of v1
- 1,325 bhutan books in one table, paginated.
- No client-side filtering yet (no monastery dropdown, no full-text search). Sortable headers only.
- Tenant-specific guard: only `tenant === 'bhutan'` renders the page; everyone else 404s. When more manuscript tenants opt in we'll generalise the filter via a `tenant.catalogueQuery` field rather than branching.

### Test plan
- [ ] Preview deploy green
- [ ] `https://bhutan.sourcelibrary.org/catalogue` renders 100 rows + pagination
- [ ] Header clicks change sort order and persist in URL
- [ ] Clicking a title navigates to the book reader and works (pairs with the tenantId backfill that just shipped — pages now actually navigate)
- [ ] `bph.sourcelibrary.org/catalogue` still hits the existing BphUnifiedCatalogue (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)