### PR TITLE
fix(embed): preserve catalogue filter params on view=books deep links

### DIFF
--- a/src/app/embed/[tenant]/page.tsx
+++ b/src/app/embed/[tenant]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import SharedLibraryView, { type SharedLibraryViewProps } from '@/components/libraries/SharedLibraryView';
 import {
     fetchTenantLibraryData,
@@ -29,19 +29,6 @@ interface Props {
 function getOptionalStringField(value: unknown): string {
     return typeof value === 'string' ? value : '';
 }
-
-// Catalog browser owns these (`c`-prefixed) param keys. They're meaningless on
-// any other view and only serve to confuse users when they leak through
-// navigation, so strip them server-side before render.
-const CATALOG_PARAM_KEYS = [
-    'cq', 'csort', 'ckeyword', 'coffset',
-    'cauthor', 'ctitle', 'ceditor', 'cplace', 'cprinter', 'cpublisher',
-    'cshelf', 'clang', 'cyfrom', 'cyto', 'cdig', 'cft',
-];
-
-// Books-grid owns these. Catalog view ignores them; strip on /catalog so the
-// URL bar doesn't look filtered when it isn't.
-const BOOKS_PARAM_KEYS = ['q', 'sort', 'language', 'offset'];
 
 export default async function EmbedTenantRoot({ params, searchParams }: Props) {
     const { tenant } = await params;
@@ -79,23 +66,14 @@ export default async function EmbedTenantRoot({ params, searchParams }: Props) {
         ? displayParam
         : (view === 'catalog' ? 'list' : 'grid');
 
-    // Strip the inactive display's params so a user landing here from a
-    // previous list/grid choice doesn't see a URL that looks filtered when
-    // nothing is being applied. The list view (BphCatalogBrowser) owns the
-    // c-prefixed keys; the grid view (CollectionFilters/books grid) owns
-    // q/sort/language/offset. Stripping is keyed off the active display, not
-    // the view filter, since either filter can be paired with either display.
-    const stripKeys = display === 'list' ? BOOKS_PARAM_KEYS : CATALOG_PARAM_KEYS;
-    const orphans = stripKeys.filter(k => typeof sp[k] === 'string' && sp[k] !== '');
-    if (orphans.length > 0) {
-        const next = new URLSearchParams();
-        for (const [k, v] of Object.entries(sp)) {
-            if (orphans.includes(k)) continue;
-            if (typeof v === 'string' && v !== '') next.set(k, v);
-        }
-        const qs = next.toString();
-        redirect(`/embed/${tenant}${qs ? `?${qs}` : ''}`);
-    }
+    // Don't strip inactive-view params here. The embed mirrors the iframe URL
+    // to the parent host (embed/v1.js → sl-navigate → replaceState), so any
+    // server-side redirect that drops params kills external deep links —
+    // ?view=books&display=grid&cq=jacob&cdig=sl on a partner site briefly
+    // loads and then gets scrubbed to ?view=books&display=grid. The active
+    // view ignores inactive params functionally; the toggle hrefs in
+    // UnifiedCatalogue emit clean per-view URLs, so stale params don't
+    // accumulate from in-app navigation either.
 
     const db = await getDb();
     const tenantDoc = await db.collection('tenants').findOne({ id: tenantId });


### PR DESCRIPTION
## Summary

External deep links into the embed with mixed-view params (e.g. `?view=books&display=grid&cq=jacob&cdig=sl`) were briefly loading the full URL and then redirecting to a stripped version. The iframe then reported the cleaned filter set to the parent host (via `sl-navigate` → `replaceState`), so the original deep link was destroyed on the partner site too. Reported by EFM on `embassyofthefreemind.com/digital-collection-search`.

The cause: `src/app/embed/[tenant]/page.tsx` was treating `c*` catalogue params as orphans whenever `display=grid`, and `q/sort/language/offset` as orphans whenever `display=list`. Originally added for URL cleanliness, but it kills any deep link that pairs a books-grid display with stored catalogue filter state (or vice versa).

This drops the cross-strip. The active view ignores inactive params functionally; the toggle hrefs in `UnifiedCatalogue` already emit clean per-view URLs (no accumulation from in-app navigation). The only behaviour that changes is that shared/bookmarked URLs now survive end-to-end.

## Out of scope

- The toggle hrefs (`listHref`/`gridHref` in `UnifiedCatalogue`) still don't carry over the previous view's filters when the user toggles in-iframe. That's a separate UX call — leaving it as-is matches current behaviour.
- No change to `embed/v1.js`; its `SYNCED_PARAMS` allow-list already includes both books-grid and catalogue keys.

## Test plan

- [ ] `https://www.embassyofthefreemind.com/digital-collection-search?view=books&display=grid&cq=jacob&cdig=sl` lands and stays — no redirect strip
- [ ] `?cq=jacob` alone still works (catalogue search)
- [ ] `?view=books&display=grid` alone still works (books grid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)