### PR TITLE
fix(gallery): filter at Hetzner write paths + cleanup 6,590 empty rows

### DIFF
--- a/scripts/maintenance/cleanup-gallery-zombies.mjs
+++ b/scripts/maintenance/cleanup-gallery-zombies.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Hide zombie gallery_images rows — rows the batch-collector / image-extract-worker
+ * wrote without filtering, when Gemini returned malformed responses (no bbox,
+ * no gallery_quality, no description). Active code paths now filter these out
+ * (see PR that landed alongside this script); this is a one-shot cleanup for
+ * the historical residue.
+ *
+ * Conservative: marks rows as `is_duplicate: true, book_visible: false`
+ * with `dedup_reason: "zombie_no_metadata"` — does NOT delete. Mirrors the
+ * pattern in scripts/dedup-gallery-within-book.mjs so views drop them but the
+ * docs remain for rollback.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/cleanup-gallery-zombies.mjs --dry-run
+ *   node scripts/maintenance/cleanup-gallery-zombies.mjs --apply
+ */
+import { MongoClient } from 'mongodb';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const DRY_RUN = !APPLY;
+
+const c = new MongoClient(process.env.MONGODB_URI);
+await c.connect();
+const db = c.db('bookstore');
+const gallery = db.collection('gallery_images');
+
+// Zombie definition: no bbox AND (no description OR empty description) AND (no image_url OR empty image_url)
+// (matches what we saw on disk: bbox:null, description:"", gallery_quality:null)
+const FILTER = {
+  $and: [
+    { $or: [{ bbox: null }, { bbox: { $exists: false } }] },
+    { $or: [{ description: { $exists: false } }, { description: '' }, { description: null }] },
+    { $or: [{ image_url: { $exists: false } }, { image_url: '' }, { image_url: null }] },
+    // Don't re-process if already hidden by a prior dedup pass
+    { is_duplicate: { $ne: true } },
+  ],
+};
+
+const total = await gallery.countDocuments(FILTER);
+console.log(`Zombie rows eligible for hiding: ${total.toLocaleString()}${DRY_RUN ? ' (DRY RUN — no writes)' : ''}`);
+
+if (total === 0) {
+  await c.close();
+  process.exit(0);
+}
+
+// Breakdown by book to gauge spread
+const byBook = await gallery.aggregate([
+  { $match: FILTER },
+  { $group: { _id: '$book_id', n: { $sum: 1 } } },
+  { $count: 'bookCount' },
+]).toArray();
+console.log(`Affecting ${byBook[0]?.bookCount?.toLocaleString() || 0} distinct books`);
+
+// Breakdown by recency
+const recent = await gallery.countDocuments({ ...FILTER, detected_at: { $gte: new Date(Date.now() - 7*86400000) } });
+console.log(`Of those, ${recent.toLocaleString()} written in the last 7 days (current bug — should drop to 0 after worker patch lands)`);
+
+if (DRY_RUN) {
+  console.log('\nSample 3 docs:');
+  const samples = await gallery.find(FILTER).limit(3).toArray();
+  for (const s of samples) {
+    console.log(`  ${s.id}  book=${s.book_id}  detected_at=${s.detected_at?.toISOString?.()}  model=${s.model}`);
+  }
+  console.log('\nRe-run with --apply to mark these rows is_duplicate=true, book_visible=false.');
+  await c.close();
+  process.exit(0);
+}
+
+console.log('\nApplying...');
+const startedAt = Date.now();
+const r = await gallery.updateMany(FILTER, {
+  $set: {
+    is_duplicate: true,
+    book_visible: false,
+    dedup_hidden_at: new Date(),
+    dedup_reason: 'zombie_no_metadata',
+    updated_at: new Date(),
+  },
+});
+console.log(`Hidden ${r.modifiedCount.toLocaleString()} rows in ${((Date.now() - startedAt)/1000).toFixed(1)}s`);
+
+await c.close();

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -449,10 +449,20 @@ async function processOneJob(db, job) {
             },
           });
 
