### PR TITLE
feat(dhash): backfill gallery_images dhash + compute at write time

### DIFF
--- a/scripts/lib/dhash.mjs
+++ b/scripts/lib/dhash.mjs
@@ -1,0 +1,36 @@
+/**
+ * Perceptual image hashing (dhash) — node-side mirror of src/lib/dhash.ts.
+ *
+ * Keep this in sync with the TS module. Used by:
+ *   - scripts/maintenance/backfill-gallery-dhash.mjs (one-time backfill)
+ *   - scripts/workers/generate-thumbnails.mjs (compute at write time)
+ *
+ * dhash = difference hash: resize to 9×8 grayscale, compare adjacent pixels.
+ * Produces a 64-bit hash, returned as 16-char hex. Images with hamming
+ * distance < 5 are visually identical.
+ */
+
+import sharp from 'sharp';
+
+const ZERO = BigInt(0);
+const ONE = BigInt(1);
+
+export async function computeDHash(imageBuffer) {
+  const pixels = await sharp(imageBuffer)
+    .greyscale()
+    .resize(9, 8, { fit: 'fill' })
+    .raw()
+    .toBuffer();
+
+  let hash = ZERO;
+  for (let y = 0; y < 8; y++) {
+    for (let x = 0; x < 8; x++) {
+      const left = pixels[y * 9 + x];
+      const right = pixels[y * 9 + x + 1];
+      if (left > right) {
+        hash |= ONE << BigInt(y * 8 + x);
+      }
+    }
+  }
+  return hash.toString(16).padStart(16, '0');
+}

