### PR TITLE
fix(seo): /gallery/image/<id> infinite redirect loop + root layout for metadata

### DIFF
--- a/src/app/gallery/image/[id]/layout.tsx
+++ b/src/app/gallery/image/[id]/layout.tsx
@@ -1,0 +1,9 @@
+// Gallery image URLs are tenant-agnostic, so the root /gallery/image/[id]
+// route mirrors the metadata + JSON-LD that the tenant version emits via
+// src/app/[tenant]/gallery/image/[id]/layout.tsx. Re-exporting keeps the
+// two surfaces in lockstep with zero duplication.
+
+import ImageLayout, { generateMetadata as parentGenerateMetadata } from '../../../[tenant]/gallery/image/[id]/layout';
+
+export { parentGenerateMetadata as generateMetadata };
+export default ImageLayout;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -307,27 +307,6 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  async function resolveTenantForGalleryImagePath(path: string): Promise<string | null> {
-    const match = path.match(/^\/gallery\/image\/([^/]+)$/);
-    if (!match) return null;
-
-    const imageId = match[1];
-    const idMatch = imageId.match(/^(.+)[:\-](\d+)$/);
-    const pageId = idMatch ? idMatch[1] : null;
-    if (!pageId) return null;
-
-    try {
-      const db = await getDbCached();
-      const page = await db.collection('pages').findOne(
-        { id: pageId },
-        { projection: { tenantId: 1 } }
-      );
-      return page?.tenantId ? await resolveTenantSlugById(page.tenantId as string) : null;
-    } catch {
-      return null;
-    }
-  }
-
   // --- Embed CORS: allow partner Webflow sites to call collection/book APIs ---
   const isEmbedRoute =
     pathname.startsWith('/api/collections') || pathname.startsWith('/api/books');
@@ -469,16 +448,16 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  if (pathname.startsWith('/gallery/image/')) {
-    const tenantSlug = await resolveTenantForGalleryImagePath(pathname)
-      || (await resolveTenantByExactSlug('default'))?.slug
-      || null;
-    if (tenantSlug) {
-      const url = request.nextUrl.clone();
-      url.pathname = `/${tenantSlug}${pathname}`;
-      return NextResponse.redirect(url, 308);
-    }
-  }
+  // Gallery image URLs are tenant-agnostic, matching the book-URL doctrine
+  // (see PR #2025, CLAUDE.md "Source Library is the destination"). A previous
+  // block here redirected `/gallery/image/<id>` to
+  // `/<tenant>/gallery/image/<id>` based on the image's owning tenant, but
+  // when that tenant resolved to a *provider*-kind row (e-codices, Internet
+  // Archive, etc.) the provider-strip rule above immediately stripped the
+  // prefix back off, producing an infinite 308 loop and making most gallery
+  // image pages unreachable. The clean URL is served by
+  // src/app/gallery/image/[id]/page.tsx (which re-exports the tenant page)
+  // plus a matching root layout that supplies the metadata + JSON-LD.
 
   // Collections are global routes. Canonicalize legacy tenant-scoped collection
   // paths (e.g. /bph/collections/astrology) to /collections/astrology.


### PR DESCRIPTION
## Summary
Auditing SEO surfaced a worse bug than expected: \`/gallery/image/<id>\` returns HTTP 308 in an infinite loop, making most gallery image pages unreachable in production. Two proxy rules contradict each other:

1. **Gallery-image tenant-prefix block** (proxy.ts:472–481): for an image whose owning tenant resolves to a provider-kind row (e-codices, Internet Archive, etc.), prefixes the path with the provider slug → 308 to \`/<provider>/gallery/image/<id>\`.
2. **Provider-strip block** (proxy.ts:432–455, added by #2025): strips provider prefixes from any path → 308 back to \`/gallery/image/<id>\`.

Repro: \`curl -sI https://sourcelibrary.org/gallery/image/6991c5563074a1745a410d6d-0\` → 308 forever.

## Fix
Per #2025's doctrine ("Source Library is the destination — content URLs are tenant-agnostic"), drop the gallery-image tenant-prefix block. The route is now served by the existing \`src/app/gallery/image/[id]/page.tsx\` which re-exports the tenant page.

Add a matching root layout (\`src/app/gallery/image/[id]/layout.tsx\`) that re-exports the tenant layout's \`generateMetadata\` + body so the global URL ships the same title, canonical, OG, Twitter, and \`VisualArtwork\` JSON-LD the tenant URL already did.

Also delete the now-unused \`resolveTenantForGalleryImagePath\` helper.

## Test plan
- [ ] On preview, \`curl -sI <preview>/gallery/image/6991c5563074a1745a410d6d-0\` returns HTTP 200 (not 308).
- [ ] Same URL shows the image title in \`<title>\`, canonical pointing to itself, and a \`<script type="application/ld+json">\` with \`@type: VisualArtwork\`.
- [ ] BPH subdomain access (\`bph.sourcelibrary.org/gallery/image/X\`) still works — uses the separate \`/embed/[tenant]/gallery/image/[id]\` route.
- [ ] \`node scripts/audit-bph-leaks.mjs\` against the preview to confirm no off-subdomain leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)