### PR TITLE
ci(e2e): stop daily 'still failing' comment churn on #1582

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -60,7 +60,10 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const date = new Date().toISOString().split('T')[0];
 
-            // Don't create duplicate issues — check for an existing open one
+            // Don't create duplicate issues — check for an existing open one.
+            // If one exists, we DO NOT comment: daily "still failing" comments add noise
+            // that nobody reads. The artifact is still uploaded to the run page; anyone
+            // investigating can find it via the workflow's run history.
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -69,13 +72,6 @@ jobs:
               per_page: 1,
             });
             if (existing.length > 0) {
-              // Add a comment to the existing issue instead
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing[0].number,
-                body: `Still failing as of ${date}.\n**Run:** ${runUrl}`,
-              });
               return;
             }
 


### PR DESCRIPTION
## Summary

- The E2E workflow appended a "Still failing as of YYYY-MM-DD" comment to the existing open `e2e-tests` issue every day on failure. 13 such comments piled up on #1582 since 2026-05-03 with zero engagement — the signal is dead and the churn distracts from real issue triage.
- The daily run still happens; the playwright-report + screenshot artifacts are still uploaded to the run page (and findable from #1582's existing run link); only the daily comment is removed.
- If the test suite ever recovers and then breaks again *after* #1582 is closed, the workflow still creates a fresh issue — that path is unchanged.

Triage findings on the actual failures (selectors + base URL drift across `bph-iframe`, `catalog`, and `crawl-all-pages` specs) are documented in https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/1582#issuecomment-4553798984. Fixing those is a separate task.

## Test plan

- [x] Verified workflow file passes basic YAML structure check (only the comment-on-existing branch is changed; create-new-issue branch is unmodified).
- [ ] Wait for the next nightly run (2026-05-28 06:00 UTC) and confirm no new comment lands on #1582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)