### PR TITLE
fix(visibility): hide conflicting-flag books and guard first-translation badge

### DIFF
--- a/scripts/maintenance/fix-conflicting-visibility.mjs
+++ b/scripts/maintenance/fix-conflicting-visibility.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Books with both `visible: true` AND `hidden: true` are a data-quality leak —
+ * `hidden_reason` (mostly "unprocessed" or "no-pages-catalog-stub") reveals the
+ * intent was to hide them, but `visible` was never unset. The homepage filter
+ * checks only `visible: true`, so these books leak into public counts and lists.
+ *
+ * This script treats `hidden: true` as authoritative and sets `visible: false`
+ * on every such book.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/fix-conflicting-visibility.mjs           # dry-run
+ *   node scripts/maintenance/fix-conflicting-visibility.mjs --apply   # write
+ */
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const uri = process.env.MONGODB_URI;
+if (!uri) { console.error('MONGODB_URI not set'); process.exit(1); }
+
+const client = await MongoClient.connect(uri);
+const db = client.db('bookstore');
+const books = db.collection('books');
+
+const query = { visible: true, hidden: true };
+const total = await books.countDocuments(query);
+
+const byReason = await books.aggregate([
+  { $match: query },
+  { $group: { _id: '$hidden_reason', n: { $sum: 1 } } },
+  { $sort: { n: -1 } },
+]).toArray();
+
+const inflating = await books.countDocuments({ ...query, pages_translated: { $gt: 0 } });
+
+console.log(`Conflicting visible:true && hidden:true: ${total}`);
+console.log('By hidden_reason:');
+for (const r of byReason) console.log(`  ${(r._id ?? '(unset)').padEnd(35)} ${r.n}`);
+console.log(`Of these, currently inflating homepage counts (pages_translated > 0): ${inflating}`);
+
+if (!APPLY) {
+  console.log('\nDry-run only. Re-run with --apply to set visible:false on all conflicting books.');
+  await client.close();
+  process.exit(0);
+}
+
+const res = await books.updateMany(query, { $set: { visible: false } });
+console.log(`\nUpdated ${res.modifiedCount} books (matched ${res.matchedCount}).`);
+
+const remaining = await books.countDocuments({ visible: true, hidden: true });
+console.log(`Remaining conflicting after update: ${remaining}`);
+
+await client.close();

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -156,7 +156,7 @@ export default function BookCard({ book, priority = false }: BookCardProps) {
             </div>
           )}
 
-          {book.is_first_translation && (
+          {book.is_first_translation && (book.pages_translated ?? 0) > 0 && (
             <div className="absolute top-2 right-2 z-10">
               <div className="bg-accent-gold text-white text-[10px] px-1.5 py-0.5 rounded-full shadow font-medium">
                 {firstTranslationBadge(book.translation_verification?.disposition, book.language)}


### PR DESCRIPTION
## Summary

Follow-up to #2048. While auditing the 812 books flagged `is_first_translation` but never translated, two data-quality issues surfaced.

### 1. 1,260 books with conflicting visibility flags

These had both `visible: true` AND `hidden: true` set. All have a `hidden_reason`:

| hidden_reason | count |
|---|---|
| `unprocessed` | 629 |
| `no-pages-catalog-stub` | 533 |
| (unset) | 98 |

The homepage filter is `visible: true`, so it was leaking these into public counts — 392 of the 1,260 had `pages_translated > 0`, inflating `translatedToEnglish` by that much.

`scripts/maintenance/fix-conflicting-visibility.mjs` treats `hidden: true` as authoritative and sets `visible: false` on every conflicting book. **Already applied in production**; homepage stats refreshed:

| Field | Before | After | Delta |
|---|---|---|---|
| totalBooks | 15,097 | 13,852 | -1,245 |
| translatedToEnglish | 13,924 | 13,534 | -390 |
| firstTranslationCount | 6,414 | 6,413 | -1 |
| authorCount | 5,562 | 5,523 | -39 |

The script is idempotent (re-running on a clean DB does nothing) and supports `--apply` vs default dry-run.

### 2. Defensive badge guard in `BookCard.tsx`

47 books were publicly visible with a "First Translation" badge but had zero translated pages — recently-flagged Tibetan / German / Dutch / French books still working through the translation queue. Worst offenders are the 29 BPH Freemasonry correspondence books (Eq. A Leone Resurgente letters) and the multi-volume Dutch *Algemeen wijsgeerig... Woordenboek*.

Added `(book.pages_translated ?? 0) > 0` to the badge render gate at `src/components/book/BookCard.tsx:159` so the claim is only shown when actually backed by content. This is defensive — even if the data is fixed today, the same situation will arise whenever a new batch-flag script runs ahead of the translation pipeline (as `bulk-flag-tibetan-ft.mjs` did in May).

## Out of scope
- The same defensive guard could be added to ~13 other render sites (`grep is_first_translation src/`). BookCard.tsx is the highest-traffic component; the others can be a follow-up cleanup or a shared helper.
- The remaining 812-47 = 765 stuck-but-not-publicly-visible books are mostly hidden:true catalog stubs that have now been removed from public view by fix #1 above.

## Test plan
- [x] Dry-run on production showed expected counts (1,260 / 392 inflating).
- [x] `--apply` ran successfully; `Remaining conflicting after update: 0`.
- [x] Homepage stats refreshed and reflect the cleanup.
- [x] `npx tsc --noEmit` — no new errors in touched files.
- [ ] Visually verify on a book that's `is_first_translation: true` and `pages_translated: 0` that the badge no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)