### PR TITLE
fix(visibility): patch active hide-script bugs + document invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,17 @@ Derek runs ~10 Claude Code terminals simultaneously, all sharing the main workin
 - **NEVER** embed secrets in code — use `process.env.VAR` with no fallback
 - Review scripts for hardcoded credentials before committing
 
+## Visibility & Stats Invariants
+Lessons from PR #2055 (see `.claude/handoffs/`). The homepage and most public surfaces filter on `visible: true`, but `hidden: true` exists as a parallel flag. When the two disagree, books leak into public counts.
+
+- **`visible` and `hidden` must be opposites.** Every writer that sets `hidden: true` must also set `visible: false` (and vice versa for un-hide). Don't write one without the other. Active writers: `scripts/maintenance/hide-{unarchived,efm-duplicates}.mjs`, `scripts/maintenance/set-launch-books.mjs`, `scripts/workers/pipeline-orchestrator.mjs`, `src/app/api/admin/duplicates/route.ts`, `src/app/api/books/[id]/visibility/route.ts`. Historical drift cleaned up by `scripts/maintenance/fix-conflicting-visibility.mjs` — re-run if `db.books.countDocuments({ visible: true, hidden: true })` ever climbs above zero again.
+- **Homepage stats live in `system_config.homepage_stats`** (Mongo). Refreshed daily at 05:00 by `scripts/maintenance/prewarm-browse.mjs`, also writable on demand by `scripts/maintenance/update-homepage-stats.mjs`. Both scripts now share the same canonical filters — keep them in sync if you touch either. The canonical filters are:
+  - `totalBooks` / `authorCount` / `languageCount`: `visible: true && pages_count > 0` (plus `pages_translated > 0` for authors/languages)
+  - `translatedToEnglish`: ≥90% "readable" — `pages_translated >= 0.9 * (pages_ocr - pages_blank)`
+  - `artworkCount`: `visible: true && resource_type ∈ {drawing, fresco, object, painting, print}`
+  - `illustrationCount`: `gallery_images.countDocuments({})`
+- **`is_first_translation: true` ≠ "we have it in English."** It's a bibliographic claim that gets set by batch-flag scripts (e.g. `scripts/maintenance/bulk-flag-tibetan-ft.mjs`) before translation completes. Render gates that show the "First Translation" badge must require `pages_translated > 0` — otherwise readers see a badge on a book they can't read. Pattern: `book.is_first_translation && (book.pages_translated ?? 0) > 0`.
+
 ## Tenant Subdomain Lockdown — CRITICAL
 Tenant subdomains (e.g. `bph.sourcelibrary.org`) MUST be a closed system. Visitors must never be able to land on, follow a link to, or be redirected to non-tenant content. EFM and other partners use these subdomains as their public face — leaks break the trust model.
 

--- a/scripts/maintenance/hide-efm-duplicates.mjs
+++ b/scripts/maintenance/hide-efm-duplicates.mjs
@@ -162,7 +162,7 @@ async function main() {
     if (ids.length > 0) {
       const result = await books.updateMany(
         { id: { $in: ids } },
-        { $set: { hidden: true, hidden_reason: 'efm_duplicate' } }
+        { $set: { hidden: true, visible: false, hidden_reason: 'efm_duplicate' } }
       );
       console.log(`\nHid ${result.modifiedCount} non-EFM duplicate books.`);
     } else {

--- a/scripts/maintenance/hide-unarchived-books.mjs
+++ b/scripts/maintenance/hide-unarchived-books.mjs
@@ -93,7 +93,7 @@ async function main() {
     // Batch update
     const result = await db.collection('books').updateMany(
       { id: { $in: bookIds } },
-      { $set: { hidden: true, hidden_reason: 'unarchived', updated_at: new Date() } }
+      { $set: { hidden: true, visible: false, hidden_reason: 'unarchived', updated_at: new Date() } }
     );
     console.log(`Updated: ${result.modifiedCount} books`);
 

--- a/scripts/maintenance/set-launch-books.mjs
+++ b/scripts/maintenance/set-launch-books.mjs
@@ -145,6 +145,7 @@ async function main() {
     {
       $set: {
         hidden: true,
+        visible: false,
         hidden_reason: 'launch_curation',
       },
     }
@@ -163,7 +164,7 @@ async function main() {
       ],
     },
     {
-      $set: { hidden: false },
+      $set: { hidden: false, visible: true },
       $unset: { hidden_reason: '' },
     }
   );


### PR DESCRIPTION
## Summary

Follow-up to #2048 + #2055. The 1,260 conflicting `visible:true && hidden:true` books cleaned up in #2055 were the *symptom*; this PR fixes the *source*.

### Root cause

Three active hide scripts in `scripts/maintenance/` were writing `hidden: true` (and `hidden_reason`) without also writing `visible: false`. Books are imported with `visible: true`, so when these scripts hide them later, the conflict shape is created. Patched:

- `hide-unarchived-books.mjs` — `hidden_reason: 'unarchived'`
- `hide-efm-duplicates.mjs` — `hidden_reason: 'efm_duplicate'`
- `set-launch-books.mjs` — `hidden_reason: 'launch_curation'` (also fixed the paired un-hide branch to set `visible: true`)

Already-correct sites left alone (pipeline-orchestrator un-hide branch, the two admin/visibility API routes).

### CLAUDE.md update

New "Visibility & Stats Invariants" section under the existing CRITICAL blocks. Documents:

- The `visible`/`hidden` opposite-pair rule with the current list of writers (so the next person who adds a hider has somewhere to register it).
- `system_config.homepage_stats` — where it lives, what cron refreshes it (`prewarm-browse.mjs` daily at 05:00), and the canonical filter for each of the 7 fields. This is the thing that drifted in #2048; documenting it should prevent the next divergence.
- The `is_first_translation` render-gate rule from #2055.

### Out of scope

- ~13 other render sites still gate "First Translation" badges on `is_first_translation` alone. BookCard.tsx was the high-traffic one; the rest is polish.
- No new automated check / health probe. If conflict rebuilds, `db.books.countDocuments({ visible: true, hidden: true })` is the canonical query — could later be wired into the existing daily `/api/admin/health` ping (`trig_01C3YQK43o12bCkNdHRHeEBz`).

## Test plan
- [x] `npx tsc --noEmit` — no new errors in touched files.
- [x] Patched scripts are dry-run-safe; existing `--apply` / `--dry-run` semantics preserved.
- [ ] Next time `set-launch-books.mjs` runs, verify the post-condition `db.books.countDocuments({ visible: true, hidden: true })` stays at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)