### PR TITLE
fix(gallery): image edits weren't persisting on reload — three causes

### DIFF
--- a/src/app/[tenant]/gallery/image/[id]/page.tsx
+++ b/src/app/[tenant]/gallery/image/[id]/page.tsx
@@ -300,12 +300,15 @@ export default function ImageDetailPage({
   const saveTitle = async () => {
     if (!data) return;
     setSaving(true);
+    setError(null);
     try {
       await gallery.update(data.id, { description: titleValue });
+      prefetchCache.delete(getCacheKey(data.id, tenant));
       setData({ ...data, description: titleValue });
       setEditingTitle(false);
     } catch (e) {
       console.error('Failed to save title:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
     } finally {
       setSaving(false);
     }
@@ -314,12 +317,17 @@ export default function ImageDetailPage({
   const saveQuality = async (newQuality: number) => {
     if (!data) return;
     setSaving(true);
+    setError(null);
     try {
       await gallery.update(data.id, { galleryQuality: newQuality });
+      // Invalidate the prefetch cache for this image so a soft-nav back
+      // doesn't resolve to the pre-edit promise.
+      prefetchCache.delete(getCacheKey(data.id, tenant));
       setData({ ...data, galleryQuality: newQuality });
       setEditingQuality(false);
     } catch (e) {
       console.error('Failed to save quality:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
     } finally {
       setSaving(false);
     }
@@ -328,12 +336,15 @@ export default function ImageDetailPage({
   const saveMuseumDescription = async () => {
     if (!data) return;
     setSaving(true);
+    setError(null);
     try {
       await gallery.update(data.id, { museumDescription: museumDescValue });
+      prefetchCache.delete(getCacheKey(data.id, tenant));
       setData({ ...data, museumDescription: museumDescValue });
       setEditingDescription(false);
     } catch (e) {
       console.error('Failed to save description:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
     } finally {
       setSaving(false);
     }
@@ -342,12 +353,15 @@ export default function ImageDetailPage({
   const saveMetadata = async () => {
     if (!data) return;
     setSaving(true);
+    setError(null);
     try {
       await gallery.update(data.id, { metadata: metadataValues });
+      prefetchCache.delete(getCacheKey(data.id, tenant));
       setData({ ...data, metadata: metadataValues });
       setEditingMetadata(false);
     } catch (e) {
       console.error('Failed to save metadata:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
     } finally {
       setSaving(false);
     }
@@ -356,8 +370,10 @@ export default function ImageDetailPage({
   const saveBbox = async () => {
     if (!data) return;
     setSaving(true);
+    setError(null);
     try {
       const result = await gallery.update(data.id, { bbox: bboxValues });
+      prefetchCache.delete(getCacheKey(data.id, tenant));
       if (result.extractedUrl) {
         setData({
           ...data,
@@ -381,6 +397,7 @@ export default function ImageDetailPage({
       setEditingBbox(false);
     } catch (e) {
       console.error('Failed to save bbox:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
     } finally {
       setSaving(false);
     }
@@ -390,8 +407,10 @@ export default function ImageDetailPage({
     if (!data) return;
     setRotation(newRotation);
     setSavingRotation(true);
+    setError(null);
     try {
       const result = await gallery.update(data.id, { rotation: newRotation });
+      prefetchCache.delete(getCacheKey(data.id, tenant));
       if (result.extractedUrl) {
         setData({ ...data, rotation: newRotation, imageUrl: result.extractedUrl, extractedUrl: result.extractedUrl, thumbnailUrl: result.thumbnailUrl });
       } else {
@@ -399,6 +418,7 @@ export default function ImageDetailPage({
       }
     } catch (e) {
       console.error('Failed to save rotation:', e);
+      setError(e instanceof Error ? `Save failed: ${e.message}` : 'Save failed');
       setRotation(data.rotation ?? 0);
     } finally {
       setSavingRotation(false);

--- a/src/app/api/gallery/image/[id]/route.ts
+++ b/src/app/api/gallery/image/[id]/route.ts
@@ -515,7 +515,8 @@ export async function PATCH(
                 }
               }
             );
-            // Sync to gallery_images
+            // Sync to gallery_images (upsert so an earlier delete from low-quality
+            // doesn't permanently strand the row out of sync with pages.detected_images)
             try {
               const galleryImageId = `${pageId}-${detectionIndex}`;
               const gallerySync: Record<string, unknown> = {
@@ -529,8 +530,17 @@ export async function PATCH(
               if (typeof body.galleryQuality === 'number') gallerySync.gallery_quality = Math.max(0, Math.min(1, body.galleryQuality));
               if (typeof body.rotation === 'number') gallerySync.rotation = body.rotation;
               if (body.bbox) gallerySync.bbox = updateFields[`detected_images.${detectionIndex}.bbox`];
-              await db.collection('gallery_images').updateOne({ id: galleryImageId, ...tenantGalleryFilter }, { $set: gallerySync });
-            } catch { /* non-fatal */ }
+              await db.collection('gallery_images').updateOne(
+                { id: galleryImageId, ...tenantGalleryFilter },
+                {
+                  $set: gallerySync,
+                  $setOnInsert: { id: galleryImageId, page_id: pageId, detection_index: detectionIndex },
+                },
+                { upsert: true },
+              );
+            } catch (e) {
+              console.error('Gallery images sync (bbox/rotation path) failed:', e);
+            }
 
             return NextResponse.json({
               success: true,
@@ -547,12 +557,14 @@ export async function PATCH(
     }
 
     // Sync changes to materialized gallery_images collection
+    let gallerySyncStatus: 'ok' | 'removed_low_quality' | 'no_change' | { error: string } = 'no_change';
     try {
       const galleryImageId = `${pageId}-${detectionIndex}`;
 
       // If quality dropped below materialization threshold, remove from gallery
       if (typeof body.galleryQuality === 'number' && body.galleryQuality < 0.5) {
         await db.collection('gallery_images').deleteOne({ id: galleryImageId, ...tenantGalleryFilter });
+        gallerySyncStatus = 'removed_low_quality';
       } else {
         const galleryUpdate: Record<string, unknown> = {};
         if (typeof body.galleryQuality === 'number') {
@@ -567,17 +579,31 @@ export async function PATCH(
 
         if (Object.keys(galleryUpdate).length > 0) {
           galleryUpdate.updated_at = new Date();
-          await db.collection('gallery_images').updateOne(
+          // Upsert: if a prior edit dropped quality < 0.5 the row was deleted
+          // (line above). Without upsert, raising quality back ≥ 0.5 would leave
+          // the gallery list view permanently out of sync with pages.detected_images.
+          // On insert, also write the foreign-key fields needed for queries.
+          const result = await db.collection('gallery_images').updateOne(
             { id: galleryImageId, ...tenantGalleryFilter },
-            { $set: galleryUpdate }
+            {
+              $set: galleryUpdate,
+              $setOnInsert: {
+                id: galleryImageId,
+                page_id: pageId,
+                detection_index: detectionIndex,
+              },
+            },
+            { upsert: true },
           );
+          gallerySyncStatus = result.upsertedCount > 0 || result.modifiedCount > 0 ? 'ok' : 'no_change';
         }
       }
     } catch (syncErr) {
-      console.warn('Gallery images sync failed (non-fatal):', syncErr);
+      console.error('Gallery images sync failed:', syncErr);
+      gallerySyncStatus = { error: syncErr instanceof Error ? syncErr.message : 'unknown' };
     }
 
-    return NextResponse.json({ success: true, updated: updateFields });
+    return NextResponse.json({ success: true, updated: updateFields, gallerySync: gallerySyncStatus });
   } catch (error) {
     console.error('Gallery image update error:', error);
     return NextResponse.json(

--- a/src/lib/api-client/types/gallery.ts
+++ b/src/lib/api-client/types/gallery.ts
@@ -108,6 +108,8 @@ export interface GalleryImageUpdateResponse {
   updated?: Record<string, unknown>;
   extractedUrl?: string;
   thumbnailUrl?: string;
+  /** Diagnostic info for the materialized gallery_images sync. */
+  gallerySync?: 'ok' | 'removed_low_quality' | 'no_change' | { error: string };
 }
 
 export interface GalleryImageDetail {


### PR DESCRIPTION
Reported: editing \`gallery_quality\` on a gallery image detail page appeared to save (no visible error), but the value bounced back to the original after reload. Investigation turned up three independent failure modes — fixing all three.

## 1. Module-scope \`prefetchCache\` served stale promises (root cause)

\`src/app/[tenant]/gallery/image/[id]/page.tsx\` keeps an in-memory \`prefetchCache: Map<key, Promise<...>>\` with a 2-minute TTL for fast soft-nav. After a successful save, the cache still held the pre-edit promise. Any soft navigation back to the same image (or return via the gallery list within 2 min) resolved to the cached stale promise — overwriting the optimistic local state.

**Fix:** every save handler calls \`prefetchCache.delete(getCacheKey(...))\` on success.

## 2. \`gallery_images\` sync used \`updateOne\` without upsert

Two paths in \`src/app/api/gallery/image/[id]/route.ts\` (line 532 + line 570) updated the materialized \`gallery_images\` row with no \`{ upsert: true }\`. When a prior edit dropped quality < 0.5, the row was deleted by the threshold branch a few lines above. Raising quality back above 0.5 on a subsequent edit then tried to update a row that no longer existed — no-op.

Result: \`pages.detected_images[idx].gallery_quality\` got the new value but the materialized \`gallery_images\` collection (what the /gallery list view reads) stayed permanently out of sync.

**Fix:** both paths now \`upsert: true\` with \`$setOnInsert\` populating \`id\`, \`page_id\`, \`detection_index\` so resurrected rows are queryable.

## 3. Save handlers silently swallowed errors

All six save handlers had \`catch (e) { console.error(...); }\` — no UI feedback. The PATCH route returns 404 when the page can't be found under the current tenant filter (orphaned gallery rows exist), but the user only saw the spinner stop with no visible change.

**Fix:** every save handler now \`setError(...)\` on catch, surfacing failures in the existing error banner. The route also returns a \`gallerySync: 'ok' | 'removed_low_quality' | 'no_change' | { error }\` field so future callers can detect partial-success cases.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Edit gallery_quality on a known image → reload page → value persists
- [ ] Drop quality < 0.5 → image removed from /gallery list (expected)
- [ ] Raise quality back ≥ 0.5 → image re-appears in /gallery list (was broken, now fixed)
- [ ] Try to save on an orphaned image → error banner appears (was silent, now visible)

Companion to PR #2027 (docs: surfaced these quality systems in CLAUDE.md).