### PR TITLE
fix(sync-worker): prefer extracted_url for gallery image_url

### DIFF
--- a/scripts/workers/sync-worker.mjs
+++ b/scripts/workers/sync-worker.mjs
@@ -244,7 +244,10 @@ async function syncGalleryImages(db) {
         book_id: '$book_id',
         page_number: '$page_number',
         detection_index: '$detection_index',
-        image_url: { $ifNull: ['$cropped_photo', { $ifNull: ['$archived_photo', { $ifNull: ['$photo_original', '$photo'] }] }] },
+        // Prefer the CDN-served crop. Pages without cropped_photo/archived_photo
+        // would otherwise fall through to upstream IIIF URLs (gallica, BSB, …),
+        // leaking those into collection-page HTML and adding 1–3s per image.
+        image_url: { $ifNull: ['$detected_images.extracted_url', { $ifNull: ['$cropped_photo', { $ifNull: ['$archived_photo', { $ifNull: ['$photo_original', '$photo'] }] }] }] },
         thumbnail_url: '$detected_images.thumbnail_url',
         extracted_url: '$detected_images.extracted_url',
         description: { $ifNull: ['$detected_images.description', ''] },


### PR DESCRIPTION
## Summary

`gallery_images.image_url` is materialized via `sync-worker.mjs:247` from `pages.cropped_photo || archived_photo || photo_original || photo`. For pages without a CDN-mirrored crop, this fell through to the upstream IIIF URL (gallica.bnf.fr, api.digitale-sammlungen.de, www.e-rara.ch, image.digitalcollections.manchester.ac.uk, …), leaking those URLs into rendered collection-page HTML and adding 1–3s of upstream-host latency per image in `<link rel="preload">` and `ImageWithMagnifier`.

This PR promotes `detected_images.extracted_url` to the first `$ifNull` preference. The renderer (`ExhibitionLayout.tsx:66`) already prefers `extracted_url` over `image_url`, so this just aligns the materialized data with what the UI shows.

## Context — what was repaired out of band

Earlier this session we rehosted upstream-host images across the data:

| field | scope | result |
|---|---|---|
| `books.thumbnail` | 1,078 books | → `images.sourcelibrary.org/thumbnails/<id>.jpg` |
| `books.image_display` + `image_thumb` | 805 books | repointed to the rehosted `thumbnail` |
| `collections.hero_image` | 41 collections | → `images.sourcelibrary.org/collection-heroes/<slug>.jpg` |
| `collections.featured_images[].image_url` | 159 entries | → `images.sourcelibrary.org/collection-featured/<slug>/<idx>.jpg` |
| `gallery_images.image_url` | 1,122 rows | repointed to CDN `extracted_url` |

The first four are persisted on documents that the worker doesn't overwrite. The last one — `gallery_images.image_url` — would have been silently reverted to upstream by the next `gallery-sync` for any of the affected books, because the materialization pulls from `pages.*` and falls back to upstream when no CDN crop is recorded. This PR is the durable fix that prevents that drift.

## What's out of scope

- **No backfill of `pages.cropped_photo`/`archived_photo`.** Those fields are still missing for thousands of pages; this PR just stops the absence from leaking upstream URLs into the materialized view.
- **No materialization re-run.** The 1,122 rows are already correct from the data fix. Future syncs for those books will keep them on the CDN with this change.
- **No code-side change to renderers.** All renderers already prefer `extracted_url || thumbnail_url || image_url`. No frontend change needed.

## Test plan

- [ ] CI typecheck + lint pass
- [ ] After deploy, trigger a sync for a previously-leaking book (e.g. one in `/collections/magic` whose gallery image used to point at gallica.bnf.fr) and confirm `gallery_images.image_url` lands on `images.sourcelibrary.org/gallery/...` rather than upstream
- [ ] `curl https://sourcelibrary.org/collections/magic | grep -oE 'https://[^"]+\.(jpg|jpeg|png|webp)' | grep -v images.sourcelibrary.org` returns empty after revalidate

🤖 Generated with [Claude Code](https://claude.com/claude-code)