### PR TITLE
fix(health): stop alerting on documented Supabase sync gaps

### DIFF
--- a/src/lib/supabase-health.ts
+++ b/src/lib/supabase-health.ts
@@ -49,11 +49,16 @@ export async function getSupabaseSyncHealth(): Promise<SyncHealthResult> {
     lag.gemini_usage = Math.round((now - new Date(result.gemini_usage.latest_at).getTime()) / 60000);
   }
 
-  // Status: warning if any table hasn't been updated in 60+ minutes,
-  // critical if 6+ hours (likely sync is broken)
-  const maxLag = Math.max(...Object.values(lag).filter((v): v is number => v !== null));
-  const status = maxLag > 360 ? 'critical'
-    : maxLag > 60 ? 'warning'
+  // Status: only `gemini_usage` represents a live-written, no-known-gap table —
+  // its lag is the one that actually indicates a sync outage.
+  //   - `pages`: no INSERT path from the live pipeline (#2020). Lag floor is the
+  //     timestamp of the last PATCH against pre-migration rows.
+  //   - `entities`: manual-only sync (.claude/docs/supabase.md Gap D). Lag accrues
+  //     by design between hand-runs of sync-entities.mjs.
+  // Both are still reported in `lag_minutes` for visibility but don't drive status.
+  const liveLag = lag.gemini_usage ?? 0;
+  const status = liveLag > 360 ? 'critical'
+    : liveLag > 60 ? 'warning'
     : 'ok';
 
   return {
@@ -103,10 +108,9 @@ async function getFallbackHealth(): Promise<SyncHealthResult> {
     lag.pages = null; // timed out — index not yet created
   }
 
-  const maxLag = Math.max(...Object.values(lag).filter((v): v is number => v !== null), 0);
-  const status = maxLag > 360 ? 'critical'
-    : maxLag > 60 ? 'warning'
-    : 'ok';
+  // Fallback path can't see gemini_usage; without the live signal we can't tell
+  // a sync outage apart from documented gaps, so don't escalate to critical.
+  const status: 'ok' | 'warning' = 'warning';
 
   return {
     status,


### PR DESCRIPTION
## Summary

The daily 07:00 health-check cron has been firing `supabase_sync.status = critical` every morning. Investigation found it was alerting on two documented structural gaps, not real outages:

- **`pages.latest_updated_at` lag** (~16h floor): no live INSERT path exists. The dual-write in `batch-collector.mjs` calls `syncPageBatch()`, which `PATCH`es existing rows only. New books' pages never reach Supabase (verified: 50/50 recently-OCR'd pages absent; all 120 books from 2026-05-25 absent). Tracked in #2020.
- **`entities.latest_updated_at` lag** (~13h floor): manual-only sync per `.claude/docs/supabase.md` Gap D. No cron writes to it.

Only `gemini_usage` is a live-written table without a known gap — its lag is the one that meaningfully indicates an outage. This PR makes `status` depend only on `gemini_usage` lag. `pages` and `entities` remain in `lag_minutes` for visibility.

The fallback path (when the `sync_health` RPC is unavailable) can't see `gemini_usage` at all, so it now returns `warning` rather than escalating to `critical` on documented gaps.

## Out of scope

Underlying sync fixes — tracked separately:
- **#2020** — wire `upsertPages` + `await` into batch-collector so new pages actually reach Supabase
- **#2021** — visual/CLIP/gallery embeddings 35+ days stale (separate root cause)

This PR is intentionally narrow: stop the daily false-positive page without papering over the real bugs.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Existing `getSupabaseSyncHealth()` shape unchanged (still returns `lag_minutes` for all three tables)
- [ ] After merge, confirm next morning's health check no longer alerts (still surfaces lag values in dashboard)

Closes #2022