### PR TITLE
feat(maintenance): bbox-cluster dedup for within-book gallery_images

### DIFF
--- a/scripts/maintenance/dedup-book-gallery-images.mjs
+++ b/scripts/maintenance/dedup-book-gallery-images.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Collapse within-book gallery_images that are extractions of the SAME
+ * recurring printed element (chapter header, decorative border, frontispiece
+ * reprinted on every verse page, page-watermark, etc.).
+ *
+ * Why this exists
+ *   Image extraction runs per page. When an illustration is *reproduced*
+ *   across many pages of a book (the recurring-template pattern), the
+ *   extractor independently flags it on each page and writes a separate
+ *   gallery_images row. The Secret Commonwealth scan has 24 rows for one
+ *   frontispiece; the Krestos Gospels has 1,461 rows of which ~1,300 are
+ *   different instances of the same handful of decorative borders.
+ *
+ * Why bbox is the right signal
+ *   When the same template element is detected on N pages, the extractor
+ *   reports near-identical normalized bboxes (x, y, width, height vary by
+ *   <0.5% in practice — same page layout, same crop). Books with
+ *   legitimately distinct illustrations have unique bboxes per page
+ *   (different woodcut sizes / placements). Sampling 5 heavily-galleried
+ *   books on 2026-05-27 confirms: recurring-template books have a few
+ *   bbox clusters of 100+; unique-illustration books have ~1 entry per
+ *   bbox cluster. Bbox + same `type` is a high-precision dedup key
+ *   without needing image fetches or dhash.
+ *
+ * Strategy
+ *   For each book (or one with --book), pull gallery_images, cluster by
+ *   (type, bbox rounded to BBOX_PRECISION). Within each cluster of size
+ *   >= MIN_CLUSTER, keep the highest gallery_quality row, archive the
+ *   rest to deleted_gallery_images with reason='recurring_template'.
+ *
+ * Safety
+ *   - Dry-run by default; needs --apply.
+ *   - Refuses if cluster cardinality > 50000 unless --force.
+ *   - Always archives (never hard-deletes) so a 7-day rollback window
+ *     mirrors the deleted_books convention in CLAUDE.md.
+ *   - --book <id-or-slug> restricts to a single book for safe experiments.
+ *
+ * Usage
+ *   node scripts/maintenance/dedup-book-gallery-images.mjs                       # full catalog dry-run
+ *   node scripts/maintenance/dedup-book-gallery-images.mjs --book 699066802ec9f7db5717aac7
+ *   node scripts/maintenance/dedup-book-gallery-images.mjs --book the-secret-commonwealth-of-elves-fauns-and-fairies-kirk --apply
+ *   node scripts/maintenance/dedup-book-gallery-images.mjs --apply --min-cluster 2 --bbox-precision 0.01
+ *
+ * Env
+ *   MONGODB_URI            — required
+ *
+ * Exit codes
+ *   0 — nothing to do, or --apply succeeded
+ *   1 — found dupes (dry-run) OR refused by safety cap
+ *   2 — script error
+ */
+import { MongoClient } from 'mongodb';
+
+const argv = process.argv.slice(2);
+const flag = name => argv.includes(`--${name}`);
+const arg = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+
+const APPLY = flag('apply');
+const FORCE = flag('force');
+const BOOK = arg('book', null);
+const MIN_CLUSTER = Number(arg('min-cluster', 2));
+const BBOX_PRECISION = Number(arg('bbox-precision', 0.01)); // 1% normalized
+const MAX_DELETE = Number(arg('max', 50_000));
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Source .env.production.local first.');
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+
+function bboxKey(bbox, precision) {
+  if (!bbox) return null;
+  const round = v => Math.round(v / precision) * precision;
+  return [round(bbox.x), round(bbox.y), round(bbox.width), round(bbox.height)]
+    .map(n => n.toFixed(3))
+    .join('_');
+}
+
+/**
+ * Cluster a book's gallery_images by (type, bbox). Returns clusters whose
+ * size meets MIN_CLUSTER. Each cluster is sorted by gallery_quality
+ * descending so cluster[0] is the keeper.
+ */
+function clusterBook(galleries, precision, minClusterSize) {
+  const clusters = new Map();
+  for (const g of galleries) {
+    const bk = bboxKey(g.bbox, precision);
+    if (!bk) continue; // images without bbox skip clustering (kept as-is)
+    const key = `${g.type || '∅'}::${bk}`;
+    const arr = clusters.get(key) || [];
+    arr.push(g);
+    clusters.set(key, arr);
+  }
+  const out = [];
+  for (const arr of clusters.values()) {
+    if (arr.length < minClusterSize) continue;
+    arr.sort((a, b) => (b.gallery_quality ?? 0) - (a.gallery_quality ?? 0));
+    out.push(arr);
+  }
+  return out;
+}
+
+async function resolveBookFilter(db, bookRef) {
+  if (!bookRef) return null;
+  const book = await db.collection('books').findOne(
+    { $or: [{ id: bookRef }, { slug: bookRef }] },
+    { projection: { id: 1, slug: 1, title: 1 } }
+  );
+  if (!book) {
+    console.error(`Book not found: ${bookRef}`);
+    process.exit(2);
+  }
+  console.log(`Filter to book: "${book.title}" (${book.id})`);
+  return book.id;
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+
+  try {
+    const bookFilter = await resolveBookFilter(db, BOOK);
+
+    // Find books that even have multiple gallery_images (worth checking).
+    // If --book is set, restrict to that one.
+    const candidateMatch = { $match: bookFilter ? { _id: bookFilter, n: { $gte: MIN_CLUSTER } } : { n: { $gte: MIN_CLUSTER } } };
+    const candidates = await db.collection('gallery_images').aggregate(
+      [
+        { $group: { _id: '$book_id', n: { $sum: 1 } } },
+        candidateMatch,
+      ],
+      { allowDiskUse: true, maxTimeMS: 120_000 }
+    ).toArray();
+
+    console.log(`Scanning ${candidates.length} candidate book(s)…\n`);
+
+    const PROJECTION = { _id: 1, id: 1, book_id: 1, page_id: 1, type: 1, bbox: 1, gallery_quality: 1, description: 1 };
+
+    let booksAffected = 0;
+    let totalRedundant = 0;
+    let totalDeleted = 0;
+    const archive = []; // rows queued for archive
+    const examples = [];
+
+    for (const cand of candidates) {
+      const galleries = await db.collection('gallery_images')
+        .find({ book_id: cand._id }, { projection: PROJECTION })
+        .toArray();
+      const clusters = clusterBook(galleries, BBOX_PRECISION, MIN_CLUSTER);
+      if (clusters.length === 0) continue;
+
+      let redundantInBook = 0;
+      for (const cluster of clusters) {
+        const [keeper, ...redundant] = cluster;
+        redundantInBook += redundant.length;
+        for (const r of redundant) {
+          archive.push({ ...r, deleted_at: new Date(), reason: 'recurring_template', kept_id: keeper.id });
+        }
+      }
+      if (redundantInBook > 0) {
+        booksAffected++;
+        totalRedundant += redundantInBook;
+        // Keep ALL affected books; we sort + truncate after the scan so the
+        // displayed top-10 actually reflects the heaviest books, not the
+        // first-encountered 10. Memory cost is bounded by `booksAffected`,
+        // which empirically is ~600 across the catalog — negligible.
+        examples.push({
+          id: cand._id,
+          total: galleries.length,
+          redundant: redundantInBook,
+          clusters: clusters.length,
+          topCluster: clusters.sort((a, b) => b.length - a.length)[0].length,
+        });
+      }
+    }
+
+    console.log(`Books affected:                ${booksAffected}`);
+    console.log(`Redundant rows (would archive): ${totalRedundant}\n`);
+    examples.sort((a, b) => b.redundant - a.redundant);
+    const top = examples.slice(0, 10);
+    // Hydrate titles only for the displayed top — saves N book lookups
+    const titles = new Map(
+      (await db.collection('books')
+        .find({ id: { $in: top.map(e => e.id) } }, { projection: { id: 1, title: 1 } })
+        .toArray()).map(b => [b.id, b.title])
+    );
+    console.log('Sample (top 10 by redundancy):');
+    for (const e of top) {
+      const title = (titles.get(e.id) || e.id).slice(0, 55);
+      console.log(`  ${e.redundant.toString().padStart(5)} redundant / ${e.total} total in ${e.clusters} cluster(s); biggest=${e.topCluster}× — "${title}"`);
+    }
+
+    if (totalRedundant === 0) {
+      console.log('\nNothing to do.');
+      process.exit(0);
+    }
+
+    if (totalRedundant > MAX_DELETE && !FORCE) {
+      console.error(`\nRefusing: ${totalRedundant} redundant rows exceeds --max (${MAX_DELETE}). Re-run with --force if intentional.`);
+      process.exit(1);
+    }
+
+    if (!APPLY) {
+      console.log('\n(dry run; pass --apply to archive)');
+      process.exit(1);
+    }
+
+    // Archive then delete in batches of 500
+    const BATCH = 500;
+    for (let i = 0; i < archive.length; i += BATCH) {
+      const chunk = archive.slice(i, i + BATCH);
+      await db.collection('deleted_gallery_images').insertMany(chunk, { ordered: false });
+      const r = await db.collection('gallery_images').deleteMany({ _id: { $in: chunk.map(x => x._id) } });
+      totalDeleted += r.deletedCount;
+      process.stderr.write(`\r[apply] ${totalDeleted}/${archive.length} archived+deleted`);
+    }
+    process.stderr.write('\n');
+
+    console.log(`\nDone. Archived ${totalDeleted} rows to deleted_gallery_images.`);
+    process.exit(0);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
Root-cause cleanup for the "24 frontispieces in one book" pattern. PRs #2093 and #2095 hid the duplicates at render time; this archives them at the data layer.

## What it does
For each book, clusters its `gallery_images` by `(type, bbox-rounded-to-1%)`. Within each cluster of size ≥ 2, keeps the highest `gallery_quality` row and archives the rest to `deleted_gallery_images` with `reason='recurring_template'`. No image fetches, no dhash dependency — bbox + type is a high-precision dedup key for within-book recurrence.

Why bbox is the right signal: when the same printed element is detected on N pages of a book (chapter headers, decorative borders, recurring frontispieces), the extractor reports near-identical normalized bboxes (variation < 0.5%). Books with legitimately distinct illustrations have unique bboxes per page (different woodcut sizes/positions).

## Verification (production dry-run)
| Book | Before | After | Archived | Biggest cluster |
|---|---|---|---|---|
| Secret Commonwealth of Elves | 24 | 2 | 22 | 22× |
| Krestos Gospels (Illuminated) | 1,461 | 253 | 1,208 | 146× |
| Ramala Shastra (Geomancy) | 172 | 28 | 144 | 79× |
| Jataka Chandrika | 93 | 10 | 83 | 84× |
| Ben cao gang mu Vol. 8 | 84 | 6 | 78 | 69× |

Full catalog: **605 books, 5,400 redundant rows** queued for archive.

## Safety
- Dry-run by default; needs `--apply`.
- `--max 50000` cap unless `--force`.
- Archives to `deleted_gallery_images`, never hard-deletes. 7-day rollback matches the `deleted_books` convention in CLAUDE.md.
- `--book <id-or-slug>` for one-book targeted runs.
- Type-strict clustering — won't merge a frontispiece with an emblem even at the same bbox.

## Out of scope (follow-ups, not in this PR)
- **Pipeline hook**: same logic at the end of `image-extract-worker.mjs` per book so newly-extracted books stay clean. Trivial to add once we're happy with the maintenance pass.
- **Stricter hash + backfill**: 17×16 dhash (256-bit) and computing it on all 128K historical rows. The 64-bit dhash is sufficient when present — coverage (0.4%) is the actual gap, not discrimination.

## Test plan
- [ ] Reviewer runs the dry-run on a tagged sample book: `node scripts/maintenance/dedup-book-gallery-images.mjs --book the-secret-commonwealth-of-elves-fauns-and-fairies-kirk` and confirms 22 redundant of 24.
- [ ] When ready, `node scripts/maintenance/dedup-book-gallery-images.mjs --apply` to archive the 5,400 rows catalog-wide.
- [ ] Re-verify a few collections (`/gallery/collections/collection-forbidden-books` etc.) — should look unchanged since #2093 already hides this at render time, but the underlying counts now match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)