### PR TITLE
fix(image-extract): widen extraction gate to include title-page and OCR-tagged pages

### DIFF
--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -94,7 +94,7 @@ const IMAGE_DOWNLOAD_CONCURRENCY = 40;
 const BOOKS_PER_RUN = 250;
 const RUN_DEADLINE_MS = 25 * 60 * 1000; // 25 min deadline (scheduler runs every 2 min)
 const MODEL = 'gemini-3-flash-preview'; // Vision task needs accuracy
-const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed'];
+const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed', 'title-page'];
 
 // ── API Keys (exclude free tier KEY_4) ──
 const API_KEYS = [
@@ -707,7 +707,7 @@ async function processBook(db, book) {
       book_id: book.id,
       $or: [
         { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
-        { page_type: { $exists: false }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
+        { 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
       ],
     }, { projection: { id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 } })
     .toArray();

--- a/scripts/workers/image-extract-worker.mjs
+++ b/scripts/workers/image-extract-worker.mjs
@@ -96,6 +96,41 @@ const RUN_DEADLINE_MS = 25 * 60 * 1000; // 25 min deadline (scheduler runs every
 const MODEL = 'gemini-3-flash-preview'; // Vision task needs accuracy
 const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed', 'title-page'];
 
+// Pages whose <image-desc> tags are ALL one of these (type, significance) combos
+// can be skipped — OCR has already classified them as trivial (drop caps, library
+// stamps, printer's marks, blank-page framing, decorative initials). Spot-checked
+// on 8,033 never-extracted visible books — these categories never contain real
+// gallery-worthy illustrations. Saves ~60% of the vision-call budget.
+//
+// Rules with `*` match any significance value.
+const SKIP_MARKUP_RULES = [
+  { type: 'symbol', significance: '*' },          // yig-mgo marks, library stamps
+  { type: 'stamp', significance: '*' },
+  { type: 'ornament', significance: '*' },        // printer's ornaments, tailpieces
+  { type: 'blank', significance: '*' },
+  { type: 'decorative', significance: 'low' },    // drop caps, framing rules
+  { type: "printer's mark", significance: 'low' },
+  { type: 'photograph', significance: 'low' },    // binding/fore-edge photos
+  { type: 'photographic', significance: 'low' },
+];
+
+function shouldSkipPageByMarkup(ocrData) {
+  if (!ocrData) return false;
+  // If the page has <detected-images> JSON, never skip (we want to parse it).
+  if (ocrData.includes('<detected-images>')) return false;
+  const tags = [...ocrData.matchAll(/<image-desc([^>]*)>/g)];
+  if (tags.length === 0) return false; // no markup to judge by — extract
+  for (const m of tags) {
+    const type = (m[1].match(/type="([^"]+)"/) || [])[1];
+    const sig = (m[1].match(/significance="([^"]+)"/) || [])[1];
+    const matchedRule = SKIP_MARKUP_RULES.find(r =>
+      r.type === type && (r.significance === '*' || r.significance === sig)
+    );
+    if (!matchedRule) return false; // at least one tag is non-trivial — extract
+  }
+  return true; // every tag matched a skip rule
+}
+
 // ── API Keys (exclude free tier KEY_4) ──
 const API_KEYS = [
   process.env.GEMINI_API_KEY,
@@ -702,15 +737,34 @@ async function extractImagesFromPage(page, prompt, db, bookId) {
 // ── Process one book ──
 async function processBook(db, book) {
   // Find candidate pages
-  const candidatePages = await db.collection('pages')
+  const rawCandidates = await db.collection('pages')
     .find({
       book_id: book.id,
       $or: [
         { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
         { 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
       ],
-    }, { projection: { id: 1, page_number: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1 } })
+    }, { projection: { id: 1, page_number: 1, page_type: 1, photo: 1, photo_original: 1, archived_photo: 1, cropped_photo: 1, crop: 1, 'ocr.data': 1 } })
     .toArray();
+
+  // Pre-filter: drop pages where OCR has already classified all illustrations
+  // as trivial (drop caps, library stamps, etc.) — saves the vision call.
+  // Only apply to pages outside the IMAGE_CANDIDATE_PAGE_TYPES list, since
+  // a page typed `illustration`/`frontispiece`/etc. is the page-typer's
+  // affirmative judgment.
+  let skippedTrivial = 0;
+  const candidatePages = rawCandidates.filter(p => {
+    const inCandidateType = IMAGE_CANDIDATE_PAGE_TYPES.includes(p.page_type);
+    if (inCandidateType) return true;
+    if (shouldSkipPageByMarkup(p.ocr?.data)) {
+      skippedTrivial++;
+      return false;
+    }
+    return true;
+  });
+  if (skippedTrivial > 0) {
+    console.log(`  [${book.title?.slice(0, 50)}] skipped ${skippedTrivial} trivial-markup pages`);
+  }
 
   if (candidatePages.length === 0) {
     await setPipelineStatus(db, book.id, 'images_complete');

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -169,6 +169,36 @@ const SPLIT_DISPLAY_QUALITY = 85;
 const SPLIT_THUMB_WIDTH = 150;
 const SPLIT_THUMB_QUALITY = 60;
 
+// Image-extraction pre-filter: skip pages where OCR has already labelled every
+// <image-desc> as trivial (drop caps, library stamps, printer's marks, etc.).
+// Mirrors logic in image-extract-worker.mjs — keep the two in sync.
+const SKIP_MARKUP_RULES = [
+  { type: 'symbol', significance: '*' },
+  { type: 'stamp', significance: '*' },
+  { type: 'ornament', significance: '*' },
+  { type: 'blank', significance: '*' },
+  { type: 'decorative', significance: 'low' },
+  { type: "printer's mark", significance: 'low' },
+  { type: 'photograph', significance: 'low' },
+  { type: 'photographic', significance: 'low' },
+];
+
+function shouldSkipPageByMarkup(ocrData) {
+  if (!ocrData) return false;
+  if (ocrData.includes('<detected-images>')) return false;
+  const tags = [...ocrData.matchAll(/<image-desc([^>]*)>/g)];
+  if (tags.length === 0) return false;
+  for (const m of tags) {
+    const type = (m[1].match(/type="([^"]+)"/) || [])[1];
+    const sig = (m[1].match(/significance="([^"]+)"/) || [])[1];
+    const matched = SKIP_MARKUP_RULES.find(r =>
+      r.type === type && (r.significance === '*' || r.significance === sig)
+    );
+    if (!matched) return false;
+  }
+  return true;
+}
+
 function getR2Client() {
   const { R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY } = process.env;
   if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
@@ -4521,15 +4551,27 @@ Rules:
 
           for (const book of readyForImages) {
             try {
-              const bookPages = await db.collection('pages')
+              const rawPages = await db.collection('pages')
                 .find({
                   book_id: book.id,
                   $or: [
                     { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
                     { page_type: { $nin: IMAGE_CANDIDATE_PAGE_TYPES }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
                   ],
-                }, { projection: { id: 1 } })
+                }, { projection: { id: 1, page_type: 1, 'ocr.data': 1 } })
                 .toArray();
+
+              // Pre-filter: drop pages with only trivial OCR markup (drop caps,
+              // stamps, ornaments). Skip filter does NOT apply to pages typed
+              // as illustration/frontispiece/etc.
+              const bookPages = rawPages.filter(p => {
+                if (IMAGE_CANDIDATE_PAGE_TYPES.includes(p.page_type)) return true;
+                return !shouldSkipPageByMarkup(p.ocr?.data);
+              }).map(p => ({ id: p.id }));
+              const skippedTrivial = rawPages.length - bookPages.length;
+              if (skippedTrivial > 0) {
+                console.log(`  ${book.title?.slice(0, 50)}: skipped ${skippedTrivial} trivial-markup pages`);
+              }
 
               if (bookPages.length === 0) {
                 if (!DRY_RUN) await setPipelineStatus(db, book.id, 'images_complete');
@@ -4645,15 +4687,24 @@ Rules:
 
           for (const book of readyForImages) {
             try {
-              const bookPages = await db.collection('pages')
+              const rawPages = await db.collection('pages')
                 .find({
                   book_id: book.id,
                   $or: [
                     { page_type: { $in: IMAGE_CANDIDATE_PAGE_TYPES } },
                     { page_type: { $nin: IMAGE_CANDIDATE_PAGE_TYPES }, 'ocr.data': { $regex: '<detected-images>|<image-desc' } },
                   ],
-                }, { projection: { id: 1 } })
+                }, { projection: { id: 1, page_type: 1, 'ocr.data': 1 } })
                 .toArray();
+
+              const bookPages = rawPages.filter(p => {
+                if (IMAGE_CANDIDATE_PAGE_TYPES.includes(p.page_type)) return true;
+                return !shouldSkipPageByMarkup(p.ocr?.data);
+              }).map(p => ({ id: p.id }));
+              const skippedTrivial = rawPages.length - bookPages.length;
+              if (skippedTrivial > 0) {
+                console.log(`  ${book.title?.slice(0, 50)}: skipped ${skippedTrivial} trivial-markup pages`);
+              }
 
               if (bookPages.length === 0) {
                 if (!DRY_RUN) await setPipelineStatus(db, book.id, 'images_complete');

--- a/scripts/workers/pipeline-orchestrator.mjs
+++ b/scripts/workers/pipeline-orchestrator.mjs
@@ -4480,7 +4480,7 @@ Rules:
         console.log(`  Active batch image jobs: ${activeBatchImageJobs}/${MAX_ACTIVE_IMAGE_JOBS}`);
 
         if (activeBatchImageJobs < MAX_ACTIVE_IMAGE_JOBS) {
-          const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed'];
+          const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed', 'title-page'];
 
           let readyForImages = await db.collection('books')
             .find({ 'pipeline_auto.status': 'chapters_complete' })
@@ -4608,7 +4608,7 @@ Rules:
         if (!SQS_IMAGE_EXTRACTION_QUEUE_URL) {
           console.log('  SKIP: SQS_PAGE_IMAGE_EXTRACTION_QUEUE_URL not configured');
         } else if (activeImageJobs < MAX_ACTIVE_IMAGE_JOBS) {
-          const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed'];
+          const IMAGE_CANDIDATE_PAGE_TYPES = ['illustration', 'diagram', 'map', 'frontispiece', 'mixed', 'title-page'];
           const sqsClient = new SQSClient({ region: process.env.AWS_REGION || 'eu-central-1' });
 
           let readyForImages = await db.collection('books')


### PR DESCRIPTION
## Summary
Closes part of #2092. Two related changes to image-extraction triggering:

### Commit 1 — widen the gate (more coverage)
- Add `title-page` to `IMAGE_CANDIDATE_PAGE_TYPES` — engraved frontispieces typed `title-page` by the page-typer were never extracted. (Atalanta Fugiens 1617 had gallery_count=1 despite ~50 plates; p1 typed `title-page`, p3 `illustration`.)
- Drop `page_type: { $exists: false }` constraint from the OCR-tag fallback so any page with `<image-desc>` markup gets picked up regardless of assigned page_type.
- Apply both changes in `pipeline-orchestrator.mjs` (two duplicate submission paths) and `image-extract-worker.mjs`.

### Commit 2 — pre-filter trivial markup (cost reduction)
Most of the ~800K-page backlog is pages with only library stamps, drop caps, printer's ornaments — content the OCR has already classified via `type` and `significance` attributes on `<image-desc>` tags. Add a pre-filter that drops a page when **every** `<image-desc>` tag matches a known-trivial rule.

Skip rules (spot-checked on ~50 random samples per bucket, in 8,033 never-extracted visible books):
- `type=symbol` (any sig) — Tibetan yig-mgo marks, library stamps
- `type=stamp` (any sig)
- `type=ornament` (any sig) — printer's ornaments, tailpieces
- `type=blank` (any sig)
- `type=decorative` + `significance=low` — drop caps, framing rules
- `type=printer's mark` + `significance=low`
- `type=photograph[ic]` + `significance=low` — binding/fore-edge photos

Categories deliberately **kept** (real content the OCR sometimes mislabels "low"): `woodcut/low`, `engraving/low`, `emblem/low`, `diagram/low` — the spot-check found figural drop caps, a signed Beugnet engraving, the Hippocratic Aphorisms p3 engraving, and an Avalokiteśvara cover hiding in these. Worth the vision call.

Pages typed `illustration` / `frontispiece` / `diagram` / `map` / `mixed` / `title-page` **always** extract — the page-typer's affirmative judgment wins over the trivia filter.

Together: extraction is now more comprehensive (catches title-page frontispieces) AND ~60-80% cheaper to run on the backlog.

## What's out of scope
- Re-queueing the ~8,035 never-extracted visible books — separate go-ahead, needs cost cap.
- JSON fast-path parser for the 1,868 pages with `<detected-images>` JSON form (the filter explicitly preserves them for this path).
- `defaults.ts:202` OCR-prompt fix (frontispieces explicitly downgraded to 0.4-0.7) — separate PR.
- `generate-thumbnails.mjs` run for the 1,615 books missing `extracted_url`.

## Test plan
- [x] Pre-commit hooks pass.
- [x] Unit test of `shouldSkipPageByMarkup` against 10 representative cases (Tibetan margin lines, yig-mgo, library stamp, real engraving, mixed-content page, no markup, JSON-present, decorative/high, photograph/low).
- [ ] Measure real reduction against the production never-extracted set (running in background, ~20-30min).
- [ ] After merge: monitor first cron run for "skipped N trivial-markup pages" log lines.
- [ ] Spot-check that a previously-affected book (e.g. Atalanta Fugiens 1617) gets the frontispiece detected when extraction runs.