### PR TITLE
fix(404): redirect bare /book, /author, /q, and library-gallery URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -291,6 +291,33 @@ const nextConfig: NextConfig = {
         destination: '/librarian/voice',
         permanent: true,
       },
+      // Bare list-roots that users hit without a slug — send them somewhere useful
+      // instead of 404. Tracked from `not_found_reports`: each gets 10+ distinct
+      // IPs per week. `/book` was previously kept as a deliberate 404 (legacy
+      // listing route), but `/search` is the closest match to user intent.
+      {
+        source: '/book',
+        destination: '/search',
+        permanent: false,
+      },
+      {
+        source: '/author',
+        destination: '/search',
+        permanent: false,
+      },
+      {
+        source: '/q',
+        destination: '/',
+        permanent: false,
+      },
+      // Library-scoped gallery URLs don't exist as routes — gallery is global
+      // per the "Source Library is the destination" URL doctrine. Strip the
+      // library prefix so external links resolve.
+      {
+        source: '/libraries/:slug/gallery/:path*',
+        destination: '/gallery/:path*',
+        permanent: true,
+      },
       // Short share links for explore pages
       {
         source: '/map',


### PR DESCRIPTION
## Summary

- Redirect bare list-root paths (`/book`, `/author`, `/q`) to `/search` (or `/` for `/q`) instead of 404
- Strip `/libraries/<slug>/gallery/...` to global `/gallery/...` per the URL doctrine in CLAUDE.md

## Why

Pulled the top patterns from `not_found_reports` last 7 days:

| URL | hits | distinct IPs |
|---|---|---|
| `/book` | 11 | 10 |
| `/q` | 10 | 9 |
| `/author` | 6 | 5 |
| `/libraries/e-rara/gallery/image/...` | 2 each | various |

These were all 404ing because:
- `/book`, `/author`, `/q` were in `NON_TENANT_PATHS` (proxy.ts) as deliberate 404s, but they're just list-roots with no slug — `/search` is a reasonable target.
- `/libraries/<slug>/gallery/<...>` has no route folder. Gallery is global per the "Source Library is the destination" doctrine (PR #2025).

## What's out of scope

- BPH `host_path` 404s: investigated, all currently return 200. Likely transient (deploy gap or DB timeout). Not actionable.
- Broken-image reports: separate concern. The dominant cause is R2 upload lag — page docs reference `images.sourcelibrary.org/pages/<id>/...` URLs that the actual files lag behind. Will follow up with a thumbnail-regen pass on Instruction of Ani (14 pages with no `-thumb.jpg`) + Allerneuste Geheimnisse (partial upload).

## Test plan
- [ ] `curl -I https://<preview>/book` → 307 to `/search`
- [ ] `curl -I https://<preview>/q` → 307 to `/`
- [ ] `curl -I https://<preview>/author` → 307 to `/search`
- [ ] `curl -I https://<preview>/libraries/e-rara/gallery/image/69a565d45a8a09c1b325e8fa-0` → 308 to `/gallery/image/...`
- [ ] `/book/<slug>` (with slug) still works
- [ ] `/q/<code>` shortlinks still work
- [ ] `/libraries/<slug>` listing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)