### PR TITLE
fix(proxy): stop source providers from claiming main-host URLs

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -240,7 +240,7 @@ export async function proxy(request: NextRequest) {
     return cachedDbPromise;
   }
 
-  async function resolveActiveTenant(slug: string): Promise<{ id: string; slug: string } | null> {
+  async function resolveActiveTenant(slug: string): Promise<{ id: string; slug: string; kind: string | null } | null> {
     if (!slug || NON_TENANT_PATHS.has(slug) || slug.includes('.') || !/^[a-z0-9-]+$/.test(slug)) {
       return null;
     }
@@ -255,7 +255,11 @@ export async function proxy(request: NextRequest) {
         status: { $ne: 'deleted' },
       });
       if (!tenant) return null;
-      return { id: tenant.id as string, slug: tenant.slug as string };
+      return {
+        id: tenant.id as string,
+        slug: tenant.slug as string,
+        kind: (tenant.kind as string | undefined) ?? null,
+      };
     } catch {
       return null;
     }
@@ -423,6 +427,31 @@ export async function proxy(request: NextRequest) {
     subdomainHeaders.set('x-tenant-slug', tenant);
     if (subdomainTenant?.id) subdomainHeaders.set('x-tenant-id', subdomainTenant.id);
     return NextResponse.rewrite(url, { request: { headers: subdomainHeaders } });
+  }
+
+  // --- Source-provider URL strip ---
+  // Source providers (Internet Archive, Gallica, Bodleian, …) live in the
+  // `tenants` Mongo collection so book metadata can credit them and queries
+  // can filter by `image_source.provider`, but they are NOT tenants in the
+  // routing sense — no partner subdomain, no scoped UI. Treating their slugs
+  // as URL prefixes (`/internet-archive/gallery`, `/gallica/book/...`)
+  // accidentally scopes the [tenant]/* routes by tenantId and hides content
+  // that the provider re-hosts but doesn't carry a tenantId for (most of
+  // gallery_images, related books, etc.). Strip the provider prefix and
+  // 308-redirect to the global equivalent so providers never claim URL space.
+  // Subdomain-kind tenants (bph, kloss-collection, bhutan) and `default`/`meta`
+  // are untouched here — their existing per-route canonicalizations below
+  // continue to apply when visited from the main host.
+  const providerStripMatch = pathname.match(/^\/([a-z0-9-]+)(\/.*)?$/);
+  if (providerStripMatch) {
+    const seg = providerStripMatch[1];
+    const rest = providerStripMatch[2] || '';
+    const providerCandidate = await resolveActiveTenant(seg);
+    if (providerCandidate?.kind === 'provider') {
+      const url = request.nextUrl.clone();
+      url.pathname = rest || '/';
+      return NextResponse.redirect(url, 308);
+    }
   }
 
   // --- Canonical book URLs ---


### PR DESCRIPTION
## The problem
The \`tenants\` Mongo collection conflates three different things (see [.claude/docs/tenant-architecture-audit-2026-05-23.md](.claude/docs/tenant-architecture-audit-2026-05-23.md)):

- **3 subdomain tenants** — \`bph\`, \`kloss-collection\`, \`bhutan\` — real partner-facing tenants
- **29 source providers** — \`internet-archive\`, \`gallica\`, \`bodleian\`, \`wellcome-collection\`, \`e-rara\`, … — libraries we re-host content FROM; not meant to be visited as tenant URLs
- 1 \`default\`, 1 \`meta\`

\`resolveActiveTenant()\` matches any row in that collection, so URLs like \`/internet-archive/gallery\` get routed through \`[tenant]/gallery/page.tsx\` with \`x-tenant-id\` set. That route filters gallery_images by tenantId, but most of the 118K images are global (no tenantId), so the page renders only 43 results. Same shape for \`/gallica/...\`, \`/bodleian/...\`, etc.

Per-route canonicalizations existed for \`/{tenant}/book\`, \`/collections\`, \`/explore\` (lines 419-468) but not for \`/gallery\` or other \`[tenant]/*\` routes.

## The fix
Add a single early-middleware block that 308-redirects any path whose first segment resolves to a \`kind: 'provider'\` tenant, stripping the prefix:

- \`/internet-archive/gallery\` → \`/gallery\`
- \`/gallica/book/foo\` → \`/book/foo\`
- \`/bodleian/\` → \`/\`

Subdomain-kind tenants (\`bph\`, \`kloss-collection\`, \`bhutan\`) and \`default\`/\`meta\` are untouched. The existing per-route canonicalizations below continue to apply when subdomain tenants are visited from the main host.

Source providers stay in the \`tenants\` collection — they're still useful as \`image_source.provider\` filters, partner credit, ingest tracking — but stop claiming URL space.

## Why not just patch /gallery specifically
A targeted gallery canonicalization fixes today's symptom. The underlying problem is that source providers were never meant to be URL paths at all. A future \`[tenant]/curate\`, \`[tenant]/timeline\`, etc. would re-introduce the same bug for any new route. One block at the top of the middleware is simpler than chasing every new route.

## Out of scope
- The audit's deeper "tenants collection conflates three concepts" finding remains. A real cleanup would move source providers to a separate \`source_providers\` collection (or drop them entirely in favor of \`image_source.provider\` on books). This PR is the minimal-risk URL fix.
- Subdomain tenants visited via the main host (\`/bph/gallery\`) are unaffected — same broken behavior as before; a follow-up.
- The orphan \`bhutan\` data (1,325 books with \`tenant_id:'bhutan'\`, no DNS) is unchanged.

## Test plan
- [ ] curl -I https://&lt;preview&gt;/internet-archive/gallery → 308 → /gallery
- [ ] curl -I https://&lt;preview&gt;/gallica/book/aurora-consurgens → 308 → /book/aurora-consurgens
- [ ] curl -I https://&lt;preview&gt;/internet-archive/ → 308 → /
- [ ] Visit /gallery on the preview — counts in the thousands (was 43 of 118K when scoped)
- [ ] bph.sourcelibrary.org/gallery still renders inside the subdomain (no change to subdomain rewrite)
- [ ] /bph/collections still 308s to /collections on the main host (existing canonicalization)
- [ ] node scripts/audit-bph-leaks.mjs passes (BPH lockdown invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)