### PR TITLE
docs: surface gallery_quality vs scan_quality + prompts archive readme

### DIFF
--- a/.claude/docs/system-map.md
+++ b/.claude/docs/system-map.md
@@ -330,6 +330,7 @@ scripts/                    # Operational scripts
 7. **Hetzner for heavy crons** — Pipeline orchestration moved off Vercel to reduce costs/timeouts. Unified scheduler manages all workers.
 8. **Supabase for read-heavy paths** — Browse, analytics, search, and libraries queries hit Supabase for speed. MongoDB remains source of truth; Supabase mirrors derived data via sync crons.
 9. **Model routing by source** — BPH books get `gemini-3-flash-preview` (premium), all others get `gemini-3.1-flash-lite-preview` (50% cheaper). See `src/lib/types/ai-models.ts`.
+10. **Two quality systems on image extraction** — One Gemini call emits both `gallery_quality` (per illustration, curatorial: "worth showing?") and `scan_quality` (per page, technical: "how cleanly digitized?"). They look similar but answer different questions. Design + extension plan in `.claude/docs/automated-image-quality-system.md`. Public-facing version: `/blog/what-makes-a-good-scan`. The live prompt + rubric live in `scripts/workers/image-extract-worker.mjs:117` and `scripts/workers/pipeline-orchestrator.mjs:1836`; `prompts/image-extraction/image-extraction-v0.md` is an out-of-date archive.
 
 ## Known Dead Code & Duplicates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,15 @@ Source: `src/lib/auth.ts` (cookies block). See `.claude/docs/auth-tenant-cookies
 - OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite-preview` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 
+## Quality systems — two distinct scores
+Image extraction emits two separate quality signals in the **same Gemini call**. They answer different questions and get stored in different places — don't conflate them.
+
+- **`gallery_quality`** (per detected illustration, range 0.0–1.0) — *Is this image worth showing in the curated gallery?* Lives on `pages.detected_images[].gallery_quality` (source of truth) and `gallery_images.gallery_quality` (materialized view). Current rubric is 4-tier (0.4–0.6 musical scores / 0.6–0.8 non-figural illustrations / 0.8–0.9 figural / 0.9–1.0 exceptional). The gallery materialization threshold is **0.5** — anything below is filtered out before write. **Rubric drift watch:** the archived prompt at `prompts/image-extraction/image-extraction-v0.md` shows the *old* 6-tier rubric; the live prompt is inline in `scripts/workers/image-extract-worker.mjs`, `scripts/workers/pipeline-orchestrator.mjs`, and `src/lib/image-extraction.ts`. PR #450 (2026-03-27) made the change.
+
+- **`scan_quality`** (per page, range 0–100 score + class enum) — *How cleanly was this page digitized?* Classes include `color_photo`, `bitonal_clean`, `bitonal_microfilm`, `microfiche`, `scanner_metadata`, `blank`, `corrupt`. Lives on `pages.scan_quality` (per page) + `books.scan_quality` (book rollup with `dominant_scan_class`, `median_score`, `has_microfilm_pages`, etc). **Currently only ~0.2% of pages have it** — scan_quality only fires when image extraction fires, and image extraction only fires on illustration-candidate pages. Design rationale + extension plan in `.claude/docs/automated-image-quality-system.md`.
+
+A famous Kircher diagram has `gallery_quality: 0.9` whether the scan is pristine or microfilmed; the same diagram on microfilm has `scan_quality.scan_class: bitonal_microfilm` regardless of how gallery-worthy it is. See `/blog/what-makes-a-good-scan` for the user-facing version.
+
 ## System Map
 - **Interactive diagram:** https://sourcelibrary.org/platform/admin/system-map — click any node for details, key files, collections, gotchas (requires platform login)
 - **Markdown reference:** `.claude/docs/system-map.md` — full text version with file layout, collection inventory, dead code list

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,66 @@
+# `prompts/` — pipeline prompt archive
+
+This directory snapshots the prompts used by Source Library's AI pipeline, organized by phase. **Most files here are reference snapshots, not the live source of truth.** Production prompts live alongside the code that calls them; the archive exists so collaborators and external researchers can read what the pipeline asks the model without cloning the worker code.
+
+## What's in here
+
+```
+prompts/
+├── book-index/              # generate keyword/subject index from full text
+├── chapter-extraction/      # detect chapter/part boundaries
+├── collection-relevance/    # is this book in scope for collection X?
+├── cover-selection/         # pick the canonical cover page
+├── faceted-tagging/         # apply structured tag facets
+├── image-extraction/        # detect + score illustrations on a page
+├── metadata-enrichment/     # fill in missing title/author/year/lang from text
+├── modernization/           # render historical text in modern spelling
+├── ocr/                     # transcribe page image to text
+├── quality-scoring/         # rate book on historical_significance + 3 others
+├── split-detection/         # is this a two-page spread that needs splitting?
+├── summary/                 # produce reader-facing summary
+├── translation/             # translate OCR text to English
+└── transliteration/         # romanize Hebrew/Arabic/Tibetan/etc
+```
+
+## Versioning convention
+
+Files are named `<prompt-name>-v<N>.md`. Higher `N` = newer. Prompts ending in `-code.md` are the code-shipped variants (escaped for JS string literals); the plain version is the human-readable text. Most directories have multiple versions because we A/B tested prompt revisions.
+
+Files have YAML frontmatter:
+```yaml
+---
+name: "Standard OCR"
+type: pipeline
+version: 10
+source: src/lib/ocr.ts            # where the live prompt is defined
+date: 2026-04-12
+status: ACTIVE | ARCHIVED         # ACTIVE = matches production at write time
+description: "..."
+---
+```
+
+## Live source of truth
+
+When in doubt, **read the code, not the archive**. The archive lags. Examples of recent drift:
+
+| Phase | Archived prompt | Live source (canonical) |
+|---|---|---|
+| image-extraction | `prompts/image-extraction/image-extraction-v0.md` (status: ARCHIVED) | `scripts/workers/image-extract-worker.mjs:117` + `scripts/workers/pipeline-orchestrator.mjs:1836` + `src/lib/image-extraction.ts` |
+| OCR | many `standard-ocr-v*.md` variants | `src/lib/prompts.ts` (active prompt resolution + DB-stored variants) |
+| translation | many `standard-translation-v*.md` variants | DB-stored, resolved via `getTranslationPrompt()` in `src/lib/prompts.ts` |
+
+For OCR and translation specifically: the live prompt is in the `prompts` MongoDB collection (not the filesystem). The worker queries the DB for `{ type: 'ocr'/'translation', is_default: true }` and uses whatever is current. The `.md` files in this directory are snapshots of past versions exported for reference.
+
+## When to update this directory
+
+- **Adding a new pipeline phase:** create `prompts/<phase>/<phase>-v0.md` with frontmatter pointing to the source file.
+- **Promoting a new prompt version:** bump the version number, copy the new prompt text, mark the previous version `status: ARCHIVED`.
+- **Discovering an archive is stale:** add the `status: ARCHIVED` banner + a link to the live source, like the one at the top of `image-extraction/image-extraction-v0.md`.
+
+Don't expect every prompt change to land here — the archive is best-effort. Code is authoritative.
+
+## Related docs
+
+- `.claude/docs/automated-image-quality-system.md` — design of the gallery_quality / scan_quality split
+- `.claude/docs/system-map.md` — pipeline overview, where each prompt fires
+- `src/lib/prompts.ts` — runtime prompt resolution (DB lookup, version pinning, custom-prompt override)

--- a/prompts/image-extraction/image-extraction-v0.md
+++ b/prompts/image-extraction/image-extraction-v0.md
@@ -4,8 +4,20 @@ type: pipeline
 version: 0
 source: src/lib/image-extraction.ts
 date: 2026-03-25
+status: ARCHIVED
 description: "Museum curator analyzing page scans — bbox, gallery quality, subjects, symbols, museum descriptions"
 ---
+
+> **⚠ ARCHIVED — not the live prompt.**
+>
+> This is a snapshot from 2026-03-25 and the rubric has drifted from production. The 6-tier `GALLERY QUALITY` rubric below is **out of date**: PR #450 (2026-03-27) replaced it with a 4-tier rubric and added explicit "SKIP decoratives" guidance. PR #2015 (2026-05-25) tightened the response schema to require `bbox`, `description`, `type`, `gallery_quality`, `gallery_rationale` on each item.
+>
+> **For the live prompt and rubric, read:**
+> - `scripts/workers/image-extract-worker.mjs` — `IMAGE_EXTRACTION_PROMPT` constant (Hetzner image-extract worker)
+> - `scripts/workers/pipeline-orchestrator.mjs` — `IMAGE_EXTRACTION_PROMPT` constant (batch path)
+> - `src/lib/image-extraction.ts` — `EXTRACTION_PROMPT` constant (SQS path, with iconclass extension)
+>
+> For the design rationale (gallery_quality vs scan_quality, three-layer architecture), see `.claude/docs/automated-image-quality-system.md`.
 
 You are a museum curator analyzing a historical book page scan. Create rich metadata for each illustration.
 


### PR DESCRIPTION
Findability gap I hit today: I spent hours investigating gallery image quality and missed the \`scan_quality\` system entirely, plus cited an out-of-date rubric from the archive. None of it was in CLAUDE.md. The design doc \`.claude/docs/automated-image-quality-system.md\` is excellent but undiscoverable.

## Changes

- **CLAUDE.md**: new "Quality systems" section. Distinguishes \`gallery_quality\` (per illustration, curatorial) from \`scan_quality\` (per page, technical). Points at \`.claude/docs/automated-image-quality-system.md\` and \`/blog/what-makes-a-good-scan\`. Flags rubric-drift watch.
- **system-map.md**: new pattern #10 covering the two-quality split and the prompt-archive-stale gotcha.
- **prompts/README.md** (new): documents versioning, the "live code is canonical" rule, and a drift table (image-extraction archive shows old 6-tier rubric; live code is 4-tier; OCR + translation prompts are DB-stored, not file-stored).
- **prompts/image-extraction/image-extraction-v0.md**: top-of-file ARCHIVED banner + \`status: ARCHIVED\` frontmatter, points at live prompt locations.

No code changes; pure documentation. Goal is that a fresh session won't repeat my mistake.