### PR TITLE
fix(bph): denormalise is_first_translation + backfill tenant gallery_images

### DIFF
--- a/scripts/maintenance/backfill-gallery-tenant-id.mjs
+++ b/scripts/maintenance/backfill-gallery-tenant-id.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Backfill `tenantId` on `gallery_images` from each image's `book.tenantId`.
+ *
+ * Why: tenant gallery pages (`/[tenant]/gallery`) filter by `tenantId` to
+ * honour invariant 2 in CLAUDE.md (every server query touching a tenant
+ * page filters by tenant). New tenants get `tenantId` set on `books` and
+ * `pages`, but the gallery_images collection was missed historically —
+ * any tenant promoted before the pipeline learned to set it has zero
+ * images visible in its gallery view, even though the book detail page
+ * (which queries by `book_id` only) renders them fine.
+ *
+ * See `memory/lesson_tenant_promotion_backfill.md` for the broader pattern.
+ *
+ * Run after promoting a new tenant, or when the gallery is silently empty
+ * on a tenant subdomain with otherwise visible books and images.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-gallery-tenant-id.mjs
+ *   # or scope to one tenant:
+ *   set -a; source .env.production.local; set +a; node scripts/maintenance/backfill-gallery-tenant-id.mjs --tenant bph
+ */
+
+import { MongoClient } from 'mongodb';
+
+const CHUNK = 500;
+
+async function main() {
+  const args = process.argv.slice(2);
+  const tenantArgIdx = args.indexOf('--tenant');
+  const onlyTenant = tenantArgIdx >= 0 ? args[tenantArgIdx + 1] : null;
+
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('MONGODB_URI missing — source .env.production.local first.');
+    process.exit(1);
+  }
+
+  const c = new MongoClient(uri);
+  await c.connect();
+  const db = c.db('bookstore');
+
+  const tenantQuery = onlyTenant ? { slug: onlyTenant } : {};
+  const tenants = await db.collection('tenants').find(
+    tenantQuery,
+    { projection: { _id: 0, id: 1, slug: 1 } },
+  ).toArray();
+
+  if (tenants.length === 0) {
+    console.error(`No tenants matched ${JSON.stringify(tenantQuery)}.`);
+    process.exit(1);
+  }
+
+  let grand = 0;
+  for (const t of tenants) {
+    const books = (await db.collection('books').find(
+      { tenantId: t.id },
+      { projection: { id: 1 } },
+    ).toArray()).map(b => b.id);
+
+    if (books.length === 0) continue;
+
+    let updated = 0;
+    for (let i = 0; i < books.length; i += CHUNK) {
+      const chunk = books.slice(i, i + CHUNK);
+      const r = await db.collection('gallery_images').updateMany(
+        { book_id: { $in: chunk }, $or: [{ tenantId: { $exists: false } }, { tenantId: null }] },
+        { $set: { tenantId: t.id } },
+      );
+      updated += r.modifiedCount;
+    }
+    if (updated > 0) console.log(t.slug.padEnd(22), 'updated:', updated);
+    grand += updated;
+  }
+
+  console.log('---');
+  console.log('total updated:', grand);
+  await c.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/migration/backfill-bph-first-translation.mjs
+++ b/scripts/migration/backfill-bph-first-translation.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * One-shot backfill: set `bph_works.is_first_translation` from Atlas
+ * `books.is_first_translation`.
+ *
+ * Background: see `supabase/migrations/20260526000000_bph_works_first_translation.sql`.
+ * The signal lives in Atlas; the BPH catalogue is Supabase. The catalogue's
+ * Advanced filter "First English translation" originally pre-fetched the
+ * universe of ids and passed them as `sl_book_id.in.(…)`, but the URL
+ * exceeded Cloudflare's 16KB cap (~38KB for 1.5K BPH-linked rows → 414).
+ * Denormalising onto bph_works lets the filter run as a single `eq`.
+ *
+ * The recurring half lives in `src/app/api/cron/sync-bph-sl-book-ids/route.ts`,
+ * which PATCHes the column alongside `sl_book_id` / `sl_book_slug` so new
+ * verifications land on the catalogue within 6 hours.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a;
+ *   node scripts/migration/backfill-bph-first-translation.mjs
+ *
+ * Idempotent — running again is a no-op for rows already in the right state.
+ */
+
+import { MongoClient } from 'mongodb';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const MONGODB_URI = process.env.MONGODB_URI;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY — source .env.production.local first.');
+  process.exit(1);
+}
+if (!MONGODB_URI) {
+  console.error('Missing MONGODB_URI.');
+  process.exit(1);
+}
+
+async function main() {
+  const c = new MongoClient(MONGODB_URI);
+  await c.connect();
+  const db = c.db('bookstore');
+
+  // Universe of first-translation book ids from Atlas.
+  const firstTranslation = await db.collection('books').find(
+    { is_first_translation: true, hidden: { $ne: true } },
+    { projection: { _id: 0, id: 1 } },
+  ).toArray();
+  const ids = firstTranslation.map(r => r.id).filter(Boolean);
+  console.log('atlas first_translation count:', ids.length);
+
+  await c.close();
+
+  const headers = {
+    apikey: SUPABASE_KEY,
+    Authorization: `Bearer ${SUPABASE_KEY}`,
+    'Content-Type': 'application/json',
+    Prefer: 'return=minimal,count=exact',
+  };
+
+  // Phase 1: set TRUE on rows linked to a first-translation book.
+  // Chunk the .in.(…) since this still goes through PostgREST (~1500 ids
+  // is well under the URL cap when split into chunks of 500).
+  const CHUNK = 500;
+  let setTrue = 0;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const url = `${SUPABASE_URL}/rest/v1/bph_works?sl_book_id=in.(${chunk.map(encodeURIComponent).join(',')})&is_first_translation=eq.false`;
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ is_first_translation: true }),
+    });
+    if (!res.ok) {
+      console.error(`PATCH chunk ${i}: ${res.status} ${await res.text()}`);
+      process.exit(1);
+    }
+    const cr = res.headers.get('content-range');
+    const n = cr ? parseInt(cr.split('/')[1] || '0', 10) : 0;
+    setTrue += n;
+  }
+  console.log('bph_works set TRUE:', setTrue);
+
+  // Phase 2: ensure FALSE on linked rows whose Atlas book is NO LONGER
+  // a first translation (e.g. verification flipped). We can't `not.in.()`
+  // a 1500-id list in one shot, so flip the comparison: fetch all currently
+  // TRUE rows from bph_works and reset any whose sl_book_id isn't in the set.
+  const currentlyTrueRes = await fetch(
+    `${SUPABASE_URL}/rest/v1/bph_works?is_first_translation=eq.true&select=sl_book_id`,
+    { headers },
+  );
+  if (!currentlyTrueRes.ok) {
+    console.error(`fetch currently TRUE: ${currentlyTrueRes.status} ${await currentlyTrueRes.text()}`);
+    process.exit(1);
+  }
+  const currentlyTrue = await currentlyTrueRes.json();
+  const idSet = new Set(ids);
+  const stale = currentlyTrue
+    .map(r => r.sl_book_id)
+    .filter(id => id && !idSet.has(id));
+
+  let setFalse = 0;
+  for (let i = 0; i < stale.length; i += CHUNK) {
+    const chunk = stale.slice(i, i + CHUNK);
+    const url = `${SUPABASE_URL}/rest/v1/bph_works?sl_book_id=in.(${chunk.map(encodeURIComponent).join(',')})`;
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ is_first_translation: false }),
+    });
+    if (!res.ok) {
+      console.error(`reset chunk ${i}: ${res.status} ${await res.text()}`);
+      process.exit(1);
+    }
+    const cr = res.headers.get('content-range');
+    const n = cr ? parseInt(cr.split('/')[1] || '0', 10) : 0;
+    setFalse += n;
+  }
+  console.log('bph_works reset to FALSE (stale flips):', setFalse);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/catalog/bph/route.ts
+++ b/src/app/api/catalog/bph/route.ts
@@ -47,34 +47,11 @@ const FIELDS_LEGACY = 'ubn, title, author, year, shelf_mark, keywords, ia_identi
 
 // Cache the schema mode for the lifetime of the runtime.
 let schemaMode: 'new' | 'legacy' | null = null;
