### PR TITLE
fix(bph): show per-book illustrations on tenant book pages

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -809,7 +809,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   <FileText className="w-4 h-4" />
                   {totalPages} scans
                 </div>
-                {embedPolicy.showGalleryImages && imageCount > 0 && (
+                {imageCount > 0 && (
                   <Link
                     href={`/gallery?bookId=${book.id}`}
                     className="flex items-center gap-2 text-accent-gold hover:text-accent-gold transition-colors"
@@ -1043,7 +1043,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                   </div>
                   {hasTranslations && (
                     <AISection kind="reading-guide">
-                      <ExpandableGuide embedPolicy={embedPolicy} bookId={book.id} detailedSummary={bookSummaryObj?.detailed || bookSummaryObj?.abstract} />
+                      <ExpandableGuide bookId={book.id} detailedSummary={bookSummaryObj?.detailed || bookSummaryObj?.abstract} />
                     </AISection>
                   )}
                 </>
@@ -1103,8 +1103,11 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
               );
             })()}
 
-            {/* Gallery Images Preview */}
-            {embedPolicy.showGalleryImages && galleryImages.length > 0 && (
+            {/* Gallery Images Preview — per-book strip is safe in embed mode
+                (every row is filtered by book_id, so tenant books only surface
+                their own images). The cross-book tenant-home gallery on
+                SharedLibraryView still respects showGalleryImages. */}
+            {galleryImages.length > 0 && (
               <div className="card p-6 mt-6">
                 <div className="flex items-center justify-between mb-4">
                   <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>

--- a/src/components/book/ExpandableGuide.tsx
+++ b/src/components/book/ExpandableGuide.tsx
@@ -7,7 +7,6 @@ import Image from 'next/image';
 import { BookText, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
 import { books, gallery } from '@/lib/api-client';
 import SectionsNav from '@/components/layout/SectionsNav';
-import { EmbedUiPolicy } from '@/lib/embed-ui-policy';
 
 interface SectionSummary {
   title: string;
@@ -32,13 +31,12 @@ interface GalleryItem {
 }
 
 interface ExpandableGuideProps {
-  embedPolicy: EmbedUiPolicy;
   bookId: string;
   /** Detailed summary text, passed from server — renders instantly on expand */
   detailedSummary?: string;
 }
 
-export default function ExpandableGuide({ embedPolicy, bookId, detailedSummary, }: ExpandableGuideProps) {
+export default function ExpandableGuide({ bookId, detailedSummary, }: ExpandableGuideProps) {
   const pathname = usePathname();
 
   // Extract tenant prefix from pathname (format: /{tenant}/book/...)
@@ -132,8 +130,10 @@ export default function ExpandableGuide({ embedPolicy, bookId, detailedSummary, 
             </div>
           )}
 
-          {/* Illustrations — lazy-loaded */}
-          {embedPolicy.showGalleryImages && illustrations.length > 0 && (
+          {/* Illustrations — lazy-loaded. Per-book, so safe in embed mode
+              (gallery.list is scoped to bookId — a tenant book's images are
+              tenant-scoped by inheritance). */}
+          {illustrations.length > 0 && (
             <div>
               <button
                 onClick={() => setShowIllustrations(!showIllustrations)}


### PR DESCRIPTION
## Summary
- The Illustrations preview strip and \"{imageCount} images\" link were hidden on tenant book detail pages (e.g. `bph.sourcelibrary.org/book/X`) because the embed-mode UI policy sets \`showGalleryImages: false\`. That gate was added in 82d3f77b as a blanket tenant-leak guard.
- Per-book galleries are already filtered by \`book_id\`, so a tenant book's images are tenant-scoped by inheritance — showing them on that book's own detail page doesn't leak cross-tenant content. Drop the gate there and in the matching Reading Guide section (\`ExpandableGuide.tsx\`).
- \`showGalleryImages\` itself stays in place — it still gates the cross-book tenant-home gallery on \`SharedLibraryView\`, which is a separate decision.

## Out of scope
- The cross-book tenant-home gallery (\`SharedLibraryView.tsx\` line 257) remains gated. If we want to surface that on BPH too, it needs a separate look to confirm \`fetchTenantLibraryData\` filters \`galleryImages\` by tenant.
- The \"View All →\" link points at \`/gallery?bookId=…\`, which the proxy keeps on-subdomain (invariant 5 in CLAUDE.md). No change to URL construction.

## Test plan
- [ ] Vercel preview: open a BPH book with illustrations on \`bph.sourcelibrary.org/book/<slug>\`; confirm the Illustrations strip renders and tiles link to \`/book/<slug>/page/<pageId>\`.
- [ ] Open the same book on \`sourcelibrary.org/book/<slug>\`; confirm illustrations still render (no regression on the parent domain).
- [ ] Click through to a tile — should stay on the same host (bph.sourcelibrary.org for BPH visitors).
- [ ] Run \`node scripts/audit-bph-leaks.mjs\` to confirm no off-subdomain anchors get introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)