### PR TITLE
feat(iiif): tile-stitch silently-capped IIIF hosts for native resolution

### DIFF
--- a/scripts/lib/iiif-utils.mjs
+++ b/scripts/lib/iiif-utils.mjs
@@ -31,6 +31,11 @@ export const DOMAIN_LIMITS = {
   'images.uba.uva.nl': 3,
   'cdm21059.contentdm.oclc.org': 3,
   'dl.ndl.go.jp': 3,
+  // BL/EAP runs behind CloudFront with no observed throttling; raised from
+  // default (5) to support the corpus-wide tile-stitch re-archive job
+  // (~240k pages × 9 tiles = ~2.16M requests). Stays well below the rate
+  // CloudFront serves for cached resources.
+  'images.eap.bl.uk': 15,
 };
 
 const DEFAULT_LIMIT = 5;
@@ -167,7 +172,7 @@ export function getIiifSizeCap(url) {
  * Fetch a IIIF info.json for a given image URL.
  * Strips the trailing `/full/.../...jpg` segment to derive the base.
  *
- * @returns {Promise<{width:number,height:number,sizes?:Array,maxArea?:number}|null>}
+ * @returns {Promise<{width:number,height:number,sizes?:Array,tiles?:Array,maxArea?:number,maxWidth?:number,profileSupports?:string[],serviceBase?:string,raw?:object}|null>}
  */
 export async function fetchIiifInfo(url, opts = {}) {
   if (!isIiifUrl(url)) return null;
@@ -177,13 +182,150 @@ export async function fetchIiifInfo(url, opts = {}) {
   try {
     const buf = await rateLimitedFetch(`${base}/info.json`, opts);
     const json = JSON.parse(buf.toString('utf8'));
+    const profileObj = Array.isArray(json.profile) ? json.profile.find(p => typeof p === 'object') : null;
     return {
       width: json.width,
       height: json.height,
       sizes: json.sizes,
-      maxArea: json.profile?.[1]?.maxArea,
+      tiles: json.tiles,
+      maxArea: profileObj?.maxArea,
+      maxWidth: profileObj?.maxWidth,
+      maxHeight: profileObj?.maxHeight,
+      profileSupports: profileObj?.supports || [],
+      serviceBase: base,
+      raw: json,
     };
   } catch {
     return null;
   }
+}
+
+/**
+ * Fetch a single IIIF tile (region at native scale).
+ *
+ * Some IIIF servers (notably the British Library's EAP service) silently
+ * cap any /full/ request at a per-request output size (e.g. 1200 px),
+ * even when info.json advertises a much larger master. Tile requests at
+ * native scale are not subject to that cap, so we reconstruct the master
+ * by stitching ≤MAX_TILE-pixel chunks.
+ */
+async function fetchIiifTile(serviceBase, x, y, w, h, opts) {
+  const url = `${serviceBase}/${x},${y},${w},${h}/${w},/0/default.jpg`;
+  return rateLimitedFetch(url, opts);
+}
+
+/**
+ * Fetch a IIIF image at native pixel resolution, stitching tiles when the
+ * server caps single-request output below the master dimensions.
+ *
+ * Strategy:
+ *  1. Fetch info.json to learn the true master size.
+ *  2. Pick a per-request chunk size: min(1024, info.maxWidth ?? 1024, info.maxHeight ?? 1024).
+ *     (1024 is the empirically-largest output that BL/EAP returns at native pixel density.)
+ *  3. Tile across (cols × rows), fetch each chunk, composite with sharp.
+ *
+ * If the server already serves /full/full/ at native, this still works
+ * (it'd be 1 tile of size = master). Callers that know native is reachable
+ * can skip this and use the simpler path.
+ *
+ * Throws on failure of any tile fetch.
+ *
+ * @param {string} photoUrl   A IIIF Image API URL anywhere in the service
+ *                            (used to derive the service base).
+ * @param {object} [opts]
+ * @param {object} [opts.info] Pre-fetched info.json (avoids a roundtrip).
+ * @param {number} [opts.maxChunk=1024] Max per-request chunk dimension.
+ * @param {Function} [opts.onProgress] (done, total) callback.
+ * @returns {Promise<{buffer: Buffer, width: number, height: number, tiles: number}>}
+ */
+export async function fetchIiifNativeRes(photoUrl, opts = {}) {
+  const sharp = (await import('sharp')).default;
+  const info = opts.info || await fetchIiifInfo(photoUrl, opts);
+  if (!info || !info.width || !info.height) {
+    throw new Error('no info.json — cannot determine native dimensions');
+  }
+  const serviceBase = info.serviceBase || photoUrl.replace(/\/full\/[^\/]+\/[^\/]+\/[^\/]+$/, '');
+  const W = info.width;
+  const H = info.height;
+
+  // Cap chunk by server-advertised maxWidth/maxHeight (some IIIF v3 servers do
+  // honor sizeByConfinedWh and announce a higher cap).
+  let chunk = opts.maxChunk ?? 1024;
+  if (info.maxWidth) chunk = Math.min(chunk, info.maxWidth);
+  if (info.maxHeight) chunk = Math.min(chunk, info.maxHeight);
+  if (chunk < 256) chunk = 256;
+
+  const cols = Math.ceil(W / chunk);
+  const rows = Math.ceil(H / chunk);
+  const totalTiles = cols * rows;
+
+  // Fetch all tiles. Per-domain rate limiting in rateLimitedFetch keeps us polite.
+  const composites = [];
+  let done = 0;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const x = col * chunk;
+      const y = row * chunk;
+      const w = Math.min(chunk, W - x);
+      const h = Math.min(chunk, H - y);
+      const buf = await fetchIiifTile(serviceBase, x, y, w, h, opts);
+      composites.push({ input: buf, left: x, top: y });
+      done++;
+      if (opts.onProgress) opts.onProgress(done, totalTiles);
+    }
+  }
+
+  // Composite onto a blank canvas at native dimensions.
+  const stitched = await sharp({
+    create: {
+      width: W,
+      height: H,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .composite(composites)
+    .jpeg({ quality: 92, mozjpeg: true })
+    .toBuffer();
+
+  return { buffer: stitched, width: W, height: H, tiles: totalTiles };
+}
+
+/**
+ * Hosts known to silently cap /full/ output below their advertised master
+ * dimensions. Their info.json typically claims to support `sizeAboveFull`
+ * and `sizeByWh` (a IIIF Image API 2.x compliance lie), but a request like
+ * /full/3000,/ returns 1200 px regardless. The only path to native pixel
+ * density on these hosts is tile requests at scaleFactor 1.
+ *
+ * Each entry is a substring matched against the service URL hostname.
+ * Sourced from scripts/_tmp-iiif-cap-audit.mjs (audit 2026-05-26).
+ */
+export const SILENT_CAP_HOSTS = [
+  'images.eap.bl.uk',                            // British Library / EAP — caps at 1200 px
+  'image.digitalcollections.manchester.ac.uk',    // Manchester — 3.25× loss in audit
+  'www.e-rara.ch',                               // e-rara — 1.67× loss
+  'collecties.tudelft.nl',                       // TU Delft — 5.92× loss
+  'rmda.kulib.kyoto-u.ac.jp',                    // Kyoto RMDA — 8.69× loss
+  'iiif.irht.cnrs.fr',                           // IRHT — 1.81× loss
+  'iiif.hab.de',                                 // HAB — 1.16× loss
+];
+
+/**
+ * Decide whether `/full/full/` is sufficient for native res, or whether we
+ * need to tile-stitch.
+ *
+ * Conservative order:
+ *  1. Known-bad host → tile.
+ *  2. Profile or info.json explicitly caps output below native → tile.
+ *  3. Otherwise → trust /full/ (most well-behaved IIIF hosts honor it).
+ */
+export function shouldTileStitch(info, photoUrl) {
+  if (!info?.width || !info?.height) return false;
+  if (photoUrl && SILENT_CAP_HOSTS.some(h => photoUrl.includes(h))) return true;
+  if (info.serviceBase && SILENT_CAP_HOSTS.some(h => info.serviceBase.includes(h))) return true;
+  if (info.maxWidth && info.maxWidth < info.width) return true;
+  if (info.maxHeight && info.maxHeight < info.height) return true;
+  if (info.maxArea && info.maxArea < info.width * info.height) return true;
+  return false;
 }

--- a/scripts/workers/archive-eap.mjs
+++ b/scripts/workers/archive-eap.mjs
@@ -32,6 +32,7 @@ process.on('unhandledRejection', (err) => {
 import { MongoClient } from 'mongodb';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { uploadPageVariants } from './lib/display-image.mjs';
+import { fetchIiifInfo, fetchIiifNativeRes, shouldTileStitch } from '../lib/iiif-utils.mjs';
 
 const args = process.argv.slice(2);
 const getArg = (name) => args.find(a => a.startsWith(`--${name}=`))?.split('=')[1];
@@ -40,6 +41,13 @@ const hasFlag = (name) => args.includes(`--${name}`);
 const PAGE_LIMIT = parseInt(getArg('limit') || '5000', 10);
 const CONCURRENCY = parseInt(getArg('concurrency') || '5', 10);
 const DRY_RUN = hasFlag('dry-run');
+
+// --upgrade re-archives pages whose existing archived image is below the
+// native master resolution (the BL silent-cap problem). Targets pages with
+// image_width <= 1200 (the BL /full/ output cap) and re-fetches via tile
+// stitching. See scripts/lib/iiif-utils.mjs::SILENT_CAP_HOSTS.
+const UPGRADE = hasFlag('upgrade');
+const BOOK_ID = getArg('book');
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
@@ -90,33 +98,50 @@ async function main() {
   await client.connect();
   const db = client.db('bookstore');
 
-  // Find EAP books by tenant_id (indexed) — avoids regex on iiif_manifest
+  // Find books. In upgrade mode, target every book with EAP imagery (any
+  // tenant). In default mode, keep the existing Bhutan-tenant filter for
+  // backwards compatibility with the unarchived-pages backlog.
+  const bookQuery = BOOK_ID
+    ? { id: BOOK_ID }
+    : UPGRADE
+      ? { 'image_source.provider': 'bl', pages_count: { $gt: 0 } }
+      : { tenant_id: 'bhutan', pages_count: { $gt: 0 } };
+
   const eapBooks = await db.collection('books')
-    .find({
-      tenant_id: 'bhutan',
-      pages_count: { $gt: 0 },
-    }, { projection: { id: 1, title: 1, pages_count: 1 } })
-    .limit(5000)
+    .find(bookQuery, { projection: { id: 1, title: 1, pages_count: 1 } })
+    .limit(BOOK_ID ? 1 : 5000)
     .maxTimeMS(30_000)
     .toArray();
 
-  console.log(`[archive-eap] Found ${eapBooks.length} EAP books`);
+  console.log(`[archive-eap] Found ${eapBooks.length} EAP books${UPGRADE ? ' (upgrade mode)' : ''}`);
 
-  // Collect unarchived pages
+  // Collect target pages. In upgrade mode: pages already archived but at the
+  // 1200 px cap (and below). In default mode: pages with no archive yet.
   const allPages = [];
   for (const book of eapBooks) {
     if (allPages.length >= PAGE_LIMIT) break;
     const remaining = PAGE_LIMIT - allPages.length;
+    const pageQuery = UPGRADE
+      ? {
+          book_id: book.id,
+          photo: { $regex: /images\.eap\.bl\.uk/ },
+          $or: [
+            { image_width: { $lte: 1200 } },
+            { image_width: { $exists: false } },
+          ],
+        }
+      : {
+          book_id: book.id,
+          photo: { $regex: /images\.eap\.bl\.uk/ },
+          $or: [
+            { archived_photo: { $exists: false } },
+            { archived_photo: null },
+            { archived_photo: '' },
+          ],
+        };
+
     const pages = await db.collection('pages')
-      .find({
-        book_id: book.id,
-        photo: { $regex: /images\.eap\.bl\.uk/ },
-        $or: [
-          { archived_photo: { $exists: false } },
-          { archived_photo: null },
-          { archived_photo: '' },
-        ],
-      }, { projection: { _id: 1, book_id: 1, page_number: 1, photo: 1 } })
+      .find(pageQuery, { projection: { _id: 1, book_id: 1, page_number: 1, photo: 1, image_width: 1, image_height: 1 } })
       .limit(remaining)
       .maxTimeMS(10_000)
       .toArray()
@@ -125,7 +150,7 @@ async function main() {
     if (pages.length > 0) allPages.push(...pages);
   }
 
-  console.log(`[archive-eap] Found ${allPages.length} unarchived pages`);
+  console.log(`[archive-eap] Found ${allPages.length} ${UPGRADE ? 'pages to upgrade' : 'unarchived pages'}`);
 
   if (allPages.length === 0 || DRY_RUN) {
     if (DRY_RUN && allPages.length > 0) {
@@ -156,17 +181,23 @@ async function main() {
       const page = allPages[i];
 
       try {
-        // Request full/full resolution (not capped at 2000px)
-        const fullResUrl = page.photo.replace(/\/full\/\d+,?\d*\//, '/full/full/');
-        const buffer = await downloadImage(fullResUrl);
+        // Fetch IIIF info.json first — we need master dims to decide between
+        // /full/full/ and tile stitching (BL silently caps /full/ at 1200 px
+        // regardless of the requested size). See scripts/lib/iiif-utils.mjs.
+        const iiifInfo = await fetchIiifInfo(page.photo).catch(() => null);
 
-        // Fetch IIIF info.json for metadata (best effort)
-        let iiifInfo = null;
-        try {
-          const serviceUrl = page.photo.replace(/\/full\/.*/, '');
-          const infoResp = await fetch(serviceUrl + '/info.json');
-          if (infoResp.ok) iiifInfo = await infoResp.json();
-        } catch {}
+        let buffer;
+        let fullResUrl;
+        let stitchedTiles = 0;
+        if (iiifInfo && shouldTileStitch(iiifInfo, page.photo)) {
+          const stitch = await fetchIiifNativeRes(page.photo, { info: iiifInfo });
+          buffer = stitch.buffer;
+          stitchedTiles = stitch.tiles;
+          fullResUrl = `${iiifInfo.serviceBase}/full/full/0/default.jpg`;
+        } else {
+          fullResUrl = page.photo.replace(/\/full\/\d+,?\d*\//, '/full/full/');
+          buffer = await downloadImage(fullResUrl);
+        }
 
         const urls = await uploadPageVariants(buffer, page.book_id, page.page_number, uploadToR2);
 
@@ -178,7 +209,7 @@ async function main() {
         if (iiifInfo) {
           iiifFields['iiif_info.width'] = iiifInfo.width;
           iiifFields['iiif_info.height'] = iiifInfo.height;
-          iiifFields['iiif_info.service_url'] = iiifInfo['@id'] || iiifInfo.id;
+          iiifFields['iiif_info.service_url'] = iiifInfo.raw?.['@id'] || iiifInfo.raw?.id || iiifInfo.serviceBase;
           if (iiifInfo.sizes) iiifFields['iiif_info.sizes'] = iiifInfo.sizes;
           if (iiifInfo.tiles) iiifFields['iiif_info.tiles'] = iiifInfo.tiles;
         }
@@ -198,6 +229,7 @@ async function main() {
               'archive_metadata.original_url': page.photo,
               'archive_metadata.full_res': true,
               'archive_metadata.bytes': buffer.byteLength,
+              'archive_metadata.fetch_method': stitchedTiles > 0 ? `tile_stitch_${stitchedTiles}` : 'full',
               updated_at: new Date(),
             }
           }

--- a/src/components/pipeline/TranslationEditor.tsx
+++ b/src/components/pipeline/TranslationEditor.tsx
@@ -1312,10 +1312,29 @@ export default function TranslationEditor({
                     {/* Image metadata + download */}
                     {pageDisplayUrl && (page.image_width || page.archived_photo) && (
                       <div className="mt-2 px-1 flex items-center justify-between text-xs" style={{ color: 'var(--text-faint)' }}>
-                        <span>
+                        <span className="inline-flex items-center gap-1">
                           {page.image_width && page.image_height
-                            ? `${page.image_width} × ${page.image_height}px`
+                            ? `${page.image_width.toLocaleString()} × ${page.image_height.toLocaleString()} px`
                             : ''}
+                          {book.image_source?.provider_name && (
+                            <>
+                              <span aria-hidden="true">·</span>
+                              {book.image_source.source_url ? (
+                                <a
+                                  href={book.image_source.source_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="hover:underline"
+                                  title={`View at ${book.image_source.provider_name}`}
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  {book.image_source.provider_name}
+                                </a>
+                              ) : (
+                                <span>{book.image_source.provider_name}</span>
+                              )}
+                            </>
+                          )}
                         </span>
                         {pageNativeUrl && (
                           <a


### PR DESCRIPTION
## Summary

Several IIIF hosts silently cap `/full/` output below the master resolution they advertise in `info.json` — even when the profile claims to support `sizeAboveFull`/`sizeByWh`. The cap is on per-request **output** size only; tile requests at native scale return full pixel density.

Result: we've been archiving 1200×900 derivatives of 3072×2304+ JP2s for **~240,000 BL/EAP pages** (and smaller losses for Manchester, e-rara, TU Delft, Kyoto RMDA, IRHT, HAB) while believing we had native res. This was found in response to footer feedback ("Is this high res?") on a Tibetan EAP manuscript.

## Audit findings (`scripts/_tmp-iiif-cap-audit.mjs`)

| Provider | Books | Loss | Notes |
|---|---|---|---|
| bl (EAP) | 1,463 | 1.41× → 239,628 pages capped at 1200 | Bulk of impact |
| manchester | 214 | 3.25× | |
| e-rara | 1,150 | 1.67× | |
| tu_delft | 8 | 5.92× | |
| kyoto_rmda | 6 | 8.69× | |
| irht | 1 | 1.81× | |
| hab | 14 | 1.16× | |

Already at native (no action needed): mdz, bsb, gallica, laurenziana, vatican, leiden, sat_daizokyo, ndl_japan, e-codices, penn_colenda, chester_beatty, wellcome, ndl, heidelberg, escorial, contentdm, bnp.

## Changes

- **`scripts/lib/iiif-utils.mjs`** — `fetchIiifNativeRes()` reconstructs the master by splitting it into ≤1024px chunks, fetching each as a IIIF region request, and compositing with sharp. `SILENT_CAP_HOSTS` is an explicit allow-list (profile fields lie). Raised the per-host rate limit for `images.eap.bl.uk` to 15 r/s (CloudFront-backed; previously default 5).
- **`scripts/workers/archive-eap.mjs`** — probes `info.json` per page, tile-stitches when the host is known-capped, falls back to `/full/full/` for well-behaved hosts. New `--upgrade` flag re-archives existing pages where `image_width <= 1200`. New `--book=<id>` flag targets a single book for smoke-testing. Records `archive_metadata.fetch_method`.
- **`src/components/pipeline/TranslationEditor.tsx`** — viewer caption now reads "W × H px · Provider name", with the provider name linking to the institution source. Was dimension-only and unattributed (the source of the user's confusion).

## What's in scope vs out of scope

In: BL/EAP tile-stitch pipeline + UI label + audit script + worker flag.

Out (deliberate): the other capped providers (Manchester, e-rara, TU Delft, Kyoto, IRHT, HAB) get the same treatment by adding their host to `SILENT_CAP_HOSTS` and pointing the same/sibling worker at them — small follow-ups once we've validated the BL re-archive at scale. Harvard's audit result (0.48× ratio) suggests a manifest-vs-page mismatch worth separate investigation.

## Test plan

- [x] `info.json` probed; tile fetches return native pixel density
- [x] `fetchIiifNativeRes` produces seam-free 3072×2304 JPEG from 9 tiles
- [x] `--dry-run --upgrade --book=…` finds the right pages
- [x] 5-page smoke test on book `69e77a660fc6fc955e35f9fd` (Gangtey): pages 1-5 upgraded from 1200×900 (~320KB) to 3072×2304 (~1.55MB), display variant regenerated, no failures
- [ ] Full 178-page upgrade running on Gangtey (background) — verify before scaling
- [ ] Verify viewer caption renders in production after merge
- [ ] After Gangtey validates: scale to the BL corpus (240k pages, est. 24-48h with concurrency 10 at ~15 r/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)