-// Cache the global set of `is_first_translation: true` book ids from Atlas.
-// The filter joins the BPH catalogue (Supabase) to this set via
-// `bph_works.sl_book_id.in.(…)`, so we only need the universe of candidate
-// ids — the rest of the filter chain (search, year range, …) is applied by
-// Supabase. Refetched per TTL to pick up new verifications without a deploy.
-let firstTranslationCache: { ids: string[]; expires: number } | null = null;
-const FIRST_TRANSLATION_TTL_MS = 5 * 60 * 1000; // 5 minutes
-async function getFirstTranslationBookIds(): Promise<string[]> {
-  if (firstTranslationCache && firstTranslationCache.expires > Date.now()) {
-    return firstTranslationCache.ids;
-  }
-  try {
-    const db = await getReadDb();
-    const rows = await db.collection('books').find(
-      { is_first_translation: true, hidden: { $ne: true } },
-      { projection: { _id: 0, id: 1 }, maxTimeMS: 8_000 },
-    ).toArray();
-    const ids = (rows as unknown as Array<{ id?: string }>)
-      .map(r => r.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
-    firstTranslationCache = { ids, expires: Date.now() + FIRST_TRANSLATION_TTL_MS };
-    return ids;
-  } catch {
-    // On Atlas failure, return an empty set so the filter yields zero results
-    // rather than silently degrading to "all books".
-    return [];
-  }
-}
+// Tracks whether the denormalised `is_first_translation` column from
+// add-bph-first-translation.sql has been applied. Auto-detected on first
+// error so a runtime that boots before the migration runs degrades to
+// "filter returns nothing" rather than erroring the whole catalogue query.
+let hasFirstTranslationColumn: boolean | null = null;
 // Tracks whether the `*_norm` diacritic-insensitive columns from
 // add-bph-diacritic-normalization.sql have been applied. Auto-detected on
 // the first query that uses them; falls back to plain ilike on the original
@@ -120,12 +97,11 @@ export async function GET(req: NextRequest) {
 
   const digitized = sp.get('digitized'); // 'true' | 'false' | 'sl' | null
 
-  // First-translation join: BPH catalogue (Supabase) → Atlas `books.is_first_translation`.
-  // Implicitly digitised-on-SL (the join key is `sl_book_id`, which is only
-  // populated for catalogue rows linked to a Source Library book). Pre-fetch
-  // the universe from Atlas, cached for 5 minutes.
+  // First-translation filter: denormalised onto `bph_works.is_first_translation`
+  // by the sync-bph-sl-book-ids cron (and one-shot backfill at
+  // scripts/migration/backfill-bph-first-translation.mjs). Implicitly digitised-on-SL —
+  // only rows with a non-null sl_book_id can carry the flag.
   const firstTranslation = sp.get('first_translation') === '1';
-  const firstTranslationIds = firstTranslation ? await getFirstTranslationBookIds() : null;
 
   const sort = sp.get('sort') || 'title';
   const offset = Math.max(0, parseInt(sp.get('offset') || '0', 10) || 0);
@@ -253,16 +229,16 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    // First-translation filter — restrict to BPH rows whose linked SL book has
-    // `is_first_translation: true`. The legacy schema has no sl_book_id column,
-    // so the filter is a no-op there (returns zero rows by design).
+    // First-translation filter — denormalised column on bph_works. Falls back
+    // to "return nothing" on the legacy schema or runtimes that booted before
+    // the migration ran (auto-detected via the retry path below).
     if (firstTranslation) {
-      if (mode === 'new' && firstTranslationIds && firstTranslationIds.length > 0) {
-        query = query.in('sl_book_id', firstTranslationIds);
+      if (mode === 'new' && hasFirstTranslationColumn !== false) {
+        query = query.eq('is_first_translation', true);
       } else {
-        // No first-translation ids known (or legacy schema) → return nothing.
-        // PostgREST doesn't have a clean "always false" predicate; use an empty
-        // `in` with a sentinel that can't appear in sl_book_id.
+        // No column → return nothing. PostgREST doesn't have a clean
+        // "always false" predicate; use a sentinel that can't appear
+        // in sl_book_id.
         query = query.eq('sl_book_id', '__no_first_translations__');
       }
     }
@@ -288,9 +264,20 @@ export async function GET(req: NextRequest) {
   }
 
   // Try the cached mode; on missing-column error, retry — first by
-  // disabling the external-link columns (the most recent addition), then
-  // the diacritic-norm columns, then by falling back to the legacy schema.
+  // disabling the first-translation column (newest addition), then the
+  // external-link columns, then the diacritic-norm columns, then by
+  // falling back to the legacy schema.
   let result = await runQuery(schemaMode || 'new');
+  if (
+    result.error &&
+    isMissingColumnError(result.error) &&
+    (schemaMode || 'new') === 'new' &&
+    firstTranslation &&
+    hasFirstTranslationColumn !== false
+  ) {
+    hasFirstTranslationColumn = false;
+    result = await runQuery('new');
+  }
   if (
     result.error &&
     isMissingColumnError(result.error) &&
@@ -318,6 +305,7 @@ export async function GET(req: NextRequest) {
     schemaMode = 'new';
     if (hasNormalizedColumns === null) hasNormalizedColumns = true;
     if (hasExternalLinks === null) hasExternalLinks = true;
+    if (hasFirstTranslationColumn === null) hasFirstTranslationColumn = true;
   }
 
   if (result.error) {

--- a/src/app/api/cron/sync-bph-sl-book-ids/route.ts
+++ b/src/app/api/cron/sync-bph-sl-book-ids/route.ts
@@ -42,6 +42,7 @@ interface LinkableRow {
   ubn: string;
   id: string;
   slug: string;
+  is_first_translation: boolean;
 }
 
 function extractUbn(dcIdentifier: unknown): string | null {
@@ -89,7 +90,7 @@ export async function GET(request: NextRequest) {
         bph_catalog_link: { $ne: false },
         visible: { $ne: false },
       },
-      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1 }, maxTimeMS: 30_000 },
+      { projection: { id: 1, slug: 1, 'dublin_core.dc_identifier': 1, is_first_translation: 1 }, maxTimeMS: 30_000 },
     )
     .toArray();
 
@@ -103,7 +104,12 @@ export async function GET(request: NextRequest) {
     }
     const id = (d as { id?: string; _id?: unknown }).id;
     if (!id) continue;
-    linkable.push({ ubn, id, slug: ((d as { slug?: string }).slug) || id });
+    linkable.push({
+      ubn,
+      id,
+      slug: ((d as { slug?: string }).slug) || id,
+      is_first_translation: (d as { is_first_translation?: boolean }).is_first_translation === true,
+    });
   }
 
   let updated = 0;
@@ -126,7 +132,11 @@ export async function GET(request: NextRequest) {
         const res = await fetch(url, {
           method: 'PATCH',
           headers,
-          body: JSON.stringify({ sl_book_id: row.id, sl_book_slug: row.slug }),
+          body: JSON.stringify({
+            sl_book_id: row.id,
+            sl_book_slug: row.slug,
+            is_first_translation: row.is_first_translation,
+          }),
           signal: AbortSignal.timeout(15_000),
         });
         if (!res.ok) {

--- a/supabase/migrations/20260526000000_bph_works_first_translation.sql
+++ b/supabase/migrations/20260526000000_bph_works_first_translation.sql
@@ -1,0 +1,24 @@
+-- Add denormalised `is_first_translation` column to bph_works.
+--
+-- The signal lives in MongoDB (`books.is_first_translation`, set by
+-- `src/lib/verify-first-translation.ts`). The BPH catalogue filter
+-- ("First English translation" in the Advanced panel) joined to it by
+-- pre-fetching the universe of ids from Atlas and passing them as
+-- `bph_works.sl_book_id.in.(…)`, but the set is ~1500 BPH-linked rows —
+-- the resulting URL is ~38KB and bursts Cloudflare's URL length cap
+-- (414 Request-URI Too Large). Denormalising onto bph_works lets the
+-- filter become a single `eq` and avoids the URL-length problem.
+--
+-- Maintenance: `src/app/api/cron/sync-bph-sl-book-ids` is extended in
+-- the same change to PATCH this column alongside `sl_book_id` /
+-- `sl_book_slug`. The one-off backfill lives at
+-- `scripts/migration/backfill-bph-first-translation.mjs`.
+
+ALTER TABLE bph_works
+  ADD COLUMN IF NOT EXISTS is_first_translation BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Partial index — the filter is "tick to show ONLY first translations",
+-- not "tick to hide them", so we only need fast lookup for the TRUE side.
+CREATE INDEX IF NOT EXISTS bph_works_is_first_translation_idx
+  ON bph_works (is_first_translation)
+  WHERE is_first_translation = TRUE;


### PR DESCRIPTION
## Summary

Hotfix for two production bugs surfaced after merging #2039 / #2040.

### 1. Catalogue filter (#2040) was 414-ing
The pre-fetch-and-\`.in.(…)\` approach worked locally but the universe is 1,547 BPH-linked first-translation books — the resulting URL is ~38KB and bursts Cloudflare's URL cap. Denormalised onto \`bph_works.is_first_translation\` per the \"option B\" path called out in #2040's description.

- \`supabase/migrations/20260526000000_bph_works_first_translation.sql\` — adds the column (BOOLEAN NOT NULL DEFAULT FALSE) and a partial index (\`WHERE is_first_translation = TRUE\`). Already applied to prod.
- \`scripts/migration/backfill-bph-first-translation.mjs\` — one-shot backfill from Atlas; idempotent. Already run (1,547 rows flipped to TRUE).
- \`/api/catalog/bph\` — swapped from cached Atlas lookup + \`.in()\` to \`query.eq('is_first_translation', true)\`. Auto-detect via \`hasFirstTranslationColumn\` flag so a runtime that boots before the migration degrades to "filter returns nothing" instead of erroring the whole catalogue.
- \`/api/cron/sync-bph-sl-book-ids\` — PATCH body now includes \`is_first_translation\` alongside \`sl_book_id\` / \`sl_book_slug\`, so re-verifications land on the catalogue within the existing 6-hour sync cycle.

### 2. Tenant gallery pages were empty for per-book views
Reproduced when clicking \"View All →\" on a BPH book's Illustrations strip (#2039). The gallery page filters by \`tenantId\` (correct, per invariant 2 in CLAUDE.md), but \`gallery_images\` was never backfilled when tenants got promoted — same pattern as \`memory/lesson_tenant_promotion_backfill.md\`. 99,082 images across all 18 tenants had \`book_id\` linked to a tenant book but no \`tenantId\`. Backfill already run.

- \`scripts/maintenance/backfill-gallery-tenant-id.mjs\` — idempotent, scoped per-tenant or all. Should be re-run after any future tenant promotion.

## Out of scope
- Setting \`tenantId\` on \`gallery_images\` at *write* time, so this gap doesn't reappear when new books get imported under existing tenants. The image-extraction pipeline writes from Hetzner workers; tracking the change there needs a separate look. Today, the cron-level safety net is the backfill script.
- Other collections that may have the same gap (e.g. \`pending_books\`, \`book_indexes\`). Out of scope for this hotfix — symptomatic check via the backfill script's pattern when needed.

## Test plan
- [ ] Vercel preview: \`bph.sourcelibrary.org/catalog?cft=1\` returns results (not a 414) — should narrow to ~1,500 first-translation works.
- [ ] Combine \`cft=1\` with other filters in Advanced; behaviour matches before (search + first-translation = AND).
- [ ] \`bph.sourcelibrary.org/gallery?bookId=<bph book id>\` shows the book's images.
- [ ] Trigger \`sync-bph-sl-book-ids\` cron once and confirm it PATCHes \`is_first_translation\` without error (look in \`cron_runs\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)