### PR TITLE
chore(crons): drop 3 vercel.json crons already scheduled on Hetzner

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,18 +3,6 @@
   "ignoreCommand": "git diff HEAD^ HEAD --quiet -- src/ public/ next.config.ts vercel.json package.json package-lock.json",
   "crons": [
     {
-      "path": "/api/cron/social-post",
-      "schedule": "0 */3 * * *"
-    },
-    {
-      "path": "/api/cron/social-reset",
-      "schedule": "0 0 * * *"
-    },
-    {
-      "path": "/api/cron/daily-pipeline-report",
-      "schedule": "0 6 * * *"
-    },
-    {
       "path": "/api/cron/warm",
       "schedule": "0 4 * * *"
     },


### PR DESCRIPTION
## Why
Hetzner has been calling these three routes via \`scripts/workers/cron-caller.mjs\` the entire time they were also in \`vercel.json\` — both hosts hit the same URLs at the same cadence, doubling invocations:

| Route | Vercel schedule | Hetzner schedule (from \`crontab -l\`) |
|---|---|---|
| \`/api/cron/social-post\` | \`0 */3 * * *\` | \`0 */3 * * *\` ✓ |
| \`/api/cron/social-reset\` | \`0 0 * * *\` | \`0 0 * * *\` ✓ |
| \`/api/cron/daily-pipeline-report\` | \`0 6 * * *\` | \`0 6 * * *\` ✓ |

\`cron-caller.log\` on Hetzner shows successful runs of all three over the past day, so Hetzner is the reliable trigger. Vercel's copies are pure duplication.

## What
Removes those three entries from \`vercel.json\`. Hetzner's crontab is unchanged.

After:
- Vercel crons: 7 → 4 (warm, collection-health, sync-bph-sl-book-ids, sync-catalog-sl-book-ids — none have Hetzner counterparts).
- Vercel invocations/day: 20 → 7.

## Test plan
- [ ] Merge and let Vercel redeploy
- [ ] After deploy: \`vercel cron ls\` (or Vercel dashboard) shows 4 entries, not 7
- [ ] Tomorrow: \`cron-caller.log\` shows social-reset + daily-pipeline-report fired (proves Hetzner is solo-running them now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)