### PR TITLE
seo: per-page metadata for /gallery, /search, tenant root; no canonical-to-root from not-found branches

### DIFF
--- a/src/app/[tenant]/book/[id]/overview/page.tsx
+++ b/src/app/[tenant]/book/[id]/overview/page.tsx
@@ -48,11 +48,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { tenant, id } = await params;
   const db = await getReadDb();
   const result = await findTenantBookByIdOrSlug(db, tenant, id, { _id: 0, title: 1, display_title: 1 });
-  if (!result) return { title: 'Book Not Found - Source Library' };
+  if (!result) return {
+    title: 'Book Not Found - Source Library',
+    robots: { index: false, follow: true },
+    alternates: { canonical: `/book/${id}/overview` },
+  };
   const title = result.book.display_title || result.book.title;
   return {
     title: `Overview — ${title} - Source Library`,
     robots: { index: false, follow: true },
+    alternates: { canonical: `/book/${id}/overview` },
   };
 }
 

--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -174,7 +174,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   if (!book) {
-    return { title: 'Book Not Found - Source Library', robots: { index: false, follow: false } };
+    // Self-referential canonical (not the inherited root '/') so Google doesn't
+    // see this as a duplicate of the homepage while it's still 200/noindex.
+    return {
+      title: 'Book Not Found - Source Library',
+      robots: { index: false, follow: false },
+      alternates: { canonical: `/book/${id}` },
+    };
   }
 
   // Wrong tenant — suppress metadata entirely so the 404 isn't indexed.
@@ -186,7 +192,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     (bookTenantUuid && tenantId && bookTenantUuid === tenantId) ||
     (bookTenantSlug && tenant && bookTenantSlug === tenant);
   if (hasTenantField && !matchesTenant) {
-    return { title: 'Not Found - Source Library', robots: { index: false, follow: false } };
+    return {
+      title: 'Not Found - Source Library',
+      robots: { index: false, follow: false },
+      alternates: { canonical: `/book/${id}` },
+    };
   }
 
   const title = book.display_title || book.title;

--- a/src/app/[tenant]/book/[id]/page/[pageId]/layout.tsx
+++ b/src/app/[tenant]/book/[id]/page/[pageId]/layout.tsx
@@ -49,8 +49,12 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   const { book, page } = await getPageData(tenant, id, pageId);
 
   if (!book || !page) {
+    // Self-referential canonical so this URL isn't seen as a duplicate of '/'
+    // (inherited root canonical). Per-page URLs are already noindex via the
+    // page-level metadata export.
     return {
       title: 'Page Not Found - Source Library',
+      alternates: { canonical: `/book/${id}/page/${pageId}` },
     };
   }
 

--- a/src/app/[tenant]/gallery/page.tsx
+++ b/src/app/[tenant]/gallery/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import { headers } from 'next/headers';
 import GalleryClient from '@/components/gallery/GalleryClient';
@@ -6,6 +7,30 @@ import SignUpCTA from '@/components/auth/SignUpCTA';
 import type { GalleryResponse } from '@/lib/api-client/types/gallery';
 
 export const revalidate = 3600; // ISR: rebuild every hour (unfiltered landing only)
