### PR TITLE
docs(r2): reconcile storage docs with measured reality

### DIFF
--- a/.claude/docs/image-architecture.md
+++ b/.claude/docs/image-architecture.md
@@ -9,7 +9,8 @@ images.sourcelibrary.org/
 ├── pages/{book_id}/{0001}.jpg            # 1200px page display images
 ├── pages/{book_id}/{0001}-thumb.jpg      # 150px page thumbnails
 ├── pages/{book_id}/{0001}-full.jpg       # Full-res original (OCR, zoom, download)
-├── archived/{book_id}/{page}.jpg         # Legacy archived pages (rewritten to /pages/ at read time)
+├── archived/{book_id}/{page}.jpg         # Legacy archived pages (77% of corpus; rewritten to /pages/ at read time — see caveat)
+├── books/{book_id}/pages/{NNNN}.jpg      # Kloss/IDP/CCAG/PDF imports — single file, no variants
 ├── gallery/{book_id}/{page}-{idx}.jpg    # 1200px extracted illustrations
 ├── gallery/{book_id}/{page}-{idx}-thumb.jpg  # 150px illustration thumbnails
 ├── gallery/{book_id}/{page}-{idx}-full.jpg   # Full-res illustration
@@ -17,10 +18,14 @@ images.sourcelibrary.org/
 ├── artwork/{slug}.jpg                    # 1200px display variant (some artworks)
 ├── artwork/{slug}-thumb.jpg              # 150px artwork thumbnail
 ├── covers/{book_id}.jpg                  # Book cover images
-└── thumbnails/{book_id}/{page}.jpg       # Legacy path (rewritten to /pages/ at read time)
+├── cropped/{book_id}/{objectId}.jpg      # Split-page crops (objectId filenames)
+├── uploads/{book_id}/{objectId}.jpg      # Raw user uploads (objectId filenames)
+└── thumbnails/{book_id}/{page}.jpg       # Oldest path (rewritten to /pages/ at read time)
 ```
 
-Path helpers: `src/lib/storage.ts` — `pagePaths()`, `galleryPaths()`, `coverPath()`, `r2Url()`.
+Path helpers: `src/lib/storage.ts` — `pagePaths()`, `galleryPaths()`, `coverPath()`, `r2Url()`. The canonical pattern matrix, by-provider distribution, and current measured coverage live in [r2-storage.md](./r2-storage.md).
+
+**Caveat — URL rewrites are aspirational, not validated.** `utils.ts` rewrites `archived/.../{N}.jpg` → `pages/.../{NNNN}.jpg` (or `-thumb.jpg`) at read time, assuming the target file exists. For ~20% of pages it doesn't — the archive worker wrote the legacy path but the canonical variants were never generated. Those pages render broken icons unless a component-level fallback kicks in. The gap is measured live at `/admin/r2-coverage`.
 
 ## Progressive Loading Chain
 

--- a/.claude/docs/r2-storage.md
+++ b/.claude/docs/r2-storage.md
@@ -4,45 +4,88 @@
 **Public URL:** `https://images.sourcelibrary.org`
 **DNS:** Cloudflare (custom domain, SSL)
 
-## Current Structure
+## TL;DR
 
