### PR TITLE
fix(homepage): count artworks by content_type, not narrow resource_type list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Lessons from PR #2055 (see `.claude/handoffs/`). The homepage and most public su
 - **Homepage stats live in `system_config.homepage_stats`** (Mongo). Refreshed daily at 05:00 by `scripts/maintenance/prewarm-browse.mjs`, also writable on demand by `scripts/maintenance/update-homepage-stats.mjs`. Both scripts now share the same canonical filters — keep them in sync if you touch either. The canonical filters are:
   - `totalBooks` / `authorCount` / `languageCount`: `visible: true && pages_count > 0` (plus `pages_translated > 0` for authors/languages)
   - `translatedToEnglish`: ≥90% "readable" — `pages_translated >= 0.9 * (pages_ocr - pages_blank)`
-  - `artworkCount`: `visible: true && resource_type ∈ {drawing, fresco, object, painting, print}`
+  - `artworkCount`: `visible: true && content_type: 'artwork'` — single-object entries (paintings, prints, sculptures, etc.), distinguished from books by being non-sequential. They typically have `pages_count: 0` (image + metadata only) or a handful of non-sequential images of the same object. Don't filter on `resource_type` here — it's a finer-grained sub-category (sculpture, religious, allegory, manuscript-illumination…) that under-counts if used alone.
   - `illustrationCount`: `gallery_images.countDocuments({})`
 - **`is_first_translation: true` ≠ "we have it in English."** It's a bibliographic claim that gets set by batch-flag scripts (e.g. `scripts/maintenance/bulk-flag-tibetan-ft.mjs`) before translation completes. Render gates that show the "First Translation" badge must require `pages_translated > 0` — otherwise readers see a badge on a book they can't read. Pattern: `book.is_first_translation && (book.pages_translated ?? 0) > 0`.
 

--- a/scripts/maintenance/prewarm-browse.mjs
+++ b/scripts/maintenance/prewarm-browse.mjs
@@ -65,7 +65,8 @@ if (process.env.MONGODB_URI) {
       ...translatedFilter,
       $expr: { $gte: ['$pages_translated', { $multiply: [{ $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] }, 0.9] }] },
     };
-    const artworkFilter = { visible: true, resource_type: { $in: ['drawing', 'fresco', 'object', 'painting', 'print'] } };
+    // Artworks: single-object entries (content_type:'artwork') — see update-homepage-stats.mjs for rationale.
+    const artworkFilter = { visible: true, content_type: 'artwork' };
 
     const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount] = await Promise.all([
       books.countDocuments(filter),

--- a/scripts/maintenance/update-homepage-stats.mjs
+++ b/scripts/maintenance/update-homepage-stats.mjs
@@ -25,8 +25,11 @@ const readableFilter = {
   $expr: { $gte: ['$pages_translated', { $multiply: [{ $subtract: [{ $ifNull: ['$pages_ocr', 0] }, { $ifNull: ['$pages_blank', 0] }] }, 0.9] }] },
 };
 
-// Visual artworks (standalone art entries with resource_type like print, painting, etc.)
-const artworkFilter = { visible: true, resource_type: { $in: ['drawing', 'fresco', 'object', 'painting', 'print'] } };
+// Visual artworks: single-object entries (paintings, prints, sculptures, etc.).
+// Tagged content_type:'artwork' at import. They have 0 pages (image + metadata)
+// or a few non-sequential images of the same object — not read like books.
+// resource_type is too narrow: it omits sculpture, religious art, allegory, etc.
+const artworkFilter = { visible: true, content_type: 'artwork' };
 
 const [totalBooks, translatedToEnglish, firstTranslationCount, authorCount, languageCount, artworkCount, illustrationCount] = await Promise.all([
   books.countDocuments(filter),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -364,7 +364,7 @@ async function getCollectionShowcase() {
 }
 
 // Last refreshed from production 2026-05-26. Only used if Mongo + Supabase are both unreachable.
-const FALLBACK_COUNTS = { totalBooks: 15097, translatedToEnglish: 13924, firstTranslationCount: 6414, authorCount: 5562, languageCount: 170, artworkCount: 5159, illustrationCount: 121292 };
+const FALLBACK_COUNTS = { totalBooks: 13869, translatedToEnglish: 13534, firstTranslationCount: 6911, authorCount: 5523, languageCount: 170, artworkCount: 13743, illustrationCount: 122550 };
 
 async function getBookCounts(): Promise<{ totalBooks: number; translatedToEnglish: number; firstTranslationCount: number; authorCount: number; languageCount: number; artworkCount: number; illustrationCount: number }> {
   // 1. MongoDB system_config cache (refreshed daily by scripts/maintenance/prewarm-browse.mjs;


### PR DESCRIPTION
## Summary

Third pass on the homepage stats. PR #2048 aligned both stat scripts to the narrow filter `resource_type ∈ {drawing, fresco, object, painting, print}` — but that filter is wrong. It misses sculpture, religious art, mythological scenes, portraits, allegory, manuscript-illumination, architectural, emblems, ritual objects, landscapes, and ~15 other clearly-artwork categories.

| Filter | Count | Note |
|---|---|---|
| `visible: true && resource_type ∈ {drawing, fresco, object, painting, print}` | 5,182 | what the homepage shows today |
| `visible: true && content_type: 'artwork'` | **13,743** | the right one |

The 14,249 in the historical cache value was someone running `content_type: 'artwork'` (or `hidden ≠ true && content_type: 'artwork'` = 14,439) manually and `$set`-ing it — months before the canonical script ever ran. The script's filter has always been the narrow one. PR #2048 "fixed" the divergence by syncing both scripts to the narrow filter; this PR fixes it the right way.

### Why content_type and not resource_type

The structural definition of artwork: a single-object entry that isn't read sequentially. Paintings, sculptures, prints. They might have multiple images (front/back of a painting, several angles of a sculpture) but those aren't a reading sequence.

Live data confirms it:
- 13,601 of 13,743 visible `content_type: 'artwork'` have `pages_count: 0` (image + metadata only)
- 63 have `pages_count: 1`
- 72 have `pages_count: 2-5` (multi-image, non-sequential)
- 7 have more (probably misclassified)

`resource_type` is the finer-grained subject/medium category beneath that — there are 30+ values (sculpture, religious, allegory, mythological, portrait, …). It under-counts if used as a top-level filter.

### Cache refresh

Already refreshed in production:

| Field | Before | After |
|---|---|---|
| artworkCount | 5,159 | **13,743** |
| firstTranslationCount | 6,413 | 6,911 (organic, +498) |
| illustrationCount | 121,292 | 122,550 |

## Out of scope

- The narrow `resource_type` list isn't used anywhere else, so this PR just changes the homepage definition. Other surfaces (`/artwork`, `/gallery`) have their own queries.
- Auditing the 142 books with `content_type: { $ne: 'artwork' } && pages_count: 1` (ancient hymns, single-tablet texts like the Code of Hammurabi) — those are short books, correctly classified as `content_type: 'book'`. No change needed.

## Test plan
- [x] `npx tsc --noEmit` — no new errors.
- [x] Refreshed prod cache; homepage will pick it up within next 60s ISR.
- [ ] Verify the homepage now shows ~13,743 artworks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)