### PR TITLE
fix(reader): swipe nav ignores active text selection

### DIFF
--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -763,6 +763,10 @@ export default function TranslationEditor({
     const target = e.target as HTMLElement;
     if (target.closest('textarea, input, button, a, [data-no-swipe]')) return;
 
+    // Don't start a swipe while the user is extending a text selection — the
+    // drag handle a finger uses to grow a highlight reads as a swipe otherwise.
+    if (typeof window !== 'undefined' && window.getSelection()?.toString().length) return;
+
     touchStartX.current = e.touches[0].clientX;
     touchStartY.current = e.touches[0].clientY;
   };
@@ -783,9 +787,14 @@ export default function TranslationEditor({
   };
 
   const handleTouchEnd = () => {
+    // If a selection is active at lift-off, the gesture was a highlight, not
+    // a swipe — bail before navigation but still reset transient state.
+    const hasSelection =
+      typeof window !== 'undefined' && !!window.getSelection()?.toString().length;
+
     const deltaX = swipeOffset * 2; // Reverse the 0.5 multiplier
 
-    if (Math.abs(deltaX) > SWIPE_THRESHOLD) {
+    if (!hasSelection && Math.abs(deltaX) > SWIPE_THRESHOLD) {
       if (deltaX > 0 && previousPage) {
         onNavigate(previousPage.id);
       } else if (deltaX < 0 && nextPage) {


### PR DESCRIPTION
## Summary
- Dragging a finger across page content to extend a text highlight read as a horizontal swipe and flipped to the previous/next page mid-selection.
- TranslationEditor's touch handlers gated on \`textarea, input, button, a, [data-no-swipe]\` but never checked \`window.getSelection()\`, so dragging from a static paragraph still tracked as a swipe.
- Two narrow guards: bail in \`handleTouchStart\` when a selection is already active, and bail in \`handleTouchEnd\` if a selection exists at lift-off (selections completed during the gesture). State still resets so the visual offset doesn't stick.

This is the single reader component for every tenant + the \`/embed/\` mounts, so the fix covers /internet-archive, /bph, /leiden, …

## Test plan
- [ ] On a touch device, open any book in the reader. Long-press a word, drag the selection handle past the 50px threshold — page should not flip, selection should extend.
- [ ] Quick horizontal flick (no selection) still navigates to previous/next page.
- [ ] Pinch-zoom and vertical scroll still work (untouched paths).
- [ ] Desktop: no change (mouse handlers don't exist, swipe is touch-only).

## Out of scope
- \`src/components/annotations/HighlightSelection.tsx\` is a no-op pass-through wrapper that looks like an abandoned stub for a quote-popover feature. Flagging for the other dev — not deleting in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)