### PR TITLE
fix(proxy): allow /sponsors as non-tenant root

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,7 +7,7 @@ import { getDb } from '@/lib/mongodb';
 const NON_TENANT_PATHS = new Set([
   'platform', 'auth', 'api', '_next', 'account', 'about', 'privacy',
   'terms', 'press-release', 'brand', 'roadmap', 'feedback', 'status',
-  'support', 'unauthorized', 'design-options', 'experiments',
+  'support', 'sponsors', 'unauthorized', 'design-options', 'experiments',
   'ficino-society', 'contribute', 'census', 'oauth', 'developers',
   'founding-donors', 'libraries', 'blog', '_archived', '.well-known',
   // Global navigation roots


### PR DESCRIPTION
PR #2078 added \`/sponsors\` but missed adding the slug to \`NON_TENANT_PATHS\` in \`src/proxy.ts\`. As a result, the apex treats every \`/sponsors\` request as a tenant slug, looks it up in the \`tenants\` collection, and 404s.

One-character fix: add \`'sponsors',\` to the allowlist alongside \`'support'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)