### PR TITLE
feat(bph): "First English translation" filter on catalogue search

### DIFF
--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -47,6 +47,34 @@ const FIELDS_LEGACY = 'ubn, title, author, year, shelf_mark, keywords, ia_identi
 
 // Cache the schema mode for the lifetime of the runtime.
 let schemaMode: 'new' | 'legacy' | null = null;
+// Cache the global set of `is_first_translation: true` book ids from Atlas.
+// The filter joins the BPH catalogue (Supabase) to this set via
+// `bph_works.sl_book_id.in.(…)`, so we only need the universe of candidate
+// ids — the rest of the filter chain (search, year range, …) is applied by
+// Supabase. Refetched per TTL to pick up new verifications without a deploy.
+let firstTranslationCache: { ids: string[]; expires: number } | null = null;
+const FIRST_TRANSLATION_TTL_MS = 5 * 60 * 1000; // 5 minutes
+async function getFirstTranslationBookIds(): Promise<string[]> {
+  if (firstTranslationCache && firstTranslationCache.expires > Date.now()) {
+    return firstTranslationCache.ids;
+  }
+  try {
+    const db = await getReadDb();
+    const rows = await db.collection('books').find(
+      { is_first_translation: true, hidden: { $ne: true } },
+      { projection: { _id: 0, id: 1 }, maxTimeMS: 8_000 },
+    ).toArray();
+    const ids = (rows as unknown as Array<{ id?: string }>)
+      .map(r => r.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    firstTranslationCache = { ids, expires: Date.now() + FIRST_TRANSLATION_TTL_MS };
+    return ids;
+  } catch {
+    // On Atlas failure, return an empty set so the filter yields zero results
+    // rather than silently degrading to "all books".
+    return [];
+  }
+}
 // Tracks whether the `*_norm` diacritic-insensitive columns from
 // add-bph-diacritic-normalization.sql have been applied. Auto-detected on
 // the first query that uses them; falls back to plain ilike on the original
@@ -92,6 +120,13 @@ export async function GET(req: NextRequest) {
 
   const digitized = sp.get('digitized'); // 'true' | 'false' | 'sl' | null
 
+  // First-translation join: BPH catalogue (Supabase) → Atlas `books.is_first_translation`.
+  // Implicitly digitised-on-SL (the join key is `sl_book_id`, which is only
+  // populated for catalogue rows linked to a Source Library book). Pre-fetch
+  // the universe from Atlas, cached for 5 minutes.
+  const firstTranslation = sp.get('first_translation') === '1';
+  const firstTranslationIds = firstTranslation ? await getFirstTranslationBookIds() : null;
+
   const sort = sp.get('sort') || 'title';
   const offset = Math.max(0, parseInt(sp.get('offset') || '0', 10) || 0);
   const limit = Math.min(200, Math.max(1, parseInt(sp.get('limit') || String(PER_PAGE), 10) || PER_PAGE));
@@ -103,7 +138,8 @@ export async function GET(req: NextRequest) {
     digitized === 'sl' &&
     !q && !author && !title && !place && !printer && !publisher && !editor &&
     !keyword && !language && !shelfMark && !provenance &&
-    yearFrom === null && yearTo === null;
+    yearFrom === null && yearTo === null &&
+    !firstTranslation;
 
   // Run the query in the requested mode. Returns the supabase result object.
   async function runQuery(mode: 'new' | 'legacy') {
@@ -214,6 +250,20 @@ export async function GET(req: NextRequest) {
         query = query.is('sl_book_id', null).is('ia_identifier', null);
       } else {
         query = query.is('ia_identifier', null);
+      }
+    }
+
+    // First-translation filter — restrict to BPH rows whose linked SL book has
+    // `is_first_translation: true`. The legacy schema has no sl_book_id column,
+    // so the filter is a no-op there (returns zero rows by design).
+    if (firstTranslation) {
+      if (mode === 'new' && firstTranslationIds && firstTranslationIds.length > 0) {
+        query = query.in('sl_book_id', firstTranslationIds);
+      } else {
+        // No first-translation ids known (or legacy schema) → return nothing.
+        // PostgREST doesn't have a clean "always false" predicate; use an empty
+        // `in` with a sentinel that can't appear in sl_book_id.
+        query = query.eq('sl_book_id', '__no_first_translations__');
       }
     }
 

--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -36,7 +36,7 @@ function getOptionalStringField(value: unknown): string {
 const CATALOG_PARAM_KEYS = [
     'cq', 'csort', 'ckeyword', 'coffset',
     'cauthor', 'ctitle', 'ceditor', 'cplace', 'cprinter', 'cpublisher',
-    'cshelf', 'clang', 'cyfrom', 'cyto', 'cdig',
+    'cshelf', 'clang', 'cyfrom', 'cyto', 'cdig', 'cft',
 ];
 
 // Books-grid owns these. Catalog view ignores them; strip on /catalog so the

--- a/src/components/libraries/BphCatalogBrowser.tsx
+++ b/src/components/libraries/BphCatalogBrowser.tsx
@@ -98,12 +98,24 @@ interface AdvancedFilters {
   yearFrom: string;
   yearTo: string;
   digitized: '' | 'true' | 'sl' | 'false' | 'held';
+  /** First English translation on Source Library. Implicitly digitised
+      (joins to Atlas `books.is_first_translation` via sl_book_id). */
+  firstTranslation: boolean;
 }
 
 const EMPTY_ADV: AdvancedFilters = {
   author: '', title: '', editor: '', place: '', printer: '', publisher: '',
   shelf_mark: '', language: '', yearFrom: '', yearTo: '', digitized: '',
+  firstTranslation: false,
 };
+
+/** A filter is "applied" when its value is non-empty (or true for the
+    boolean flags). Helper so all the `Object.entries(adv)…` call sites
+    agree on the shape and don't trip over `false !== ''`. */
+function isAdvFilterApplied(key: string, value: string | boolean, lockDigitized: boolean): boolean {
+  if (typeof value === 'boolean') return value;
+  return value !== '' && !(lockDigitized && key === 'digitized');
+}
 
 const PER_PAGE = 50;
 
@@ -213,6 +225,7 @@ export default function BphCatalogBrowser({
     yearFrom: searchParams.get('cyfrom') || '',
     yearTo: searchParams.get('cyto') || '',
     digitized: lockDigitized ? 'sl' : ((searchParams.get('cdig') || '') as AdvancedFilters['digitized']),
+    firstTranslation: searchParams.get('cft') === '1',
   };
   // "Has a user-applied advanced filter?" — drives whether the Advanced
   // panel is open on mount. Exclude the digitised filter when it's forced
@@ -220,7 +233,7 @@ export default function BphCatalogBrowser({
   // so the panel doesn't auto-open just because the user picked a top-level
   // view. Same exclusion rule as `advCount` below.
   const hasAnyAdv = Object.entries(initialAdv).some(
-    ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
+    ([k, v]) => isAdvFilterApplied(k, v as string | boolean, lockDigitized)
   );
   // The unified catalogue's grid view links here with `?cadv=1` so the
   // Advanced panel auto-opens on arrival — partner-requested affordance so
@@ -256,6 +269,7 @@ export default function BphCatalogBrowser({
     if (a.yearFrom) params.set('yearFrom', a.yearFrom);
     if (a.yearTo) params.set('yearTo', a.yearTo);
     if (a.digitized) params.set('digitized', a.digitized);
+    if (a.firstTranslation) params.set('first_translation', '1');
     return params;
   }, []);
 
@@ -273,7 +287,7 @@ export default function BphCatalogBrowser({
     // (e.g. the BPH digitised baseline lives upstream in MongoDB, not in the
     // Supabase query result this component sees).
     const isFiltered = !!q || !!kw || Object.entries(a).some(
-      ([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')
+      ([k, v]) => isAdvFilterApplied(k, v as string | boolean, lockDigitized)
     );
 
     setLoading(true);
@@ -322,6 +336,7 @@ export default function BphCatalogBrowser({
     setOrDel('cyfrom', a.yearFrom);
     setOrDel('cyto', a.yearTo);
     setOrDel('cdig', a.digitized);
+    setOrDel('cft', a.firstTranslation ? '1' : '');
     const qs = params.toString();
     const path = window.location.pathname;
     window.history.replaceState(null, '', qs ? `${path}?${qs}` : path);
@@ -372,10 +387,18 @@ export default function BphCatalogBrowser({
     applyAdvanced(nextAdv);
   }, 300);
 
-  const handleAdvChange = (key: keyof AdvancedFilters, value: string) => {
+  const handleAdvChange = (key: keyof AdvancedFilters, value: string | boolean) => {
     const next = { ...adv, [key]: value } as AdvancedFilters;
     setAdv(next);
     debouncedApplyAdvanced(next);
+  };
+
+  // Toggle-style controls apply immediately (no typing debounce) — saves the
+  // user 300 ms of staring at a stale list after a single click.
+  const handleAdvToggle = (key: keyof AdvancedFilters, value: boolean) => {
+    const next = { ...adv, [key]: value } as AdvancedFilters;
+    setAdv(next);
+    applyAdvanced(next);
   };
 
   const clearAll = () => {
@@ -391,7 +414,9 @@ export default function BphCatalogBrowser({
   // When the digitised filter is locked by the parent (Show digitised list view),
   // don't count it as a user-applied filter — it's part of the view, not a chip.
   const advCount = useMemo(
-    () => Object.entries(adv).filter(([k, v]) => v !== '' && !(lockDigitized && k === 'digitized')).length,
+    () => Object.entries(adv).filter(
+      ([k, v]) => isAdvFilterApplied(k, v as string | boolean, lockDigitized)
+    ).length,
     [adv, lockDigitized]
   );
   const currentPage = Math.floor(offset / PER_PAGE) + 1;
@@ -582,6 +607,18 @@ export default function BphCatalogBrowser({
                 </select>
               </div>
             )}
+            <div>
+              <label className="block text-xs text-muted mb-1">Translation</label>
+              <label className="inline-flex items-center gap-2 text-sm text-primary cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={adv.firstTranslation}
+                  onChange={(e) => handleAdvToggle('firstTranslation', e.target.checked)}
+                  className="rounded border-border-light text-accent-rust focus:ring-accent-rust/30"
+                />
+                First English translation
+              </label>
+            </div>
           </div>
           <div className="flex items-center gap-2 mt-4">
             <button


### PR DESCRIPTION
## Summary
- Adds a \"First English translation\" filter to the BPH catalogue (Advanced panel) for works whose Source Library edition is marked \`is_first_translation: true\` (set by \`verify-first-translation.ts\`).
- The signal lives in Atlas (\`books.is_first_translation\`); the catalogue itself is Supabase (\`bph_works\`). The route pre-fetches the universe of first-translation book ids from Atlas (5-minute TTL cache) and joins via \`bph_works.sl_book_id.in.(…)\`.
- Implicitly digitised-on-SL — only rows linked to a Source Library book can carry the signal.

## Plumbing
- API: \`GET /api/catalog/bph?first_translation=1\`
- URL param on the catalogue browser: \`cft=1\` (added to \`CATALOG_PARAM_KEYS\` in \`src/app/embed/[tenant]/page.tsx\` so it survives the orphan-strip).
- UI: checkbox in the \`BphCatalogBrowser\` Advanced panel, beside Digitisation.
- Toggle changes apply immediately (no 300 ms debounce — a single click shouldn't sit on a stale list).
- The filter counts toward the Advanced badge and clears with \"Clear all\".

## Choice: pre-fetch the universe vs. denormalise
Chose **A (pre-fetch + cache)** over denormalising \`is_first_translation\` onto \`bph_works\`. Reasons:
- Set is small (low hundreds today), easily fits a single \`in.(…)\` URL.
- No Supabase migration required; the sync cron doesn't need updating.
- 5-min TTL is acceptable — first-translation verification runs rarely.

If the set grows past comfortable URL length, the natural follow-up is to denormalise (single boolean column on \`bph_works\`, kept fresh by the existing \`sync-bph-sl-book-ids\` cron).

## Out of scope
- Same filter on the main \`/[tenant]/catalog\` page (uses \`CatalogBrowser\`, not \`BphCatalogBrowser\`). \`ScholarCatalog\` already exposes this for \`/catalog/scholar\`.
- Renaming the label if the BPH team prefers \"First translation into English\" / \"First modern translation\" — happy to adjust.

## Test plan
- [ ] On \`bph.sourcelibrary.org/catalog?display=list\`, open the Advanced panel and tick \"First English translation\". List should narrow to digitised BPH works that have a first-translation badge on their SL detail page.
- [ ] Combine with other filters (year range, author, place) — they AND together.
- [ ] Tick the box, then uncheck — count returns to the baseline.
- [ ] URL: with the box ticked, URL bar should carry \`cft=1\`. Pasting that URL in a new tab restores the filter on load.
- [ ] Combine with \"Show digitised & translated\" parent toggle — should still narrow further (digitised \`sl_book_id\` ∩ first-translation set).
- [ ] Atlas-down failure: filter returns 0 rows (\`getFirstTranslationBookIds\` swallows errors and returns empty), not the whole catalogue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)