### PR TITLE
fix(homepage): align daily stats refresh with canonical filters

### DIFF
--- a/scripts/maintenance/prewarm-browse.mjs
+++ b/scripts/maintenance/prewarm-browse.mjs
@@ -49,7 +49,9 @@ for (let i = 0; i < urls.length; i += 5) {
 
 console.log(`Done: ${ok} OK, ${fail} failed (${new Date().toISOString()})`);
 
-// Optionally refresh homepage stats
+// Optionally refresh homepage stats. Filter logic must stay in sync with
+// scripts/maintenance/update-homepage-stats.mjs — homepage reads the same
+// system_config doc and expects all 7 fields (incl. artwork + illustration counts).
 if (process.env.MONGODB_URI) {
   try {
     const { MongoClient } = await import('mongodb');
@@ -57,18 +59,25 @@ if (process.env.MONGODB_URI) {
     const db = client.db('bookstore');
     const books = db.collection('books');
 
-    const filter = { hidden: { $ne: true }, pages_count: { $gt: 0 } };
+    const filter = { visible: true, pages_count: { $gt: 0 } };
     const translatedFilter = { ...filter, pages_translated: { $gt: 0 } };
+    const readableFilter = {
+      ...translatedFilter,
+      $expr: { $gte: ['$pages_translated', { $multiply: [{ $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] }, 0.9] }] },
+    };
+    const artworkFilter = { visible: true, resource_type: { $in: ['drawing', 'fresco', 'object', 'painting', 'print'] } };
 
-    const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount] = await Promise.all([
+    const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount] = await Promise.all([
       books.countDocuments(filter),
-      books.countDocuments(translatedFilter),
+      books.countDocuments(readableFilter),
       books.countDocuments({ ...translatedFilter, is_first_translation: true }),
       books.distinct('author', translatedFilter).then(a => a.length),
       books.distinct('language', translatedFilter).then(l => l.filter(x => x && !x.includes(',') && !x.includes(' and ')).length),
+      books.countDocuments(artworkFilter),
+      db.collection('gallery_images').countDocuments({}),
     ]);
 
-    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, updatedAt: new Date() };
+    const stats = { totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount, updatedAt: new Date() };
     await db.collection('system_config').updateOne(
       { _id: 'homepage_stats' },
       { $set: stats },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -363,10 +363,12 @@ async function getCollectionShowcase() {
   return JSON.parse(JSON.stringify(items));
 }
 
-const FALLBACK_COUNTS = { totalBooks: 10675, translatedToEnglish: 10293, firstTranslationCount: 5607, authorCount: 4718, languageCount: 138, artworkCount: 14249, illustrationCount: 94811 };
+// Last refreshed from production 2026-05-26. Only used if Mongo + Supabase are both unreachable.
+const FALLBACK_COUNTS = { totalBooks: 15097, translatedToEnglish: 13924, firstTranslationCount: 6414, authorCount: 5562, languageCount: 170, artworkCount: 5159, illustrationCount: 121292 };
 
 async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglish: number; firstTranslationCount: number; authorCount: number; languageCount: number; artworkCount: number; illustrationCount: number }> {
-  // 1. MongoDB system_config cache (updated by update-homepage-stats.mjs cron)
+  // 1. MongoDB system_config cache (refreshed daily by scripts/maintenance/prewarm-browse.mjs;
+  // also writable on demand via scripts/maintenance/update-homepage-stats.mjs).
   // Preferred over Supabase because it uses the >=90% "readable" threshold which
   // Supabase books_catalog cannot compute (no column-to-column comparison in PostgREST).
   try {


### PR DESCRIPTION
## Summary

The headline numbers on the homepage (`/`) come from `system_config.homepage_stats`, refreshed daily at 05:00 by `scripts/maintenance/prewarm-browse.mjs`. That inline refresh had been diverging from the standalone updater (`update-homepage-stats.mjs`), producing visibly wrong numbers:

| Field | Cached (shown) | Live | Drift |
|---|---|---|---|
| totalBooks | 15,831 | 15,097 | +734 overstated |
| translatedToEnglish | 14,564 | 13,917 | +647 overstated |
| firstTranslationCount | 5,935 | 6,414 | -479 understated |
| **artworkCount** | **14,249** | **5,159** | **+9,090 — 2.8x overstated** |
| **illustrationCount** | **94,811** | **121,286** | **-26,475 understated** |

Three divergences fixed:

1. Filter was `hidden: { \$ne: true }` (matches books where the flag is unset) instead of `visible: true`.
2. `translatedToEnglish` was using `pages_translated > 0` instead of the >=90% "readable" threshold that `page.tsx` documents.
3. `artworkCount` and `illustrationCount` were not written at all — they had been frozen at whatever the last manual run of `update-homepage-stats.mjs` produced, which explains the huge artwork overstatement.

This PR moves the canonical filters into the daily cron so both scripts produce the same shape. Also refreshes the `FALLBACK_COUNTS` constant (last touched 2026-05-01) and corrects the stale comment in `getBookCounts()`.

The cache was refreshed manually before opening this PR so the live homepage already shows correct numbers (visible after the next ISR cycle / 60s revalidation).

## Out of scope
- Merging `update-homepage-stats.mjs` and `prewarm-browse.mjs` into one script — both have separate use cases (cron + manual on-demand). Left as two files; the canonical filter logic is now duplicated but kept in sync via a comment.
- Investigating *why* `artworkCount` dropped from 14,249 to 5,159 over time (likely a `resource_type` cleanup); that's a separate question.

## Test plan
- [x] `npx tsc --noEmit` — no new errors in touched files (pre-existing d3 errors in `carbon-ledger/interactives/` exist on main).
- [x] Cache already refreshed in production via `update-homepage-stats.mjs` — live homepage now shows correct numbers within next 60s revalidation.
- [ ] Verify next 05:00 cron run produces identical numbers to a manual `update-homepage-stats.mjs` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)