### PR TITLE
Drop category pills from About This Book

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -29,7 +29,6 @@ import PublishEditionButton from '@/components/editions/PublishEditionButton';
 import EditionsPanel from '@/components/editions/EditionsPanel';
 import SchemaOrgMetadata from '@/components/seo/SchemaOrgMetadata';
 import DublinCoreMeta from '@/components/seo/DublinCoreMeta';
-import CategoryPicker from '@/components/ui/CategoryPicker';
 import FeedbackWidget from '@/components/feedback/FeedbackWidget';
 import ExpandableGuide from '@/components/book/ExpandableGuide';
 import { AISection } from '@/components/embed/AISection';
@@ -1025,13 +1024,6 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
             <AISection className="card p-6">
               <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>About This Book</h2>
 
-              {/* Categories */}
-              <div className="mb-4 pb-4 border-b border-stone-100">
-                <CategoryPicker
-                  bookId={book.id}
-                  currentCategories={book.categories || []}
-                />
-              </div>
               {hasSummary ? (
                 <>
                   <div className="prose-content max-w-none">


### PR DESCRIPTION
## Summary
- Removes the AI-assigned category tag pills (mysticism, theology, etc.) and the inline "Edit" affordance from the "About This Book" card on every book page.
- The Edit button let any signed-in user mutate categories, which Derek doesn't want exposed broadly. The pills themselves added visual noise to the bibliographic header.
- Same change covers bph.sourcelibrary.org because the embed route reuses BookDetailPage.

## Out of scope
- `CategoryPicker.tsx` is left in place — no other callers, but keeping the file in case admin-only re-use is added later. Easy follow-up cleanup.
- Underlying `book.categories` data is untouched; only the rendered UI is removed.

## Test plan
- [ ] sourcelibrary.org/book/<any-id> — "About This Book" still renders summary; no pills/Edit button above it.
- [ ] bph.sourcelibrary.org/book/<any-bph-id> — same.
- [ ] Scholar-mode toggle still hides the whole AISection (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)