### PR TITLE
fix(librarian): preserve tables, hide broken images, log timeouts

### DIFF
--- a/src/app/api/embassy/chat/route.ts
+++ b/src/app/api/embassy/chat/route.ts
@@ -181,17 +181,41 @@ export async function POST(request: NextRequest) {
   const send = (event: Record<string, unknown>) =>
     writer.write(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
 
+  const startedAt = Date.now();
+  // Track the last step so the watchdog can record where we stalled if
+  // Vercel kills the function before the catch block runs.
+  let lastStepType: string = 'init';
+  let toolCallCount = 0;
+
+  // Watchdog: fires ~10s before maxDuration to leave a breadcrumb in
+  // embassy_errors when a request is about to be killed. Without this,
+  // a timeout produces zero server-side trace because the function dies
+  // before the catch block.
+  const watchdog = setTimeout(async () => {
+    try {
+      await db.collection('embassy_errors').insertOne({
+        kind: 'timeout_warning',
+        threadId: activeThreadId,
+        message: message.slice(0, 500),
+        error: `Approaching maxDuration (${maxDuration}s). Last step: ${lastStepType}. Tool calls so far: ${toolCallCount}. Elapsed: ${Math.round((Date.now() - startedAt) / 1000)}s.`,
+        createdAt: new Date(),
+      });
+    } catch { /* best effort */ }
+  }, (maxDuration - 10) * 1000);
+
   const pipePromise = (async () => {
     try {
       await send({ type: 'threadId', threadId: activeThreadId });
 
       for await (const step of streamAgenticResponse(message, history, activeThreadId)) {
+        lastStepType = step.type;
         switch (step.type) {
           case 'thinking':
             await send({ type: 'thinking', text: step.text });
             break;
 
           case 'tool_call':
+            toolCallCount++;
             await send({ type: 'tool_call', name: step.name, query: step.query });
             break;
 
@@ -225,17 +249,23 @@ export async function POST(request: NextRequest) {
         }
       }
 
+      clearTimeout(watchdog);
       await send({ type: 'done' });
       await writer.close();
     } catch (err) {
+      clearTimeout(watchdog);
       const errMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);
       console.error('[Embassy] Agentic stream error:', errMsg);
       // Log to DB for easier debugging
       try {
         await db.collection('embassy_errors').insertOne({
+          kind: 'agent_error',
           threadId: activeThreadId,
           message: message.slice(0, 500),
           error: errMsg.slice(0, 5000),
+          lastStepType,
+          toolCallCount,
+          elapsedMs: Date.now() - startedAt,
           createdAt: new Date(),
         });
       } catch { /* best effort */ }

--- a/src/app/librarian/LibrarianClient.tsx
+++ b/src/app/librarian/LibrarianClient.tsx
@@ -9,51 +9,7 @@ import remarkGfm from 'remark-gfm';
 import { tenantBookUrl } from '@/lib/slugify';
 // remarkBreaks removed — we use ensureParagraphBreaks() instead for proper spacing
 import SiteHeader from '@/components/layout/SiteHeader';
-
-/**
- * Post-process Gemini output: convert bare sourcelibrary URLs to markdown links.
- * Gemini often outputs `https://sourcelibrary.org/book/slug?page=5` as plain text
- * instead of wrapping it in `[text](url)`. This catches those and linkifies them.
- */
-function linkifySourceUrls(text: string): string {
-  // Don't linkify URLs that are already inside markdown link syntax [text](url)
-  let result = text.replace(
-    /(?<!\]\()https:\/\/sourcelibrary\.org\/book\/([a-z0-9-]+)(?:\?page=(\d+))?/g,
-    (match, _slug, page) => {
-      const label = page ? `View source (p. ${page})` : 'View in collection';
-      return `[${label}](${match})`;
-    },
-  );
-  // Linkify bare author URLs
-  result = result.replace(
-    /(?<!\]\()https:\/\/sourcelibrary\.org\/author\/([^\s)]+)/g,
-    (match, name) => {
-      const label = decodeURIComponent(name);
-      return `[${label}](${match})`;
-    },
-  );
-  return result;
-}
-
-/**
- * Ensure proper markdown paragraph breaks.
- * Gemini often outputs single \n between paragraphs, but standard markdown
- * needs \n\n for a visible paragraph break. Simple approach: double ALL
- * single newlines, then collapse any runs of 3+ newlines back to 2.
- * Only exception: code blocks are left untouched.
- */
-function ensureParagraphBreaks(text: string): string {
-  // Split on code fences, process only non-code sections
-  const parts = text.split(/(```[\s\S]*?```)/);
-  return parts.map((part, i) => {
-    // Odd indices are code blocks — leave them alone
-    if (i % 2 === 1) return part;
-    // Replace single \n with \n\n, then collapse triples back to doubles
-    return part
-      .replace(/([^\n])\n(?!\n)/g, '$1\n\n')
-      .replace(/\n{3,}/g, '\n\n');
-  }).join('');
-}
+import { ensureParagraphBreaks, linkifySourceUrls } from './_lib/markdownPrep';
 
 // ── Types ─────────────────────────────────────────────────────────────
 
@@ -452,7 +408,9 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
         }
       }
     } catch (err) {
-      if ((err as Error).name !== 'AbortError') {
+      const e = err as Error;
+      if (e.name !== 'AbortError') {
+        console.error('[Librarian] request failed:', e.name, e.message, e);
         updateLastAssistant(m => ({
           ...m,
           content: 'The Librarian seems to be away. Please try again in a moment.',
@@ -691,7 +649,18 @@ export default function LibrarianClient({ featuredPassage }: LibrarianClientProp
                                     img: ({ src, alt }) => (
                                       <a href={src as string} target="_blank" rel="noopener noreferrer">
                                         {/* eslint-disable-next-line @next/next/no-img-element */}
-                                        <img src={src as string} alt={(alt as string) || ''} className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-4" loading="lazy" />
+                                        <img
+                                          src={src as string}
+                                          alt={(alt as string) || ''}
+                                          className="rounded-lg shadow-md max-h-[300px] w-auto cursor-pointer hover:shadow-lg transition-shadow my-4"
+                                          loading="lazy"
+                                          onError={(e) => {
+                                            const img = e.currentTarget;
+                                            const wrapper = img.closest('a');
+                                            if (wrapper) wrapper.style.display = 'none';
+                                            else img.style.display = 'none';
+                                          }}
+                                        />
                                       </a>
                                     ),
                                   }}

--- a/src/app/librarian/_lib/markdownPrep.ts
+++ b/src/app/librarian/_lib/markdownPrep.ts
@@ -1,0 +1,70 @@
+/**
+ * Post-process Gemini output: convert bare sourcelibrary URLs to markdown links.
+ * Gemini often outputs `https://sourcelibrary.org/book/slug?page=5` as plain text
+ * instead of wrapping it in `[text](url)`. This catches those and linkifies them.
+ */
+export function linkifySourceUrls(text: string): string {
+  let result = text.replace(
+    /(?<!\]\()https:\/\/sourcelibrary\.org\/book\/([a-z0-9-]+)(?:\?page=(\d+))?/g,
+    (match, _slug, page) => {
+      const label = page ? `View source (p. ${page})` : 'View in collection';
+      return `[${label}](${match})`;
+    },
+  );
+  result = result.replace(
+    /(?<!\]\()https:\/\/sourcelibrary\.org\/author\/([^\s)]+)/g,
+    (match, name) => {
+      const label = decodeURIComponent(name);
+      return `[${label}](${match})`;
+    },
+  );
+  return result;
+}
+
+/**
+ * Ensure proper markdown paragraph breaks for Gemini output.
+ *
+ * Gemini emits single \n between paragraphs; standard markdown needs \n\n.
+ * We double single newlines, but skip lines inside structures that depend on
+ * being on adjacent lines: fenced code blocks and GFM tables.
+ */
+export function ensureParagraphBreaks(text: string): string {
+  // Step 1: protect fenced code blocks.
+  const codeParts = text.split(/(```[\s\S]*?```)/);
+  return codeParts
+    .map((part, i) => (i % 2 === 1 ? part : processProse(part)))
+    .join('');
+}
+
+function processProse(chunk: string): string {
+  const lines = chunk.split('\n');
+  if (lines.length === 0) return '';
+  let result = lines[0];
+  for (let i = 1; i < lines.length; i++) {
+    const prev = lines[i - 1];
+    const cur = lines[i];
+    // Keep lines adjacent (single \n) only when:
+    //   - both sides are table rows — preserves contiguous GFM table
+    //   - both sides are blockquote continuations — keeps them as one quote
+    //   - one side is already blank — existing break suffices
+    // Otherwise insert a blank line so prose paragraphs (and table-to-prose
+    // / prose-to-table transitions) get proper block separation.
+    const keepTight =
+      (isTableLine(prev) && isTableLine(cur)) ||
+      (isBlockquoteLine(prev) && isBlockquoteLine(cur)) ||
+      prev === '' ||
+      cur === '';
+    result += keepTight ? '\n' : '\n\n';
+    result += cur;
+  }
+  return result.replace(/\n{3,}/g, '\n\n');
+}
+
+function isTableLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('|') && trimmed.endsWith('|') && trimmed.length >= 2;
+}
+
+function isBlockquoteLine(line: string): boolean {
+  return line.trimStart().startsWith('>');
+}

--- a/src/app/librarian/thread/[id]/page.tsx
+++ b/src/app/librarian/thread/[id]/page.tsx
@@ -7,26 +7,7 @@ import { useRouter } from 'next/navigation';
 import SiteHeader from '@/components/layout/SiteHeader';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-
-function linkifySourceUrls(text: string): string {
-  return text.replace(
-    /(?<!\]\()https:\/\/sourcelibrary\.org\/book\/([a-z0-9-]+)(?:\?page=(\d+))?/g,
-    (match, _slug, page) => {
-      const label = page ? `View source (p. ${page})` : 'View in collection';
-      return `[${label}](${match})`;
-    },
-  );
-}
-
-function ensureParagraphBreaks(text: string): string {
-  const parts = text.split(/(```[\s\S]*?```)/);
-  return parts.map((part, i) => {
-    if (i % 2 === 1) return part;
-    return part
-      .replace(/([^\n])\n(?!\n)/g, '$1\n\n')
-      .replace(/\n{3,}/g, '\n\n');
-  }).join('');
-}
+import { ensureParagraphBreaks, linkifySourceUrls } from '../../_lib/markdownPrep';
 
 interface ThreadMessage {
   id: string;
@@ -873,7 +854,18 @@ export default function ThreadPage({ params }: { params: Promise<{ id: string }>
                         img: ({ src, alt }) => (
                           <a href={src as string} target="_blank" rel="noopener noreferrer">
                             {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={src as string} alt={(alt as string) || ''} className="rounded-lg shadow-md max-h-[400px] w-auto" loading="lazy" />
+                            <img
+                              src={src as string}
+                              alt={(alt as string) || ''}
+                              className="rounded-lg shadow-md max-h-[400px] w-auto"
+                              loading="lazy"
+                              onError={(e) => {
+                                const img = e.currentTarget;
+                                const wrapper = img.closest('a');
+                                if (wrapper) wrapper.style.display = 'none';
+                                else img.style.display = 'none';
+                              }}
+                            />
                           </a>
                         ),
                       }}

--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -812,7 +812,7 @@ Every mention of a book should link to it. Every mention of an author should lin
 When quoting a key passage, include the original language text (Latin, German, Hebrew, etc.) alongside the English if it is notable or if the user appears to be working in that language. Use a blockquote with both versions.
 
 **Step 6: Show images and suggest next steps.**
-When search_images returns results, embed the best 1-3 images using markdown: \`![description](imageUrl)\`. After answering, suggest what to explore next.
+When search_images or search_artworks returns results, embed the best 1-3 images using markdown: \`![description](imageUrl)\`. **Only use URLs returned by a tool call this turn.** NEVER invent, paraphrase, guess, or recall image URLs — fabricated URLs render as broken thumbnails for the user. If you have no tool-returned image URL, do not write any \`![...](...)\` syntax at all. After answering, suggest what to explore next.
 
 Be honest about gaps — if a hypothesis doesn't pan out, say so. If a relevant book isn't in the collection, mention it.
 


### PR DESCRIPTION
## Summary

Three failure modes in the Librarian chat — all surfaced from a single user session today on the Babylonian zodiac transition. Tables came through as raw pipes, a hallucinated image URL rendered as a broken thumbnail, and the whole conversation died with \"The Librarian seems to be away\" and **zero server-side trace** in \`embassy_errors\`.

## Changes

### Markdown tables (root cause: client-side pre-processor)
\`ensureParagraphBreaks\` in \`LibrarianClient.tsx\` was doubling every \`\\n\` outside code fences. GFM table rows need *consecutive* single newlines for remark-gfm to recognize the block — the helper was making each row look like a separate paragraph.

- Extracted to a shared module: \`src/app/librarian/_lib/markdownPrep.ts\`
- New rule: keep lines tight (single \`\\n\`) when both sides are table rows OR both are blockquote continuations; insert a blank line otherwise
- Sanity-tested against tables, blockquotes, lists, and headings before committing
- Both \`LibrarianClient.tsx\` and \`thread/[id]/page.tsx\` now use the shared helpers (the thread page had a verbatim copy of the buggy code)

### Hallucinated image URLs
The model sometimes emits \`![alt](url)\` for URLs it didn't get from a tool call. Now:
- The rendered \`<img>\` has an \`onError\` handler that hides the wrapper if the URL fails to load (defense in depth — also covers transient CDN issues)
- System prompt explicitly forbids image markdown for URLs not returned by a tool this turn

### Timeout visibility (root cause: Vercel killed the function)
\`maxDuration = 120\`. Six tool-use rounds × Gemini latency can blow past that. When Vercel kills mid-stream, the server's \`catch\` never runs and nothing reaches \`embassy_errors\`.

- New watchdog: \`setTimeout\` at \`maxDuration - 10s\` writes a \`kind: 'timeout_warning'\` record with the last step type, tool call count, and elapsed ms. Cleared on normal completion or real error.
- Existing error inserts now tagged \`kind: 'agent_error'\` and carry the same diagnostic fields
- Client catch logs the underlying \`err.name\` and \`err.message\` to the browser console (previously silently swallowed)

## Out of scope (intentional)

- Raising \`maxDuration\` or cutting \`MAX_ROUNDS\` from 6 → 4. These are the obvious throughput levers, but they're product/UX calls that deserve their own PR with metrics behind them. This PR is purely about **observability + rendering correctness** so we can see what's happening before tuning.
- A general markdown-correctness pass on the prose helpers (lists are still loosened by the doubling). Pre-existing behavior, not a regression.

## Test plan

- [ ] Preview deploy: open Librarian, ask \"The Babylonian Transition (18 to 12 signs)\" and confirm the table renders as a table
- [ ] Confirm broken image URLs no longer render a placeholder icon
- [ ] If a Librarian session times out, confirm a \`timeout_warning\` row appears in \`bookstore.embassy_errors\` with non-zero \`toolCallCount\`
- [ ] Confirm an intentional server-side throw produces an \`agent_error\` row with \`lastStepType\` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)