### PR TITLE
chore(cron): wire gallery-coverage-snapshot to crontab.production

### DIFF
--- a/scripts/workers/crontab.production
+++ b/scripts/workers/crontab.production
@@ -46,6 +46,11 @@
 # R2 coverage snapshot (every 6h — updates the doc /admin/r2-coverage reads)
 30 */6 * * * cd /root/sourcelibrary && flock -n /tmp/sl-r2-snapshot.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/r2-coverage-snapshot.mjs" >> /var/log/sourcelibrary/r2-snapshot.log 2>&1
 
+# Gallery_images CDN coverage snapshot (every 12h, offset 3h from the page-side
+# snapshot so they don't compete for the undici connection pool). ~90s on
+# the full catalog. Surfaced on the same /admin/r2-coverage page.
+45 3,15 * * * cd /root/sourcelibrary && flock -n /tmp/sl-gallery-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/gallery-coverage-snapshot.mjs" >> /var/log/sourcelibrary/gallery-coverage.log 2>&1
+
 # Archive auto-unblock (daily — retry books blocked >14d ago with transient failure reasons)
 0 9 * * * cd /root/sourcelibrary && flock -n /tmp/sl-archive-unblock.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/archive-auto-unblock.mjs" >> /var/log/sourcelibrary/archive-auto-unblock.log 2>&1
 


### PR DESCRIPTION
## Summary
Adds the gallery_images CDN coverage snapshot to `scripts/workers/crontab.production` at every 12h (03:45 / 15:45 UTC), offset 3h from the page-side r2-coverage snapshot so they don't share the undici per-origin connection pool peak.

## Install on Hetzner (required for the line to survive)
`sync-crontab.sh` runs at 04:00 daily and dumps Hetzner's *live* crontab back to git, overwriting this file. So the git-side entry needs a matching live entry on Hetzner — otherwise the next sync will strip it.

After this PR merges, run on Hetzner:
```bash
(crontab -l; echo '45 3,15 * * * cd /root/sourcelibrary && flock -n /tmp/sl-gallery-coverage.lock bash -c "set -a; source .env.production.local; set +a; node scripts/workers/gallery-coverage-snapshot.mjs" >> /var/log/sourcelibrary/gallery-coverage.log 2>&1') | crontab -
```

## Why the timing
- 03:45 / 15:45 UTC = 12h cadence (page-side snapshot is every 6h at `30 */6`).
- 92s job on full catalog (6,989 books). Low Atlas load — only the `\$sample` per book is hot, rest is HTTP I/O against R2.
- Offset chosen so the two snapshot workers don't share the undici per-origin connection pool peak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)