--- a/scripts/maintenance/backfill-gallery-dhash.mjs
+++ b/scripts/maintenance/backfill-gallery-dhash.mjs
@@ -43,8 +43,15 @@ async function fetchImage(url) {
 }
 
 async function processOne(gi) {
-  const url = gi.extracted_url || gi.thumbnail_url;
-  if (!url) return { id: gi.id, error: 'no url' };
+  // Accept thumbnail_url as a fallback only if extracted_url is empty/missing.
+  // Empty strings are common (~1.5% of rows) and would otherwise cycle forever
+  // through the find().limit() loop because the row keeps matching the
+  // dhash-unset filter — see the sentinel-write logic below.
+  const url =
+    (typeof gi.extracted_url === 'string' && gi.extracted_url) ||
+    (typeof gi.thumbnail_url === 'string' && gi.thumbnail_url) ||
+    null;
+  if (!url) return { id: gi.id, error: 'no-source' };
   try {
     const buf = await fetchImage(url);
     const dhash = await computeDHash(buf);
@@ -73,6 +80,10 @@ async function main() {
   const db = client.db('bookstore');
   const coll = db.collection('gallery_images');
 
+  // Filter: rows missing a dhash field altogether. Errored runs write
+  // `dhash: null` as a sentinel so failed rows don't reappear in subsequent
+  // find().limit() iterations — without that, every empty-URL row would cycle
+  // forever, blocking real candidates from being seen.
   const filter = {
     dhash: { $exists: false },
     extracted_url: { $exists: true, $ne: null },
@@ -110,8 +121,24 @@ async function main() {
     if (!DRY_RUN) {
       const ops = [];
       for (const r of results) {
-        if (r.error) continue;
-        ops.push({ updateOne: { filter: { id: r.id }, update: { $set: { dhash: r.dhash } } } });
+        if (r.error) {
+          // Write a sentinel so this row stops matching the `dhash: { $exists: false }`
+          // filter on the next iteration. Without this, errored rows cycle forever and
+          // the script never advances to other candidates.
+          ops.push({
+            updateOne: {
+              filter: { id: r.id },
+              update: { $set: { dhash: null, dhash_error: r.error.slice(0, 120) } },
+            },
+          });
+          continue;
+        }
+        ops.push({
+          updateOne: {
+            filter: { id: r.id },
+            update: { $set: { dhash: r.dhash }, $unset: { dhash_error: '' } },
+          },
+        });
       }
       if (ops.length) await coll.bulkWrite(ops, { ordered: false });
     }

--- a/scripts/maintenance/backfill-gallery-dhash.mjs
+++ b/scripts/maintenance/backfill-gallery-dhash.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Backfill dhash on gallery_images rows that don't have one (issue #2113).
+ *
+ * Reads gallery_images where `dhash` is unset and `extracted_url` is set,
+ * downloads the cropped image from R2, computes the 64-bit dhash via
+ * scripts/lib/dhash.mjs, and writes it back.
+ *
+ * Idempotent: skips rows that already have a dhash. Safe to re-run.
+ * Concurrency-safe: each $set is independent.
+ *
+ * Usage:
+ *   set -a; source .env.production.local; set +a
+ *   node scripts/maintenance/backfill-gallery-dhash.mjs --dry-run
+ *   node scripts/maintenance/backfill-gallery-dhash.mjs --apply --limit=500
+ *   node scripts/maintenance/backfill-gallery-dhash.mjs --apply --concurrency=30
+ */
+
+import { MongoClient } from 'mongodb';
+import { computeDHash } from '../lib/dhash.mjs';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const DRY_RUN = args.includes('--dry-run') || !APPLY;
+function getArg(name, def) {
+  const a = args.find(x => x.startsWith(`--${name}=`));
+  return a ? a.split('=')[1] : def;
+}
+const LIMIT = parseInt(getArg('limit', '0'), 10); // 0 = no limit
+const CONCURRENCY = parseInt(getArg('concurrency', '20'), 10);
+const FETCH_TIMEOUT_MS = 30_000;
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Hint: set -a; source .env.production.local; set +a');
+  process.exit(1);
+}
+
+async function fetchImage(url) {
+  const resp = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function processOne(gi) {
+  const url = gi.extracted_url || gi.thumbnail_url;
+  if (!url) return { id: gi.id, error: 'no url' };
+  try {
+    const buf = await fetchImage(url);
+    const dhash = await computeDHash(buf);
+    return { id: gi.id, dhash };
+  } catch (e) {
+    return { id: gi.id, error: e?.message ?? String(e) };
+  }
+}
+
+async function processPool(items, concurrency, fn) {
+  let idx = 0;
+  const results = [];
+  async function worker() {
+    while (idx < items.length) {
+      const i = idx++;
+      results[i] = await fn(items[i]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+  return results;
+}
+
+async function main() {
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  const db = client.db('bookstore');
+  const coll = db.collection('gallery_images');
+
+  const filter = {
+    dhash: { $exists: false },
+    extracted_url: { $exists: true, $ne: null },
+  };
+
+  const remaining = await coll.countDocuments(filter);
+  const totalWithDhash = await coll.countDocuments({ dhash: { $exists: true } });
+  const totalRows = await coll.estimatedDocumentCount();
+  console.log(`gallery_images: ${totalRows} total, ${totalWithDhash} with dhash`);
+  console.log(`remaining to backfill: ${remaining}${LIMIT ? ` (will process up to ${LIMIT})` : ''}`);
+  console.log(`mode: ${DRY_RUN ? 'DRY RUN (no writes)' : 'APPLY'}, concurrency: ${CONCURRENCY}`);
+
+  const target = LIMIT > 0 ? Math.min(LIMIT, remaining) : remaining;
+  if (target === 0) {
+    console.log('Nothing to do.');
+    await client.close();
+    return;
+  }
+
+  const BATCH = 200; // pull this many rows at a time, then process in pool
+  let processed = 0, ok = 0, errors = 0;
+  const errorSamples = [];
+  const t0 = Date.now();
+
+  while (processed < target) {
+    const chunkSize = Math.min(BATCH, target - processed);
+    const chunk = await coll
+      .find(filter, { projection: { _id: 0, id: 1, extracted_url: 1, thumbnail_url: 1 } })
+      .limit(chunkSize)
+      .toArray();
+    if (chunk.length === 0) break;
+
+    const results = await processPool(chunk, CONCURRENCY, processOne);
+
+    if (!DRY_RUN) {
+      const ops = [];
+      for (const r of results) {
+        if (r.error) continue;
+        ops.push({ updateOne: { filter: { id: r.id }, update: { $set: { dhash: r.dhash } } } });
+      }
+      if (ops.length) await coll.bulkWrite(ops, { ordered: false });
+    }
+
+    for (const r of results) {
+      if (r.error) {
+        errors++;
+        if (errorSamples.length < 5) errorSamples.push(`${r.id}: ${r.error}`);
+      } else ok++;
+    }
+
+    processed += chunk.length;
+    const elapsed = (Date.now() - t0) / 1000;
+    const rate = processed / elapsed;
+    const etaSec = ((target - processed) / Math.max(rate, 0.1)).toFixed(0);
+    process.stdout.write(
+      `\r  processed=${processed}/${target} ok=${ok} err=${errors} rate=${rate.toFixed(1)}/s eta=${etaSec}s   `,
+    );
+  }
+
+  console.log('\nDone.');
+  if (errorSamples.length > 0) {
+    console.log('Sample errors:');
+    for (const e of errorSamples) console.log('  ' + e);
+  }
+
+  await client.close();
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/workers/generate-thumbnails.mjs
+++ b/scripts/workers/generate-thumbnails.mjs
@@ -21,6 +21,7 @@
 import { MongoClient } from 'mongodb';
 import sharp from 'sharp';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { computeDHash } from '../lib/dhash.mjs';
 
 // ── Config ──
 
@@ -133,6 +134,10 @@ async function generateThumbnails(sourceUrl, bbox, rotation, bookId, pageId, det
     .jpeg({ quality: 70 })
     .toBuffer();
 
+  // Compute dhash on the cropped image — same buffer the dedup logic will
+  // see at render time (src/lib/dhash.ts). Cheap; runs alongside the upload.
+  const dhash = await computeDHash(extractedBuffer);
+
   // Upload to R2
   const blobPrefix = `gallery/${bookId}/${pageId}-${detectionIndex}`;
   const [extractedBlob, thumbnailBlob] = await Promise.all([
@@ -144,6 +149,7 @@ async function generateThumbnails(sourceUrl, bbox, rotation, bookId, pageId, det
   return {
     extractedUrl: extractedBlob.url + cacheBust,
     thumbnailUrl: thumbnailBlob.url + cacheBust,
+    dhash,
   };
 }
 
@@ -280,6 +286,7 @@ async function main() {
         $set: {
           [`detected_images.${detectionIndex}.extracted_url`]: urls.extractedUrl,
           [`detected_images.${detectionIndex}.thumbnail_url`]: urls.thumbnailUrl,
+          [`detected_images.${detectionIndex}.dhash`]: urls.dhash,
         },
       }
     );
@@ -292,6 +299,7 @@ async function main() {
         $set: {
           extracted_url: urls.extractedUrl,
           thumbnail_url: urls.thumbnailUrl,
+          dhash: urls.dhash,
           updated_at: new Date(),
         },
       }


### PR DESCRIPTION
Closes #2113. Unblocks the duplicates review queue (#2107).

## What's in
- `scripts/maintenance/backfill-gallery-dhash.mjs` — one-time backfill. Reads gallery_images where `dhash` is unset + `extracted_url` is set, downloads the cropped image, computes the 64-bit dhash, writes it back. Idempotent. Smoke-tested on 20 rows at ~9/s with concurrency 10.
- `scripts/workers/generate-thumbnails.mjs` now computes dhash on every freshly cropped image and writes it to both `pages.detected_images[].dhash` and `gallery_images.dhash`. Future rows are current automatically — no follow-up backfill needed once this merges.
- `scripts/lib/dhash.mjs` — node-side mirror of `src/lib/dhash.ts`. Both .mjs scripts import from here. Keep in sync with the TS file.

## Scope
- ~93K gallery_images currently need backfill (the other ~36K are missing `extracted_url` itself — that's the separate Bucket-2 problem in #2092).
- Full backfill at concurrency 30 should take ~1 hour. Idempotent + resumable; safe to run in chunks (`--limit=N`).

## Cost / risk
- Zero Gemini calls. Just R2 GETs (cheap, no per-request fee on Cloudflare) + Atlas writes (negligible).
- dhash is additive — nothing reads it as required besides the existing dedup logic, which already gracefully skips rows without one.

## Out of scope (follow-ups)
- Pair-sampling for the duplicates queue (separate PR after dhash is widespread)
- Backfilling the ~36K rows missing `extracted_url` — separate concern (#2092 Bucket 2)

## Test plan
- [x] Smoke test: 20 rows, all 20 written, sample dhashes verified in Atlas
- [ ] Run full backfill at `concurrency=30 --apply` and report final counts
- [ ] After merge: confirm next `generate-thumbnails` cron writes `dhash` on newly cropped rows