### PR TITLE
chore: drop legacy ocr_status/translation_status writes (Q4)

### DIFF
--- a/scripts/import/direct-import-cosmogony.ts
+++ b/scripts/import/direct-import-cosmogony.ts
@@ -92,8 +92,6 @@ async function importBook(client: MongoClient, book: typeof COSMOGONY_TEXTS[0]) 
     pages_count: book.page_count,
     pages_ocr: 0,
     pages_translated: 0,
-    ocr_status: 'pending',
-    translation_status: 'not_started',
     created_at: now,
     updated_at: now,
     curator_notes: book.notes


### PR DESCRIPTION
Tiny cleanup following the carbon-audit handoff (`.claude/handoffs/2026-05-25-pipeline-data-questions.md` Q4).

`books.ocr_status` and `books.translation_status` had 4 / 10 entries across 46K books — leftover from a pipeline-progress design abandoned in favor of per-page tracking. Investigation confirmed:

- Not in the Book TypeScript schema (`src/lib/types/book.ts`)
- Not read or returned by any public API on the books collection
- No cron or worker reads or writes them
- Only writer with pipeline-style values (`'pending'` / `'not_started'`) is the one-off script in this PR

## Out of scope, on purpose
- `catalog_coverage` collection legitimately uses these field names (different collection, different semantics — they're derived per-book status enums on the coverage table).
- `scripts/import/ndl-daoist-import.mjs` writes `translation_status` with editorial prose ("Partial — James Ware translated the Inner Chapters (1966)…"). Different purpose entirely; worth a rename to `external_translation_notes` in a follow-up, but not bundled here.
- The 14 books in prod that still carry the stale field. 14 records out of 46K is noise; not worth a $unset migration.

## Test plan
- [ ] `npx tsc --noEmit` — no new errors (field never was in the schema)
- [ ] Grep confirms no readers of `books.ocr_status` / `books.translation_status` exist on the books collection