### PR TITLE
embed: mirror iframe filter/sort/view on parent URL (Laura's ask)

### DIFF
--- a/public/embed/v1.js
+++ b/public/embed/v1.js
@@ -86,8 +86,65 @@
     catch (e) { return null; }
   }
 
-  function makeNavKey(book, page) {
-    return (book || '') + '::' + (page || '');
+  // Iframe URL params that we mirror onto the parent (Webflow) URL so the
+  // visitor's current filter/sort/view/pagination state is shareable and
+  // bookmarkable. host_path / _r are internal embed plumbing and excluded.
+  // Listed both books-grid keys and catalogue (c-prefixed) keys; the iframe
+  // only ever uses one set at a time.
+  var SYNCED_PARAMS = [
+    // shared
+    'view', 'display',
+    // books grid
+    'q', 'sort', 'language', 'offset',
+    // catalogue list (BphCatalogBrowser)
+    'cq', 'csort', 'clang', 'coffset', 'cauthor', 'ctitle', 'ceditor',
+    'cplace', 'cprinter', 'cpublisher', 'cshelf', 'cyfrom', 'cyto',
+    'cdig', 'ckeyword'
+  ];
+
+  function getParentFilters() {
+    try {
+      var sp = new URL(window.location.href).searchParams;
+      var out = {};
+      for (var i = 0; i < SYNCED_PARAMS.length; i++) {
+        var v = sp.get(SYNCED_PARAMS[i]);
+        if (v) out[SYNCED_PARAMS[i]] = v;
+      }
+      return out;
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function filtersToQuery(filters) {
+    var parts = [];
+    if (!filters) return '';
+    for (var k in filters) {
+      if (Object.prototype.hasOwnProperty.call(filters, k) && filters[k]) {
+        parts.push(encodeURIComponent(k) + '=' + encodeURIComponent(filters[k]));
+      }
+    }
+    return parts.join('&');
+  }
+
+  // Deterministic key for dedupe: sort keys so {q:'x',sort:'y'} matches
+  // {sort:'y',q:'x'}.
+  function filtersKey(filters) {
+    var keys = [];
+    if (!filters) return '';
+    for (var k in filters) {
+      if (Object.prototype.hasOwnProperty.call(filters, k) && filters[k]) keys.push(k);
+    }
+    keys.sort();
+    var pairs = [];
+    for (var i = 0; i < keys.length; i++) {
+      pairs.push(keys[i] + '=' + filters[keys[i]]);
+    }
+    return pairs.join('&');
+  }
+
+  function makeNavKey(book, page, filters) {
+    return (book || '') + '::' + (page || '') + '::' + filtersKey(filters);
   }
 
   function getHostPathname() {
@@ -132,7 +189,7 @@
     return parts.join('&');
   }
 
-  function buildIframeSrc(book, page) {
+  function buildIframeSrc(book, page, filters) {
     var base = BASE_URL + '/';
     if (book && page) {
       return withEmbedContext(base + 'embed/' + TENANT + '/book/' + encodeURIComponent(book) + '/page/' + encodeURIComponent(page));
@@ -143,8 +200,12 @@
     if (COLLECTION) {
       return withEmbedContext(base + 'embed/' + TENANT + '/collections/' + encodeURIComponent(COLLECTION));
     }
-    var initial = buildInitialQuery();
-    return withEmbedContext(base + 'embed/' + TENANT + (initial ? '?' + initial : ''));
+    // Parent-URL filter state (mirrored from a previous iframe interaction or
+    // a shared/bookmarked link) takes precedence over the data-* initial
+    // config. The data-* attributes are defaults for the first visit only.
+    var hasParentFilters = filters && filtersKey(filters) !== '';
+    var query = hasParentFilters ? filtersToQuery(filters) : buildInitialQuery();
+    return withEmbedContext(base + 'embed/' + TENANT + (query ? '?' + query : ''));
   }
 
   // --- CSS ---
@@ -200,7 +261,7 @@
 
     var iframe = document.createElement('iframe');
     iframe.id = 'sl-embed-iframe';
-    iframe.src = buildIframeSrc(getParam('book'), getParam('page'));
+    iframe.src = buildIframeSrc(getParam('book'), getParam('page'), getParentFilters());
     iframe.setAttribute('allowfullscreen', '');
     iframe.setAttribute('title', 'Source Library');
 
@@ -215,11 +276,16 @@
 
     // --- State ---
     // What the host URL currently has (from browser perspective)
-    var hostNavKey = makeNavKey(getParam('book'), getParam('page'));
+    var hostNavKey = makeNavKey(getParam('book'), getParam('page'), getParentFilters());
     // What the iframe is currently showing (tracked via sl-navigate)
     var frameNavKey = hostNavKey;
     // Guard: true while handling popstate to prevent sl-navigate from pushing
     var isPopstateNav = false;
+    // True until the iframe's first sl-navigate. If the server strip-redirects
+    // orphaned filter params on initial load, the first sl-navigate will
+    // disagree with our parent-URL-derived hostNavKey — replace, don't push,
+    // so visitors don't have to hit back twice to leave the page.
+    var isInitialNav = true;
     // For forced reloads when client nav fails
     var reloadCounter = 0;
     // Track expected history length to detect iframe full navigations
@@ -268,8 +334,11 @@
       // Navigation report from iframe
       if (data.type !== 'sl-navigate') return;
 
-      var newNavKey = makeNavKey(data.book, data.page);
+      var iframeFilters = data.filters || {};
+      var newNavKey = makeNavKey(data.book, data.page, iframeFilters);
       var historyGrewUnexpectedly = history.length > expectedHistoryLength;
+      var wasInitialNav = isInitialNav;
+      isInitialNav = false;
 
       // Update frame tracking
       frameNavKey = newNavKey;
@@ -289,20 +358,38 @@
       // Scroll to top on navigation
       scrollToTop();
 
-      // Build the new URL
+      // Build the new URL. book/page are always synced. Filter params are
+      // only mirrored when the iframe is on a listing (no book) — when
+      // entering a book detail we want to preserve whatever filter state the
+      // visitor had so back-button restores it.
       var url = new URL(window.location.href);
       url.searchParams.delete('book');
       url.searchParams.delete('page');
       if (data.book) url.searchParams.set('book', data.book);
       if (data.page) url.searchParams.set('page', data.page);
+      if (!data.book) {
+        for (var i = 0; i < SYNCED_PARAMS.length; i++) url.searchParams.delete(SYNCED_PARAMS[i]);
+        for (var fk in iframeFilters) {
+          if (Object.prototype.hasOwnProperty.call(iframeFilters, fk) && iframeFilters[fk]) {
+            url.searchParams.set(fk, iframeFilters[fk]);
+          }
+        }
+      }
 
-      // If history grew unexpectedly (iframe did full navigation), use replaceState
-      // instead of pushState to avoid duplicate entries
-      if (historyGrewUnexpectedly) {
-        window.history.replaceState({ book: data.book || null, page: data.page || null }, '', url.toString());
+      var stateObj = {
+        book: data.book || null,
+        page: data.page || null,
+        filters: data.book ? null : iframeFilters
+      };
+
+      // Replace (not push) when history grew unexpectedly OR when this is
+      // the iframe's first nav after init — both cases would otherwise leave
+      // a phantom history entry that the back button has to step over.
+      if (historyGrewUnexpectedly || wasInitialNav) {
+        window.history.replaceState(stateObj, '', url.toString());
         hostNavKey = newNavKey;
       } else {
-        window.history.pushState({ book: data.book || null, page: data.page || null }, '', url.toString());
+        window.history.pushState(stateObj, '', url.toString());
         hostNavKey = newNavKey;
         expectedHistoryLength = history.length;
       }
@@ -312,7 +399,8 @@
     window.addEventListener('popstate', function () {
       var book = getParam('book');
       var page = getParam('page');
-      var targetNavKey = makeNavKey(book, page);
+      var filters = getParentFilters();
+      var targetNavKey = makeNavKey(book, page, filters);
 
       // Update host tracking
       hostNavKey = targetNavKey;
@@ -331,7 +419,7 @@
       scrollToTop();
 
       // Try fast client-side navigation first
-      var src = buildIframeSrc(book, page);
+      var src = buildIframeSrc(book, page, filters);
 
       try {
         iframe.contentWindow.postMessage({
@@ -339,6 +427,7 @@
           tenant: TENANT,
           book: book || null,
           page: page || null,
+          filters: filters
         }, BASE_URL);
       } catch (e) { /* cross-origin, fallback handles it */ }
 

--- a/src/components/embed/EmbedHostNavigationListener.tsx
+++ b/src/components/embed/EmbedHostNavigationListener.tsx
@@ -8,11 +8,20 @@ interface HostNavigateData {
     tenant?: string | null;
     book?: string | null;
     page?: string | null;
+    filters?: Record<string, string>;
 }
+
+// Internal iframe-only params we never compare against host-driven targets
+// (host_path is appended by embed/v1.js; _r is the reload cache-buster).
+const INTERNAL_PARAMS = new Set(['host_path', '_r']);
 
 /**
  * Listens for host-driven navigation commands from embed v1.js and
  * performs client-side route transitions inside the iframe for faster UX.
+ *
+ * Host can send a book/page deep-link OR a filter snapshot (when the
+ * visitor hits back/forward on a URL whose filter state differs from the
+ * iframe's current view).
  */
 export default function EmbedHostNavigationListener() {
     const router = useRouter();
@@ -36,10 +45,23 @@ export default function EmbedHostNavigationListener() {
             } else if (book) {
                 target = '/embed/' + tenant + '/book/' + book;
             } else {
-                target = '/embed/' + tenant;
+                const qs = new URLSearchParams();
+                const filters = data.filters || {};
+                for (const [k, v] of Object.entries(filters)) {
+                    if (v) qs.set(k, v);
+                }
+                const query = qs.toString();
+                target = '/embed/' + tenant + (query ? '?' + query : '');
             }
 
-            const current = window.location.pathname + window.location.search;
+            // Normalise the current URL (strip internal iframe-only params) so
+            // the equality check actually fires when nothing has changed —
+            // otherwise the leftover host_path param makes every popstate
+            // trigger a wasted route.replace + nav-start flash.
+            const currentSp = new URLSearchParams(window.location.search);
+            INTERNAL_PARAMS.forEach((k) => currentSp.delete(k));
+            const currentSearch = currentSp.toString();
+            const current = window.location.pathname + (currentSearch ? '?' + currentSearch : '');
             if (current === target) return;
 
             // Show the loader before kicking off the route transition so it

--- a/src/components/embed/EmbedNavigationReporter.tsx
+++ b/src/components/embed/EmbedNavigationReporter.tsx
@@ -1,34 +1,55 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 interface Props {
   book?: string | null;
   page?: string | null;
 }
 
+// Internal-only iframe params that must not be mirrored to the parent URL.
+// `host_path` is appended by embed/v1.js so the iframe knows the parent path;
+// `_r` is the popstate-fallback reload cache-buster.
+const INTERNAL_PARAMS = new Set(['host_path', '_r']);
+
 /**
  * Fires a postMessage to the parent frame when Source Library pages are
  * embedded via embed.js on partner sites (e.g. Webflow).
  *
- * The parent embed.js listens for { type: 'sl-navigate' } and updates
- * the host page URL (?book=slug&page=pageId) for shareability and back-button support.
+ * The parent embed.js listens for { type: 'sl-navigate' } and mirrors the
+ * iframe's URL state onto the host page URL so visitors can bookmark and
+ * share their current filter/sort/view selection. `book`/`page` cover the
+ * book deep-link contract; `filters` carries everything else (q, sort,
+ * view, display, c-prefixed catalogue filters, language, offset, ...).
  *
  * Only fires when inside an iframe — no-ops when loaded directly.
  */
 export default function EmbedNavigationReporter({ book = null, page = null }: Props) {
+  const searchParams = useSearchParams();
+  // searchParams identity can change between renders without contents changing;
+  // depend on the string form so the effect re-fires exactly when the iframe
+  // URL's query actually changes (filter clicks, sort changes, pagination).
+  const searchKey = searchParams.toString();
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (window.self === window.top) return; // not in an iframe
 
+    const filters: Record<string, string> = {};
+    for (const [k, v] of searchParams.entries()) {
+      if (INTERNAL_PARAMS.has(k)) continue;
+      if (v) filters[k] = v;
+    }
+
     window.parent.postMessage(
-      { type: 'sl-navigate', book, page },
+      { type: 'sl-navigate', book, page, filters },
       '*'
     );
 
     // Signal to EmbedNavigationOverlay that the new page has begun rendering.
     window.dispatchEvent(new Event('embed:nav-end'));
-  }, [book, page]);
+  }, [book, page, searchKey, searchParams]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
Makes the visitor's full UI state — search query, filters, sort, view, pagination — shareable and bookmarkable from the host (Webflow) URL, not just the iframe URL.

Before: only \`?book=\` and \`?page=\` round-tripped between iframe and parent. Everything else (q, sort, view, display, c-prefixed catalogue filters, language, offset) was trapped inside the iframe — invisible to the host, lost on copy-paste.

After: iframe state changes push to the parent URL; parent URL changes (initial load, back/forward) sync into the iframe. When the visitor enters a book detail, filter params are preserved on the parent URL so the back-button restores the listing they came from.

## Changes

- **\`src/components/embed/EmbedNavigationReporter.tsx\`** — switched to \`useSearchParams\` so the effect re-fires when filters/sort/view change (previously only book/page). Posts all non-internal query params as \`filters\` in the sl-navigate payload.
- **\`public/embed/v1.js\`** — added \`SYNCED_PARAMS\`, \`getParentFilters()\`, \`filtersToQuery()\`, \`filtersKey()\` helpers. Extended \`buildIframeSrc\` to accept filters from the parent URL on init/popstate. Extended the sl-navigate handler to mirror filter state to the parent via pushState. Added \`isInitialNav\` flag so the iframe's first sl-navigate (which may clean orphan params via the server's strip-redirect) replaces history rather than pushing a duplicate.
- **\`src/components/embed/EmbedHostNavigationListener.tsx\`** — accepts \`filters\` in sl-host-navigate. Builds \`/embed/<tenant>?q=…&sort=…\` targets when no book is set. Normalises current URL (strips host_path/_r) before equality check so popstate doesn't trigger spurious route.replace flashes.

## Design choices

- **Used existing param names** (\`q\`, \`sort\`, \`view\`, \`display\`, \`cauthor\`, \`cyfrom\`, …) rather than translating to a generic \`filter=k:v\` shape. Keeps the parent URL consistent with what the server already speaks; no translation layer to maintain. Easy follow-up if we want prettier URLs for partners.
- **Preserve filter state when entering a book.** Reporter still emits filter state on book pages (which is empty), but v1.js only clears/overwrites filter params on the parent URL when \`data.book\` is null. Visitor can browse into a book and back out and the listing context is intact.
- **No new param names** — colliding with the existing \`?book=\`/\`?page=\` deep-link contract would have broken existing share links.

## Test plan

Verified locally with a playwright integration test against \`npm run dev\` (BPH tenant). All 10 checks pass:

- [x] Fresh load: host URL unchanged, iframe at \`/embed/bph\`
- [x] Reload with \`?q=mushroom&sort=year_desc\` on host: iframe inits in that state
- [x] Iframe sort change: host mirrors \`sort=title&view=books&display=grid\`, stale params cleared
- [x] Browser back: both sides revert to \`q=mushroom&sort=year_desc\`
- [x] Iframe enters book: host gains \`book=<slug>\`, \`q=mushroom\` preserved

## What's out of scope
- No prettier URL shape (\`filter=k:v\`, \`sort=date-desc\`, \`page=2\`). Easy to layer on later if a partner asks; would be a pure embed/v1.js change.
- Vercel deploy is still blocked by the cron-quota issue (cf. PR #2031); this won't go live until that's unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)