### PR TITLE
feat(sync): Hetzner cron to sync Mongo pages → Supabase pages

### DIFF
--- a/.claude/docs/supabase.md
+++ b/.claude/docs/supabase.md
@@ -86,8 +86,10 @@ MongoDB (writes)
   │                                      └── Hetzner cron syncs → Supabase
   ├── track/route.ts ──writes──→ MongoDB analytics_pageviews
   │                                └── Hetzner cron syncs → Supabase
-  └── books collection ──sync──→ Supabase books_catalog
-                                   └── Hetzner cron (sync-books-catalog.mjs)
+  ├── books collection ──sync──→ Supabase books_catalog
+  │                                └── Hetzner cron (sync-books-catalog.mjs)
+  └── pages collection ──sync──→ Supabase pages
+                                   └── Hetzner cron (sync-pages-content.mjs)
 
 Supabase (reads)
   ├── /browse/titles,authors,years ──reads──→ books_catalog
@@ -109,6 +111,7 @@ Audited 2026-05-14. Every Mongo→Supabase write path in the codebase:
 | 2 | MongoDB books → `books_catalog` | PATCH `/api/books/[id]` → `mirrorBookToCatalog()` | on curator edit | ~11 fields: title, display_title, author, thumbnail, thumbnail_blob, language, published, categories, publisher, place_published, doi | ⚠️ **only fires from the PATCH route**; direct DB updates from `scripts/` bypass it |
 | 3 | MongoDB books → `bph_works.sl_book_id` | Vercel cron `/api/cron/sync-bph-sl-book-ids` | every 6h | `sl_book_id`, `sl_book_slug` | ✓ Honors `bph_catalog_link: false` opt-out (PR #1752, 2026-05-14) |
 | 4 | MongoDB pages → `pages_images` | Hetzner `scripts/workers/supabase-sync.mjs` | every 5 min, last-10-min window | id, book_id, page_number, archived_photo, display_photo, thumbnail_blob | ⚠️ window-only; no retry/backfill if a sync window misses a row |
+| 4b | MongoDB pages → `pages` (content + OCR/translation) | Hetzner `scripts/workers/sync-pages-content.mjs` | every 5 min, last-15-min window | id, book_id, page_number, photo*, ocr.*, translation.*, page_type, columns, script_type, detected_images, image_extraction_updated_at | ✓ Queries via `pages_ocr_updated_idx` and `pages_translation_updated_idx` with explicit `.hint()` (planner picks coll-scan otherwise). Idempotent upsert. Backfill: `--since=ISO` or `--book=ID`. Closed gap #2020. |
 | 5 | MongoDB → 5 analytics tables | Hetzner `scripts/workers/supabase-sync.mjs` | every 5 min | pipeline_snapshots, analytics_pageviews, analytics_events, cron_runs, loading_metrics | ✓ |
 | 6 | MongoDB entities → `entities` | `scripts/workers/sync-entities.mjs` | manual / one-shot | id, name, canonical_name, type, book_count, mentions, aliases, wikidata_id, portrait_url | ⚠️ no recurring trigger; new entities go stale |
 | 7 | MongoDB book.gemini_usage → `gemini_usage` | Synchronous dual-write in `gemini-logger.ts` | per Gemini call | usage rows | ✓ Fire-and-forget (see Gotchas) |
@@ -164,9 +167,12 @@ All prefixed `sl-`. Managed inside Supabase (no external cron needed).
 
 ```
 */5 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-supabase-sync.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/supabase-sync.mjs" >> /var/log/sourcelibrary/supabase-sync.log 2>&1
+*/5 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-sync-pages-content.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-pages-content.mjs" >> /var/log/sourcelibrary/sync-pages-content.log 2>&1
 ```
 
-Syncs the 5 non-dual-write collections incrementally. Typical run: ~300 rows in ~3 seconds.
+`supabase-sync.mjs` syncs the 5 non-dual-write analytics collections incrementally — typical run ~300 rows in ~3 seconds.
+
+`sync-pages-content.mjs` syncs Mongo pages → Supabase `pages` table (OCR + translation columns) — typical 15-min window covers ~2K pages in <15s. Backfill mode: `--since=2026-05-22T00:00:00Z` or `--book=BOOK_ID` for one-off catch-up.
 
 ## Embedding Server (Hetzner)
 

--- a/scripts/workers/sync-pages-content.mjs
+++ b/scripts/workers/sync-pages-content.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Supabase pages-content sync worker.
+ *
+ * Closes the gap documented in #2020: the live OCR pipeline writes pages to
+ * MongoDB but never inserts them into Supabase. The previous dual-write
+ * (`syncPageBatch` in `lib/supabase-page-writer.mjs`) PATCHes existing rows
+ * fire-and-forget, which silently no-ops on new books.
+ *
+ * This worker reads MongoDB as the source of truth and upserts pages whose
+ * `updated_at` is newer than `now - WINDOW_MIN`. Idempotent on `id`.
+ *
+ * Crontab entry (Hetzner, every 5 minutes):
+ *   *\/5 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-sync-pages-content.lock \
+ *     bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-pages-content.mjs" \
+ *     >> /var/log/sourcelibrary/sync-pages-content.log 2>&1
+ *
+ * Backfill mode (one-off catch-up for missed history):
+ *   node scripts/workers/sync-pages-content.mjs --since=2026-05-23T00:00:00Z
+ *   node scripts/workers/sync-pages-content.mjs --book=BOOK_ID
+ *
+ * Env vars: MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://ykhxaecbbxaaqlujuzde.supabase.co';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!MONGODB_URI || !SUPABASE_SERVICE_KEY) {
+  console.error(`[${new Date().toISOString()}] Missing MONGODB_URI or SUPABASE_SERVICE_ROLE_KEY`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const SINCE_ARG = args.find(a => a.startsWith('--since='))?.split('=')[1];
+const BOOK_ID = args.find(a => a.startsWith('--book='))?.split('=')[1];
+const WINDOW_MIN = parseInt(args.find(a => a.startsWith('--window-min='))?.split('=')[1] || '15', 10);
+const BATCH_SIZE = parseInt(args.find(a => a.startsWith('--batch='))?.split('=')[1] || '500', 10);
+const MAX_PAGES = parseInt(args.find(a => a.startsWith('--max='))?.split('=')[1] || '50000', 10);
+
+/** Flatten a MongoDB page doc to Supabase row format (matches pages table schema). */
+function flattenPage(doc) {
+  const ocr = doc.ocr || {};
+  const translation = doc.translation || {};
+  return {
+    id: doc.id,
+    book_id: doc.book_id,
+    page_number: doc.page_number,
+    photo: doc.photo ?? null,
+    photo_original: doc.photo_original ?? null,
+    archived_photo: doc.archived_photo ?? null,
+    cropped_photo: doc.cropped_photo ?? null,
+    crop: doc.crop ?? null,
+    ocr_data: typeof ocr.data === 'string' ? ocr.data : null,
+    ocr_model: ocr.model ?? null,
+    ocr_language: ocr.language ?? null,
+    ocr_source: ocr.source ?? null,
+    ocr_prompt_version: ocr.prompt_version ?? null,
+    ocr_batch_job_id: ocr.batch_job_id ?? null,
+    ocr_input_tokens: ocr.input_tokens ?? null,
+    ocr_output_tokens: ocr.output_tokens ?? null,
+    ocr_updated_at: ocr.updated_at ? new Date(ocr.updated_at).toISOString() : null,
+    translation_data: typeof translation.data === 'string' ? translation.data : null,
+    translation_model: translation.model ?? null,
+    translation_language: translation.language ?? null,
+    translation_source_language: translation.source_language ?? null,
+    translation_source: translation.source ?? null,
+    translation_prompt_version: translation.prompt_version ?? null,
+    translation_batch_job_id: translation.batch_job_id ?? null,
+    translation_input_tokens: translation.input_tokens ?? null,
+    translation_output_tokens: translation.output_tokens ?? null,
+    translation_updated_at: translation.updated_at ? new Date(translation.updated_at).toISOString() : null,
+    translation_recitation_blocked: translation.recitation_blocked ?? false,
+    translation_safety_blocked: translation.safety_blocked ?? false,
+    translation_safety_reason: translation.safety_reason ?? null,
+    page_type: doc.page_type ?? null,
+    columns: doc.columns ?? 1,
+    script_type: doc.script_type ?? null,
+    detected_images: doc.detected_images ?? null,
+    image_extraction_updated_at: doc.image_extraction_updated_at
+      ? new Date(doc.image_extraction_updated_at).toISOString() : null,
+    created_at: doc.created_at ? new Date(doc.created_at).toISOString() : new Date().toISOString(),
+    updated_at: doc.updated_at ? new Date(doc.updated_at).toISOString() : new Date().toISOString(),
+  };
+}
+
+async function upsertBatch(rows) {
+  const resp = await fetch(`${SUPABASE_URL}/rest/v1/pages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: SUPABASE_SERVICE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+      Prefer: 'resolution=merge-duplicates,return=minimal',
+    },
+    body: JSON.stringify(rows),
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`Supabase upsert failed (${resp.status}): ${text.substring(0, 300)}`);
+  }
+}
+
+/** Recursive halve-and-retry: if a batch fails, split it. */
+async function upsertWithRetry(rows, depth = 0) {
+  if (rows.length === 0) return { synced: 0, failed: 0 };
+  try {
+    await upsertBatch(rows);
+    return { synced: rows.length, failed: 0 };
+  } catch (err) {
+    if (depth >= 4 || rows.length <= 1) {
+      console.error(`  Giving up on ${rows.length} rows at depth ${depth}: ${err.message}`);
+      return { synced: 0, failed: rows.length };
+    }
+    const mid = Math.ceil(rows.length / 2);
+    const left = await upsertWithRetry(rows.slice(0, mid), depth + 1);
+    const right = await upsertWithRetry(rows.slice(mid), depth + 1);
+    return { synced: left.synced + right.synced, failed: left.failed + right.failed };
+  }
+}
+
+async function main() {
+  const startTime = Date.now();
+  const client = new MongoClient(MONGODB_URI, { maxPoolSize: 2 });
+  await client.connect();
+  const db = client.db('bookstore');
+
+  // Page rows MUST have id + book_id + page_number to satisfy NOT NULL constraints.
+  const projection = {
+    _id: 0,
+    id: 1, book_id: 1, page_number: 1,
+    photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1,
+    ocr: 1, translation: 1,
+    page_type: 1, columns: 1, script_type: 1,
+    detected_images: 1, image_extraction_updated_at: 1,
+    created_at: 1, updated_at: 1,
+  };
+
+  const stats = { seen: 0, skipped: 0, synced: 0, failed: 0 };
+  const seenIds = new Set();
+  let batch = [];
+
+  async function flush() {
+    if (batch.length === 0) return;
+    if (!DRY_RUN) {
+      const result = await upsertWithRetry(batch);
+      stats.synced += result.synced;
+      stats.failed += result.failed;
+    }
+    batch = [];
+  }
+
+  async function processDoc(doc) {
+    if (!doc.id || !doc.book_id || doc.page_number == null) {
+      stats.skipped++;
+      return;
+    }
+    if (seenIds.has(doc.id)) return;
+    seenIds.add(doc.id);
+    stats.seen++;
+    batch.push(flattenPage(doc));
+    if (batch.length >= BATCH_SIZE) await flush();
+  }
+
+  // The `pages` collection has no index on top-level `updated_at`. It DOES have
+  // indexes on `ocr.updated_at` and `translation.updated_at`. We can't $or those
+  // — the planner picks a collection scan over the 3.3M-row table and times out.
+  // Instead, run separate cursors with explicit hints and dedupe by id.
+  if (BOOK_ID) {
+    const cursor = db.collection('pages')
+      .find({ book_id: BOOK_ID }, { projection })
+      .hint('pages_book_pagenum_idx')
+      .batchSize(BATCH_SIZE)
+      .maxTimeMS(120_000)
+      .limit(MAX_PAGES);
+    for await (const doc of cursor) await processDoc(doc);
+  } else {
+    const since = SINCE_ARG
+      ? new Date(SINCE_ARG)
+      : new Date(Date.now() - WINDOW_MIN * 60 * 1000);
+
+    const indexedScans = [
+      { field: 'ocr.updated_at', index: 'pages_ocr_updated_idx' },
+      { field: 'translation.updated_at', index: 'pages_translation_updated_idx' },
+    ];
+
+    for (const { field, index } of indexedScans) {
+      if (stats.seen >= MAX_PAGES) break;
+      const cursor = db.collection('pages')
+        .find({ [field]: { $gte: since } }, { projection })
+        .hint(index)
+        .batchSize(BATCH_SIZE)
+        .maxTimeMS(120_000)
+        .limit(MAX_PAGES - stats.seen);
+      for await (const doc of cursor) {
+        await processDoc(doc);
+        if (stats.seen >= MAX_PAGES) break;
+      }
+    }
+  }
+  await flush();
+
+  await client.close();
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  const mode = BOOK_ID ? `book=${BOOK_ID}`
+    : SINCE_ARG ? `since=${SINCE_ARG}`
+    : `window=${WINDOW_MIN}min`;
+
+  if (stats.seen > 0 || stats.failed > 0) {
+    console.log(`[${new Date().toISOString()}] sync-pages-content ${mode}: seen=${stats.seen} synced=${stats.synced} skipped=${stats.skipped} failed=${stats.failed} in ${elapsed}s${DRY_RUN ? ' (dry-run)' : ''}`);
+  }
+
+  // Write cron_runs record for observability (skipped in dry-run and backfill modes)
+  if (!DRY_RUN && !BOOK_ID && !SINCE_ARG && (stats.seen > 0 || stats.failed > 0)) {
+    try {
+      const cronClient = new MongoClient(MONGODB_URI, { maxPoolSize: 1 });
+      await cronClient.connect();
+      await cronClient.db('bookstore').collection('cron_runs').insertOne({
+        cron: 'sync-pages-content',
+        timestamp: new Date(),
+        duration_ms: Date.now() - startTime,
+        status: stats.failed > 0 ? 'failed' : 'success',
+        actions: stats,
+        summary: `Synced ${stats.synced} pages (${stats.failed} failed) from ${WINDOW_MIN}-min window`,
+      });
+      await cronClient.close();
+    } catch (e) {
+      console.warn(`  Could not write cron_runs record: ${e.message}`);
+    }
+  }
+
+  process.exit(stats.failed > 0 ? 1 : 0);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary

Closes #2020 — the structural gap where the live OCR pipeline writes pages to MongoDB but never inserts them into Supabase.

- Verified gap on production before this PR: 50/50 pages OCR'd in the last 5 hours were absent from Supabase, plus all 120 books created on 2026-05-25 had zero pages in Supabase.
- New worker `scripts/workers/sync-pages-content.mjs`: every-5-min, last-15-min window, idempotent upsert by `id`. Backfill modes via `--since=ISO` or `--book=BOOK_ID`.
- Uses explicit `.hint()` on `pages_ocr_updated_idx` / `pages_translation_updated_idx`. Without the hint, the planner picks a collection-scan on the 3.3M-row pages table and times out at 120s (verified). `$or` across both partial indexes triggers the same bad plan, so the worker runs two separate cursors + dedup by id.
- After running locally against a 60-min window: `pages.latest_updated_at` lag dropped from 16.7h → 0.0h.

## Out of scope

- Ripping out the now-redundant `syncPageBatch` fire-and-forget in `batch-collector.mjs`. Keep it as belt-and-braces until the cron has been running cleanly for a few days, then remove in a follow-up PR.
- Entities cron (Gap D in `.claude/docs/supabase.md`).
- Visual/CLIP/gallery embeddings staleness (#2021).

## Deploy steps

1. Merge this PR.
2. On Hetzner, pull and add the crontab entry (also documented in `.claude/docs/supabase.md`):
   ```
   cd /root/sourcelibrary && git pull
   crontab -e   # add:
   */5 * * * * cd /root/sourcelibrary && flock -n /tmp/sl-sync-pages-content.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/sync-pages-content.mjs" >> /var/log/sourcelibrary/sync-pages-content.log 2>&1
   ```
3. One-time backfill for the historical gap (Tshamdrak batch and anything else missed during the dual-write era):
   ```
   set -a; source .env.production.local; set +a
   node scripts/workers/sync-pages-content.mjs --since=2026-05-22T00:00:00Z --max=200000
   ```

## Test plan

- [x] `--dry-run` on 15-min window: 2,018 pages identified in 4.4s
- [x] `--dry-run --book=BOOK_ID`: 432 pages identified in 0.6s for one Tshamdrak book
- [x] Live `--book=BOOK_ID`: 432 pages synced in 1.8s, verified by `GET /rest/v1/pages?book_id=eq.BOOK_ID` returning OCR timestamps
- [x] Live `--window-min=60`: 10,321 pages synced in 68s (~150 pages/s — comfortably under 5-min cron schedule)
- [x] `sync_health` lag confirms: `pages.latest_updated_at` 0.0h ago, `pages.latest_ocr_at` 0.2h ago, `pages.latest_translation_at` 0.0h ago
- [ ] After deploy, watch `/var/log/sourcelibrary/sync-pages-content.log` for the first few cron runs
- [ ] Run the one-time backfill and confirm Tshamdrak books appear in Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)