### PR TITLE
fix(support): replace dead Mollie EFM link with Stripe

### DIFF
--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   alternates: { canonical: '/support' },
 };
 
-const MOLLIE_URL = 'https://payment-links.mollie.com/en/payment/ug24y6U3mtCvzCwUhfPHD/details';
+const EFM_STRIPE_URL = 'https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08';
 const DONORPERFECT_URL = 'https://form-renderer-app.donorperfect.io/give/naf/embassyofthefreemind';
 const CONTACT_EMAIL = 'derek@sourcelibrary.org';
 
@@ -273,7 +273,7 @@ export default async function SupportPage() {
                   <span className="block text-xs text-stone-500 mt-1">501(c)(3)</span>
                 </a>
                 <a
-                  href={MOLLIE_URL}
+                  href={EFM_STRIPE_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="bg-[#faf8f5] rounded-xl border border-stone-200 p-4 hover:border-stone-400 transition-colors block text-center"


### PR DESCRIPTION
## Summary
- The "Donate via EFM" button on `/support` pointed at a Mollie payment link. EFM has moved off Mollie, so that URL no longer works.
- Replace it with the Stripe Payment Link supplied by EFM: `https://donate.stripe.com/9B67sLbO1bOg2GxfxP9fW08`.
- Rename the constant `MOLLIE_URL` → `EFM_STRIPE_URL` for clarity.

Only one call site in `src/app/support/page.tsx`; verified via repo-wide grep — no other code references the Mollie URL.

## Test plan
- [ ] Visit `/support` on the preview deployment and click "Donate via EFM" — confirm it lands on the Stripe Payment Link.
- [ ] Confirm the US (NAF/DonorPerfect) and "Contact Us" tiles are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)