### PR TITLE
fix(librarian): strip OCR markup tags from source-card snippets

### DIFF
--- a/src/lib/embassy/librarian.ts
+++ b/src/lib/embassy/librarian.ts
@@ -3,6 +3,7 @@ import { GoogleGenAI, Type, type FunctionDeclaration } from '@google/genai';
 import { buildBookSearchStage, buildPageSearchStage } from '@/lib/atlas-search';
 import { supabase } from '@/lib/supabase';
 import { ObjectId } from 'mongodb';
+import { stripAnnotations } from '@/lib/semantic-alignment';
 
 /**
  * The Librarian — Research agent for Source Library.
@@ -390,7 +391,7 @@ async function executeSearchSemantic(query: string): Promise<
           bookAuthor: b.author || 'Unknown',
           bookSlug: visibleMap.get(b.book_id),
           page_number: page?.page_number || 0,
-          snippet: page?.snippet || (b.summary_text || '').slice(0, 500),
+          snippet: stripAnnotations(page?.snippet || (b.summary_text || '').slice(0, 500)),
           score: b.similarity,
         };
       });
@@ -572,7 +573,7 @@ async function executeTool(
 
       const sources: SourceCard[] = data.passages.map(p => ({
         book_id: p.book_id, bookTitle: p.bookTitle, bookAuthor: p.bookAuthor, bookSlug: p.bookSlug,
-        pageNumber: p.page_number, snippet: p.text.slice(0, 200), inCollection: true,
+        pageNumber: p.page_number, snippet: stripAnnotations(p.text).slice(0, 200), inCollection: true,
       }));
 
       return {
@@ -596,7 +597,7 @@ async function executeTool(
 
       const sources: SourceCard[] = results.map(r => ({
         book_id: r.book_id, bookTitle: r.bookTitle, bookAuthor: r.bookAuthor, bookSlug: r.bookSlug,
-        pageNumber: r.page_number, snippet: r.snippet.slice(0, 200), inCollection: true,
+        pageNumber: r.page_number, snippet: stripAnnotations(r.snippet).slice(0, 200), inCollection: true,
       }));
 
       return {

--- a/src/lib/semantic-alignment.ts
+++ b/src/lib/semantic-alignment.ts
@@ -70,8 +70,11 @@ function cosineSimilarity(a: number[], b: number[]): number {
  * are structural annotations that pollute the semantic signal.
  * On the flagged Theatrum Chemicum page, 64% of text was tags — stripping
  * them turned a false positive (0.68) into correct alignment.
+ *
+ * Also used to clean snippets shown to end users (e.g. Librarian source cards),
+ * where raw "<header>" markup leaks into the UI otherwise.
  */
-function stripAnnotations(text: string): string {
+export function stripAnnotations(text: string): string {
   return text
     // Remove full XML tag pairs and their content for meta/structural tags
     .replace(/<(?:meta|language|page-type|page-num|header|sig|folio|warning)>[^]*?<\/(?:meta|language|page-type|page-num|header|sig|folio|warning)>/g, '')


### PR DESCRIPTION
## Summary

The Librarian's source-card excerpt was rendering raw OCR/translation markup. From a screenshot in today's session:

> *<header>MAGIC AND EXPERIMENTAL SCIENCE CHAP…*

shown as the excerpt under *A History of Magic and Experimental Science, Vol. I* (Thorndike, p. 735).

The OCR pipeline annotates pages with structural tags (`<header>`, `<page-num>`, `<margin>`, `<meta>`, …). These belong in the data — not in the UI snippet.

## Fix

Reuse the existing `stripAnnotations()` helper from `src/lib/semantic-alignment.ts` (was internal — exported now) at the three snippet-assembly sites in `src/lib/embassy/librarian.ts`:

- `executeSearchSemantic` book-summary fallback
- `executeTool` → `search_collection` passage snippets
- `executeTool` → `search_semantic` result snippets

Server-side strip keeps the RSC payload clean and protects any future surface that consumes `SourceCard`.

## Test plan
- [ ] Visit `/librarian`, run a search that hits Thorndike's *History of Magic* (or any book with `<header>` markup on the matched page), confirm excerpt no longer shows the tag
- [ ] Spot-check both keyword (`search_collection`) and semantic (`search_semantic`) result paths
- [ ] No `<...>` markup visible in any source-card snippet
- [ ] No regression: snippets still render with the right text content, just cleaner

🤖 Generated with [Claude Code](https://claude.com/claude-code)