### PR TITLE
fix(collections): "Browse Full Catalog" → in-page "Browse Catalog" expand

### DIFF
--- a/src/components/collections/CollectionAllBooks.tsx
+++ b/src/components/collections/CollectionAllBooks.tsx
@@ -237,13 +237,24 @@ export default function CollectionAllBooks({
             <h2 className="text-2xl sm:text-3xl text-primary font-display">
               All {isArt ? 'Works' : 'Books'}
             </h2>
-            <Link
-              href={isArt ? '/artwork' : '/catalog'}
-              className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-accent-rust/30 text-accent-rust hover:bg-accent-rust hover:text-white transition-colors"
-            >
-              {isArt ? 'All Art Collections' : 'Browse Full Catalog'}
-              <span>&rarr;</span>
-            </Link>
+            {isArt ? (
+              <Link
+                href="/artwork"
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-accent-rust/30 text-accent-rust hover:bg-accent-rust hover:text-white transition-colors"
+              >
+                All Art Collections
+                <span>&rarr;</span>
+              </Link>
+            ) : !expanded ? (
+              <button
+                type="button"
+                onClick={() => { setExpanded(true); handleViewToggle('list'); }}
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-accent-rust/30 text-accent-rust hover:bg-accent-rust hover:text-white transition-colors cursor-pointer"
+              >
+                Browse Catalog
+                <span>&rarr;</span>
+              </button>
+            ) : null}
           </div>
           <p className="text-sm text-muted mt-1">
             {expanded ? (


### PR DESCRIPTION
## Summary

- The "Browse Full Catalog" button in the collection page's "All Books" header used to link to global `/catalog`, which felt like navigating away from the collection.
- Replaced with an in-page button that expands the catalog view and switches to list mode — keeping the reader in the collection.
- Renamed label: "Browse Full Catalog" → "Browse Catalog".
- Art-collection variant unchanged (still links to `/artwork` — no in-page equivalent).

## Test plan

- [ ] Visit https://sourcelibrary.org/collections/yoga (or any non-art collection)
- [ ] Click "Browse Catalog" in the "All Books" header — should expand the in-page view to list mode without navigating away
- [ ] Verify button disappears once expanded
- [ ] Visit any art collection (e.g. `/collections/visual-art`) — should still say "All Art Collections" linking to `/artwork`

🤖 Generated with [Claude Code](https://claude.com/claude-code)