+
+const GALLERY_TITLE = 'Image Gallery — Source Library';
+const GALLERY_DESCRIPTION = 'Browse illustrations, engravings, woodcuts, alchemical emblems, and diagrams extracted from rare historical texts — searchable by subject, technique, and period.';
+
+export const metadata: Metadata = {
+  title: GALLERY_TITLE,
+  description: GALLERY_DESCRIPTION,
+  alternates: {
+    canonical: '/gallery',
+  },
+  openGraph: {
+    title: GALLERY_TITLE,
+    description: GALLERY_DESCRIPTION,
+    type: 'website',
+    siteName: 'Source Library',
+    locale: 'en_US',
+    url: '/gallery',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: GALLERY_TITLE,
+    description: GALLERY_DESCRIPTION,
+  },
+};
 
 interface GalleryPageProps {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;

--- a/src/app/[tenant]/languages/[code]/page.tsx
+++ b/src/app/[tenant]/languages/[code]/page.tsx
@@ -74,7 +74,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
 
-  if (count === 0) return { title: 'Language Not Found - Source Library', robots: { index: false, follow: true } };
+  if (count === 0) return {
+    title: 'Language Not Found - Source Library',
+    robots: { index: false, follow: true },
+    alternates: { canonical: `/languages/${code}` },
+  };
 
   const description = `Browse ${count} ${langName} texts in Source Library — digitized and translated from original manuscripts and early printed books.`;
 

--- a/src/app/[tenant]/page.tsx
+++ b/src/app/[tenant]/page.tsx
@@ -67,10 +67,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // bph subdomain to the main site — a tenant-lockdown leak (CLAUDE.md
   // invariant #5: "Share/quote URLs use the request host"). On
   // bph.sourcelibrary.org the canonical resolves to https://bph.sourcelibrary.org/;
-  // on path-based access (sourcelibrary.org/bph) it stays on the main host.
+  // on path-based access (sourcelibrary.org/bph) or preview deploys
+  // (sourcelibrary-v2-git-*.vercel.app/bph) it stays at /bph on that host.
+  //
+  // Detection is "does the leftmost label of the host equal the tenant slug?"
+  // — anything else (main host, preview host, IP) is path-based.
   const host = getRequestBaseUrl(h);
-  const isSubdomainHost = !host.endsWith('//sourcelibrary.org');
-  const canonical = isSubdomainHost ? `${host}/` : `${host}/${tenant}`;
+  const hostname = host.replace(/^https?:\/\//, '').split('/')[0].split(':')[0];
+  const leftmostLabel = hostname.split('.')[0];
+  const isTenantSubdomain = leftmostLabel === tenant;
+  const canonical = isTenantSubdomain ? `${host}/` : `${host}/${tenant}`;
 
   return {
     title,

--- a/src/app/[tenant]/page.tsx
+++ b/src/app/[tenant]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
+import type { Metadata } from 'next';
 import SharedLibraryView, { type SharedLibraryViewProps } from '@/components/libraries/SharedLibraryView';
 import { getTenantContextFromRequest } from '@/lib/tenant-context';
 import {
@@ -13,10 +14,84 @@ import {
 import { getDb } from '@/lib/mongodb';
 import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter';
 import { getPartnerByProvider, getPartnerBySlug } from '@/lib/library-partners';
+import { getRequestBaseUrl } from '@/lib/shortlinks';
 
 interface Props {
   params: Promise<{ tenant: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { tenant } = await params;
+  const h = await headers();
+  const { id: tenantId } = getTenantContextFromRequest(h);
+
+  // Default-tenant root (sourcelibrary.org) is handled by src/app/page.tsx, but
+  // ISR-safety / route precedence means this generateMetadata may also fire for
+  // it. Fall back to the root layout's metadata in that case.
+  if (!tenantId || tenant === 'default') {
+    return {};
+  }
+
+  let tenantName = tenant;
+  let tenantDescription = '';
+  try {
+    const db = await getDb();
+    const tenantDoc = await db.collection('tenants').findOne(
+      { id: tenantId },
+      { projection: { _id: 0, name: 1, description: 1 } }
+    );
+    if (tenantDoc) {
+      if (typeof tenantDoc.name === 'string' && tenantDoc.name) tenantName = tenantDoc.name;
+      if (typeof tenantDoc.description === 'string') tenantDescription = tenantDoc.description;
+    }
+  } catch {
+    // Fall through with slug-based fallback if Mongo is unreachable.
+  }
+
+  const canonicalPartner = getPartnerBySlug(tenant);
+  if (!tenantDescription && canonicalPartner?.description) {
+    tenantDescription = canonicalPartner.description;
+  }
+  if (!tenantDescription) {
+    tenantDescription = `Browse the ${tenantName} reading room on Source Library — digitized, OCR'd, and translated rare texts curated for this collection.`;
+  }
+  if (tenantDescription.length > 200) {
+    tenantDescription = tenantDescription.slice(0, 197) + '...';
+  }
+
+  const title = `${tenantName} — Source Library`;
+
+  // Canonical must be absolute and host-aware. metadataBase is fixed to
+  // https://sourcelibrary.org, so a relative '/bph' would 308-canonical the
+  // bph subdomain to the main site — a tenant-lockdown leak (CLAUDE.md
+  // invariant #5: "Share/quote URLs use the request host"). On
+  // bph.sourcelibrary.org the canonical resolves to https://bph.sourcelibrary.org/;
+  // on path-based access (sourcelibrary.org/bph) it stays on the main host.
+  const host = getRequestBaseUrl(h);
+  const isSubdomainHost = !host.endsWith('//sourcelibrary.org');
+  const canonical = isSubdomainHost ? `${host}/` : `${host}/${tenant}`;
+
+  return {
+    title,
+    description: tenantDescription,
+    alternates: {
+      canonical,
+    },
+    openGraph: {
+      title,
+      description: tenantDescription,
+      type: 'website',
+      siteName: 'Source Library',
+      locale: 'en_US',
+      url: canonical,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: tenantDescription,
+    },
+  };
 }
 
 export default async function TenantRoot({ params, searchParams }: Props) {

--- a/src/app/[tenant]/topics/[slug]/page.tsx
+++ b/src/app/[tenant]/topics/[slug]/page.tsx
@@ -89,7 +89,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
-  if (!match) return { title: 'Topic Not Found - Source Library', robots: { index: false, follow: true } };
+  if (!match) return {
+    title: 'Topic Not Found - Source Library',
+    robots: { index: false, follow: true },
+    alternates: { canonical: `/topics/${slug}` },
+  };
 
   return {
     title: `${match._id} | Source Library`,

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,3 +1,5 @@
 import GalleryPage from '../[tenant]/gallery/page';
 
+export { metadata } from '../[tenant]/gallery/page';
+
 export default GalleryPage;

--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from 'react';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Search - Source Library',
+  description: 'Search over 10,000 translated primary sources — alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit, Chinese classics, Arabic philosophy, and more.',
+  alternates: {
+    canonical: '/search',
+  },
+  openGraph: {
+    title: 'Search - Source Library',
+    description: 'Search over 10,000 translated primary sources — alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit, Chinese classics, Arabic philosophy, and more.',
+    type: 'website',
+    siteName: 'Source Library',
+    locale: 'en_US',
+    url: '/search',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Search - Source Library',
+    description: 'Search over 10,000 translated primary sources — alchemy, Hermetica, Kabbalah, natural philosophy, Sanskrit, Chinese classics, Arabic philosophy, and more.',
+  },
+};
+
+export default function SearchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <Suspense>
+      <h1 className="sr-only">Search Source Library</h1>
+      {children}
+    </Suspense>
+  );
+}

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -89,7 +89,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   } catch {
     return { title: 'Source Library', robots: { index: false, follow: false } };
   }
-  if (!match) return { title: 'Topic Not Found - Source Library', robots: { index: false, follow: true } };
+  if (!match) return {
+    title: 'Topic Not Found - Source Library',
+    robots: { index: false, follow: true },
+    alternates: { canonical: `/topics/${slug}` },
+  };
 
   return {
     title: `${match._id} | Source Library`,


### PR DESCRIPTION
## Summary

Audit found that several high-traffic routes were inheriting the root layout's `title` and `alternates.canonical: '/'`, so Google was seeing them as duplicates of the homepage:

- `/gallery` and `/search` shipped the root title verbatim with `canonical=https://sourcelibrary.org`.
- `bph.sourcelibrary.org/` (and every tenant root) had no `generateMetadata`, so the subdomain home canonical-pointed at the main site — also a CLAUDE.md tenant-lockdown leak (invariant #5: *Share/quote URLs use the request host*).
- `/book/<bad-slug>`, `/book/<slug>/page/<bad-pageId>`, `/topics/<bad-slug>`, `/languages/<bad-code>`, `/book/<bad-slug>/overview` returned `200` with `X Not Found` titles AND canonical-to-root, telling Google the bad URL was a duplicate of the homepage.

## Changes
- `src/app/[tenant]/gallery/page.tsx`: add `metadata` (title, description, canonical=`/gallery`, OG, Twitter).
- `src/app/gallery/page.tsx`: re-export metadata so the root wrapper inherits the same SEO surface.
- `src/app/search/layout.tsx`: new layout mirroring the existing tenant search layout so root `/search` gets its own title + canonical.
- `src/app/[tenant]/page.tsx`: tenant-aware `generateMetadata`. Title is `{tenant.name} — Source Library`; canonical is built from `getRequestBaseUrl(headers)` so `bph.sourcelibrary.org` canonical-points to itself (metadataBase is fixed and would otherwise force the leak).
- Five `X Not Found` metadata branches now set a self-referential `alternates.canonical`.

## Out of scope
- The deeper issue of `notFound()` returning HTTP 200 on these routes — needs a Next.js / Vercel runtime investigation in its own PR.
- A `title.template` sweep — 177 existing per-page titles hardcode ` - Source Library`, so adding a template would double-suffix them. Follow-up PR can convert all 177 + add the template.
- Missing JSON-LD on author/blog/library pages.
- Gallery image detail page being client-only (no server-side metadata).

## Test plan
- [ ] On the Vercel preview, curl `/`, `/gallery`, `/search?q=alchemy`, `/book/curious-physics-hellwig`, `/book/curious-physics-hellwig/page/99999`, `bph-*.vercel.app/`, and `/asdf-bad-path` and confirm titles + canonicals.
- [ ] `node scripts/audit-bph-leaks.mjs` on the preview to confirm no off-subdomain leaks from the tenant root canonical change.
- [ ] Spot-check Twitter/Slack/LinkedIn unfurls for `/gallery` and a tenant root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)