### PR TITLE
fix(maintenance): drop dangerous page_translations DELETE SQL footer

### DIFF
--- a/.claude/docs/embeddings.md
+++ b/.claude/docs/embeddings.md
@@ -45,7 +45,7 @@ Run `scripts/maintenance/delete-stale-embeddings.mjs` periodically. It cross-ref
 
 Baseline at 2026-05-26 (after first cleanup pass): 338 truly orphaned rows total across `book_embeddings`, `artwork_embeddings`, and `clip_embeddings`. `gallery_text_embeddings` was already clean. The numbers should stay small as long as the script runs occasionally; deletions in Mongo are rare (CRITICAL data protection rules forbid bulk deletes).
 
-`page_translations` (~3.9M rows) is too big for REST paging — the script prints a SQL one-liner to run in the Supabase editor when needed. The DELETE there uses `WHERE NOT EXISTS (SELECT 1 FROM book_embeddings …)` as a proxy for "book still exists" — works because `book_embeddings` has one row per book and the cleanup runs on it first.
+`page_translations` (~3.9M rows) is **not cleaned** by the maintenance script. The table holds the actual translation text (column `translation`, Gemini Batch output) — deleting from it destroys readable content, unlike the embedding-only tables above. The script prints a COUNT query for visibility but no DELETE. If orphans there ever need cleaning, treat it as a deliberate one-off: derive the live set from `bookstore.books` (NOT `book_embeddings`, which only covers embedded books), cross-check `bookstore.deleted_books`, sample-inspect, archive before DELETE.
 
 ### Re-embedding
 - Page-level: `node scripts/workers/embed-gemini.mjs --book <id>` re-embeds a specific book.

--- a/scripts/maintenance/delete-stale-embeddings.mjs
+++ b/scripts/maintenance/delete-stale-embeddings.mjs
@@ -4,12 +4,17 @@
  * These are orphaned — the source book was deleted (or never imported) and the
  * embedding is unreachable through any UI / RPC.
  *
+ * SCOPE: pure vector embedding tables only — book_embeddings, artwork_embeddings,
+ * gallery_text_embeddings, clip_embeddings. Deletes are recoverable by re-running
+ * the embed worker (free Tier).
+ *
+ * NOT in scope: `page_translations`. That table holds the **translation text
+ * itself** (column `translation`, the Gemini Batch API output), not just an
+ * embedding. Deleting from it destroys readable content. See the page_translations
+ * section below — it intentionally does NOT emit any DELETE SQL.
+ *
  * We do NOT delete embeddings for hidden books — visibility toggles and
  * re-embedding (especially page-level) is expensive.
- *
- * The four small tables are paged-and-deleted via the Supabase REST client.
- * `page_translations` (~3.9M rows) is too big for REST; the script emits a
- * SQL one-liner to run in the Supabase SQL editor.
  *
  * Usage:
  *   set -a; source .env.production.local; set +a
@@ -81,27 +86,30 @@ for (const t of SMALL_TABLES) {
   console.log(`${t.name.padEnd(28)} DELETED ${deleted} rows.`);
 }
 
-// page_translations is too big to page via REST. Emit a SQL one-liner.
+// page_translations is intentionally NOT cleaned by this script. The table
+// holds the **translation text itself** (column `translation`, Gemini Batch
+// API output), so a DELETE there destroys readable content — not just a
+// re-derivable vector. Counting orphans is fine; deleting them needs a
+// separate, much-more-careful workflow (cross-check against bookstore.books
+// AND deleted_books, sample inspect, ideally archive before delete).
 console.log(`
-─── page_translations cleanup ─────────────────────────────────
-Too large for REST paging (~3.9M rows). Run in Supabase SQL editor:
+─── page_translations: NOT cleaned by this script ─────────────
+page_translations.translation holds Gemini-translated text — deleting
+rows there is destructive in a way these embedding tables are not.
 
-  -- One-shot cleanup. Replace the literal array with the current
-  -- valid book_id list, or load into a temp table first if it's huge.
-  -- Quick check:
+Counting orphans (read-only, safe):
   SELECT COUNT(*) FROM page_translations p
    WHERE NOT EXISTS (
      SELECT 1 FROM book_embeddings b WHERE b.book_id::text = p.book_id::text
    );
-  -- (Using book_embeddings as the implicit "live book" set after this
-  -- script cleans it. Once book_embeddings is orphan-free, every
-  -- page_translations row whose book_id isn't there is also orphaned.)
 
-  -- Delete (run after the COUNT looks reasonable):
-  DELETE FROM page_translations p
-   WHERE NOT EXISTS (
-     SELECT 1 FROM book_embeddings b WHERE b.book_id::text = p.book_id::text
-   );
+If you find orphans worth removing, write a deliberate script that:
+  1. Builds the live-book set from bookstore.books (NOT book_embeddings —
+     books with translations may not yet have an embedding row).
+  2. Cross-checks candidate book_ids against bookstore.deleted_books so
+     restorable books are spared.
+  3. Samples 10–20 of the resulting "true orphans" and inspects them.
+  4. Archives the rows (or at least the translation text) before DELETE.
 ───────────────────────────────────────────────────────────────`);
 
 if (!APPLY) console.log('\nDry-run only. Re-run with --apply to delete from the four small tables.');


### PR DESCRIPTION
## Summary

`scripts/maintenance/delete-stale-embeddings.mjs` (added yesterday in #2063) printed a ready-to-paste DELETE SQL block for `page_translations` at the end of every run. That SQL was unsafe:

1. **`page_translations.translation` holds the actual Gemini-translated text**, not just an embedding vector. The other four tables the script handles are pure vectors (recoverable by re-running the embed worker); this one is not. A DELETE there destroys readable content that costs real money to regenerate.
2. **The `book_embeddings` proxy is broken** as a "live book" check. Books that have OCR + translations but were never embedded would show up as orphans and get nuked. The right proxy is `bookstore.books` directly.

This caused real alarm in a session today when running the COUNT returned **323,531 rows** — and the framing in #2066 ("orphan cleanup, 30 seconds to run, then forget about it") would have led someone to paste the DELETE without a second look.

## Changes

- Script: drop the DELETE block. Keep a COUNT in the printed footer (read-only, useful for visibility), explicitly document why no DELETE is offered, and outline the careful path if cleanup is ever truly needed (use `bookstore.books`, cross-check `deleted_books`, sample, archive, then delete).
- Script header docstring updated to scope the script as **embeddings-only**.
- `.claude/docs/embeddings.md`: replaced the "the DELETE works because book_embeddings has one row per book" paragraph with the same warning.

## Test plan

- [x] node --check scripts/maintenance/delete-stale-embeddings.mjs passes
- [x] No code-side imports of the page_translations DELETE SQL (it only printed to stdout)
- [ ] Dry-run still prints orphan counts for the four embedding tables exactly as before
- [ ] The page_translations section now prints the COUNT-only message

## Related

- Issue #2066 (follow-up #1) — will be edited separately to retract the DELETE recommendation
- PR #2063 — original cleanup script, the small-table sweep ran successfully (338 rows removed across 3 tables, all pure embeddings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)