### PR TITLE
feat(sponsors): replace "Named collection" with Scholar-in-Residence

### DIFF
--- a/src/app/sponsors/page.tsx
+++ b/src/app/sponsors/page.tsx
@@ -25,10 +25,10 @@ const MEMBERSHIP_INCLUDES = [
 
 const SPONSORSHIP_EXAMPLES = [
   {
-    label: 'Named collection',
-    range: '$25K – $50K',
+    label: 'Scholar-in-Residence',
+    range: '$25K – $75K',
     description:
-      'Permanent attribution on a thematic collection — e.g. "The [Company] Alchemy Library," "The [Company] Tibetan Manuscripts." Includes a launch and a co-written introduction.',
+      'Fund a year of work by a named expert on a specific collection — vetting translations, writing critical apparatus, contributing a foreword and launch lecture. Both the scholar’s name and yours appear on the collection. Concrete deliverable, real scholarship — not just a name on a page.',
   },
   {
     label: 'Annual gathering at the BPH',
@@ -357,9 +357,9 @@ export default async function SponsorsPage() {
             Get in touch.
           </h2>
           <p className="text-base md:text-lg text-stone-300 leading-relaxed mb-10">
-            Tell us what you&apos;d like to do — annual membership, a named collection, an
-            expedition, or something we haven&apos;t built yet. We&apos;ll come back inside a week
-            with a concrete proposal.
+            Tell us what you&apos;d like to do — annual membership, funding a Scholar-in-Residence on
+            a collection you care about, an expedition, or something we haven&apos;t built yet.
+            We&apos;ll come back inside a week with a concrete proposal.
           </p>
           <a
             href={mailto}


### PR DESCRIPTION
The "Named collection" framing — sponsor's name on a collection page for \$25K-\$50K — is thin for what it asks. This PR reframes the same product around what the money actually *does*: fund a year of a named expert working on that collection.

**Scholar-in-Residence — \$25K-\$75K**

> Fund a year of work by a named expert on a specific collection — vetting translations, writing critical apparatus, contributing a foreword and launch lecture. Both the scholar's name and yours appear on the collection. Concrete deliverable, real scholarship — not just a name on a page.

Why this is the right reframing:

- **Pricing isn't arbitrary** — it's a scholar's real US/EU part-time review honorarium.
- **Delivery is concrete and verifiable** — translations get vetted, apparatus gets written, a foreword + launch lecture happen.
- **Marginal cost matches price** — the money literally pays the scholar.
- **Tone isn't marketplace** — reads as "endow a research fellowship," which is dignified and matches the institutional voice.
- **Strategically aligned** — the canonical plan budgets \$1M / 5yr for the scholar network; this is the mechanism to actually fund it. And it matches the scholarly-review promise already on /about and /support.
- **Works for both audiences** — a corporate sponsor or a wealthy individual (a yogi who loves Sanskrit) can fund a scholar on the topic they care about.

Also updates the CTA copy from "a named collection" to "funding a Scholar-in-Residence on a collection you care about."

🤖 Generated with [Claude Code](https://claude.com/claude-code)