-          // Queue gallery_images docs for bulk insert after the loop
+          // Queue gallery_images docs for bulk insert after the loop.
+          // Filter matches src/workers/image-extraction-processor-logic.ts (SQS path):
+          //  - bbox required (skips malformed responses / zombie rows)
+          //  - gallery_quality must be present and >= QUALITY_THRESHOLD
+          //  - detection_source already known ('vision_model' here), no need to gate
+          // Threshold is under review; coordinate any change with the SQS path
+          // and scripts/workers/image-extract-worker.mjs.
+          const QUALITY_THRESHOLD = 0.5;
           if (!galleryDocs) galleryDocs = [];
           for (let di = 0; di < detectedImages.length; di++) {
             const img = detectedImages[di];
+            if (!img.bbox) continue;
+            if (typeof img.gallery_quality !== 'number') continue;
+            if (img.gallery_quality < QUALITY_THRESHOLD) continue;
             galleryDocs.push({
               id: `${pageId}-${di}`,
               page_id: pageId,

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -786,8 +786,17 @@ async function processBook(db, book) {
         totalImages += detectedImages.length;
         pageSet.detected_images = detectedImages;
 
+        // Filter matches src/workers/image-extraction-processor-logic.ts (SQS path):
+        //  - bbox required (skips malformed responses / zombie rows)
+        //  - gallery_quality must be present and >= QUALITY_THRESHOLD
+        // Threshold is under review; coordinate any change with the SQS path
+        // and scripts/workers/batch-collector.mjs.
+        const QUALITY_THRESHOLD = 0.5;
         for (let di = 0; di < detectedImages.length; di++) {
           const img = detectedImages[di];
+          if (!img.bbox) continue;
+          if (typeof img.gallery_quality !== 'number') continue;
+          if (img.gallery_quality < QUALITY_THRESHOLD) continue;
           const galleryDoc = {
             id: `${pageId}-${di}`,
             page_id: pageId,


### PR DESCRIPTION
Found via data-drift survey: 6,590 `gallery_images` rows in prod with `bbox: null`, `gallery_quality: null`, `description: ""`, `image_url: null`. **5,913 of them written in the last 7 days** — bug is live.

## Root cause

The SQS realtime image-extraction path (`src/workers/image-extraction-processor-logic.ts:289-300`) filters detections before writing to `gallery_images`:
- Requires `bbox`
- Requires `detection_source` in `[vision_model, manual, ocr_tag]`
- Requires `gallery_quality >= 0.5`

But the two Hetzner-side writers were pushing **every** detected image with no filter:

- `scripts/workers/batch-collector.mjs:452-474` — batch API result collector (produces most of the empty rows)
- `scripts/workers/image-extract-worker.mjs:789-831` — realtime Hetzner worker

When Gemini's response was malformed or partial, the worker still built an entry with `bbox: undefined, gallery_quality: undefined, description: ''`, then pushed a gallery row anyway.

## Fix

Apply the same `bbox + gallery_quality >= 0.5` filter at both Hetzner paths. Threshold value lives once per file with a coordination comment so any future change touches all three paths.

## Cleanup

`scripts/maintenance/cleanup-gallery-zombies.mjs` — conservative one-shot. Marks existing empty rows as `is_duplicate: true, book_visible: false, dedup_reason: "zombie_no_metadata"` so they drop out of views. **Does not delete** — preserves for rollback. Mirrors the existing `scripts/dedup-gallery-within-book.mjs` pattern. Will run with `--apply` on prod after this merges.

Dry-run on prod:
```
Zombie rows eligible for hiding: 6,590
Affecting 515 distinct books
Of those, 5,913 written in the last 7 days
```

## Out of scope

- Consolidating the three gallery-write paths into one shared filter function — one is TS, two are JS, would need a cross-language port. Comments cross-reference each other so coordinated changes are findable.
- Revisiting the 0.5 threshold itself — separate conversation. Threshold lives in one constant per file.

## Test plan

- [ ] `npx tsc --noEmit` — no new errors
- [ ] After merge, run `node scripts/maintenance/cleanup-gallery-zombies.mjs --apply`
- [ ] Re-run the diagnostic query in 7 days: `gallery_images.countDocuments({bbox: null, description: ''})` should stay near zero