-### Active prefixes (new convention)
+The library has accumulated **six URL conventions** across different eras and import scripts. The canonical convention is `pages/{bookId}/{NNNN}` with three variants — but only ~7% of pages live there today. The other 93% are scattered across legacy paths that are still actively read. Reader code (`src/lib/utils.ts:91-124`) papers over much of it via URL rewrites, but the rewrites are aspirational: when the canonical file doesn't actually exist on R2 the rewrite produces a 404.
+
+**Current coverage** (measured 2026-05-28 via `/admin/r2-coverage`):
+- 94.0% of pages have an R2 URL stored in `archived_photo` (record-level coverage).
+- 80.3% have the display `.jpg` variant actually serving content on R2 (file-level).
+- 80.3% have the `-thumb.jpg` variant.
+- 79.7% have full-res (counting both `/pages/-full.jpg` AND `/archived/<N>.jpg`).
+
+**The ~20% gap** is the user-visible broken-icon problem — most of it concentrated in mdz (162K pages), harvard (108K), and gallica (32K).
+
+## Active path conventions, by frequency
+
+Sampled from a 100K-page snapshot of `pages.archived_photo`:
+
+| Pattern | Share | Where it comes from |
+|---|---|---|
+| `archived/{bookId}/{N}.jpg` | 77.4% | Pre-`pagePaths()` archiver. Unpadded `N`, no `-full` suffix. The dominant pattern in the corpus. Still actively read; reader code at `src/lib/utils.ts:101` rewrites it to `pages/{bookId}/{NNNN}.jpg` for display. |
+| `pages/{bookId}/{NNNN}-full.jpg` | 6.8% | Canonical `pagePaths(...).full`. Used by new pipeline writers — uploads (`src/lib/uploads/processing.ts`), split pages (`src/lib/page-split/split-processing.ts`), the resize worker (`scripts/workers/resize-worker.mjs`), BPH split worker, and bulk-import scripts. |
+| `books/{bookId}/pages/{NNNN}.jpg` | 1.8% | Used by **kloss, IDP, CCAG, and PDF imports**. Writers: `scripts/import/import-kloss-collection.mjs`, `scripts/import/import-idp-batch.mjs`, `scripts/import/ccag-vii-pdf-direct.mjs`, `src/app/api/import/pdf/route.ts`. Single high-res file per page — NO display or thumb variants generated. |
+| `cropped/{bookId}/{objectId}.jpg` | (subset of "other", ~11%) | Split-page crops with ObjectId filenames. |
+| `uploads/{bookId}/{objectId}.jpg` | (subset of "other") | Raw user uploads with ObjectId filenames. |
+| `thumbnails/{bookId}/{N}.jpg` | <0.1% | Oldest pattern. Reader rewrites to `pages/.../-thumb.jpg`. |
+| `pages/{bookId}/sp{NNNN}.jpg`, `spdm{N}-{NNNN}.jpg` etc. | (BPH-specific) | BPH split-page outputs use prefixes like `sp0001.jpg`, `spdm61-0001.jpg`. Same `pages/` prefix, different filename shape. |
+
+### Other prefixes
 
 ```
-pages/{bookId}/{0001}-full.jpg      Full-res original (OCR, zoom, download)
-pages/{bookId}/{0001}.jpg           Display size, 1200px wide (browser display)
-pages/{bookId}/{0001}-thumb.jpg     Thumbnail, 150px (browse grids, search)
-
-gallery/{bookId}/{imageId}.jpg      Extracted illustration, display size
-gallery/{bookId}/{imageId}-full.jpg Extracted illustration, full-res
-gallery/{bookId}/{imageId}-thumb.jpg Extracted illustration, 300px thumbnail
-
-covers/{bookId}.jpg                 Book cover image
-
-video/hero-bg.webm                  Homepage hero video (webm)
-video/hero-bg.mp4                   Homepage hero video (mp4)
-video/hero-poster.jpg               Hero video poster fallback
-
-assets/embassy-of-the-free-mind-logo.png   Partner logo
-assets/partners-unesco.avif                Partner logo
-
-artwork/...                         Visual art wing images
+gallery/{bookId}/{imageId}.jpg          Extracted illustration, display size
+gallery/{bookId}/{imageId}-full.jpg     Extracted illustration, full-res
+gallery/{bookId}/{imageId}-thumb.jpg    Extracted illustration, 300px thumbnail
+covers/{bookId}.jpg                     Book cover image
+artwork/{slug}.jpg, -thumb, -full       Visual art wing — follows pagePaths-style variants
+video/hero-bg.webm, .mp4, hero-poster.jpg   Homepage hero
+assets/...                              Partner logos
+book-thumbnails/{bookId}.jpg            Old book cover path (legacy)
+_test/...                               Test files, safe to delete
 ```
 
