### PR TITLE
chore: bump mongodb 6.12 → 6.21 + gitignore incoming/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ src/lib/vendor/lamejs-bundle.js
 .claude/docs/dedup-review-queue/
 .claude/docs/dedup-review-queue-resolved/
 backups/
+
+# Book ingestion staging (PDFs, page images, metadata waiting to be processed)
+incoming/

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "epub-gen-memory": "^1.1.2",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.560.0",
-        "mongodb": "^6.12.0",
+        "mongodb": "^6.21.0",
         "next": "^16.1.6",
         "next-auth": "^5.0.0-beta.30",
         "nodemailer": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "epub-gen-memory": "^1.1.2",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.560.0",
-    "mongodb": "^6.12.0",
+    "mongodb": "^6.21.0",
     "next": "^16.1.6",
     "next-auth": "^5.0.0-beta.30",
     "nodemailer": "^8.0.1",


### PR DESCRIPTION
## Summary

- Bumps `mongodb` from `^6.12.0` to `^6.21.0` (resolved lockfile version was already 6.21.0 — only the constraint moves).
- Adds `incoming/` to `.gitignore` to prevent book-ingestion staging artifacts (PDFs, page images, metadata) from being committed.

## Background

A local checkpoint commit (`8ddb4612` "Live canon stats — dashboard + assistant tool, no more hardcoded counts") was found on someone's main branch but never pushed. It contained 3 modifications and 677 additions. The 677 additions were stale uncommitted work from a different feature (the named "Live canon stats" feature actually lives in `~/sourcelibraryfundraising`, not this repo) plus the entire `incoming/` directory that got swept in. Most of it doesn't belong in main.

The only functional change in this repo from that checkpoint was the mongodb dep bump. This PR carries just that, plus the gitignore guard so a similar accidental sweep can't happen again.

## Out of scope

- The 677-file checkpoint commit itself is not landing. The local branch retaining it can be archived or deleted on review.
- The fundraising-side canon-stats feature (mongodb.ts, /api/canon-stats, DashboardStats, assistant tool) lives in the other repo and is not changed here.

## Test plan

- [x] `npx tsc --noEmit` — pre-existing `d3-sankey` errors in `TokenSankey.tsx` unrelated to mongodb (not introduced by this change).
- [x] Pre-commit `check-imports` hook passes (`All imports resolve successfully` across 1364 files).
- [ ] Vercel preview build green (will appear after push).
- [ ] DCO check green (signoff included on the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)