### PR TITLE
seo: experimental segment not-found.tsx for /book/[id] — testing 404 status

### DIFF
--- a/src/app/[tenant]/book/[id]/not-found.tsx
+++ b/src/app/[tenant]/book/[id]/not-found.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react';
+import NotFoundContent from '@/components/layout/NotFoundContent';
+
+// Route-segment not-found.tsx for /book/[id]. When notFound() is called from
+// page.tsx or any of its children (BookInfo Suspense child included),
+// Next.js renders this UI AND sets HTTP status 404. The global
+// src/app/not-found.tsx renders the same body but, with ISR enabled at the
+// page level (revalidate = 86400), the status sometimes commits as 200
+// because streaming has already started — Vercel then caches that 200 for
+// 24h. A segment-local not-found.tsx is the documented App Router escape
+// hatch for that.
+export default function BookNotFound() {
+  return (
+    <Suspense>
+      <NotFoundContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Hypothesis under test
With \`revalidate=86400\` (ISR) on \`/book/[id]\`, \`notFound()\` thrown from the page body returns HTTP **200** in production — verified on \`https://sourcelibrary.org/book/<bad-slug>\` with brand-new URLs. The not-found UI renders (\`<template data-dgst="NEXT_HTTP_ERROR_FALLBACK;404">\` is in the body), but the response status commits as 200 and Vercel caches it for 24h via the ISR cache-control header.

A route-segment \`not-found.tsx\` is the App Router escape hatch documented for exactly this situation: when notFound() can fire inside a streaming boundary, the segment-local not-found file lets Next.js preserve the 404 status because it knows the boundary statically.

## Change
Add \`src/app/[tenant]/book/[id]/not-found.tsx\` rendering the existing \`NotFoundContent\` component. Smoke-test on the preview:

- \`curl -o /dev/null -w '%{http_code}\\n' <preview>/book/never-seen-before-$(date +%s)\` should return **404** (today: 200).

If the hypothesis holds, follow-up PR replicates the pattern in:
- \`src/app/[tenant]/book/[id]/page/[pageId]/\`
- \`src/app/[tenant]/topics/[slug]/\` and \`src/app/topics/[slug]/\`
- \`src/app/[tenant]/languages/[code]/\`

If it doesn't, fallback is \`dynamic = 'force-dynamic'\` on those routes (loses ISR but guarantees correct status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)