-### Legacy prefixes (old convention, still serving)
+## Reader behavior — rewrites are aspirational
 
-```
-archived/{bookId}/{pageNumber}.jpg  Old archiving path (duplicate of pages/)
-uploads/{bookId}/{objectId}.jpg     Raw uploads with ObjectId filenames
-cropped/{bookId}/{objectId}.jpg     Split-page crops with ObjectId filenames
-thumbnails/{bookId}/{pageNumber}.jpg Old thumbnail path
-book-thumbnails/{bookId}.jpg        Old book cover path
-books/...                           Legacy, unclear purpose
-_test/...                           Test files, safe to delete
+`src/lib/utils.ts:91-124` rewrites legacy paths to canonical form at read time:
+- `thumbnails/{bookId}/{num}.jpg` → `pages/{bookId}/{NNNN}.jpg` (or `-thumb.jpg`)
+- `archived/{bookId}/{num}.jpg` → `pages/{bookId}/{NNNN}.jpg` (or `-thumb.jpg`)
+- `pages/{bookId}/{NNNN}-full.jpg` ↔ `pages/{bookId}/{NNNN}.jpg` ↔ `-thumb.jpg`
+
+**The rewrite assumes the target file exists.** For unmigrated books the rewrite produces a URL that 404s. That's the root cause of broken-icon reports for legacy books — the page record has `archived_photo: ".../archived/<id>/1.jpg"` (which exists), the reader rewrites that to `.../pages/<id>/0001-thumb.jpg` (which doesn't), and the user sees a broken icon. Component-level fallbacks catch some cases (BookCard swaps to a working URL), but not all.
+
+The `books/{bookId}/pages/...` and BPH `sp*` patterns are **not** rewritten — readers consume those URLs directly. Kloss/IDP/CCAG books therefore have no display or thumb variant available unless one is generated separately.
+
+## Coverage truth — the variant-coverage dashboard
+
+`/admin/r2-coverage` (powered by `scripts/workers/r2-coverage-snapshot.mjs`) measures both:
+1. **Record-level** — `archived_photo` points at any R2 URL (94.0%).
+2. **Variant-level** — HEAD-probes the canonical `pages/<id>/<NNNN>{.jpg,-thumb.jpg,-full.jpg}` AND the legacy `archived/<id>/<N>.jpg`, samples N pages per book. Tells you whether the file actually exists at the URL we'd expect for the display/thumb/full reader paths.
+
+**Known blind spots:** the variant probe only checks `pages/` and `archived/` patterns. Books whose images live exclusively at `books/<id>/pages/...` (kloss/IDP/CCAG) or BPH-prefix paths (`sp*`) get flagged as missing variants even though they're readable. So **the dashboard's 80.3% display number is biased downward** — true reader-visible coverage is somewhat higher.
+
+## Path Helpers — the canonical convention for NEW writes
+
+All paths are generated by helpers in `src/lib/storage.ts`:
+
+```typescript
+import { pagePaths, galleryPaths, coverPath, r2Url } from '@/lib/storage';
+
+pagePaths('abc123', 5)
+// → { full: 'pages/abc123/0005-full.jpg',
+//      display: 'pages/abc123/0005.jpg',
+//      thumb: 'pages/abc123/0005-thumb.jpg' }
+
+galleryPaths('abc123', 'img-001')
+// → { full: 'gallery/abc123/img-001-full.jpg', ... }
+
+coverPath('abc123')
+// → 'covers/abc123.jpg'
+
+r2Url('pages/abc123/0005.jpg')
+// → 'https://images.sourcelibrary.org/pages/abc123/0005.jpg'
 ```
 
-Legacy data still works — MongoDB fields point to valid URLs. Gradual migration
-to new prefixes tracked in GitHub issue #442.
+**Rule for new writers: use `pagePaths()`.** Don't add a seventh URL convention. If you're modifying `scripts/import/import-kloss-collection.mjs`, `scripts/import/import-idp-batch.mjs`, `scripts/import/ccag-vii-pdf-direct.mjs`, or `src/app/api/import/pdf/route.ts`, those are the four writers currently emitting `books/{bookId}/pages/...` — convert them to `pagePaths()` if you touch them.
 
 ## Path Helpers
 

--- a/.claude/handoffs/2026-05-28-r2-coverage-and-gap-fill.md
+++ b/.claude/handoffs/2026-05-28-r2-coverage-and-gap-fill.md
@@ -1,0 +1,103 @@
+# R2 coverage measurement + gap-fill scope (2026-05-28)
+
+## Trigger
+
+Started from "look at the 404 and broken image errors we have" + "do we log broken images when it shows the icon for the image instead of the cover". Followed the question through:
+- `broken_image_reports` (logged via `src/components/BrokenImageReporter.tsx`, fired into `/api/analytics/broken-image`) showed real broken-icon hits.
+- The existing `/admin/r2-coverage` dashboard claimed 93.5% coverage. The dashboard was lying — it only measured "is `archived_photo` an R2 URL" (record-level), not "does the file actually serve content at the URL we expect" (variant-level).
+
+## Work shipped
+
+### PR #2068 — bare-path redirects (merged-ready)
+- `/book`, `/author`, `/q` → `/search` or `/`
+- `/libraries/<slug>/gallery/<...>` → `/gallery/<...>` (per URL doctrine)
+- Branch: `worktree-fix-404s-broken-images`
+
+### PR #2080 — variant-level HEAD probing in coverage snapshot
+- Worker (`scripts/workers/r2-coverage-snapshot.mjs`) now HEAD-samples 3 pages × 3 variants per book, aggregates per-book/per-provider/library, writes into `system_config._id='r2_coverage_snapshot'`.
+- Probes both `pages/<id>/<NNNN>-full.jpg` AND legacy `archived/<id>/<N>.jpg` for the full variant (dual-path fix landed in second commit on the branch).
+- Library denominator uses **resolved** probes per variant, not attempted — so network noise can't drag the % toward zero.
+- Concurrency 20 (fit undici's 10-conn-per-origin pool with headroom), 15s timeout, retry-once on 5xx/timeout.
+- Gap-book ranking weights display 3×, thumb 2×, full 1× so reader-visible gaps surface first.
+- Skips `etcsl`/`tu_darmstadt` (text-only by design).
+- Branch: `worktree-r2-variant-coverage`. Run on 2026-05-28 took 56 min (25 min Atlas agg + 42 min probe).
+
+### This PR — doc reconciliation
+- Updated `.claude/docs/r2-storage.md` to reflect the actual six URL conventions in production R2.
+- Updated `.claude/docs/image-architecture.md` to note that `utils.ts` URL rewrites are aspirational (target file may not exist) and to add the missing `books/` and split paths.
+- Added this handoff.
+
+## Snapshot results (2026-05-28 00:06 CEST)
+
+- **Record-level coverage:** 94.0%
+- **Variant-level coverage (file actually exists on R2):**
+  - Display `.jpg`: 80.3%
+  - Thumb `-thumb.jpg`: 80.3%
+  - Full (either `-full.jpg` or legacy `/archived/<N>.jpg`): 79.7%
+- **Books with at least one variant gap:** 7,070 (down from 20,054 before the dual-path fix)
+- **Unresolved probes:** 329 / 179,502 = 0.18%
+
+By provider — biggest absolute gaps:
+
+| Provider | Books | Pages | Unarchived (record-level) | R2 % |
+|---|---|---|---|---|
+| mdz | 1,426 | 530K | 162K | 69% |
+| harvard | 821 | 174K | 108K | 38% |
+| internet_archive | 8,257 | 3.29M | 42K | 99% |
+| gallica | 251 | 77K | 32K | 58% |
+| bl | 1,463 | 284K | 19K | 93% |
+| etcsl | 373 | 5,759 | 5,759 | 0% (intentional, text-only) |
+| tu_darmstadt | 12 | 3,428 | 3,428 | 0% (intentional) |
+| sat_daizokyo | 41 | 5,435 | 3,108 | 43% |
+
+**Total library gap:** 385,679 unarchived pages + 1,367 explicitly failed.
+
+## Six URL conventions in production R2
+
+Sampled 100K `pages.archived_photo` values:
+
+| Pattern | Share | Notes |
+|---|---|---|
+| `archived/{bookId}/{N}.jpg` (unpadded) | 77.4% | Pre-`pagePaths()` archiver. Reader rewrites to `pages/.../{NNNN}.jpg` for display — but the rewritten URL only works if the canonical file was actually generated. For ~20% of pages it wasn't. |
+| `pages/{bookId}/{NNNN}-full.jpg` | 6.8% | Canonical `pagePaths(...).full`. New writes go here. |
+| `books/{bookId}/pages/{NNNN}.jpg` | 1.8% | Kloss, IDP, CCAG, PDF imports. Single file per page — no display/thumb variants. |
+| `cropped/{bookId}/{objectId}.jpg` | ~5% | Split-page crops, objectId filenames. |
+| `uploads/{bookId}/{objectId}.jpg` | ~3% | Raw user uploads. |
+| `thumbnails/{bookId}/{N}.jpg` | <0.1% | Oldest. Reader rewrites. |
+| BPH `pages/{bookId}/sp{NNNN}.jpg`, `spdm{N}-{NNNN}.jpg` | (subset of `pages/`) | Split-page variants inside the canonical prefix. |
+
+## Decision: pragmatic over architectural
+
+Two cleanup paths considered:
+1. **Architectural** — migrate all 5M+ legacy `/archived/` files to `pages/<id>/<NNNN>-full.jpg`, regenerate variants, delete legacy. Months of work. No user-visible benefit since readers don't request `/pages/-full.jpg` directly.
+2. **Pragmatic** — make the dashboard tell the truth (DONE in PR #2080), then fill the ~20% gap where the URL rewrite produces a 404. Weeks of work. Direct user impact.
+
+Chose pragmatic. Architectural cleanup is on the back-burner — only worth doing if we ever want to delete legacy paths.
+
+## Next steps (gap-fill scope)
+
+1. **Backfill mdz** — 162K unarchived pages, 1,426 books. Source is api.digitale-sammlungen.de IIIF. `scripts/maintenance/archive-images-fast.ts` exists; needs a "find unarchived mdz pages" feeder and runs at scale.
+2. **Backfill harvard** — 108K unarchived pages, 821 books. Source is mps.lib.harvard.edu IIIF. Same pattern as mdz.
+3. **Backfill gallica** — 32K pages, 251 books. Source is gallica.bnf.fr IIIF.
+4. **Backfill internet_archive stragglers** — 42K pages. Worth investigating WHY they're still on source URLs after IA's main pipeline ran.
+5. **Extend the variant-probe worker** to also check `books/<id>/pages/...` and BPH `sp*` prefixes so kloss/BPH books stop showing as false-positive variant gaps. Worker already handles dual-path full-res; this would add two more recognized paths.
+6. **Decide on the `books/<id>/pages/` writers** — kloss/IDP/CCAG/PDF currently emit a different URL convention. If we touch those importers, convert to `pagePaths()`.
+
+## Files modified
+
+PR #2068:
+- `next.config.ts` — bare-path redirects
+
+PR #2080:
+- `scripts/workers/r2-coverage-snapshot.mjs` — variant probe phase + dual-path full-res
+- `src/app/api/admin/r2-coverage/route.ts` — pass `variant_coverage` through
+- `src/app/[tenant]/admin/r2-coverage/page.tsx` — cards + variant gap tab
+
+This PR (docs):
+- `.claude/docs/r2-storage.md` — reflect actual conventions
+- `.claude/docs/image-architecture.md` — note aspirational rewrites
+- `.claude/handoffs/2026-05-28-r2-coverage-and-gap-fill.md` — this file
+
+## CLAUDE.md update?
+
+The current CLAUDE.md doesn't have a Storage/R2 section. Worth adding a brief one pointing at `r2-storage.md` and the dashboard, so future contributors don't make the same wrong-assumption mistakes we hit twice today (assuming `pagePaths()` was the only convention; assuming `-full.jpg` was missing when it was just at a different path). NOT added in this PR — left for a separate doctrine review.

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -92,8 +92,19 @@ export async function storagePut(
 }
 
 // --- Path helpers ---
-// Standard R2 path convention. All image storage should use these.
-// Given bookId + pageNumber, URLs are fully predictable without DB lookups.
+// Canonical R2 path convention. All NEW image storage must use these.
+//
+// Reality check: the corpus has accumulated six URL conventions across
+// different eras. The canonical `pages/{bookId}/{NNNN}` shape below covers
+// only ~7% of existing pages. The other 93% are still at legacy paths —
+// dominantly `archived/{bookId}/{N}.jpg` (77%). Reader code in utils.ts
+// rewrites those legacy URLs to the canonical shape at render time, but
+// the rewrite is aspirational: it assumes the file exists at the canonical
+// path, and for ~20% of pages it doesn't.
+//
+// See .claude/docs/r2-storage.md for the full path inventory, per-provider
+// distribution, and link to the /admin/r2-coverage dashboard which measures
+// the gap between record-level and file-level coverage.
 
 /** Page image paths — pages/{bookId}/{0001}.jpg, pages/{bookId}/{0001}-full.jpg, etc. */
 export function pagePaths(bookId: string, pageNumber: number) {


### PR DESCRIPTION
## Summary

Update the storage docs to match the actual URL distribution in production R2 (sampled 100K `archived_photo` values + per-provider spot probes done today). Existing docs were partly stale or wrong.

## What was wrong

- `r2-storage.md` called the `books/` prefix "Legacy, unclear purpose". Actually used by 4 active import scripts (kloss, IDP, CCAG, PDF) for single-file-per-page uploads — ~1.8% of the corpus, 1,500+ books.
- Neither `r2-storage.md` nor `image-architecture.md` mentioned that `utils.ts` URL rewrites are aspirational: `/archived/<id>/<N>.jpg` → `/pages/<id>/<NNNN>.jpg` produces a 404 for ~20% of pages because the canonical variants were never generated. **This is the root cause of broken-icon reports for legacy books.**
- No doc cross-referenced the `/admin/r2-coverage` dashboard or the measured coverage (94.0% record-level, 80.3% file-level for display variant).

## What this PR changes

- **`.claude/docs/r2-storage.md`** rewritten: TL;DR with measured coverage, six active path conventions with per-pattern provenance, the "rewrites are aspirational" caveat, link to the dashboard, rule that new writers must use `pagePaths()`.
- **`.claude/docs/image-architecture.md`**: added the `/books/` and `/cropped/` and `/uploads/` patterns; aspirational-rewrite caveat; cross-link to `r2-storage.md`.
- **`src/lib/storage.ts`**: header comment on `pagePaths()` now explains that it's the canonical NEW convention but only ~7% of corpus lives here, points readers at the docs and the dashboard.
- **New handoff** at `.claude/handoffs/2026-05-28-r2-coverage-and-gap-fill.md` capturing the research, PRs that shipped today (#2068, #2080), gap scope by provider, and the pragmatic-vs-architectural decision rationale.

## What's out of scope

- No code logic changes. The `pagePaths()` definition stays exactly the same; only its JSDoc was updated.
- CLAUDE.md doesn't have a Storage/R2 section yet — worth adding a brief one but I left that for a separate doctrine review (noted in handoff).
- The gap-fill work itself (backfilling mdz/harvard/gallica) is scoped in the handoff but not implemented here.

## Test plan

- [ ] Skim `r2-storage.md` — coverage numbers match `/admin/r2-coverage`
- [ ] `image-architecture.md` caveat reads correctly
- [ ] `storage.ts` JSDoc renders without breaking imports
- [ ] Handoff is discoverable in `.claude/handoffs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)