### PR TITLE
fix(first-translation): gate badge on pages_translated > 0 across all sites

### DIFF
--- a/src/app/[tenant]/book/[id]/page.tsx
+++ b/src/app/[tenant]/book/[id]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Book, Page, TranslationEdition } from '@/lib/types';
 import { findBookByIdOrSlug } from '@/lib/book-lookup';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import { deduplicateByDHash } from '@/lib/dhash';
 import { getBookDetail } from '@/lib/books-catalog';
 import { Calendar, Globe, FileText, BookMarked, Images, BookOpen } from 'lucide-react';
@@ -830,7 +831,7 @@ async function BookInfo({ id, tenantId, tenantSlug, embedPolicy }: { id: string;
                 )}
               </div>
 
-              {book.is_first_translation && (
+              {isPublishedFirstTranslation(book) && (
                 <div className="mt-3">
                   <details className="group">
                     <summary className="inline-flex px-2.5 py-1 bg-accent-gold/20 text-accent-gold hover:bg-accent-gold/30 text-xs font-medium rounded-full border border-accent-gold/30 transition-colors cursor-pointer list-none [&::-webkit-details-marker]:hidden">

--- a/src/app/[tenant]/collections/[id]/page.tsx
+++ b/src/app/[tenant]/collections/[id]/page.tsx
@@ -19,6 +19,7 @@ import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter'
 import { bookTitle, sanitizeThumbnail, withTimeout } from '@/lib/collections-utils';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import { browseBooks } from '@/lib/books-catalog';
 
 // ISR: rebuild at most once per day
@@ -111,6 +112,7 @@ interface CuratedHighlight {
   thumbnail?: string;
   thumbnail_blob?: string;
   is_first_translation?: boolean;
+  pages_translated?: number;
   ft_disposition?: string;
   language?: string;
   id: string;
@@ -487,6 +489,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
         slug: book.slug as string | undefined,
         thumbnail: sanitizeThumbnail(book.thumbnail_blob as string) || sanitizeThumbnail(book.thumbnail as string),
         is_first_translation: book.is_first_translation as boolean | undefined,
+        pages_translated: book.pages_translated as number | undefined,
         ft_disposition: (book.translation_verification as Record<string, unknown> | undefined)?.disposition as string | undefined,
         language: book.language as string | undefined,
         id: h.book_id,
@@ -537,7 +540,7 @@ async function fetchCollectionData(id: string, tenantId: string | null, provider
       const exBooks = await withTimeout(
         db.collection('books').find(
           { id: { $in: [...allBookIds] }, visible: true },
-          { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, 'translation_verification.disposition': 1 } },
+          { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, pages_translated: 1, 'translation_verification.disposition': 1 } },
         ).toArray(),
         8000, [],
       );
@@ -917,7 +920,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                   </h2>
                   <p className="text-base text-muted mb-3">
                     {featured.author}{featured.year ? `, ${featured.year}` : ''}
-                    {featured.is_first_translation && (
+                    {isPublishedFirstTranslation(featured) && (
                       <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
                         {firstTranslationBadge(featured.ft_disposition, featured.language)}
                       </span>
@@ -1091,7 +1094,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         </h3>
                         <p className="text-sm text-muted mb-2">
                           {h.author}{h.year ? `, ${h.year}` : ''}
-                          {h.is_first_translation && (
+                          {isPublishedFirstTranslation(h) && (
                             <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
                               {firstTranslationBadge(h.ft_disposition, h.language)}
                             </span>
@@ -1144,7 +1147,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         </h3>
                         <p className="text-xs text-muted mb-1">
                           {h.author}{h.year ? `, ${h.year}` : ''}
-                          {h.is_first_translation && (
+                          {isPublishedFirstTranslation(h) && (
                             <span className="ml-1.5 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
                               {firstTranslationBadge(h.ft_disposition, h.language)}
                             </span>
@@ -1196,7 +1199,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         </h4>
                         <p className="text-xs text-muted truncate">
                           {h.author}{h.year ? `, ${h.year}` : ''}
-                          {h.is_first_translation && (
+                          {isPublishedFirstTranslation(h) && (
                             <span className="ml-1.5 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
                               {firstTranslationBadge(h.ft_disposition, h.language)}
                             </span>

--- a/src/app/[tenant]/research/translation-lag/page.tsx
+++ b/src/app/[tenant]/research/translation-lag/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { getReadDb } from '@/lib/mongodb';
 import ContentPageLayout, { ContentHeader } from '@/components/layout/ContentPageLayout';
 import TranslationLagViz from '@/components/research/TranslationLagViz';
+import { isPublishedFirstTranslation } from '@/lib/book';
 
 export const revalidate = 60;
 
@@ -22,6 +23,7 @@ interface LagDataPoint {
   composed_display: string;
   lag: number;
   is_first_translation: boolean;
+  pages_translated: number;
   categories: string[];
 }
 
@@ -37,7 +39,7 @@ async function fetchLagData(): Promise<LagDataPoint[]> {
     {
       projection: {
         title: 1, display_title: 1, year: 1, language: 1, slug: 1,
-        source_work_dates: 1, author: 1, categories: 1, is_first_translation: 1,
+        source_work_dates: 1, author: 1, categories: 1, is_first_translation: 1, pages_translated: 1,
       },
       maxTimeMS: 30000,
     },
@@ -70,6 +72,7 @@ async function fetchLagData(): Promise<LagDataPoint[]> {
       composed_display: comp.date_display || String(compDate),
       lag,
       is_first_translation: b.is_first_translation || false,
+      pages_translated: b.pages_translated || 0,
       categories: b.categories || [],
     });
   }
@@ -194,7 +197,7 @@ export default async function TranslationLagPage() {
                     <a href={`/book/${d.slug}`} className="text-[var(--accent-rust)] hover:underline">
                       {d.title}
                     </a>
-                    {d.is_first_translation && (
+                    {isPublishedFirstTranslation(d) && (
                       <span className="ml-2 text-xs bg-[var(--accent-gold)]/15 text-[var(--accent-gold-dark)] px-1.5 py-0.5 rounded">
                         First translation
                       </span>

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -20,6 +20,7 @@ import EmbedNavigationReporter from '@/components/embed/EmbedNavigationReporter'
 import { bookTitle, sanitizeThumbnail, withTimeout, collectionCountLabel, ART_EXCLUDED_RESOURCE_TYPES } from '@/lib/collections-utils';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import { browseBooks } from '@/lib/books-catalog';
 
 // ISR: rebuild at most once per day
@@ -112,6 +113,7 @@ interface CuratedHighlight {
   thumbnail?: string;
   thumbnail_blob?: string;
   is_first_translation?: boolean;
+  pages_translated?: number;
   ft_disposition?: string;
   language?: string;
   id: string;
@@ -496,6 +498,7 @@ async function fetchCollectionData(id: string, provider?: string) {
         slug: book.slug as string | undefined,
         thumbnail: sanitizeThumbnail(book.thumbnail_blob as string) || sanitizeThumbnail(book.thumbnail as string),
         is_first_translation: book.is_first_translation as boolean | undefined,
+        pages_translated: book.pages_translated as number | undefined,
         ft_disposition: (book.translation_verification as Record<string, unknown> | undefined)?.disposition as string | undefined,
         language: book.language as string | undefined,
         id: h.book_id,
@@ -550,7 +553,7 @@ async function fetchCollectionData(id: string, provider?: string) {
             visible: true,
             ...(providerClause ? { $and: [providerClause] } : {}),
           },
-          { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, 'translation_verification.disposition': 1 } },
+          { projection: { id: 1, slug: 1, title: 1, display_title: 1, author: 1, year: 1, language: 1, thumbnail: 1, thumbnail_blob: 1, image_display: 1, image_thumb: 1, is_first_translation: 1, pages_translated: 1, 'translation_verification.disposition': 1 } },
         ).toArray(),
         8000, [],
       );
@@ -975,7 +978,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                   </h2>
                   <p className="text-base text-muted mb-3">
                     {featured.author}{featured.year ? `, ${featured.year}` : ''}
-                    {featured.is_first_translation && (
+                    {isPublishedFirstTranslation(featured) && (
                       <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
                         {firstTranslationBadge(featured.ft_disposition, featured.language)}
                       </span>
@@ -1175,7 +1178,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         </h3>
                         <p className="text-sm text-muted mb-2">
                           {h.author}{h.year ? `, ${h.year}` : ''}
-                          {h.is_first_translation && (
+                          {isPublishedFirstTranslation(h) && (
                             <span className="ml-2 text-[10px] font-medium bg-accent-rust/10 text-accent-rust px-1.5 py-0.5 rounded">
                               {firstTranslationBadge(h.ft_disposition, h.language)}
                             </span>
@@ -1228,7 +1231,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         </h3>
                         <p className="text-xs text-muted mb-1">
                           {h.author}{h.year ? `, ${h.year}` : ''}
-                          {h.is_first_translation && (
+                          {isPublishedFirstTranslation(h) && (
                             <span className="ml-1.5 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
                               {firstTranslationBadge(h.ft_disposition, h.language)}
                             </span>
@@ -1280,7 +1283,7 @@ export default async function CollectionDetailPage({ params, provider }: Props &
                         </h4>
                         <p className="text-xs text-muted truncate">
                           {h.author}{h.year ? `, ${h.year}` : ''}
-                          {h.is_first_translation && (
+                          {isPublishedFirstTranslation(h) && (
                             <span className="ml-1.5 text-[9px] font-medium bg-accent-rust/10 text-accent-rust px-1 py-0.5 rounded">
                               {firstTranslationBadge(h.ft_disposition, h.language)}
                             </span>

--- a/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/GenericCatalogEntry.tsx
@@ -4,6 +4,7 @@ import { supabase } from '@/lib/supabase';
 import { getReadDb } from '@/lib/mongodb';
 import { tenantBookUrl } from '@/lib/slugify';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import type { LibraryPartner } from '@/lib/library-partners';
 import { AISection } from '@/components/embed/AISection';
 
@@ -281,7 +282,7 @@ export default async function GenericCatalogEntry({
                   {translationPct != null && (
                     <Field label="Translation" value={`${translationPct}% translated to English`} />
                   )}
-                  {slBook.is_first_translation && (
+                  {isPublishedFirstTranslation(slBook) && (
                     <FieldRaw label="Status">
                       <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-accent-rust/10 text-accent-rust border border-accent-rust/30">
                         First English translation

--- a/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
+++ b/src/app/embed/[tenant]/catalog/[ubn]/page.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabase';
 import { getReadDb, getDb } from '@/lib/mongodb';
 import { tenantBookUrl } from '@/lib/slugify';
 import { formatAuthor, getBookThumbnailUrl } from '@/lib/utils';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import { getPartnerBySlug } from '@/lib/library-partners';
 import { auth } from '@/lib/auth';
 import { ROLE_LEVEL, type Role } from '@/lib/auth';
@@ -469,7 +470,7 @@ export default async function CatalogEntryPage({ params }: Props) {
               {translationPct != null && (
                 <Field label="Translation" value={`${translationPct}% translated to English`} />
               )}
-              {slBook.is_first_translation && (
+              {isPublishedFirstTranslation(slBook) && (
                 <FieldRaw label="Status">
                   <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-accent-rust/10 text-accent-rust border border-accent-rust/30">
                     First English translation

--- a/src/components/CollectionBookCard.tsx
+++ b/src/components/CollectionBookCard.tsx
@@ -7,6 +7,7 @@ import { BookOpen, Calendar, FileText } from 'lucide-react';
 import { cn, getBookThumbnailUrl } from '@/lib/utils';
 import { bookCoverResponsiveLoader } from '@/lib/book-cover-loader';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import AuthorName from '@/components/AuthorName';
 import { getEffectiveByline } from '@/lib/byline';
 import { useEmbedHref } from '@/lib/EmbedContext';
@@ -105,9 +106,9 @@ export default function CollectionBookCard({ book, priority = false, bookUrlPref
           )}
 
           {/* Status badges */}
-          {(book.is_first_translation || book.has_doi) && (
+          {(isPublishedFirstTranslation(book) || book.has_doi) && (
             <div className="absolute top-3 right-3 z-10 flex flex-col gap-1.5 items-end">
-              {book.is_first_translation && (
+              {isPublishedFirstTranslation(book) && (
                 <div className="bg-accent-gold text-white text-xs px-2 py-1 rounded-full shadow-lg font-medium">
                   {firstTranslationBadge(book.ft_disposition, book.language)}
                 </div>

--- a/src/components/book/BookCard.tsx
+++ b/src/components/book/BookCard.tsx
@@ -8,6 +8,7 @@ import type { Book } from '@/lib/types';
 import { recordLoadingMetric } from '@/lib/analytics';
 import { bookUrl } from '@/lib/slugify';
 import { firstTranslationBadge } from '@/lib/first-translation-labels';
+import { isPublishedFirstTranslation } from '@/lib/book';
 import { getBookThumbnailUrl } from '@/lib/utils';
 import AuthorName from '@/components/AuthorName';
 import { getEffectiveByline } from '@/lib/byline';
@@ -156,7 +157,7 @@ export default function BookCard({ book, priority = false }: BookCardProps) {
             </div>
           )}
 
-          {book.is_first_translation && (book.pages_translated ?? 0) > 0 && (
+          {isPublishedFirstTranslation(book) && (
             <div className="absolute top-2 right-2 z-10">
               <div className="bg-accent-gold text-white text-[10px] px-1.5 py-0.5 rounded-full shadow font-medium">
                 {firstTranslationBadge(book.translation_verification?.disposition, book.language)}

--- a/src/components/research/TranslationLagViz.tsx
+++ b/src/components/research/TranslationLagViz.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { linearScale, niceTicks } from '@/components/analytics/charts/chart-utils';
+import { isPublishedFirstTranslation } from '@/lib/book';
 
 interface DataPoint {
   title: string;
@@ -13,6 +14,7 @@ interface DataPoint {
   composed_display: string;
   lag: number;
   is_first_translation: boolean;
+  pages_translated: number;
   categories: string[];
 }
 
@@ -291,7 +293,7 @@ export default function TranslationLagViz({ data }: { data: DataPoint[] }) {
           <div className="text-xs font-medium mt-1" style={{ color: 'var(--accent-rust)' }}>
             {tooltip.point.lag.toLocaleString('en-US')} year lag
           </div>
-          {tooltip.point.is_first_translation && (
+          {isPublishedFirstTranslation(tooltip.point) && (
             <div className="text-xs text-[var(--accent-gold-dark)] mt-0.5">First English translation</div>
           )}
         </div>

--- a/src/lib/book.ts
+++ b/src/lib/book.ts
@@ -1,0 +1,14 @@
+import type { Book } from './types/book';
+
+/**
+ * True when a book makes the "first translation" bibliographic claim AND has at
+ * least one translated page rendered. `is_first_translation` is set by batch
+ * scripts before translation lands, so render gates must also check
+ * `pages_translated > 0` to avoid badging unreadable books.
+ *
+ * See `.claude/docs/embeddings.md` and the "Visibility & Stats Invariants" in
+ * CLAUDE.md (lesson `lesson_is_first_translation_gate`).
+ */
+export const isPublishedFirstTranslation = (
+  b: Pick<Book, 'is_first_translation' | 'pages_translated'>,
+): boolean => !!b.is_first_translation && (b.pages_translated ?? 0) > 0;


### PR DESCRIPTION
## Summary

Resolves follow-up #2 in #2066. Extracts a single `isPublishedFirstTranslation(book)` helper to `src/lib/book.ts` and applies it at every render site for the "First English Translation" badge. `is_first_translation` is a bibliographic claim that batch-flag scripts set *before* translation lands, so render gates must require `pages_translated > 0` to avoid advertising unreadable books — see [lesson_is_first_translation_gate](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/blob/main/CLAUDE.md).

PR #2055 fixed only the highest-traffic site (`BookCard`). This PR covers the remaining 14 sites plus normalizes `BookCard` to use the same helper.

## What changed

- New helper: `src/lib/book.ts` — `isPublishedFirstTranslation(b: Pick<Book, 'is_first_translation' | 'pages_translated'>)`
- Applied at 15 render sites across 9 files
- Added `pages_translated` to projections + types where the data wasn't being fetched:
  - `CuratedHighlight` interface (both collections pages) + merge map
  - Exhibition books projection (`src/app/[tenant]/collections/[id]/page.tsx`)
  - `LagDataPoint` type + projection (`src/app/[tenant]/research/translation-lag/page.tsx`)
  - `DataPoint` type (`src/components/research/TranslationLagViz.tsx`)

## Scope notes

- The other `is_first_translation` references in `TranslationLagViz.tsx` (line 67 filter, line 140 count, line 224 dot-size) are categorical/research uses, not badge renders — left as-is. The issue lists only line 294.
- Pure code change. No data migration. ISR/CDN will re-render on next visit.

## Test plan

- [x] `npx tsc --noEmit` clean (pre-existing carbon-ledger d3 errors only, unrelated)
- [ ] Vercel preview renders a known unreadable first-translation book (`is_first_translation: true`, `pages_translated: 0`) — badge should NOT appear on collection cards, catalog entries, or research table
- [ ] Same book with `pages_translated > 0` — badge appears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)