### PR TITLE
chore(crons): move 3 high-frequency crons from Vercel to Hetzner

### DIFF
--- a/scripts/workers/cron-caller.mjs
+++ b/scripts/workers/cron-caller.mjs
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
-// Hetzner cron caller — triggers Vercel API cron endpoints via HTTP.
+// Hetzner cron caller — triggers Source Library API cron endpoints via HTTP.
 //
-// Usage: node cron-caller.mjs <cron-name>
-// Examples: archive-ocr, social-post, social-reset, daily-pipeline-report
+// Usage:
+//   node cron-caller.mjs <cron-name>      # → POST/GET /api/cron/<cron-name>
+//   node cron-caller.mjs /api/health/auth # → POST/GET <full path verbatim>
+//
+// Examples: archive-ocr, social-post, daily-pipeline-report, /api/health/auth
 // Requires env vars: BASE_URL, CRON_SECRET
 
-const cronName = process.argv[2];
-if (!cronName) {
-  console.error('Usage: node cron-caller.mjs <cron-name>');
+const arg = process.argv[2];
+if (!arg) {
+  console.error('Usage: node cron-caller.mjs <cron-name | /full/path>');
   process.exit(1);
 }
 
@@ -19,7 +22,12 @@ if (!CRON_SECRET) {
   process.exit(1);
 }
 
-const url = `${BASE_URL}/api/cron/${cronName}`;
+// Argument can be either a short cron name (prepended with /api/cron/) or an
+// absolute path starting with `/` (used verbatim). The latter is for routes
+// that don't live under /api/cron/* — e.g. /api/health/auth.
+const path = arg.startsWith('/') ? arg : `/api/cron/${arg}`;
+const label = arg.startsWith('/') ? arg : arg;
+const url = `${BASE_URL}${path}`;
 const timestamp = new Date().toISOString();
 
 console.log(`[${timestamp}] Calling ${url}`);
@@ -42,12 +50,12 @@ try {
   try { parsed = JSON.parse(body); } catch { parsed = body; }
 
   if (res.ok) {
-    console.log(`[${timestamp}] ${cronName} OK (${res.status}):`, JSON.stringify(parsed).substring(0, 500));
+    console.log(`[${timestamp}] ${label} OK (${res.status}):`, JSON.stringify(parsed).substring(0, 500));
   } else {
-    console.error(`[${timestamp}] ${cronName} FAILED (${res.status}):`, JSON.stringify(parsed).substring(0, 500));
+    console.error(`[${timestamp}] ${label} FAILED (${res.status}):`, JSON.stringify(parsed).substring(0, 500));
     process.exit(1);
   }
 } catch (err) {
-  console.error(`[${timestamp}] ${cronName} ERROR:`, err.message);
+  console.error(`[${timestamp}] ${label} ERROR:`, err.message);
   process.exit(1);
 }

--- a/scripts/workers/setup-hetzner.sh
+++ b/scripts/workers/setup-hetzner.sh
@@ -112,19 +112,6 @@ cat >> /tmp/crontab_clean <<CRON
 
 # Sync worker: refresh page counts and gallery images every 2 hours
 0 */2 * * * cd ${INSTALL_DIR} && flock -n /tmp/sl-sync.lock bash -c 'set -a; source .env.production.local; set +a; node scripts/workers/sync-worker.mjs' >> ${LOG_DIR}/sync.log 2>&1
-
-# Source Library HTTP cron triggers (replaces vercel.json crons to stay under Vercel's plan limit).
-# Each route reads CRON_SECRET via verifyCronAuth — same secret Hetzner already has in .env.production.local.
-# CURL_OPTS: -f (fail on HTTP error so cron logs the failure), -sS (silent but show errors), -L (follow redirects).
-
-# Auth health probe every 10 min — checks Google OAuth + Resend keys
-*/10 * * * * curl -fsSL -X GET -H "Authorization: Bearer \$(grep '^CRON_SECRET=' ${ENV_FILE} | cut -d= -f2- | tr -d '\"')" https://sourcelibrary.org/api/health/auth >> ${LOG_DIR}/http-crons.log 2>&1
-
-# DB + zombie-job health check hourly
-0 * * * * curl -fsSL -X GET -H "Authorization: Bearer \$(grep '^CRON_SECRET=' ${ENV_FILE} | cut -d= -f2- | tr -d '\"')" https://sourcelibrary.org/api/cron/health-check >> ${LOG_DIR}/http-crons.log 2>&1
-
-# Latency trend aggregator hourly (consumes cron_runs left by health-check)
-5 * * * * curl -fsSL -X GET -H "Authorization: Bearer \$(grep '^CRON_SECRET=' ${ENV_FILE} | cut -d= -f2- | tr -d '\"')" https://sourcelibrary.org/api/cron/latency-trend >> ${LOG_DIR}/http-crons.log 2>&1
 CRON
 
 crontab /tmp/crontab_clean
@@ -137,11 +124,6 @@ echo "Workers installed:"
 echo "  */5  min  - pipeline-orchestrator.mjs  -> ${LOG_DIR}/pipeline.log"
 echo "  */10 min  - batch-collector.mjs        -> ${LOG_DIR}/collector.log"
 echo "  every 2h  - sync-worker.mjs            -> ${LOG_DIR}/sync.log"
-echo ""
-echo "HTTP crons installed (replaces removed vercel.json entries):"
-echo "  */10 min  - GET /api/health/auth        -> ${LOG_DIR}/http-crons.log"
-echo "  hourly    - GET /api/cron/health-check  -> ${LOG_DIR}/http-crons.log"
-echo "  hourly @5 - GET /api/cron/latency-trend -> ${LOG_DIR}/http-crons.log"
 echo ""
 echo "Monitoring:"
 echo "  tail -f ${LOG_DIR}/pipeline.log"

--- a/scripts/workers/setup-hetzner.sh
+++ b/scripts/workers/setup-hetzner.sh
@@ -112,6 +112,19 @@ cat >> /tmp/crontab_clean <<CRON
 
 # Sync worker: refresh page counts and gallery images every 2 hours
 0 */2 * * * cd ${INSTALL_DIR} && flock -n /tmp/sl-sync.lock bash -c 'set -a; source .env.production.local; set +a; node scripts/workers/sync-worker.mjs' >> ${LOG_DIR}/sync.log 2>&1
+
+# Source Library HTTP cron triggers (replaces vercel.json crons to stay under Vercel's plan limit).
+# Each route reads CRON_SECRET via verifyCronAuth — same secret Hetzner already has in .env.production.local.
+# CURL_OPTS: -f (fail on HTTP error so cron logs the failure), -sS (silent but show errors), -L (follow redirects).
+
+# Auth health probe every 10 min — checks Google OAuth + Resend keys
+*/10 * * * * curl -fsSL -X GET -H "Authorization: Bearer \$(grep '^CRON_SECRET=' ${ENV_FILE} | cut -d= -f2- | tr -d '\"')" https://sourcelibrary.org/api/health/auth >> ${LOG_DIR}/http-crons.log 2>&1
+
+# DB + zombie-job health check hourly
+0 * * * * curl -fsSL -X GET -H "Authorization: Bearer \$(grep '^CRON_SECRET=' ${ENV_FILE} | cut -d= -f2- | tr -d '\"')" https://sourcelibrary.org/api/cron/health-check >> ${LOG_DIR}/http-crons.log 2>&1
+
+# Latency trend aggregator hourly (consumes cron_runs left by health-check)
+5 * * * * curl -fsSL -X GET -H "Authorization: Bearer \$(grep '^CRON_SECRET=' ${ENV_FILE} | cut -d= -f2- | tr -d '\"')" https://sourcelibrary.org/api/cron/latency-trend >> ${LOG_DIR}/http-crons.log 2>&1
 CRON
 
 crontab /tmp/crontab_clean
@@ -124,6 +137,11 @@ echo "Workers installed:"
 echo "  */5  min  - pipeline-orchestrator.mjs  -> ${LOG_DIR}/pipeline.log"
 echo "  */10 min  - batch-collector.mjs        -> ${LOG_DIR}/collector.log"
 echo "  every 2h  - sync-worker.mjs            -> ${LOG_DIR}/sync.log"
+echo ""
+echo "HTTP crons installed (replaces removed vercel.json entries):"
+echo "  */10 min  - GET /api/health/auth        -> ${LOG_DIR}/http-crons.log"
+echo "  hourly    - GET /api/cron/health-check  -> ${LOG_DIR}/http-crons.log"
+echo "  hourly @5 - GET /api/cron/latency-trend -> ${LOG_DIR}/http-crons.log"
 echo ""
 echo "Monitoring:"
 echo "  tail -f ${LOG_DIR}/pipeline.log"

--- a/src/app/api/cron/health-check/route.ts
+++ b/src/app/api/cron/health-check/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { verifyCronAuth } from '@/lib/cron-auth';
 
 export const maxDuration = 30;
 export const preferredRegion = 'fra1';
@@ -21,7 +22,10 @@ interface HealthIssue {
   severity: 'warning' | 'critical';
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authError = verifyCronAuth(request);
+  if (authError) return authError;
+
   const issues: HealthIssue[] = [];
   const latencies: Record<string, number> = {};
   const t0 = Date.now();

--- a/src/app/api/cron/latency-trend/route.ts
+++ b/src/app/api/cron/latency-trend/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
+import { verifyCronAuth } from '@/lib/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
@@ -16,7 +17,10 @@ const CONSECUTIVE_CHECKS_FOR_ALERT = 2;
  * Computes averages, trend direction, and sends alerts if latency is degrading.
  * Stores results in system_config.latency_trend.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authError = verifyCronAuth(request);
+  if (authError) return authError;
+
   const db = await getDb();
 
   // Fetch health-check cron runs from the last 24 hours

--- a/src/app/api/health/auth/route.ts
+++ b/src/app/api/health/auth/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getDb, forceReconnect } from '@/lib/mongodb';
+import { verifyCronAuth } from '@/lib/cron-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 15;
@@ -18,7 +19,10 @@ interface AuthCheck {
  * Tests the actual OAuth/email flows would succeed, not just that env vars exist.
  * Called by Hetzner cron every 10 minutes. Alerts via Resend on failure.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const authError = verifyCronAuth(request);
+  if (authError) return authError;
+
   const checks: AuthCheck[] = [];
 
   // 1. Google OAuth — test that OIDC discovery + client config works

--- a/vercel.json
+++ b/vercel.json
@@ -11,24 +11,12 @@
       "schedule": "0 0 * * *"
     },
     {
-      "path": "/api/cron/health-check",
-      "schedule": "0 * * * *"
-    },
-    {
       "path": "/api/cron/daily-pipeline-report",
       "schedule": "0 6 * * *"
     },
     {
       "path": "/api/cron/warm",
       "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/api/cron/latency-trend",
-      "schedule": "0 * * * *"
-    },
-    {
-      "path": "/api/health/auth",
-      "schedule": "*/10 * * * *"
     },
     {
       "path": "/api/cron/collection-health",


### PR DESCRIPTION
## Why
Vercel is rejecting deployments today with the cron-jobs usage/pricing limit. We had 10 crons doing ~212 invocations/day, dominated by three high-frequency ones:

| Path | Schedule | Invocations/day |
|---|---|---|
| `/api/health/auth` | `*/10 * * * *` | 144 |
| `/api/cron/health-check` | `0 * * * *` | 24 |
| `/api/cron/latency-trend` | `0 * * * *` | 24 |
| | | **192 / 212** |

Source Library already runs pipeline workers on Hetzner (`scripts/workers/setup-hetzner.sh`), so we just extend that setup with three curl-based HTTP triggers.

## What this PR does
1. **Adds `verifyCronAuth` to the 3 routes.** Vercel auto-injects `CRON_SECRET` for its own crons, so this is backward-compatible — if we ever want to move a route back to Vercel, no further change needed.
2. **Adds 3 curl-based entries to `setup-hetzner.sh`.** Reads `CRON_SECRET` from `${ENV_FILE}` at invocation time (no secret baked into the crontab). Logs to `/var/log/sourcelibrary/http-crons.log`.
3. **Removes those 3 entries from `vercel.json`.** Vercel goes from 10 crons / 212 invocations/day → 7 crons / 20 invocations/day.

## Deployment — order matters
1. **SSH to Hetzner first.** Pull main, then `bash scripts/workers/setup-hetzner.sh`. The script's `crontab` rewrite picks up the new entries and the new crontab takes effect immediately. Verify with `crontab -l` and `tail -f /var/log/sourcelibrary/http-crons.log`.
2. **Then merge this PR.** Vercel's old cron schedules disappear on next deploy.

Doing it in that order means there's never a gap in monitoring. If reversed, auth/latency probes go silent until the Hetzner crontab is refreshed.

## Out of scope
- The remaining 7 Vercel crons (social-post, social-reset, daily-pipeline-report, warm, collection-health, sync-bph-sl-book-ids, sync-catalog-sl-book-ids) are once-daily or every-3h — well under any plan limit, so they stay on Vercel.
- The auth/latency cron routes were previously unauthenticated GET endpoints. They're now `Authorization: Bearer $CRON_SECRET` only. If anything else was hitting them (manual debugging, dashboards), it'll now 401 — but a quick grep found no internal callers.

## Test plan
- [ ] Local: `curl -i http://localhost:3000/api/cron/health-check` → 401
- [ ] Local: `curl -i -H "Authorization: Bearer \$CRON_SECRET" http://localhost:3000/api/cron/health-check` → 200 with usual payload
- [ ] On Hetzner after re-running setup-hetzner.sh: `crontab -l` shows the three new curl entries
- [ ] On Hetzner after a few hours: `tail /var/log/sourcelibrary/http-crons.log` shows successful 200s
- [ ] After merge: `vercel.json` has 7 crons; Vercel dashboard shows deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)