### PR TITLE
fix(embeddings): nightly cron for image-side embedding tables (#2021)

### DIFF
--- a/scripts/workers/image-embeddings-cron.mjs
+++ b/scripts/workers/image-embeddings-cron.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Nightly incremental update for the three image-side embedding tables that
+ * don't have an inline writer in the pipeline:
+ *
+ *   - artwork_embeddings       (Gemini text on artwork metadata)
+ *   - gallery_text_embeddings  (Gemini text on gallery image descriptions)
+ *   - clip_embeddings          (CLIP visual on artworks, book covers, gallery)
+ *
+ * book_embeddings is intentionally NOT here — enrich-worker writes it inline
+ * during Phase 6.5. See issue #2021 for context.
+ *
+ * Each underlying backfill script is already idempotent: it loads the set of
+ * already-embedded ids from Supabase and only embeds the diff. So this
+ * wrapper is safe to run repeatedly; if interrupted it will resume on the
+ * next run.
+ *
+ * Required env (in production): MONGODB_URI, SUPABASE_URL,
+ * SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_URL, GEMINI_API_KEY.
+ *
+ * The cron entry on Hetzner re-exports
+ *   GEMINI_API_KEY=$GEMINI_API_KEY_TIER3
+ * so the Gemini calls run on the paid tier 3 quota (matches the existing
+ * embed-gemini cron pattern in .claude/docs/hetzner-scheduler-crontab.md).
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..', '..');
+
+const PHASES = [
+  {
+    name: 'artwork',
+    script: 'scripts/migration/backfill-artwork-embeddings.mjs',
+    args: ['--incremental'],
+  },
+  {
+    name: 'gallery-text',
+    script: 'scripts/migration/backfill-gallery-text-embeddings.mjs',
+    args: [],
+  },
+  {
+    name: 'clip',
+    script: 'scripts/backfill-clip-embeddings.mjs',
+    args: [],
+  },
+];
+
+function runPhase(phase) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    console.log(`\n[${new Date().toISOString()}] === ${phase.name} starting ===`);
+    const child = spawn(
+      process.execPath,
+      [path.join(REPO_ROOT, phase.script), ...phase.args],
+      { cwd: REPO_ROOT, stdio: 'inherit', env: process.env },
+    );
+    child.on('exit', (code) => {
+      const secs = ((Date.now() - started) / 1000).toFixed(1);
+      console.log(
+        `[${new Date().toISOString()}] === ${phase.name} exit ${code} (${secs}s) ===`,
+      );
+      resolve(code ?? 1);
+    });
+    child.on('error', (err) => {
+      console.error(`[${phase.name}] spawn error:`, err.message);
+      resolve(1);
+    });
+  });
+}
+
+async function main() {
+  const results = [];
+  for (const phase of PHASES) {
+    const code = await runPhase(phase);
+    results.push({ name: phase.name, code });
+  }
+
+  const failed = results.filter((r) => r.code !== 0);
+  console.log(
+    `\n[${new Date().toISOString()}] summary: ${results.length - failed.length}/${results.length} ok` +
+      (failed.length ? `, failed: ${failed.map((f) => `${f.name}(${f.code})`).join(', ')}` : ''),
+  );
+  process.exit(failed.length ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Fatal:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #2021. Three Supabase embedding tables (`artwork_embeddings`, `gallery_text_embeddings`, `clip_embeddings`) had no recurring writer — only one-shot migration backfill scripts. They froze 35+ days ago (last write Apr 20-21) while 34,374 new `gallery_images` rows piled up in Mongo. Visual/CLIP search and artwork semantic search silently returned stale subsets.

## What this PR does

Adds `scripts/workers/image-embeddings-cron.mjs` — a thin wrapper that runs the three existing idempotent backfill scripts in sequence:

| Script | Skip strategy |
|---|---|
| `backfill-artwork-embeddings.mjs --incremental` | Loads existing `book_id`s from `artwork_embeddings`, embeds the diff |
| `backfill-gallery-text-embeddings.mjs` | Loads existing `id`s, embeds the diff (default behavior) |
| `backfill-clip-embeddings.mjs` | Loads existing `id`s, embeds the diff (default behavior) |

The wrapper is safe to run repeatedly; if interrupted it resumes on the next run.

## Cron line (to be installed on Hetzner)

Mirrors the existing `embed-gemini` cron pattern. Re-exports `GEMINI_API_KEY=$GEMINI_API_KEY_TIER3` so Gemini calls run on a **Tier 3 Postpay** project — confirmed paid in AI Studio, so prompts/responses are not retained for model training. CLIP calls a local Hetzner server; no Google call.

```
0 2 * * * cd /root/sourcelibrary && flock -n /tmp/sl-image-embeddings.lock bash -c "set -a; source .env.production.local; set +a; export GEMINI_API_KEY=\$GEMINI_API_KEY_TIER3; node scripts/workers/image-embeddings-cron.mjs" >> /var/log/sourcelibrary/image-embeddings.log 2>&1
```

`sync-crontab.sh` will commit the cron line back to `scripts/workers/crontab.production` on its next run.

## 35-day gap backfill

Kicked off in background on Hetzner with TIER3 key. Sizing from dry-run:
- artwork: 3,593 rows (done — 2,100 embedded, 30 errors on malformed metadata)
- gallery_text: ~33K rows (running; 1,000 embedded so far, throttled by Gemini's embedding QPM cap, self-retries on 429)
- clip: 77,140 rows (running; ~3/s via Hetzner CLIP server, ~7h total)

## Out of scope — filed as follow-up

`artwork_embeddings` has **no usable vector index**. The column is 3072-dim `vector` and pgvector's HNSW `vector_cosine_ops` caps at 2000 dims, so `CREATE INDEX` silently succeeds but the planner refuses to use it (verified: even with `enable_seqscan = off`, planner picks the Seq Scan). The current 17K-row sequential scan takes ~250ms — tolerable but won't scale. Proper fix requires either a `halfvec(3072)` column migration or dropping to ≤2000 dims and re-embedding all rows.

## Test plan

- [ ] Verify wrapper runs end-to-end on Hetzner (`node scripts/workers/image-embeddings-cron.mjs` after merge)
- [ ] First scheduled run lands at 02:00 Europe/Amsterdam; check `/var/log/sourcelibrary/image-embeddings.log`
- [ ] After backfill completes, confirm Supabase tables show writes within last 24h: `gallery_images` count vs `gallery_text_embeddings` count diff narrows; `clip_embeddings` row count climbs past 100K
- [ ] No regression in pipeline scheduler (the new job runs at 02:00, off-peak from translate/OCR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)