### PR TITLE
fix(seo): default to indexable when pages_ocr is null (catches external-source books)

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -236,11 +236,18 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (book.doi) scholarMeta['citation_doi'] = book.doi;
 
   // Don't index books with no meaningful content for search engines:
-  // - No OCR at all, or
+  // - 0 OCR pages, or
   // - Very thin (1-3 OCR pages) with no translation
-  const pagesOcr = book.pages_ocr ?? 0;
-  const pagesTranslated = book.pages_translated ?? 0;
-  const shouldIndex = pagesOcr > 3 || (pagesOcr > 0 && pagesTranslated > 0);
+  //
+  // Default to indexable when pages_ocr is null/undefined: the Supabase
+  // catalog mirror doesn't have OCR counts for some external-source imports
+  // (ETCSL, CDLI, etc.), and `null ?? 0` falsely flagged them as 0-page
+  // shells. Only noindex when we *know* the book is thin.
+  const pagesOcr = book.pages_ocr;
+  const pagesTranslated = book.pages_translated;
+  const shouldIndex = pagesOcr == null
+    || pagesOcr > 3
+    || (pagesOcr > 0 && (pagesTranslated ?? 0) > 0);
 
   return {
     title: `${title} - Source Library`,


### PR DESCRIPTION
## Why

PR #2016 fixed the "Book Not Found" noindex for global books. After deploy, spot-checked the same URLs and a second layer of the same problem surfaced:

\`\`\`
<meta property="og:title" content="The cursing of Agade (Ur III / Old Babylonian (c. 2100–1600 BCE))"/>
<meta name="robots" content="noindex"/>
\`\`\`

The title is correct (so the metadata function is no longer falling into the "Book Not Found" branch — #2016 working) but the page is still being noindex'd. Confirmed across `proverbs-collection-3` (199 pages OCR'd), `philonis-alexandrini-...-cohn` (190), `the-cursing-of-agade` (20). A book whose Supabase row IS synced (`legs-par-bshad-...`) renders without noindex.

## Root cause

`src/app/[tenant]/book/[id]/page.tsx:243`:

```ts
const pagesOcr = book.pages_ocr ?? 0;
const pagesTranslated = book.pages_translated ?? 0;
const shouldIndex = pagesOcr > 3 || (pagesOcr > 0 && pagesTranslated > 0);
```

`getCachedBookLookup` tries the Supabase `books_catalog` mirror first. ETCSL/CDLI/other external-source imports aren't synced — `pages_ocr` comes back **null**. The `?? 0` converts null → 0, `0 > 3` is false, `shouldIndex` is false, page emits noindex. Atlas has the real OCR counts (20, 190, 199), and the page body renders correctly from Atlas, but the metadata function never re-fetches.

## What

Treat `pages_ocr == null` as "unknown, assume indexable" instead of "definitely 0". Books with a real `0` (Supabase synced and the count is genuinely zero) still get noindex; only the data-gap case is corrected.

## Verify after merge

```bash
curl -s https://sourcelibrary.org/book/the-cursing-of-agade | grep -oE '<meta name="robots"[^>]*>'
# expect: empty (no noindex)
```

## Out of scope

- Backfilling Supabase `pages_ocr` from Atlas. Right fix in the long run, but a data job, not a code change. Today's PR makes the code resilient regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)