### PR TITLE
chore(ai): rename gemini-3.1-flash-lite-preview → gemini-3.1-flash-lite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,8 @@ Source: `src/lib/auth.ts` (cookies block). See `.claude/docs/auth-tenant-cookies
 - Production database: `bookstore`, NOT `sourcelibrary_research`. As of 2026-05-26: ~46K total docs, ~29K `visible: true` (publicly shown), ~15K with `pages_count > 0` (actually processed), ~14K with any OCR. The `tier` field is legacy (only used by `src/app/page.tsx` homepage ranking, seeded by `scripts/tmp-write-highlighted-books.mjs`); current canonical "live" filter across all public APIs is `visible: true && pages_count > 0` (see `/api/books/library`).
 
 ## AI Models — IMPORTANT
-- Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite-preview` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
-- OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite-preview` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
+- Summary/Index generation: enrich-worker uses `gemini-3.1-flash-lite` for all phases — summary+index (Phase 6), chapters (Phase 7), quality scoring (Phase 7.5), collection assignment (Phase 7.6). NEVER use models older than v3.
+- OCR/Translation routing: `gemini-3-flash-preview` for BPH books, `gemini-3.1-flash-lite` for everything else (50% cheaper). See `src/lib/types/ai-models.ts`.
 - Reference: https://ai.google.dev/gemini-api/docs/models
 
 ## Quality systems — two distinct scores

--- a/scripts/analysis/classify-astrology-translations.mjs
+++ b/scripts/analysis/classify-astrology-translations.mjs
@@ -20,7 +20,7 @@ import { GoogleGenAI } from '@google/genai';
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const BATCH_SIZE = args.includes('--batch-size') ? parseInt(args[args.indexOf('--batch-size') + 1]) : 20;
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const API_KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
 
 if (!process.env.MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }

--- a/scripts/artwork-enrichment.mjs
+++ b/scripts/artwork-enrichment.mjs
@@ -21,7 +21,7 @@ const SLUG_FILTER = process.argv.find((_, i, a) => a[i - 1] === '--slug') || nul
 
 const client = new MongoClient(process.env.MONGODB_URI);
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' });
+const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
 
 // Visual art collections that artworks can be assigned to
 const VISUAL_ART_COLLECTIONS = [
@@ -296,7 +296,7 @@ async function main() {
         const now = new Date();
         const provenanceEntry = {
           source: 'ai_enrichment',
-          model: 'gemini-3.1-flash-lite-preview',
+          model: 'gemini-3.1-flash-lite',
           date: now,
           script: 'artwork-enrichment.mjs',
         };
@@ -324,7 +324,7 @@ async function main() {
             period: enrichment.period || null,
             culture: enrichment.culture || null,
             museum_description: enrichment.museum_description || null,
-            model: 'gemini-3.1-flash-lite-preview',
+            model: 'gemini-3.1-flash-lite',
             enriched_at: now,
           },
           updated_at: now,

--- a/scripts/audit-subcollections.mjs
+++ b/scripts/audit-subcollections.mjs
@@ -59,7 +59,7 @@ ${bookList}`;
 
     try {
       const response = await ai.models.generateContent({
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         contents: prompt,
       });
       const text = response.text || '';

--- a/scripts/backfill-iconclass-artworks.mjs
+++ b/scripts/backfill-iconclass-artworks.mjs
@@ -15,7 +15,7 @@ import { GoogleGenAI } from '@google/genai';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--limit') || '7000');
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 
 const PROMPT = `Classify this artwork using Iconclass codes (iconclass.org). Return 2-5 codes, most specific first.
 

--- a/scripts/backfill-iconclass-gallery.mjs
+++ b/scripts/backfill-iconclass-gallery.mjs
@@ -16,7 +16,7 @@ import { GoogleGenAI } from '@google/genai';
 const DRY_RUN = process.argv.includes('--dry-run');
 const LIMIT = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--limit') || '100000');
 const CONCURRENCY = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--concurrency') || '10');
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const PAGE_SIZE = 500; // Fetch more, skip already-tagged in app code
 
 const PROMPT = `Classify this illustration from a historical book using Iconclass codes (iconclass.org). Return 2-5 codes, most specific first.

--- a/scripts/backfill-thin-subs.mjs
+++ b/scripts/backfill-thin-subs.mjs
@@ -96,7 +96,7 @@ ${bookList}`;
 
       try {
         const response = await ai.models.generateContent({
-          model: 'gemini-3.1-flash-lite-preview',
+          model: 'gemini-3.1-flash-lite',
           contents: prompt,
         });
         const text = response.text || '';

--- a/scripts/batch/SPREAD-OCR-README.md
+++ b/scripts/batch/SPREAD-OCR-README.md
@@ -49,7 +49,7 @@ After OCR results are collected, this script:
 ## Pipeline flow
 
 **IMPORTANT**: The Vercel `batch-ocr-async` route uses INLINE submission for books <20 pages.
-Inline does NOT work with `gemini-3.1-flash-lite-preview` (jobs stuck PENDING forever).
+Inline does NOT work with `gemini-3.1-flash-lite` (jobs stuck PENDING forever).
 The Hetzner `pipeline-orchestrator.mjs` uses FILE-BASED submission which works.
 See `.claude/docs/spread-splitting.md` "Batch Submission — Critical Details" for full explanation.
 
@@ -106,7 +106,7 @@ safety settings, and file cleanup — all already working at scale.
 ### 6. Model pricing confusion
 **Issue**: Pricing varies significantly between models and between realtime/batch.
 **Actual pricing (from Gemini docs, 2026-04-01)**:
-- `gemini-3.1-flash-lite-preview` batch: input $0.125/1M, output $0.75/1M
+- `gemini-3.1-flash-lite` batch: input $0.125/1M, output $0.75/1M
 - `gemini-3-flash-preview` batch: input $0.25/1M, output $1.50/1M
 - Per spread page: ~2,400 input + ~900 output tokens
 - 184K pages with Lite batch: **~$45**

--- a/scripts/batch/batch-transliterate.mjs
+++ b/scripts/batch/batch-transliterate.mjs
@@ -13,7 +13,7 @@
  *   node scripts/batch/batch-transliterate.mjs --language greek
  *   node scripts/batch/batch-transliterate.mjs --concurrency 20
  *
- * Cost: ~$0.0001/page using gemini-3.1-flash-lite-preview (text-only).
+ * Cost: ~$0.0001/page using gemini-3.1-flash-lite (text-only).
  * ~$19 total for all 190k non-Latin OCR'd pages.
  */
 
@@ -27,7 +27,7 @@ if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
 if (!GEMINI_API_KEY) { console.error('No GEMINI_API_KEY found'); process.exit(1); }
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${GEMINI_API_KEY}`;
 
 // Model pricing per 1M tokens (USD) — default for unknown models

--- a/scripts/batch/submit-spread-ocr.mjs
+++ b/scripts/batch/submit-spread-ocr.mjs
@@ -23,7 +23,7 @@
  *   --key=N|auto    API key index (0=TIER3, 1=KEY_2, 2=primary, auto=round-robin)
  *   --book-id=X     Submit a specific book
  *   --dry-run       List candidates without submitting
- *   --model=X       Override model (default: gemini-3.1-flash-lite-preview)
+ *   --model=X       Override model (default: gemini-3.1-flash-lite)
  *
  * Prerequisites:
  *   - MONGODB_URI, CRON_SECRET set in env
@@ -34,7 +34,7 @@
  *   2. API key quota: route rotates keys on 429. --key=auto distributes across keys.
  *   3. UvA IIIF timeouts: route has per-image timeout. Failed images are skipped, not fatal.
  *   4. Safety blocks: ~2-5% of pages blocked by Gemini. Collector handles partial results.
- *   5. Model support: gemini-3.1-flash-lite-preview confirmed working via file-based batch
+ *   5. Model support: gemini-3.1-flash-lite confirmed working via file-based batch
  *      (431 completed + 1564 saved in DB). Our earlier failure was inline submission.
  */
 
@@ -55,7 +55,7 @@ const MAX_PAGES = parseInt(getArg('max-pages') || '500', 10);
 const DELAY_SEC = parseInt(getArg('delay') || '3', 10);
 const DRY_RUN = hasFlag('dry-run');
 const BOOK_ID = getArg('book-id');
-const MODEL = getArg('model') || 'gemini-3.1-flash-lite-preview';
+const MODEL = getArg('model') || 'gemini-3.1-flash-lite';
 const KEY_ARG = getArg('key');
 
 const uniqueKeys = [...new Set([

--- a/scripts/batch/verify-spread-ocr.mjs
+++ b/scripts/batch/verify-spread-ocr.mjs
@@ -37,7 +37,7 @@ let query;
 if (BOOK_ID) {
   query = { book_id: BOOK_ID, created_at: { $gte: new Date('2026-04-03') } };
 } else {
-  query = { created_at: { $gte: new Date('2026-04-03') }, job_name: /^batches\//, model: 'gemini-3.1-flash-lite-preview' };
+  query = { created_at: { $gte: new Date('2026-04-03') }, job_name: /^batches\//, model: 'gemini-3.1-flash-lite' };
 }
 
 const jobs = await db.collection('batch_jobs').find(query).toArray();

--- a/scripts/create-political-thought-subs.mjs
+++ b/scripts/create-political-thought-subs.mjs
@@ -268,7 +268,7 @@ ${bookList}`;
 
     try {
       const response = await ai.models.generateContent({
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         contents: prompt,
       });
       const text = response.text || '';

--- a/scripts/create-subcollections.mjs
+++ b/scripts/create-subcollections.mjs
@@ -531,7 +531,7 @@ ${bookList}`;
 
     try {
       const response = await ai.models.generateContent({
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         contents: prompt,
       });
       const text = response.text || '';

--- a/scripts/enrichment/assign-collections-ai.mjs
+++ b/scripts/enrichment/assign-collections-ai.mjs
@@ -181,7 +181,7 @@ function buildCollectionSummary(collections) {
 
 // ── Gemini Classification ─────────────────────────────────────────────────────
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 
 function buildSystemPrompt(collections) {
   const summary = buildCollectionSummary(collections);

--- a/scripts/enrichment/assign-sacred-subcollections.mjs
+++ b/scripts/enrichment/assign-sacred-subcollections.mjs
@@ -81,7 +81,7 @@ async function classifyBatch(ai, books, batchIndex) {
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       const response = await ai.models.generateContent({
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         contents: prompt,
         config: {
           systemInstruction: SYSTEM_PROMPT,

--- a/scripts/enrichment/backfill-year-from-published.mjs
+++ b/scripts/enrichment/backfill-year-from-published.mjs
@@ -12,7 +12,7 @@ import { MongoClient } from 'mongodb';
 import fs from 'fs';
 
 // ── Config ──────────────────────────────────────────────────────────
-const GEMINI_MODEL = 'gemini-3.1-flash-lite-preview';
+const GEMINI_MODEL = 'gemini-3.1-flash-lite';
 const GEMINI_BATCH_SIZE = 50; // books per Gemini call
 const GEMINI_CONCURRENCY = 3;
 

--- a/scripts/enrichment/enrich-metadata-text.mjs
+++ b/scripts/enrichment/enrich-metadata-text.mjs
@@ -21,7 +21,7 @@ import fs from 'fs';
 
 // ── Config ──────────────────────────────────────────────────────────
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const PAGES_PER_BOOK = 10; // OCR text from first 10 pages is plenty
 const CONCURRENCY = 10;    // Much higher than vision — text is fast
 const DELAY_BETWEEN_BATCHES_MS = 500;

--- a/scripts/enrichment/extract-author-from-ocr.mjs
+++ b/scripts/enrichment/extract-author-from-ocr.mjs
@@ -41,7 +41,7 @@ import path from 'path';
 
 // ── Config ──────────────────────────────────────────────────────────
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const PAGES_PER_BOOK = 10; // title page lives in the first ~3-5 pages, 10 is safe
 const PAGE_OCR_TRUNCATE = 2500; // per-page char cap — title pages are short
 const CONCURRENCY = 8;
@@ -209,7 +209,7 @@ async function extractAuthor(book, ocrSamples) {
 // ── Cost ─────────────────────────────────────────────────────────────
 
 function calculateCost(usage) {
-  // gemini-3.1-flash-lite-preview pricing — matches enrich-metadata-text.mjs
+  // gemini-3.1-flash-lite pricing — matches enrich-metadata-text.mjs
   const inputCostPer1M = 0.15;
   const outputCostPer1M = 0.60;
   return (

--- a/scripts/enrichment/extract-publisher-from-ocr.mjs
+++ b/scripts/enrichment/extract-publisher-from-ocr.mjs
@@ -22,7 +22,7 @@ const LIMIT = LIMIT_ARG > -1 ? parseInt(process.argv[LIMIT_ARG + 1]) : 50;
 const AUTHOR_ARG = process.argv.indexOf('--author');
 const AUTHOR_FILTER = AUTHOR_ARG > -1 ? process.argv[AUTHOR_ARG + 1] : null;
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 
 const PROMPT = `Extract the publisher/printer and place of publication from this historical book title page.
 

--- a/scripts/enrichment/match-bph-unknowns-to-catalogue.mjs
+++ b/scripts/enrichment/match-bph-unknowns-to-catalogue.mjs
@@ -25,7 +25,7 @@
  *      (c) leading-word of title + year window
  *      Union+dedupe ≈ 15-30 candidates per book.
  *
- *   2. Gemini — `gemini-3.1-flash-lite-preview` per CLAUDE.md, with two
+ *   2. Gemini — `gemini-3.1-flash-lite` per CLAUDE.md, with two
  *      function-calling tools:
  *
  *      - search_catalogue({ title?, author?, year_from?, year_to?,
@@ -67,7 +67,7 @@ import fs from 'fs';
 
 // ── Config ───────────────────────────────────────────────────────────
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 6;
 const DELAY_BETWEEN_BATCHES_MS = 200;
 const PREFILTER_PER_QUERY = 15;

--- a/scripts/enrichment/normalize-languages.mjs
+++ b/scripts/enrichment/normalize-languages.mjs
@@ -15,7 +15,7 @@ import { MongoClient } from 'mongodb';
 import fs from 'fs';
 
 // ── Config ──────────────────────────────────────────────────────────
-const GEMINI_MODEL = 'gemini-3.1-flash-lite-preview';
+const GEMINI_MODEL = 'gemini-3.1-flash-lite';
 const GEMINI_BATCH_SIZE = 30; // books per Gemini call
 const PAGES_FOR_INFERENCE = 3; // page images to send per book
 

--- a/scripts/enrichment/search-translation-evidence.mjs
+++ b/scripts/enrichment/search-translation-evidence.mjs
@@ -19,7 +19,7 @@ import { MongoClient } from 'mongodb';
 import fs from 'fs';
 
 // ── Config ──────────────────────────────────────────────────────────
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 3;
 const API_DELAY_MS = 400;
 const BATCH_DELAY_MS = 300;

--- a/scripts/enrichment/shwep-llm-match.mjs
+++ b/scripts/enrichment/shwep-llm-match.mjs
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MONGODB_URI = process.env.MONGODB_URI;
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const EPISODES_PER_BATCH = 15;
 
 const args = process.argv.slice(2);

--- a/scripts/enrichment/validate-translation-evidence.mjs
+++ b/scripts/enrichment/validate-translation-evidence.mjs
@@ -23,7 +23,7 @@ import { MongoClient } from 'mongodb';
 import fs from 'fs';
 
 // ── Config ──────────────────────────────────────────────────────────
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 5;
 const DELAY_MS = 400;
 const API_DELAY_MS = 1200;

--- a/scripts/enrichment/verify-first-translations.mjs
+++ b/scripts/enrichment/verify-first-translations.mjs
@@ -20,7 +20,7 @@ import { MongoClient } from 'mongodb';
 import fs from 'fs';
 
 // ── Config ──────────────────────────────────────────────────────────
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 5;
 const DELAY_MS = 500;
 const NEW_DISCOVERIES_CSV = '/Users/dereklomas/secondrenaissance/scripts/latin_translations_new_discoveries.csv';

--- a/scripts/enrichment/verify-istc-candidates.mjs
+++ b/scripts/enrichment/verify-istc-candidates.mjs
@@ -260,7 +260,7 @@ async function runTier3(db, candidates) {
 
   // Dynamic import of the TS verification function via tsx
   // We call the Gemini API directly instead to avoid tsx dependency in scripts
-  const MODEL = 'gemini-3.1-flash-lite-preview';
+  const MODEL = 'gemini-3.1-flash-lite';
   const TEMPERATURE = 0.1;
   const MAX_ROUNDS = 10;
 

--- a/scripts/eval/lib/runners.mjs
+++ b/scripts/eval/lib/runners.mjs
@@ -11,7 +11,7 @@ import Anthropic from '@anthropic-ai/sdk';
 
 const PRICING = {
   'gemini-3-flash-preview':       { input: 0.50, output: 3.00 },
-  'gemini-3.1-flash-lite-preview': { input: 0.075, output: 0.30 },
+  'gemini-3.1-flash-lite': { input: 0.075, output: 0.30 },
   'gemini-3.1-pro-preview':       { input: 2.50, output: 15.00 },
   'gemini-2.5-flash':             { input: 0.15, output: 0.60 },
   'claude-opus-4-6':              { input: 15.00, output: 75.00 },
@@ -203,8 +203,8 @@ export async function runClaude(model, imageBuffer, prompt, opts = {}) {
 
 const MODEL_ALIASES = {
   'flash': 'gemini-3-flash-preview',
-  'flash-lite': 'gemini-3.1-flash-lite-preview',
-  'lite': 'gemini-3.1-flash-lite-preview',
+  'flash-lite': 'gemini-3.1-flash-lite',
+  'lite': 'gemini-3.1-flash-lite',
   'pro': 'gemini-3.1-pro-preview',
   'opus': 'claude-opus-4-6',
   'sonnet': 'claude-sonnet-4-6',

--- a/scripts/eval/results/arabic-consistency-2026-04-23.json
+++ b/scripts/eval/results/arabic-consistency-2026-04-23.json
@@ -2,7 +2,7 @@
   "corpus": "arabic",
   "models": [
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0,
@@ -100,8 +100,8 @@
             828
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -142,8 +142,8 @@
             3364
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 0.3333333333333333,
@@ -276,8 +276,8 @@
             893
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -318,8 +318,8 @@
             1238
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 0.3333333333333333,
@@ -452,8 +452,8 @@
             2615
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -494,8 +494,8 @@
             2445
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 0.3333333333333333,
@@ -557,16 +557,16 @@
         "avgCharSim": 0.7076683805507581,
         "avgSylSim": 0.4323808605493056
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 1,
         "avgCharSim": 1,
         "avgSylSim": 1
       },
-      "gemini-3.1-flash-lite-preview@t0.3": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0.3": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0.3,
         "pages": 3,
         "avgMcr": 0.3333333333333333,
@@ -577,7 +577,7 @@
     "crossModel": [
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.5534316792757884,
         "syllableSimilarity": 0.05461733175198601,
         "pages": 3
@@ -592,8 +592,8 @@
     "costByModel": {
       "gemini-3-flash-preview@t0": 0.018198000000000002,
       "gemini-3-flash-preview@t0.3": 0.018978,
-      "gemini-3.1-flash-lite-preview@t0": 0.0031927500000000003,
-      "gemini-3.1-flash-lite-preview@t0.3": 0.0054385499999999995
+      "gemini-3.1-flash-lite@t0": 0.0031927500000000003,
+      "gemini-3.1-flash-lite@t0.3": 0.0054385499999999995
     }
   }
 }

--- a/scripts/eval/results/arabic-consistency-2026-04-24.json
+++ b/scripts/eval/results/arabic-consistency-2026-04-24.json
@@ -3,7 +3,7 @@
   "models": [
     "gemini-3.1-pro-preview",
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0
@@ -101,8 +101,8 @@
             829
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -235,8 +235,8 @@
             1396
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -369,8 +369,8 @@
             2533
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -432,8 +432,8 @@
         "avgCharSim": 0.9155733980979988,
         "avgSylSim": 0.8744222855333966
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 0.7777777777777777,
@@ -451,14 +451,14 @@
       },
       {
         "modelA": "gemini-3.1-pro-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.5776488890047262,
         "syllableSimilarity": 0.022851695843155443,
         "pages": 3
       },
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.600980553648591,
         "syllableSimilarity": 0.04176094907802225,
         "pages": 3
@@ -473,7 +473,7 @@
     "costByModel": {
       "gemini-3.1-pro-preview@t0": 0.10561499999999999,
       "gemini-3-flash-preview@t0": 0.020721,
-      "gemini-3.1-flash-lite-preview@t0": 0.0031855499999999997
+      "gemini-3.1-flash-lite@t0": 0.0031855499999999997
     }
   }
 }

--- a/scripts/eval/results/hebrew-consistency-2026-04-23.json
+++ b/scripts/eval/results/hebrew-consistency-2026-04-23.json
@@ -2,7 +2,7 @@
   "corpus": "hebrew",
   "models": [
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0,
@@ -88,8 +88,8 @@
             0
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -130,8 +130,8 @@
             2859
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 0.3333333333333333,
@@ -264,8 +264,8 @@
             617
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -306,8 +306,8 @@
             4735
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 0.3333333333333333,
@@ -440,8 +440,8 @@
             611
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -482,8 +482,8 @@
             15957
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 0.3333333333333333,
@@ -545,16 +545,16 @@
         "avgCharSim": 0.3343431197334146,
         "avgSylSim": 0.05704081925681235
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 1,
         "avgCharSim": 1,
         "avgSylSim": 1
       },
-      "gemini-3.1-flash-lite-preview@t0.3": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0.3": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0.3,
         "pages": 3,
         "avgMcr": 0.3333333333333333,
@@ -565,7 +565,7 @@
     "crossModel": [
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.10229037401549564,
         "syllableSimilarity": 0.001067417195412322,
         "pages": 3
@@ -580,8 +580,8 @@
     "costByModel": {
       "gemini-3-flash-preview@t0": 0.013713000000000003,
       "gemini-3-flash-preview@t0.3": 0.014853500000000002,
-      "gemini-3.1-flash-lite-preview@t0": 0.01141965,
-      "gemini-3.1-flash-lite-preview@t0.3": 0.01269075
+      "gemini-3.1-flash-lite@t0": 0.01141965,
+      "gemini-3.1-flash-lite@t0.3": 0.01269075
     }
   }
 }

--- a/scripts/eval/results/hebrew-consistency-2026-04-24.json
+++ b/scripts/eval/results/hebrew-consistency-2026-04-24.json
@@ -3,7 +3,7 @@
   "models": [
     "gemini-3.1-pro-preview",
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0
@@ -101,8 +101,8 @@
             657
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -235,8 +235,8 @@
             623
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -369,8 +369,8 @@
             622
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -432,8 +432,8 @@
         "avgCharSim": 0.5381764501937311,
         "avgSylSim": 0.3498548188722786
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 0.7777777777777777,
@@ -451,14 +451,14 @@
       },
       {
         "modelA": "gemini-3.1-pro-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.4542644868360901,
         "syllableSimilarity": 0.31503996304188014,
         "pages": 3
       },
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.05600132858575061,
         "syllableSimilarity": 0.0033136910920186524,
         "pages": 3
@@ -473,7 +473,7 @@
     "costByModel": {
       "gemini-3.1-pro-preview@t0": 0.7594650000000001,
       "gemini-3-flash-preview@t0": 0.013662,
-      "gemini-3.1-flash-lite-preview@t0": 0.01722255
+      "gemini-3.1-flash-lite@t0": 0.01722255
     }
   }
 }

--- a/scripts/eval/results/sanskrit-consistency-2026-04-24.json
+++ b/scripts/eval/results/sanskrit-consistency-2026-04-24.json
@@ -3,7 +3,7 @@
   "models": [
     "gemini-3.1-pro-preview",
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0
@@ -101,8 +101,8 @@
             1456
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -235,8 +235,8 @@
             1773
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -369,8 +369,8 @@
             1888
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -432,8 +432,8 @@
         "avgCharSim": 0.8718065623034937,
         "avgSylSim": 0.8134316493691495
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 0.7777777777777777,
@@ -451,14 +451,14 @@
       },
       {
         "modelA": "gemini-3.1-pro-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.9658566578505988,
         "syllableSimilarity": 0.75125992226508,
         "pages": 3
       },
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.9864093355247432,
         "syllableSimilarity": 0.7864182442833916,
         "pages": 3
@@ -473,7 +473,7 @@
     "costByModel": {
       "gemini-3.1-pro-preview@t0": 0.10314000000000001,
       "gemini-3-flash-preview@t0": 0.020915999999999997,
-      "gemini-3.1-flash-lite-preview@t0": 0.0024427499999999996
+      "gemini-3.1-flash-lite@t0": 0.0024427499999999996
     }
   }
 }

--- a/scripts/eval/results/tibetan-consistency-2026-04-23.json
+++ b/scripts/eval/results/tibetan-consistency-2026-04-23.json
@@ -2,7 +2,7 @@
   "corpus": "tibetan",
   "models": [
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0,
@@ -100,8 +100,8 @@
             31
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -142,8 +142,8 @@
             31
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 1,
@@ -264,8 +264,8 @@
             32
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -306,8 +306,8 @@
             16
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 1,
@@ -440,8 +440,8 @@
             19
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -482,8 +482,8 @@
             14
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0.3": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0.3": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0.3,
           "mcr": {
             "rate": 1,
@@ -545,16 +545,16 @@
         "avgCharSim": 1,
         "avgSylSim": 1
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 1,
         "avgCharSim": 1,
         "avgSylSim": 1
       },
-      "gemini-3.1-flash-lite-preview@t0.3": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0.3": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0.3,
         "pages": 3,
         "avgMcr": 1,
@@ -565,7 +565,7 @@
     "crossModel": [
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.7387096774193548,
         "syllableSimilarity": 0.6022727272727273,
         "pages": 3
@@ -580,8 +580,8 @@
     "costByModel": {
       "gemini-3-flash-preview@t0": 0.018951000000000003,
       "gemini-3-flash-preview@t0.3": 0.017213000000000003,
-      "gemini-3.1-flash-lite-preview@t0": 0.0021478499999999998,
-      "gemini-3.1-flash-lite-preview@t0.3": 0.00214905
+      "gemini-3.1-flash-lite@t0": 0.0021478499999999998,
+      "gemini-3.1-flash-lite@t0.3": 0.00214905
     }
   }
 }

--- a/scripts/eval/results/tibetan-consistency-2026-04-24.json
+++ b/scripts/eval/results/tibetan-consistency-2026-04-24.json
@@ -3,7 +3,7 @@
   "models": [
     "gemini-3.1-pro-preview",
     "gemini-3-flash-preview",
-    "gemini-3.1-flash-lite-preview"
+    "gemini-3.1-flash-lite"
   ],
   "temperatures": [
     0
@@ -101,8 +101,8 @@
             31
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -235,8 +235,8 @@
             32
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 0.6666666666666666,
@@ -369,8 +369,8 @@
             19
           ]
         },
-        "gemini-3.1-flash-lite-preview@t0": {
-          "model": "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-flash-lite@t0": {
+          "model": "gemini-3.1-flash-lite",
           "temperature": 0,
           "mcr": {
             "rate": 1,
@@ -432,8 +432,8 @@
         "avgCharSim": 1,
         "avgSylSim": 1
       },
-      "gemini-3.1-flash-lite-preview@t0": {
-        "model": "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite@t0": {
+        "model": "gemini-3.1-flash-lite",
         "temp": 0,
         "pages": 3,
         "avgMcr": 0.8888888888888888,
@@ -451,14 +451,14 @@
       },
       {
         "modelA": "gemini-3.1-pro-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.7509903791737408,
         "syllableSimilarity": 0.6022727272727273,
         "pages": 3
       },
       {
         "modelA": "gemini-3-flash-preview@t0",
-        "modelB": "gemini-3.1-flash-lite-preview@t0",
+        "modelB": "gemini-3.1-flash-lite@t0",
         "charSimilarity": 0.7456140350877193,
         "syllableSimilarity": 0.6022727272727273,
         "pages": 3
@@ -473,7 +473,7 @@
     "costByModel": {
       "gemini-3.1-pro-preview@t0": 0.097995,
       "gemini-3-flash-preview@t0": 0.019536,
-      "gemini-3.1-flash-lite-preview@t0": 0.0021478499999999998
+      "gemini-3.1-flash-lite@t0": 0.0021478499999999998
     }
   }
 }

--- a/scripts/experiments/batch-size-experiment.mjs
+++ b/scripts/experiments/batch-size-experiment.mjs
@@ -25,7 +25,7 @@ import path from 'path';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY_3 || process.env.GEMINI_API_KEY;
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
 const args = process.argv.slice(2);

--- a/scripts/fix-untitled-slugs.mjs
+++ b/scripts/fix-untitled-slugs.mjs
@@ -10,7 +10,7 @@ import { MongoClient } from 'mongodb';
 import { GoogleGenAI } from '@google/genai';
 
 const DRY_RUN = process.argv.includes('--dry-run');
-const GEMINI_MODEL = 'gemini-3.1-flash-lite-preview';
+const GEMINI_MODEL = 'gemini-3.1-flash-lite';
 
 const client = new MongoClient(process.env.MONGODB_URI);
 

--- a/scripts/maintenance/backfill-batch-costs.mjs
+++ b/scripts/maintenance/backfill-batch-costs.mjs
@@ -26,7 +26,7 @@ if (!MONGODB_URI) { console.error('MONGODB_URI not set'); process.exit(1); }
 const DRY_RUN = process.argv.includes('--dry-run');
 
 const MODEL_PRICING = {
-  'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.50 },
+  'gemini-3.1-flash-lite': { input: 0.25, output: 1.50 },
   'gemini-3-flash-preview': { input: 0.50, output: 3.00 },
   'gemini-3-pro-preview': { input: 2.50, output: 10.00 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60 },

--- a/scripts/maintenance/backfill-sn-authors.mjs
+++ b/scripts/maintenance/backfill-sn-authors.mjs
@@ -15,7 +15,7 @@
 import { GoogleGenerativeAI, HarmCategory, HarmBlockThreshold } from '@google/generative-ai';
 import { MongoClient, ObjectId } from 'mongodb';
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const APPLY = process.argv.includes('--apply');
 const LIMIT = (() => {
   const i = process.argv.indexOf('--limit');

--- a/scripts/maintenance/fix-chinese-dates-ai.mjs
+++ b/scripts/maintenance/fix-chinese-dates-ai.mjs
@@ -15,7 +15,7 @@ await client.connect();
 const db = client.db('bookstore');
 
 const genAI = new GoogleGenerativeAI(geminiKey);
-const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' });
+const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
 
 // Get distinct titles (many are multi-volume with same base title)
 const books = await db.collection('books').find({

--- a/scripts/maintenance/populate-curated-collections.mjs
+++ b/scripts/maintenance/populate-curated-collections.mjs
@@ -179,7 +179,7 @@ async function callGeminiWithRetry(model, prompt, retries = 3) {
 
 async function selectBooksWithGemini(collection, candidates) {
   const model = genAI.getGenerativeModel({
-    model: 'gemini-3.1-flash-lite-preview',
+    model: 'gemini-3.1-flash-lite',
     generationConfig: {
       responseMimeType: 'application/json',
       temperature: 0.1,

--- a/scripts/match-bph-orphans-gemini.mjs
+++ b/scripts/match-bph-orphans-gemini.mjs
@@ -35,7 +35,7 @@ import { MongoClient } from 'mongodb';
 import { GoogleGenAI } from '@google/genai';
 import fs from 'fs';
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const SUPABASE_URL = 'https://ykhxaecbbxaaqlujuzde.supabase.co';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
 const MONGODB_URI = process.env.MONGODB_URI;

--- a/scripts/migration/backfill-ocr-near-complete.mjs
+++ b/scripts/migration/backfill-ocr-near-complete.mjs
@@ -26,7 +26,7 @@ const OCR_FILE_BATCH_SIZE = 150;
 
 // Models
 const MODEL_FLASH = 'gemini-3-flash-preview';
-const MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+const MODEL_LITE = 'gemini-3.1-flash-lite';
 
 // ── CLI args ──
 const args = process.argv.slice(2);

--- a/scripts/rework-subcollections.mjs
+++ b/scripts/rework-subcollections.mjs
@@ -170,7 +170,7 @@ ${bookList}`;
 
     try {
       const response = await ai.models.generateContent({
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         contents: prompt,
       });
       const text = response.text || '';

--- a/scripts/split-book.mjs
+++ b/scripts/split-book.mjs
@@ -167,7 +167,7 @@ let ocrPromptText = null;
 async function initGemini() {
   const { GoogleGenerativeAI } = await import('@google/generative-ai');
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-  geminiModel = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' });
+  geminiModel = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
   const ocrDoc = await db.collection('prompts').findOne({ type: 'ocr', is_default: true });
   const spreadPrefix = `**TWO-PAGE SPREAD HANDLING:**
 This image is a two-page spread (open book scan). Process BOTH pages separately.
@@ -499,7 +499,7 @@ console.log();
 // --- Step 6: Delete old pages, insert new ones ---
 console.log('\n--- Step 6: Delete old pages, insert new ones ---');
 
-const ocrModel = WITH_OCR ? 'gemini-3.1-flash-lite-preview' : (existingPages[0]?.ocr?.model || 'gemini-3.1-flash-lite-preview');
+const ocrModel = WITH_OCR ? 'gemini-3.1-flash-lite' : (existingPages[0]?.ocr?.model || 'gemini-3.1-flash-lite');
 const promptVersion = WITH_OCR ? `spread-v2+ocr-v${ocrVersion}` : (existingPages[0]?.ocr?.prompt_version || 'spread-v2+ocr-v10');
 
 // Find best cover

--- a/scripts/tmp-backfill-scholarly-briefs.mjs
+++ b/scripts/tmp-backfill-scholarly-briefs.mjs
@@ -44,7 +44,7 @@ const BAD_OPENERS = [
 
 const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
 const model = genAI.getGenerativeModel({
-  model: 'gemini-3.1-flash-lite-preview',
+  model: 'gemini-3.1-flash-lite',
   generationConfig: { temperature: 0.3, maxOutputTokens: 2000 }
 });
 

--- a/scripts/tmp-recitation-retry.mjs
+++ b/scripts/tmp-recitation-retry.mjs
@@ -20,7 +20,7 @@ const KEYS = [
   process.env.GEMINI_API_KEY,
 ].filter(Boolean);
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const CONCURRENCY = 5;
 const DRY_RUN = process.argv.includes('--dry-run');
 const maxGapArg = process.argv.indexOf('--max-gap');

--- a/scripts/workers/batch-collector.mjs
+++ b/scripts/workers/batch-collector.mjs
@@ -88,7 +88,7 @@ console.log(`[batch-collector] Keys: ${ALL_KEYS.length} | Concurrency: ${CONCURR
 // ── Cost calculation (mirrors gemini-logger.ts) ──
 
 const MODEL_PRICING = {
-  'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.50 },
+  'gemini-3.1-flash-lite': { input: 0.25, output: 1.50 },
   'gemini-3-flash-preview': { input: 0.50, output: 3.00 },
   'gemini-3-pro-preview': { input: 2.50, output: 10.00 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60 },

--- a/scripts/workers/enrich-worker.mjs
+++ b/scripts/workers/enrich-worker.mjs
@@ -52,14 +52,14 @@ async function revalidateBookPage(bookId) {
 // ── Config ──
 const MONGODB_URI = process.env.MONGODB_URI;
 const DEFAULT_MODEL = 'gemini-3-flash-preview';
-const LITE_MODEL = 'gemini-3.1-flash-lite-preview';
+const LITE_MODEL = 'gemini-3.1-flash-lite';
 const TARGET_BATCH_CHARS = 50000;
 const MAX_RETRIES = 3;
 
 // Model pricing per 1M tokens (USD)
 const MODEL_PRICING = {
   'gemini-3-flash-preview': { input: 0.50, output: 3.00 },
-  'gemini-3.1-flash-lite-preview': { input: 0.075, output: 0.30 },
+  'gemini-3.1-flash-lite': { input: 0.075, output: 0.30 },
   'default': { input: 0.10, output: 0.40 },
 };
 

--- a/scripts/workers/lib/supabase-usage-logger.mjs
+++ b/scripts/workers/lib/supabase-usage-logger.mjs
@@ -13,7 +13,7 @@ const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 // Model pricing per 1M tokens
 const MODEL_PRICING = {
-  'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.50 },
+  'gemini-3.1-flash-lite': { input: 0.25, output: 1.50 },
   'gemini-3-flash-preview': { input: 0.50, output: 3.00 },
   'gemini-3-pro-preview': { input: 2.50, output: 10.00 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60 },

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -78,7 +78,7 @@ async function saveRevisionBeforeOverwrite(db, pageId, field) {
 }
 
 const OCR_MODEL_FLASH = 'gemini-3-flash-preview';
-const OCR_MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+const OCR_MODEL_LITE = 'gemini-3.1-flash-lite';
 
 // Latin-script languages safe for flash-lite. Anything else (Tibetan, Arabic,
 // Hebrew, CJK, Cyrillic, Greek, Syriac, etc.) routes to flash because
@@ -479,14 +479,14 @@ function hashString(str) {
 }
 
 const TRANSLATE_MODEL_FLASH = 'gemini-3-flash-preview';
-const TRANSLATE_MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+const TRANSLATE_MODEL_LITE = 'gemini-3.1-flash-lite';
 function getTranslateModelForBook(book) {
   if (book?.image_source?.provider === 'bph') return TRANSLATE_MODEL_FLASH;
   return TRANSLATE_MODEL_LITE;
 }
 const TRANSLATE_MODEL = TRANSLATE_MODEL_FLASH; // Legacy fallback
 const TRANSLATE_PROMPT_VERSION = 'v10';
-const TRANSLITERATION_MODEL = 'gemini-3.1-flash-lite-preview';
+const TRANSLITERATION_MODEL = 'gemini-3.1-flash-lite';
 const TRANSLITERATION_PROMPT = `You are a scholarly transliterator. Convert the following text to Latin characters using standard academic Romanization conventions.
 
 CRITICAL RULES:
@@ -2766,7 +2766,7 @@ async function run() {
             const base64 = resized.toString('base64');
 
             const SPLIT_CONFIRM_KEY = process.env.GEMINI_API_KEY_TIER3 || process.env.GEMINI_API_KEY;
-            const SPLIT_CONFIRM_MODEL = 'gemini-3.1-flash-lite-preview';
+            const SPLIT_CONFIRM_MODEL = 'gemini-3.1-flash-lite';
             const geminiUrl = `${GEMINI_API_BASE}/models/${SPLIT_CONFIRM_MODEL}:generateContent?key=${SPLIT_CONFIRM_KEY}`;
             const geminiRes = await fetch(geminiUrl, {
               method: 'POST',

--- a/scripts/workers/translate-worker.mjs
+++ b/scripts/workers/translate-worker.mjs
@@ -37,7 +37,7 @@ const BATCH_SIZE = parseInt(process.argv.find(a => a.startsWith('--batch-size=')
 const SINGLE_PAGE = process.argv.includes('--single-page');
 const MAX_BATCH_OCR_CHARS = 20000; // If total OCR text exceeds this, reduce batch size
 const MODEL_FLASH = 'gemini-3-flash-preview';
-const MODEL_LITE = 'gemini-3.1-flash-lite-preview';
+const MODEL_LITE = 'gemini-3.1-flash-lite';
 
 // Latin-script languages safe for flash-lite translation. Non-Latin scripts
 // (Tibetan, Arabic, Hebrew, CJK, Cyrillic, Greek, Syriac, etc.) route to flash.
@@ -236,7 +236,7 @@ function contentHash(text) {
 
 // ── Cost calculation ──
 const MODEL_PRICING = {
-  'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.50 },
+  'gemini-3.1-flash-lite': { input: 0.25, output: 1.50 },
   'gemini-3-flash-preview': { input: 0.50, output: 3.00 },
 };
 function calculateCost(inputTokens, outputTokens, model) {

--- a/scripts/workers/transliterate-greek.mjs
+++ b/scripts/workers/transliterate-greek.mjs
@@ -21,7 +21,7 @@ const DRY_RUN = args.includes('--dry-run');
 const LIMIT = parseInt(args.find((_, i) => args[i - 1] === '--limit') || '0') || Infinity;
 const CONCURRENCY = parseInt(args.find((_, i) => args[i - 1] === '--concurrency') || '3');
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const PROMPT = `You are a scholarly transliterator. Convert the following text to Latin characters using standard academic Romanization conventions.
 
 Rules:

--- a/src/app/[tenant]/admin/system-map/page.tsx
+++ b/src/app/[tenant]/admin/system-map/page.tsx
@@ -386,7 +386,7 @@ const serviceData: Record<string, ServiceInfo> = {
     details: [
       'The orchestrator runs every 2 minutes on Hetzner (46.224.122.120). Individual phases also run as separate cron entries so a slow phase doesn\'t block others. Crontab is versioned at scripts/workers/crontab.production.',
       'OCR: Submitted directly to Gemini Batch API from Hetzner (50% cost discount). Results collected by batch-collector.mjs every 10 min. Lambda is only used for preview OCR (first 25 pages).',
-      'Translation: Hetzner translate-worker.mjs calls Gemini API directly (no SQS, no Lambda). 15 concurrent books, self-dispatches from metadata_enriched (no Phase 4 wait). Each book gets 200 pages then is parked as translate_partial — fresh books always prioritized. ~14K pages/hr peak, ~7K sustained. Model routing: gemini-3-flash-preview for BPH, gemini-3.1-flash-lite-preview for others.',
+      'Translation: Hetzner translate-worker.mjs calls Gemini API directly (no SQS, no Lambda). 15 concurrent books, self-dispatches from metadata_enriched (no Phase 4 wait). Each book gets 200 pages then is parked as translate_partial — fresh books always prioritized. ~14K pages/hr peak, ~7K sustained. Model routing: gemini-3-flash-preview for BPH, gemini-3.1-flash-lite for others.',
       'Enrichment: Summary, index, chapters, transliteration — all orchestrated from Hetzner, calling Vercel API routes for summary/index/chapters and running transliteration inline.',
       'Image Extraction: Still uses Lambda workers via SQS (Phase 8). Results written via write-processor Lambda.',
       'Backpressure: MongoDB Atlas saturates at ~40 concurrent connections. Adaptive limits auto-adjust based on DB latency (healthy → ramp up 20%, degraded → reduce 50%, critical → slam to minimums).',
@@ -411,15 +411,15 @@ const serviceData: Record<string, ServiceInfo> = {
     url: 'https://sourcelibrary.org/admin/pipeline',
     summary: 'Enriches books with AI-generated metadata: summaries, chapter extraction, searchable indexes, and transliteration of non-Latin scripts. Now consolidated into the Hetzner orchestrator (Phases 3.5, 6, 7, 3.7).',
     details: [
-      'Summary + Index (Phase 6): Calls Vercel API /api/books/[id]/index from Hetzner. enrich-worker uses gemini-3.1-flash-lite-preview for summary/index.',
+      'Summary + Index (Phase 6): Calls Vercel API /api/books/[id]/index from Hetzner. enrich-worker uses gemini-3.1-flash-lite for summary/index.',
       'Chapter extraction (Phase 7): Calls Vercel API /api/books/[id]/extract-chapters from Hetzner. Skips books with <10 pages.',
-      'Transliteration (Phase 3.7): Runs inline on Hetzner via Gemini. For non-Latin scripts (Greek, Hebrew, Arabic, Chinese, etc.). Uses gemini-3.1-flash-lite-preview (text-only, cheap).',
+      'Transliteration (Phase 3.7): Runs inline on Hetzner via Gemini. For non-Latin scripts (Greek, Hebrew, Arabic, Chinese, etc.). Uses gemini-3.1-flash-lite (text-only, cheap).',
       'Metadata enrichment (Phase 3.5): Calls Vercel API /api/books/[id]/verify-metadata. Detects language, categories, description, source_work_dates.',
       'All enrichment phases are non-critical — failures skip ahead rather than blocking the pipeline.',
       'Legacy: The enrich-books Vercel cron exists in _archived/ but is not active. All enrichment runs from the Hetzner orchestrator now.',
     ],
     gotchas: [
-      'enrich-worker uses gemini-3.1-flash-lite-preview for summary/index.',
+      'enrich-worker uses gemini-3.1-flash-lite for summary/index.',
       'Enrichment only runs on books that have completed translation (translate_complete status).',
     ],
     files: [
@@ -509,7 +509,7 @@ const serviceData: Record<string, ServiceInfo> = {
       'Input: SQS message with pageId and imageUrl. Downloads the page image from R2/archive source.',
       'Processing: Sends image to Gemini with Standard OCR prompt v6. All languages, no language-specific prompts.',
       'Output: WriteResultMessage to writeResults SQS queue with OCR text, content hash, detected_images.',
-      'Error handling: RECITATION fallback chain: gemini-3-flash-preview, gemini-3.1-flash-lite-preview.',
+      'Error handling: RECITATION fallback chain: gemini-3-flash-preview, gemini-3.1-flash-lite.',
       'Reserved concurrency: 10 Lambda instances.',
     ],
     gotchas: [
@@ -588,16 +588,16 @@ const serviceData: Record<string, ServiceInfo> = {
   gemini: {
     label: 'Gemini AI', subtitle: '11-key rotation', color: '#4285f4', icon: '🤖',
     url: 'https://ai.google.dev/gemini-api/docs/models',
-    summary: 'Google\'s Gemini is the AI backbone for everything: OCR, translation, image extraction, enrichment, and classification. Model routing: gemini-3-flash-preview for BPH books, gemini-3.1-flash-lite-preview for everything else. 11 API keys with rotation.',
+    summary: 'Google\'s Gemini is the AI backbone for everything: OCR, translation, image extraction, enrichment, and classification. Model routing: gemini-3-flash-preview for BPH books, gemini-3.1-flash-lite for everything else. 11 API keys with rotation.',
     details: [
-      'Model routing: BPH books use gemini-3-flash-preview (higher quality). All other books use gemini-3.1-flash-lite-preview (50% cheaper). Summary/index generation uses lite. Transliteration always uses lite (text-only).',
+      'Model routing: BPH books use gemini-3-flash-preview (higher quality). All other books use gemini-3.1-flash-lite (50% cheaper). Summary/index generation uses lite. Transliteration always uses lite (text-only).',
       'Key rotation: 11 API keys (GEMINI_API_KEY, GEMINI_API_KEY_2 through _10, GEMINI_API_KEY_TIER3). On rate limit (429), rotate to next key. translate-worker.mjs and pipeline-orchestrator.mjs each manage their own rotation.',
       'Batch API: Used for OCR (50% cost discount, submitted from Hetzner). NEVER for translation (lacks cross-page context). Batch jobs are only visible to the creating API key.',
       'Cost tracking: Every API call logged to gemini_usage with model, tokens, cost, latency. ~$0.009/page full pipeline. Monthly run rate ~$3,700-$4,000.',
       'Prompt management: OCR uses Standard OCR v6. Translation prompt includes previous page context. Enrichment prompts in metadata-enrichment.ts. Prompts collection stores versioned copies for A/B testing.',
     ],
     gotchas: [
-      'Summary/index generation uses gemini-3.1-flash-lite-preview (not flash).',
+      'Summary/index generation uses gemini-3.1-flash-lite (not flash).',
       'Batch API jobs are only visible to the creating API key. Lost visibility if you switch keys.',
       'NEVER use Batch API for translation.',
     ],

--- a/src/app/about/research/page.tsx
+++ b/src/app/about/research/page.tsx
@@ -215,7 +215,7 @@ export default function ResearchPage() {
               </div>
               <div>
                 <h3 className="font-semibold text-primary">All Other Sources</h3>
-                <p className="text-xs font-mono text-muted">gemini-3.1-flash-lite-preview</p>
+                <p className="text-xs font-mono text-muted">gemini-3.1-flash-lite</p>
               </div>
             </div>
             <p className="text-secondary text-[15px] leading-relaxed">

--- a/src/app/api/[tenant]/books/[id]/index/route.ts
+++ b/src/app/api/[tenant]/books/[id]/index/route.ts
@@ -95,7 +95,7 @@ async function processBatch(
   bookLanguage?: string
 ): Promise<BatchExtraction> {
   const model = genAI.getGenerativeModel({
-    model: 'gemini-3.1-flash-lite-preview',
+    model: 'gemini-3.1-flash-lite',
     generationConfig: {
       temperature: 0.2, // Low temperature for consistent extraction
       maxOutputTokens: 2000,
@@ -171,7 +171,7 @@ CRITICAL for quotes:
     logGeminiCall({
       type: 'index',
       mode: 'realtime',
-      model: 'gemini-3.1-flash-lite-preview',
+      model: 'gemini-3.1-flash-lite',
       book_id: bookId,
       page_count: pages.length,
       input_tokens: usageMetadata?.promptTokenCount || 0,
@@ -640,7 +640,7 @@ async function generateBookSummary(
   researchContext?: string,
   chapters?: ChapterInfo[]
 ): Promise<GeneratedSummary> {
-  const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
 
   // If no batch extractions, fall back to research-only summary
   if (batchExtractions.length === 0) {
@@ -762,7 +762,7 @@ IMPORTANT: Use the actual quotes provided above. Don't invent new ones.`;
   logGeminiCall({
     type: 'summary',
     mode: 'realtime',
-    model: 'gemini-3.1-flash-lite-preview',
+    model: 'gemini-3.1-flash-lite',
     book_id: bookId,
     page_count: batchExtractions.length, // Number of batch sections processed
     input_tokens: usageMetadata?.promptTokenCount || 0,
@@ -1294,7 +1294,7 @@ export async function GET(
         data: bookSummary.brief,
         generated_at: new Date(),
         page_coverage: Math.round((pageSummaries.length / pages.length) * 100),
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         prompt_version: INDEX_PROMPT_VERSION,
         source: 'ai',
       };
@@ -1305,7 +1305,7 @@ export async function GET(
         themes: batchExtractions.flatMap(b => b.themes).filter((v, i, a) => a.indexOf(v) === i).slice(0, 20),
         quotes: groundedBatchQuotes.slice(0, 15),
         generated_at: new Date(),
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         prompt_version: INDEX_PROMPT_VERSION,
         source: 'ai',
       };

--- a/src/app/api/books/[id]/index/route.ts
+++ b/src/app/api/books/[id]/index/route.ts
@@ -95,7 +95,7 @@ async function processBatch(
   bookLanguage?: string
 ): Promise<BatchExtraction> {
   const model = genAI.getGenerativeModel({
-    model: 'gemini-3.1-flash-lite-preview',
+    model: 'gemini-3.1-flash-lite',
     generationConfig: {
       temperature: 0.2, // Low temperature for consistent extraction
       maxOutputTokens: 2000,
@@ -171,7 +171,7 @@ CRITICAL for quotes:
     logGeminiCall({
       type: 'index',
       mode: 'realtime',
-      model: 'gemini-3.1-flash-lite-preview',
+      model: 'gemini-3.1-flash-lite',
       book_id: bookId,
       page_count: pages.length,
       input_tokens: usageMetadata?.promptTokenCount || 0,
@@ -640,7 +640,7 @@ async function generateBookSummary(
   researchContext?: string,
   chapters?: ChapterInfo[]
 ): Promise<GeneratedSummary> {
-  const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' });
+  const model = genAI.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
 
   // If no batch extractions, fall back to research-only summary
   if (batchExtractions.length === 0) {
@@ -765,7 +765,7 @@ IMPORTANT: Use the actual quotes provided above. Don't invent new ones.`;
   logGeminiCall({
     type: 'summary',
     mode: 'realtime',
-    model: 'gemini-3.1-flash-lite-preview',
+    model: 'gemini-3.1-flash-lite',
     book_id: bookId,
     page_count: batchExtractions.length, // Number of batch sections processed
     input_tokens: usageMetadata?.promptTokenCount || 0,
@@ -1289,7 +1289,7 @@ export async function GET(
         data: bookSummary.brief,
         generated_at: new Date(),
         page_coverage: Math.round((pageSummaries.length / pages.length) * 100),
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         prompt_version: INDEX_PROMPT_VERSION,
         source: 'ai',
       };
@@ -1300,7 +1300,7 @@ export async function GET(
         themes: batchExtractions.flatMap(b => b.themes).filter((v, i, a) => a.indexOf(v) === i).slice(0, 20),
         quotes: groundedBatchQuotes.slice(0, 15),
         generated_at: new Date(),
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         prompt_version: INDEX_PROMPT_VERSION,
         source: 'ai',
       };

--- a/src/app/api/identify/route.ts
+++ b/src/app/api/identify/route.ts
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
 
     // Run Gemini vision + CLIP visual search in parallel
     const apiKey = getNextApiKey();
-    const model = 'gemini-3.1-flash-lite-preview';
+    const model = 'gemini-3.1-flash-lite';
 
     // Promise 1: Gemini structured identification
     const geminiPromise = fetch(

--- a/src/app/api/search/ai-expand/route.ts
+++ b/src/app/api/search/ai-expand/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       try {
         const client = getGeminiClient();
         // flash-lite follows structured format reliably and is 50% cheaper
-        const model = client.getGenerativeModel({ model: 'gemini-3.1-flash-lite-preview' });
+        const model = client.getGenerativeModel({ model: 'gemini-3.1-flash-lite' });
 
         const result = await model.generateContentStream({
           contents: [{

--- a/src/app/platform/(protected)/admin/system-map/page.tsx
+++ b/src/app/platform/(protected)/admin/system-map/page.tsx
@@ -386,7 +386,7 @@ const serviceData: Record<string, ServiceInfo> = {
     details: [
       'The orchestrator runs every 2 minutes on Hetzner (46.224.122.120). Individual phases also run as separate cron entries so a slow phase doesn\'t block others. Crontab is versioned at scripts/workers/crontab.production.',
       'OCR: Submitted directly to Gemini Batch API from Hetzner (50% cost discount). Results collected by batch-collector.mjs every 10 min. Lambda is only used for preview OCR (first 25 pages).',
-      'Translation: Hetzner translate-worker.mjs calls Gemini API directly (no SQS, no Lambda). 15 concurrent books, self-dispatches from metadata_enriched (no Phase 4 wait). Each book gets 200 pages then is parked as translate_partial — fresh books always prioritized. ~14K pages/hr peak, ~7K sustained. Model routing: gemini-3-flash-preview for BPH, gemini-3.1-flash-lite-preview for others.',
+      'Translation: Hetzner translate-worker.mjs calls Gemini API directly (no SQS, no Lambda). 15 concurrent books, self-dispatches from metadata_enriched (no Phase 4 wait). Each book gets 200 pages then is parked as translate_partial — fresh books always prioritized. ~14K pages/hr peak, ~7K sustained. Model routing: gemini-3-flash-preview for BPH, gemini-3.1-flash-lite for others.',
       'Enrichment: Summary, index, chapters, transliteration — all orchestrated from Hetzner, calling Vercel API routes for summary/index/chapters and running transliteration inline.',
       'Image Extraction: Still uses Lambda workers via SQS (Phase 8). Results written via write-processor Lambda.',
       'Backpressure: MongoDB Atlas saturates at ~40 concurrent connections. Adaptive limits auto-adjust based on DB latency (healthy → ramp up 20%, degraded → reduce 50%, critical → slam to minimums).',
@@ -411,15 +411,15 @@ const serviceData: Record<string, ServiceInfo> = {
     url: 'https://sourcelibrary.org/admin/pipeline',
     summary: 'Enriches books with AI-generated metadata: summaries, chapter extraction, searchable indexes, and transliteration of non-Latin scripts. Now consolidated into the Hetzner orchestrator (Phases 3.5, 6, 7, 3.7).',
     details: [
-      'Summary + Index (Phase 6): Calls Vercel API /api/books/[id]/index from Hetzner. enrich-worker uses gemini-3.1-flash-lite-preview for summary/index.',
+      'Summary + Index (Phase 6): Calls Vercel API /api/books/[id]/index from Hetzner. enrich-worker uses gemini-3.1-flash-lite for summary/index.',
       'Chapter extraction (Phase 7): Calls Vercel API /api/books/[id]/extract-chapters from Hetzner. Skips books with <10 pages.',
-      'Transliteration (Phase 3.7): Runs inline on Hetzner via Gemini. For non-Latin scripts (Greek, Hebrew, Arabic, Chinese, etc.). Uses gemini-3.1-flash-lite-preview (text-only, cheap).',
+      'Transliteration (Phase 3.7): Runs inline on Hetzner via Gemini. For non-Latin scripts (Greek, Hebrew, Arabic, Chinese, etc.). Uses gemini-3.1-flash-lite (text-only, cheap).',
       'Metadata enrichment (Phase 3.5): Calls Vercel API /api/books/[id]/verify-metadata. Detects language, categories, description, source_work_dates.',
       'All enrichment phases are non-critical — failures skip ahead rather than blocking the pipeline.',
       'Legacy: The enrich-books Vercel cron exists in _archived/ but is not active. All enrichment runs from the Hetzner orchestrator now.',
     ],
     gotchas: [
-      'enrich-worker uses gemini-3.1-flash-lite-preview for summary/index.',
+      'enrich-worker uses gemini-3.1-flash-lite for summary/index.',
       'Enrichment only runs on books that have completed translation (translate_complete status).',
     ],
     files: [
@@ -509,7 +509,7 @@ const serviceData: Record<string, ServiceInfo> = {
       'Input: SQS message with pageId and imageUrl. Downloads the page image from R2/archive source.',
       'Processing: Sends image to Gemini with Standard OCR prompt v6. All languages, no language-specific prompts.',
       'Output: WriteResultMessage to writeResults SQS queue with OCR text, content hash, detected_images.',
-      'Error handling: RECITATION fallback chain: gemini-3-flash-preview, gemini-3.1-flash-lite-preview.',
+      'Error handling: RECITATION fallback chain: gemini-3-flash-preview, gemini-3.1-flash-lite.',
       'Reserved concurrency: 10 Lambda instances.',
     ],
     gotchas: [
@@ -588,16 +588,16 @@ const serviceData: Record<string, ServiceInfo> = {
   gemini: {
     label: 'Gemini AI', subtitle: '11-key rotation', color: '#4285f4', icon: '🤖',
     url: 'https://ai.google.dev/gemini-api/docs/models',
-    summary: 'Google\'s Gemini is the AI backbone for everything: OCR, translation, image extraction, enrichment, and classification. Model routing: gemini-3-flash-preview for BPH books, gemini-3.1-flash-lite-preview for everything else. 11 API keys with rotation.',
+    summary: 'Google\'s Gemini is the AI backbone for everything: OCR, translation, image extraction, enrichment, and classification. Model routing: gemini-3-flash-preview for BPH books, gemini-3.1-flash-lite for everything else. 11 API keys with rotation.',
     details: [
-      'Model routing: BPH books use gemini-3-flash-preview (higher quality). All other books use gemini-3.1-flash-lite-preview (50% cheaper). Summary/index generation uses lite. Transliteration always uses lite (text-only).',
+      'Model routing: BPH books use gemini-3-flash-preview (higher quality). All other books use gemini-3.1-flash-lite (50% cheaper). Summary/index generation uses lite. Transliteration always uses lite (text-only).',
       'Key rotation: 11 API keys (GEMINI_API_KEY, GEMINI_API_KEY_2 through _10, GEMINI_API_KEY_TIER3). On rate limit (429), rotate to next key. translate-worker.mjs and pipeline-orchestrator.mjs each manage their own rotation.',
       'Batch API: Used for OCR (50% cost discount, submitted from Hetzner). NEVER for translation (lacks cross-page context). Batch jobs are only visible to the creating API key.',
       'Cost tracking: Every API call logged to gemini_usage with model, tokens, cost, latency. ~$0.009/page full pipeline. Monthly run rate ~$3,700-$4,000.',
       'Prompt management: OCR uses Standard OCR v6. Translation prompt includes previous page context. Enrichment prompts in metadata-enrichment.ts. Prompts collection stores versioned copies for A/B testing.',
     ],
     gotchas: [
-      'Summary/index generation uses gemini-3.1-flash-lite-preview (not flash).',
+      'Summary/index generation uses gemini-3.1-flash-lite (not flash).',
       'Batch API jobs are only visible to the creating API key. Lost visibility if you switch keys.',
       'NEVER use Batch API for translation.',
     ],

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -36,7 +36,7 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> = 
   'gemini-2.0-flash-exp': { input: 0.10, output: 0.40 },
   'gemini-1.5-flash': { input: 0.075, output: 0.30 },
   'gemini-1.5-pro': { input: 1.25, output: 5.00 },
-  'gemini-3.1-flash-lite-preview': { input: 0.075, output: 0.30 },
+  'gemini-3.1-flash-lite': { input: 0.075, output: 0.30 },
   // Fallback for unknown models
   'default': { input: 0.10, output: 0.40 },
 };

--- a/src/lib/gemini-logger.ts
+++ b/src/lib/gemini-logger.ts
@@ -59,7 +59,7 @@ import { supabaseAdmin } from './supabase';
 
 // Pricing per 1M tokens (as of Jan 2025)
 const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.50 },
+  'gemini-3.1-flash-lite': { input: 0.25, output: 1.50 },
   'gemini-3-flash-preview': { input: 0.50, output: 3.00 },
   'gemini-3-pro-preview': { input: 2.50, output: 10.00 },
   'gemini-2.5-flash': { input: 0.15, output: 0.60 },

--- a/src/lib/types/ai-models.ts
+++ b/src/lib/types/ai-models.ts
@@ -1,14 +1,14 @@
 // Available Gemini models for processing
 export const GEMINI_MODELS = [
   { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', description: 'Best Quality - Use for BPH and complex content' },
-  { id: 'gemini-3.1-flash-lite-preview', name: 'Gemini 3.1 Flash Lite', description: 'Cost-Efficient - 50% cheaper, comparable quality' },
+  { id: 'gemini-3.1-flash-lite', name: 'Gemini 3.1 Flash Lite', description: 'Cost-Efficient - 50% cheaper, comparable quality' },
 ] as const;
 
 // Full-quality model (BPH books, complex scripts, image extraction)
 export const DEFAULT_MODEL = 'gemini-3-flash-preview';
 
 // Cost-efficient model for standard OCR and translation
-export const DEFAULT_LITE_MODEL = 'gemini-3.1-flash-lite-preview';
+export const DEFAULT_LITE_MODEL = 'gemini-3.1-flash-lite';
 
 // Default model for batch operations (50% cheaper via Batch API)
 export const DEFAULT_BATCH_MODEL = 'gemini-3-flash-preview';

--- a/src/lib/ustc-matcher.ts
+++ b/src/lib/ustc-matcher.ts
@@ -20,7 +20,7 @@ import { Db } from 'mongodb';
 import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
 import { logGeminiCall, type GeminiTrigger } from './gemini-logger';
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const MAX_ROUNDS = 5;
 const TEMPERATURE = 0.1;
 

--- a/src/lib/verify-first-translation.ts
+++ b/src/lib/verify-first-translation.ts
@@ -24,7 +24,7 @@ import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
 import { logGeminiCall, type GeminiTrigger } from './gemini-logger';
 import { logMetadataChange } from './book-changelog';
 
-const MODEL = 'gemini-3.1-flash-lite-preview';
+const MODEL = 'gemini-3.1-flash-lite';
 const MAX_ROUNDS = 10; // Max Gemini round-trips (tool calls + responses)
 const TEMPERATURE = 0.1;
 

--- a/src/workers/ocr-processor-logic.ts
+++ b/src/workers/ocr-processor-logic.ts
@@ -251,7 +251,7 @@ export async function processOcrPage(message: PageProcessingMessage): Promise<vo
 
     // RECITATION errors: Retry with fallback model
     if (classified.category === 'safety_filter' && error instanceof Error && error.message.includes('RECITATION')) {
-      const fallbackModels = ['gemini-3-flash-preview', 'gemini-3.1-flash-lite-preview'];
+      const fallbackModels = ['gemini-3-flash-preview', 'gemini-3.1-flash-lite'];
       const currentModelIndex = fallbackModels.indexOf(modelId);
       const nextModel = fallbackModels[currentModelIndex + 1];
 


### PR DESCRIPTION
## Summary

- Google retired the `-preview` suffix after the model went GA — `gemini-3.1-flash-lite-preview` now returns **404 NOT_FOUND** from `generateContent` (still shows in `GET /v1beta/models` metadata, but unusable).
- 65 files / 209 references renamed across production code paths: enrich-worker phases 6–7.6 (summary, index, chapters, quality scoring, collection assignment), `/api/identify`, batch translate, `scripts/batch/batch-transliterate.mjs`, system-map docs, CLAUDE.md.
- Pricing tables re-key under the new name. Historical `gemini_usage.cost_usd` is stored at write time, so past cost reporting is unaffected.

## Why this matters

Every enrich-worker phase from summary/index onwards has been silently 404-ing in production. Discovered while seeding IAST transliteration for the Tier 1 yoga books — the batch script reported "285 err" while the on-demand `/api/pages/[id]/transliterate` (which uses `gemini-3-flash-preview`, a separate still-live model) kept working.

## Verification

- `npx tsc --noEmit`: zero new errors. The 14 pre-existing carbon-ledger d3-types errors are unrelated.
- Confirmed `gemini-3.1-flash-lite` returns 200 OK with same output quality as the retired `-preview` name.
- Confirmed `gemini-3-flash-preview` (different model, no GA rename yet) is unchanged and still works.

## Test plan

- [ ] Vercel preview deploys cleanly
- [ ] Hit `/api/identify` on a sample book — should now succeed (currently 404s)
- [ ] Trigger a Phase 6 summary/index regen on any book — should now produce output (currently silent failure)
- [ ] Run a transliteration via the batch script — should produce IAST instead of "ERR" lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)