### PR TITLE
docs(embeddings): map the architecture + add orphan-row cleanup

### DIFF
--- a/.claude/docs/embeddings.md
+++ b/.claude/docs/embeddings.md
@@ -1,0 +1,59 @@
+# Embeddings
+
+Source Library has **five embedding stores** in Supabase, indexing different things at different granularities. All live in the `secondrenaissance` project (ID `ykhxaecbbxaaqlujuzde`). No embeddings live in Mongo Atlas — Atlas holds the source of truth for content; Supabase holds derived vectors.
+
+## The five stores
+
+| Table | Dim | Model | Granularity | Filled by | Read via RPC | Used at |
+|---|---|---|---|---|---|---|
+| `page_translations` | 768 (vector) | `gemini-embedding-2-preview` | One row per translated page | `scripts/workers/embed-gemini.mjs` (Hetzner cron) | `match_semantic`, `match_pages_in_books` | `src/lib/semantic-search.ts` global + scoped page search |
+| `book_embeddings` | 768 (vector) | `gemini-embedding-2-preview` | One row per book (title + author + summary + entities) | `enrich-worker` Phase 6.5 (inline) | `match_books_semantic` | `src/lib/semantic-search.ts` book-level retrieval |
+| `artwork_embeddings` | **3072 (halfvec)** | `gemini-embedding-2-preview` | One row per artwork (title + author + summary + subjects + figures + symbols) | `scripts/migration/backfill-artwork-embeddings.mjs` + `scripts/workers/image-embeddings-cron.mjs` | `match_artworks_semantic` | `src/lib/semantic-search.ts` artwork retrieval |
+| `gallery_text_embeddings` | 768 (vector) | `gemini-embedding-2-preview` | One row per gallery image (museum description text) | `scripts/workers/image-embeddings-cron.mjs` | `match_gallery_text` | `src/lib/embeddings.ts`, `src/app/api/gallery/{route,similar/route}.ts` |
+| `clip_embeddings` | 512 (vector) | CLIP visual | One row per image (artwork covers, gallery extractions) | `scripts/backfill-clip-embeddings.mjs` + `scripts/workers/image-embeddings-cron.mjs` | `match_gallery_text` (CLIP text→image) | gallery similar-image queries |
+
+Approximate current row counts (May 2026): pages ~3.9M, books 33,828, artworks 19,731, gallery_text 116,641, clip 151,957.
+
+## Why three different dimensions
+
+- **768 (`vector`)** is the Gemini `gemini-embedding-2-preview` default and fits well inside `pgvector`'s `vector_cosine_ops` HNSW operator class (cap: 2000 dims). Used for the three text stores that index short-to-medium passages: pages, book summaries, gallery captions.
+- **3072 (`halfvec`)** is the same Gemini model's max-quality output. Artwork descriptions are longer and need the extra capacity. 3072 is above the 2000-dim HNSW cap for `vector_cosine_ops`, so the column type is `halfvec` (fp16) and the index uses `halfvec_cosine_ops` — see `lesson_pgvector_hnsw_dim_cap.md` for the gotcha. The 7th-decimal-place precision loss is negligible for retrieval.
+- **512 (`vector`)** is CLIP's native output dim. Visual model, completely independent from the Gemini text embeddings.
+
+## Who writes what, when
+
+- `embed-gemini.mjs` is the page-level workhorse. Embeds OCR + translation per page. Runs as a Hetzner cron (see `.claude/docs/hetzner-scheduler-crontab.md`); modes: `--full`, `--incremental` (default), `--missing-only`, `--book ID`. Cost: free tier on `gemini-embedding-2-preview`, ~13 texts/sec sustained.
+- `enrich-worker` Phase 6.5 writes `book_embeddings` inline as books finish enrichment. **Not in `image-embeddings-cron.mjs`** — see the file header comment + issue #2021 for why.
+- `image-embeddings-cron.mjs` is the nightly catch-up for the three image-side tables that don't have an inline writer: `artwork_embeddings`, `gallery_text_embeddings`, `clip_embeddings`. Each underlying backfill is idempotent (loads already-embedded IDs, embeds the diff). The cron re-exports `GEMINI_API_KEY=$GEMINI_API_KEY_TIER3` so Gemini text runs on paid Tier 3 quota.
+
+## Who reads them
+
+All retrieval flows through `src/lib/semantic-search.ts` (text) or `src/lib/embeddings.ts` (gallery). The RPC names map 1:1 to the table they query — `match_books_semantic` reads `book_embeddings`, etc. Callers:
+
+- **Global page search:** `/api/search` (and the MCP server's `search_within_book` / `search_concept`) → `match_semantic`.
+- **In-book page search:** `match_pages_in_books` scans pages for a given book_id set — faster than the global RPC when you already know the books.
+- **Book-level retrieval:** `match_books_semantic` for "find me books similar to this concept."
+- **Artwork retrieval:** `match_artworks_semantic` for the artwork browse / search experience.
+- **Gallery similar-image:** `/api/gallery/similar` → `match_gallery_text` (CLIP text→image alignment + Gemini text-on-description).
+
+## Maintenance
+
+### Stale rows
+Embeddings are kept for hidden books on purpose — visibility toggles and re-embedding is expensive. They are NOT kept for books that have been deleted from Mongo entirely; those are pure orphans.
+
+Run `scripts/maintenance/delete-stale-embeddings.mjs` periodically. It cross-references each table's `book_id` against the full Mongo `books` collection (visible + hidden + everything) and deletes only the rows with no matching book at all. Default is dry-run; `--apply` writes.
+
+Baseline at 2026-05-26 (after first cleanup pass): 338 truly orphaned rows total across `book_embeddings`, `artwork_embeddings`, and `clip_embeddings`. `gallery_text_embeddings` was already clean. The numbers should stay small as long as the script runs occasionally; deletions in Mongo are rare (CRITICAL data protection rules forbid bulk deletes).
+
+`page_translations` (~3.9M rows) is too big for REST paging — the script prints a SQL one-liner to run in the Supabase editor when needed. The DELETE there uses `WHERE NOT EXISTS (SELECT 1 FROM book_embeddings …)` as a proxy for "book still exists" — works because `book_embeddings` has one row per book and the cleanup runs on it first.
+
+### Re-embedding
+- Page-level: `node scripts/workers/embed-gemini.mjs --book <id>` re-embeds a specific book.
+- Book-level: enrich-worker Phase 6.5 handles it during enrichment. To force, re-run enrichment for the book.
+- Artwork / gallery / clip: idempotent backfill scripts in `scripts/migration/` — delete the row(s) and re-run the cron.
+
+### Index health
+The HNSW index has to be present and the planner has to choose it — `CREATE INDEX` succeeds silently even when it produces an unusable index above the dim cap. Always `EXPLAIN ANALYZE` a real `match_*` query after touching a vector column or index. See `lesson_pgvector_hnsw_dim_cap.md` and `lesson_silent_probe_failures.md`.
+
+### Cost
+Page-level embedding cost was zero for the full backfill (free tier). Incremental runs are negligible. The artwork / gallery / CLIP cron runs on paid Tier 3 because it batches across many tables and would otherwise risk hitting free-tier quota at burst times.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ Detect the work domain from the user's prompt and load the right context automat
 - **UI/frontend/navigation:** read `memory/ui-navigation.md` (or `/ui-context`)
 - **Data fixes/maintenance/stuck books:** read `memory/data-quality.md` (or `/maintenance`)
 - **MCP server/CLI:** read `memory/mcp-server.md`
+- **Embeddings / semantic search:** read `.claude/docs/embeddings.md` — five Supabase tables (`page_translations`, `book_embeddings`, `artwork_embeddings`, `gallery_text_embeddings`, `clip_embeddings`), three workers, five RPCs.
 - **Book acquisition / curation:** `/curator` or `/library-curator`
 - **Quality auditing:** `/qa-audit`
 - **Batch processing:** `/batch-translate`

--- a/scripts/maintenance/delete-stale-embeddings.mjs
+++ b/scripts/maintenance/delete-stale-embeddings.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Delete embedding rows whose `book_id` no longer exists in `bookstore.books`.
+ * These are orphaned — the source book was deleted (or never imported) and the
+ * embedding is unreachable through any UI / RPC.
+ *
+ * We do NOT delete embeddings for hidden books — visibility toggles and
+ * re-embedding (especially page-level) is expensive.
+ *
+ * The four small tables are paged-and-deleted via the Supabase REST client.
+ * `page_translations` (~3.9M rows) is too big for REST; the script emits a
+ * SQL one-liner to run in the Supabase SQL editor.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/delete-stale-embeddings.mjs            # dry-run
+ *   node scripts/maintenance/delete-stale-embeddings.mjs --apply    # write
+ */
+import { MongoClient } from 'mongodb';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+
+const MONGODB_URI = process.env.MONGODB_URI;
+const SUPABASE_URL = (process.env.SUPABASE_URL || '').trim();
+const SUPABASE_KEY = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+if (!MONGODB_URI || !SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Need MONGODB_URI, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const mongo = await MongoClient.connect(MONGODB_URI);
+const db = mongo.db('bookstore');
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+console.log('Loading book_ids from Mongo…');
+const validIds = new Set();
+const cursor = db.collection('books').find({}, { projection: { id: 1, _id: 1 } });
+for await (const b of cursor) {
+  if (b.id) validIds.add(String(b.id));
+  if (b._id) validIds.add(String(b._id));
+}
+console.log(`  ${validIds.size} candidate id strings.\n`);
+
+// REST-paged tables — small enough that scan-and-dedupe is fine.
+const SMALL_TABLES = [
+  { name: 'book_embeddings',         key: 'book_id' },
+  { name: 'artwork_embeddings',      key: 'book_id' },
+  { name: 'gallery_text_embeddings', key: 'book_id' },
+  { name: 'clip_embeddings',         key: 'book_id' },
+];
+
+const PAGE = 1000;
+
+for (const t of SMALL_TABLES) {
+  let from = 0;
+  const seen = new Set();
+  while (true) {
+    const { data, error } = await sb.from(t.name).select(t.key).range(from, from + PAGE - 1);
+    if (error) { console.error(`  ${t.name} fetch error: ${error.message}`); break; }
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      const v = row[t.key];
+      if (v != null) seen.add(String(v));
+    }
+    from += PAGE;
+    if (data.length < PAGE) break;
+  }
+  const orphans = [...seen].filter(id => !validIds.has(id));
+  console.log(`${t.name.padEnd(28)} distinct_book_ids=${seen.size}  orphans=${orphans.length}`);
+
+  if (!APPLY || orphans.length === 0) continue;
+
+  let deleted = 0;
+  for (let i = 0; i < orphans.length; i += 100) {
+    const chunk = orphans.slice(i, i + 100);
+    const { error, count } = await sb.from(t.name).delete({ count: 'exact' }).in(t.key, chunk);
+    if (error) { console.error(`  delete error: ${error.message}`); break; }
+    deleted += count ?? 0;
+  }
+  console.log(`${t.name.padEnd(28)} DELETED ${deleted} rows.`);
+}
+
+// page_translations is too big to page via REST. Emit a SQL one-liner.
+console.log(`
+─── page_translations cleanup ─────────────────────────────────
+Too large for REST paging (~3.9M rows). Run in Supabase SQL editor:
+
+  -- One-shot cleanup. Replace the literal array with the current
+  -- valid book_id list, or load into a temp table first if it's huge.
+  -- Quick check:
+  SELECT COUNT(*) FROM page_translations p
+   WHERE NOT EXISTS (
+     SELECT 1 FROM book_embeddings b WHERE b.book_id::text = p.book_id::text
+   );
+  -- (Using book_embeddings as the implicit "live book" set after this
+  -- script cleans it. Once book_embeddings is orphan-free, every
+  -- page_translations row whose book_id isn't there is also orphaned.)
+
+  -- Delete (run after the COUNT looks reasonable):
+  DELETE FROM page_translations p
+   WHERE NOT EXISTS (
+     SELECT 1 FROM book_embeddings b WHERE b.book_id::text = p.book_id::text
+   );
+───────────────────────────────────────────────────────────────`);
+
+if (!APPLY) console.log('\nDry-run only. Re-run with --apply to delete from the four small tables.');
+
+await mongo.close();


### PR DESCRIPTION
## Summary

Out of conversation with Derek today: nothing in the repo described the embedding architecture as a whole. CLAUDE.md didn't mention embeddings; `.claude/docs/` had 16 reference files but none for this. The lore was scattered across migration SQL files and worker script headers.

### `.claude/docs/embeddings.md`

Covers:
- **Five tables**, with dims that aren't uniform: `page_translations.embedding` (768, vector), `book_embeddings` (768), `artwork_embeddings` (**3072, halfvec** — the gotcha case from `lesson_pgvector_hnsw_dim_cap.md`), `gallery_text_embeddings` (768), `clip_embeddings` (512, CLIP visual).
- **Who fills them:** `scripts/workers/embed-gemini.mjs` (page-level, free tier, Hetzner cron), `enrich-worker` Phase 6.5 (book-level, inline), `scripts/workers/image-embeddings-cron.mjs` (the three image-side tables, nightly, paid Tier 3).
- **Five RPCs and who reads them.** All retrieval flows through `src/lib/semantic-search.ts` (text) or `src/lib/embeddings.ts` (gallery).
- Maintenance: stale-row hygiene + how to re-embed + the dim-cap pitfall.

### `scripts/maintenance/delete-stale-embeddings.mjs`

Cross-references each table's `book_id` against the full Mongo `books` collection (visible + hidden — visibility legitimately toggles) and deletes only the rows whose book has been deleted from Mongo entirely.

Dry-run by default. Applied in this session:

| Table | Distinct book_ids | Orphans | Deleted |
|---|---|---|---|
| book_embeddings | 33,831 | 135 | ✅ |
| artwork_embeddings | 19,731 | 89 | ✅ |
| gallery_text_embeddings | 6,378 | 0 | — |
| clip_embeddings | 42,692 | 114 | ✅ |

Total: 338 truly orphaned rows. Much smaller than the "~20K stale" I'd initially estimated when comparing row count to visible books — that estimate was wrong because the extra rows are mostly for *hidden* books (legitimately kept).

### Out of scope

- **`page_translations` cleanup** (~3.9M rows). Too big for REST paging. Script emits a SQL one-liner to run in the Supabase editor — left for a separate, deliberate run.
- **Updating `lesson_pgvector_hnsw_dim_cap.md`** in auto-memory. The lesson is still correct (artwork_embeddings is indeed 3072-halfvec), so no update needed.

## Test plan
- [x] Dry-run produced expected per-table orphan counts.
- [x] `--apply` ran cleanly; 338 deletes across three tables; gallery_text was already clean.
- [x] `npx tsc --noEmit` — no new errors (no `.ts` touched).
- [ ] Future runs of the script should report `orphans=0` until books are next deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)