### PR TITLE
fix(proxy): route /encyclopedia/* on the apex to the default tenant

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -20,6 +20,8 @@ const FAST_PAGES = [
   '/libraries',
   '/timeline',
   '/search?q=Ficino',
+  '/encyclopedia',
+  '/encyclopedia/Archimedes',
 ];
 
 // Collection and book pages hit Atlas directly and can be slow on ISR cache miss

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,6 +19,10 @@ const NON_TENANT_PATHS = new Set([
   'map', 'constellation',
   // Legacy root paths (pages moved to /[tenant]/*) — kept here to 404 cleanly
   'book', 'collections',
+  // Global encyclopedia (entities) — lives under /[tenant]/encyclopedia in
+  // the file tree, exposed at /encyclopedia/* on the apex via the rewrite
+  // block below. Listed here so the apex first-segment branch will not 404.
+  'encyclopedia',
   // Other root pages
   'admin', 'author', 'work', 'connect', 'data', 'read',
   'research', 'embed', 'shwep', 'for-researchers', 'for-libraries', 'identify',
@@ -544,6 +548,22 @@ export async function proxy(request: NextRequest) {
     if (tenantSlug) {
       const url = request.nextUrl.clone();
       url.pathname = `/${tenantSlug}${pathname}`;
+      return NextResponse.rewrite(url);
+    }
+  }
+
+  // Internal tenant routing for /encyclopedia and /encyclopedia/{name}:
+  // The route lives at [tenant]/encyclopedia/* but entities are global — there
+  // is no per-tenant scoping. The apex URL stays clean (/encyclopedia/...)
+  // and we rewrite under the default tenant so the [tenant] segment resolves.
+  // Without this block the apex first-segment branch 404s the URL because
+  // 'encyclopedia' isn't a real tenant slug. ~873K entities and 1.24K GSC
+  // soft-404s depended on this fix (#2019).
+  if (pathname === '/encyclopedia' || pathname.startsWith('/encyclopedia/')) {
+    const defaultTenantSlug = (await resolveTenantByExactSlug('default'))?.slug;
+    if (defaultTenantSlug) {
+      const url = request.nextUrl.clone();
+      url.pathname = `/${defaultTenantSlug}${pathname}`;
       return NextResponse.rewrite(url);
     }
   }


### PR DESCRIPTION
## Summary

- `/encyclopedia` and every `/encyclopedia/{name}` URL returned 404 since at least mid-April — the route lives under `src/app/[tenant]/encyclopedia/` but the proxy had no rewrite for the apex hostname. 873K entity pages silently invisible; 1.24K Soft 404s piled up in GSC.
- Mirrors the existing `/book/` rewrite pattern: adds `'encyclopedia'` to `NON_TENANT_PATHS` so it isn't matched as an unknown tenant, then rewrites `/encyclopedia(/*)` → `/{default}/encyclopedia(/*)`. Entities are global; no per-entity tenant lookup needed.
- Extends `e2e/smoke.spec.ts` `FAST_PAGES` with `/encyclopedia` and `/encyclopedia/Archimedes` so the fix is exercised on every smoke run.

## Out of scope

- **Tenant subdomain behavior** (`bph.sourcelibrary.org/encyclopedia/...`) still falls through to the existing tenant-subdomain catchall (rewrite to embed root). That's not great but it's the same behavior every non-supported tenant path gets today. Worth a separate decision: redirect to apex, or render embedded encyclopedia. Tracked under [#2073](https://github.com/Embassy-of-the-Free-Mind/sourcelibrary-v2/issues/2073).
- **The broader tenant-scoped route audit** suggested in #2019 (browse, search, gallery, etc. — every `[tenant]/...` folder that needs explicit apex routing). Also tracked under #2073. This PR fixes the single most-impactful gap.
- **Latent regex bug in `tests/unit/proxy-non-tenant-paths.test.ts`** — the `'([^']+)'` extractor breaks if a comment inside `NON_TENANT_PATHS` contains an apostrophe (I hit this with \"doesn't\" and rephrased; future contributors may not). One-line fix to make the regex tolerate comments; deliberately not bundling here.

## Test plan

- [x] `npx tsc --noEmit` — no new errors (17 pre-existing in carbon-ledger blog interactives).
- [x] `npx vitest run tests/unit/proxy-non-tenant-paths.test.ts` — passes (new entry is allowlisted correctly).
- [ ] Vercel preview deploy → curl `/encyclopedia` and `/encyclopedia/Archimedes` (no tenant in URL), expect 200 with the entity page rendered.
- [ ] Smoke spec includes `/encyclopedia` and `/encyclopedia/Archimedes` for ongoing coverage.

Refs #2019, #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)